### PR TITLE
Enhance CondoAreaDetailForm UI/UX

### DIFF
--- a/src/features/appraisal/forms/CondoAreaDetailForm.tsx
+++ b/src/features/appraisal/forms/CondoAreaDetailForm.tsx
@@ -1,51 +1,26 @@
 import FormTable from '@/features/request/components/tables/FormTable';
-import Input from '@/shared/components/Input';
-import type { AreaDetailDtoType } from '@/shared/schemas/v1';
-import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 interface CondoAreaDetailFormProps {
   name: string;
 }
 function CondoAreaDetailForm({ name }: CondoAreaDetailFormProps) {
-  const { control } = useFormContext();
-  const {
-    field,
-    fieldState: { error },
-  } = useController({ name: name, control });
-
-  const properties = useWatch({ name: `${name}` });
-  const totalArea = calcTotalArea(properties);
-
   return (
     <div className="col-span-12 border-2 rounded-2xl border-gray-100">
-      <FormTable headers={propertiesTableHeader} name={`${name}`} />
-      <div className="px-6 pb-6">
-        <Input
-          type="number"
-          {...field}
-          label="Total Area (Sq. M.)"
-          value={totalArea}
-          error={error?.message}
-          readOnly
-          disabled
-        />
-      </div>
+      <FormTable headers={propertiesTableHeader} name={name} sumColumns={['areaSize']} />
     </div>
   );
 }
 
 const propertiesTableHeader = [
-  { name: 'areaDescription', label: 'Area Detail' },
-  { name: 'areaSize', label: 'Area', inputType: 'number' as const },
+  { rowNumberColumn: true as const, label: '#' },
+  { name: 'areaDescription', label: 'Area Detail', width: '70%' },
+  {
+    name: 'areaSize',
+    label: 'Area (Sq. M.)',
+    inputType: 'number' as const,
+    width: '20%',
+    align: 'right' as const,
+  },
 ];
-function calcTotalArea(properties: AreaDetailDtoType[]): number {
-  if (!properties || !Array.isArray(properties)) return 0;
-  return properties.reduce((acc, property) => acc + convertToNumber(property.areaSize, 0), 0);
-}
-
-function convertToNumber(n: any, fallback: number): number {
-  const number = Number(n);
-  return isNaN(number) ? fallback : number;
-}
 
 export default CondoAreaDetailForm;

--- a/src/features/request/components/tables/FormTable.tsx
+++ b/src/features/request/components/tables/FormTable.tsx
@@ -26,6 +26,7 @@ interface FormTableRegularHeader {
   label: string;
   inputType?: 'text' | 'number' | 'dropdown';
   width?: string; // Optional fixed width like '150px' or '20%'
+  align?: 'left' | 'center' | 'right';
   decimalPlaces?: number; // For number inputs (default: 2)
   options?: ListBoxItem[]; // For dropdown input type
 }
@@ -166,8 +167,12 @@ const FormTable = ({ name, headers, sumColumns = [], totalFieldName }: FormTable
             {headers.map((header, index) => (
               <th
                 key={index}
-                className={`text-primary text-sm font-semibold py-3 px-4 text-left first:rounded-tl-lg ${isReadOnly && index === headers.length - 1 ? 'rounded-tr-lg' : ''}`}
-                style={{ width: 'width' in header ? header.width : 'auto', minWidth: '120px' }}
+                className={`text-primary text-sm font-semibold py-3 px-4 ${'align' in header && header.align ? `text-${header.align}` : 'text-left'} first:rounded-tl-lg ${isReadOnly && index === headers.length - 1 ? 'rounded-tr-lg' : ''}`}
+                style={
+                  'rowNumberColumn' in header
+                    ? { width: '60px' }
+                    : { width: 'width' in header ? header.width : 'auto', minWidth: '120px' }
+                }
               >
                 {header.label}
               </th>
@@ -287,13 +292,14 @@ const FormTable = ({ name, headers, sumColumns = [], totalFieldName }: FormTable
         {hasSumRow && (
           <tfoot>
             <tr className="bg-gray-50 border-t-2 border-gray-200">
-              {headers.map((header, index) => {
+              {(() => { let hasRenderedTotalLabel = false; return headers.map((header, index) => {
                 if ('name' in header && sumColumns.includes(header.name)) {
                   const currentTotal = totalFieldName
                     ? (watch(totalFieldName) ?? calculatedTotal)
                     : calculatedTotal;
+                  const alignClass = 'align' in header && header.align === 'right' ? 'text-right' : '';
                   return (
-                    <td key={index} className="py-3 px-4">
+                    <td key={index} className={`py-3 px-4 ${alignClass}`}>
                       {isReadOnly ? (
                         <span className="text-sm font-semibold text-gray-900 text-right block">
                           {formatNumber(currentTotal)}
@@ -344,13 +350,16 @@ const FormTable = ({ name, headers, sumColumns = [], totalFieldName }: FormTable
                           )}
                         </div>
                       ) : (
-                        <span className="text-sm font-semibold text-gray-900">
+                        <span className="text-sm font-semibold text-gray-900 block">
                           {formatNumber(calculatedTotal)}
                         </span>
                       )}
                     </td>
                   );
-                } else if (index === 0) {
+                } else if ('rowNumberColumn' in header) {
+                  return <td key={index} className="py-3 px-4" />;
+                } else if (!hasRenderedTotalLabel) {
+                  hasRenderedTotalLabel = true;
                   return (
                     <td key={index} className="py-3 px-4 text-sm font-semibold text-gray-600">
                       <div className="flex items-center gap-2">
@@ -367,7 +376,7 @@ const FormTable = ({ name, headers, sumColumns = [], totalFieldName }: FormTable
                 } else {
                   return <td key={index} className="py-3 px-4" />;
                 }
-              })}
+              }); })()}
               {!isReadOnly && <td className="py-3 px-4" />}
             </tr>
           </tfoot>
@@ -449,7 +458,7 @@ const TableCell = ({ name, index, editIndex, value, header, control }: TableCell
       {editIndex === index ? (
         renderInput()
       ) : (
-        <div className={isNumber ? 'text-right' : ''}>{formatDisplayValue(value)}</div>
+        <div className={isNumber ? 'text-right' : 'truncate'}>{formatDisplayValue(value)}</div>
       )}
       {error && <div className="mt-1 text-sm text-danger">{error?.message}</div>}
     </div>


### PR DESCRIPTION
## Summary
- Simplify `CondoAreaDetailForm` by using FormTable's built-in `sumColumns` instead of a separate total `<Input>`, removing dead code (unused imports, `calcTotalArea`, `convertToNumber`)
- Add row number (`#`) column and unit label (`Area (Sq. M.)`) to area detail table headers
- Fix FormTable to properly handle `rowNumberColumn` — narrow width (60px), correct footer "Total" label placement, right-aligned sum values, and text truncation for long cell values
- Rename `condoAreaDetails` to `areaDetails` in form schema, defaults, and mappers to align with API
- Add `id` field to `AreaDetailDto` schema
- Update API client schema and v1 types

## Test plan
- [ ] Verify condo area detail table shows `#` column, `Area (Sq. M.)` header, and sum footer row
- [ ] Verify row number column does not overlap with Area Detail column
- [ ] Verify sum footer value is right-aligned matching the column values
- [ ] Verify long area description text is truncated with ellipsis
- [ ] Verify area details data loads and saves correctly with the renamed field
- [ ] Verify other FormTable usages (without row number column) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)