### PR TITLE
Update condo area detail field name and API schemas

### DIFF
--- a/src/features/appraisal/forms/CondoDetailForm.tsx
+++ b/src/features/appraisal/forms/CondoDetailForm.tsx
@@ -75,7 +75,7 @@ function CondoDetailForm() {
 
       <SectionRow title="Area Details" icon="chart-area">
         <div className="col-span-12">
-          <CondoAreaDetailForm name={'condoAreaDetails'} />
+          <CondoAreaDetailForm name={'areaDetails'} />
         </div>
       </SectionRow>
 

--- a/src/features/appraisal/schemas/form.ts
+++ b/src/features/appraisal/schemas/form.ts
@@ -165,6 +165,7 @@ export const createBuildingForm = z.object({
 
 const AreaDetailDto = z
   .object({
+    id: z.string().uuid().nullable(),
     areaDescription: z.string().nullable(),
     areaSize: z.coerce.number().nullable(),
   })
@@ -226,7 +227,7 @@ export const createCondoForm = z.object({
   roofType: z.string().nullable(),
   roofTypeOther: z.string().nullable(),
 
-  condoAreaDetails: z.array(AreaDetailDto).nullable(),
+  areaDetails: z.array(AreaDetailDto).nullable(),
   totalBuildingArea: z.coerce.number(),
 
   isExpropriated: z.boolean(),
@@ -614,7 +615,7 @@ export const createCondoFormDefault: createCondoFormType = {
   bathroomFloorMaterialTypeOther: '',
   roofType: '',
   roofTypeOther: '',
-  condoAreaDetail: [],
+  areaDetails: [],
   totalBuildingArea: 0,
   isExpropriated: false,
   expropriationRemark: '',

--- a/src/features/appraisal/utils/mappers.ts
+++ b/src/features/appraisal/utils/mappers.ts
@@ -227,7 +227,7 @@ export const mapCondoPropertyResponseToForm = (
     roofType: response.roofType ?? '',
     roofTypeOther: response.roofTypeOther ?? '',
 
-    condoAreaDetails: response.condoAreaDetails ?? [],
+    areaDetails: response.areaDetails ?? [],
     totalBuildingArea: response.totalBuildingArea ?? 0,
 
     isExpropriated: response.isExpropriated ?? false,

--- a/src/shared/schemas/api.client.json
+++ b/src/shared/schemas/api.client.json
@@ -480,6 +480,37 @@
         }
       }
     },
+    "/requests/{requestId}/documents": {
+      "get": {
+        "tags": ["Request Documents"],
+        "summary": "Get all documents for a request",
+        "description": "Retrieves all documents for a request, grouped by request-level and per-title sections.",
+        "operationId": "GetRequestDocumentsByRequestId",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetRequestDocumentsByRequestIdResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/requests/{requestId}/comments/{commentId}": {
       "patch": {
         "tags": ["Request Comments"],
@@ -1452,9 +1483,12 @@
         }
       }
     },
-    "/parameter": {
+    "/parameters": {
       "get": {
-        "tags": ["Api"],
+        "tags": ["Parameter"],
+        "summary": "Get parameters",
+        "description": "Retrieve a list of parameters filtered by group, country, language, code, or active status.",
+        "operationId": "GetParameters",
         "parameters": [
           {
             "name": "ParId",
@@ -1517,7 +1551,27 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ParameterDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -4159,6 +4213,106 @@
         }
       }
     },
+    "/market-comparables/{id}": {
+      "put": {
+        "tags": ["MarketComparables"],
+        "summary": "Update an existing Market Comparable",
+        "description": "Updates an existing Market Comparable in the system.",
+        "operationId": "UpdateMarketComparable",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMarketComparableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateMarketComparableResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["MarketComparables"],
+        "summary": "Get market comparable by ID",
+        "description": "Retrieves a market comparable with full details including factor data and images.",
+        "operationId": "GetMarketComparableById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMarketComparableByIdResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/market-comparables/{id}/factor-data": {
       "put": {
         "tags": ["MarketComparables"],
@@ -4371,12 +4525,12 @@
         }
       }
     },
-    "/market-comparables/{id}": {
-      "get": {
+    "/market-comparable/{id}": {
+      "delete": {
         "tags": ["MarketComparables"],
-        "summary": "Get market comparable by ID",
-        "description": "Retrieves a market comparable with full details including factor data and images.",
-        "operationId": "GetMarketComparableById",
+        "summary": "Delete market comparable by ID",
+        "description": "Deletes a market comparable by its ID.",
+        "operationId": "DeleteMarketComparable",
         "parameters": [
           {
             "name": "id",
@@ -4394,7 +4548,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetMarketComparableByIdResponse"
+                  "$ref": "#/components/schemas/DeleteMarketComparableResponse"
                 }
               }
             }
@@ -7227,11 +7381,81 @@
         }
       }
     },
-    "/appraisals/{appraisalId}/gallery/property-links/{mappingId}/unset-thumbnail": {
+    "/appraisals/{appraisalId}/appendices/{appendixId}/layout": {
+      "put": {
+        "tags": ["Appendix"],
+        "summary": "Update appendix layout columns",
+        "description": "Updates the layout column count (1, 2, or 3) for a specific appendix.",
+        "operationId": "UpdateAppendixLayout",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "appendixId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAppendixLayoutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAppendixLayoutResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appraisals/{appraisalId}/properties/{propertyId}/photos/{photoId}/unset-thumbnail": {
       "put": {
         "tags": ["AppraisalGallery"],
         "summary": "Unset property thumbnail",
-        "description": "Removes the thumbnail designation from the specified photo mapping.",
+        "description": "Removes the thumbnail designation from the specified photo for the property.",
         "operationId": "UnsetPropertyThumbnail",
         "parameters": [
           {
@@ -7244,7 +7468,16 @@
             }
           },
           {
-            "name": "mappingId",
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "photoId",
             "in": "path",
             "required": true,
             "schema": {
@@ -7390,11 +7623,11 @@
         }
       }
     },
-    "/appraisals/{appraisalId}/gallery/property-links/{mappingId}/set-thumbnail": {
+    "/appraisals/{appraisalId}/properties/{propertyId}/photos/{photoId}/set-thumbnail": {
       "put": {
         "tags": ["AppraisalGallery"],
         "summary": "Set property thumbnail",
-        "description": "Sets the specified photo mapping as the thumbnail for its property. Automatically unsets any existing thumbnail.",
+        "description": "Sets the specified photo as the thumbnail for the property. Automatically unsets any existing thumbnail.",
         "operationId": "SetPropertyThumbnail",
         "parameters": [
           {
@@ -7407,7 +7640,16 @@
             }
           },
           {
-            "name": "mappingId",
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "photoId",
             "in": "path",
             "required": true,
             "schema": {
@@ -7423,6 +7665,106 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SetPropertyThumbnailResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appraisals/{appraisalId}/law-and-regulations": {
+      "put": {
+        "tags": ["LawAndRegulation"],
+        "summary": "Save law and regulations for an appraisal",
+        "description": "Batch saves all law and regulation entries. Items not in the request are deleted.",
+        "operationId": "SaveLawAndRegulations",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveLawAndRegulationsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveLawAndRegulationsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["LawAndRegulation"],
+        "summary": "Get law and regulations for an appraisal",
+        "description": "Returns all law and regulation entries with their images for the given appraisal.",
+        "operationId": "GetLawAndRegulations",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLawAndRegulationsResult"
                 }
               }
             }
@@ -7552,6 +7894,65 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RemovePropertyFromGroupResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appraisals/{appraisalId}/appendices/{appendixId}/documents/{documentId}": {
+      "delete": {
+        "tags": ["Appendix"],
+        "summary": "Remove a document from an appendix",
+        "description": "Removes a document reference from the specified appendix.",
+        "operationId": "RemoveAppendixDocument",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "appendixId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoveAppendixDocumentResponse"
                 }
               }
             }
@@ -8207,6 +8608,37 @@
         }
       }
     },
+    "/appraisals/{appraisalId}/appendices": {
+      "get": {
+        "tags": ["Appendix"],
+        "summary": "Get all appendices for an appraisal",
+        "description": "Returns all appendix entries with their documents, joined with appendix type names.",
+        "operationId": "GetAppraisalAppendices",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAppraisalAppendicesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/appraisal/{appraisalId}/{propertyId}": {
       "delete": {
         "tags": ["Api"],
@@ -8700,7 +9132,7 @@
       "put": {
         "tags": ["PhotoTopic"],
         "summary": "Assign photo to topic",
-        "description": "Assigns a gallery photo to a topic, or unassigns it by passing null.",
+        "description": "Syncs a gallery photo's topic assignments. Pass desired topic IDs; old ones are removed, new ones are added.",
         "operationId": "AssignPhotoToTopic",
         "parameters": [
           {
@@ -8815,6 +9247,76 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appraisals/{appraisalId}/appendices/{appendixId}/documents": {
+      "post": {
+        "tags": ["Appendix"],
+        "summary": "Attach a document to an appendix",
+        "description": "Adds a document reference to the specified appendix.",
+        "operationId": "AddAppendixDocument",
+        "parameters": [
+          {
+            "name": "appraisalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "appendixId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddAppendixDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddAppendixDocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -9230,6 +9732,34 @@
           }
         }
       },
+      "AddAppendixDocumentRequest": {
+        "required": ["galleryPhotoId", "displaySequence"],
+        "type": "object",
+        "properties": {
+          "galleryPhotoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displaySequence": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "AddAppendixDocumentResponse": {
+        "required": ["documentId", "appendixId"],
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "appendixId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "AddApproachRequest": {
         "required": ["approachType"],
         "type": "object",
@@ -9556,9 +10086,12 @@
             "default": null,
             "nullable": true
           },
-          "photoTopicId": {
-            "type": "string",
-            "format": "uuid",
+          "photoTopicIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
             "default": null,
             "nullable": true
           }
@@ -9786,6 +10319,28 @@
         },
         "nullable": true
       },
+      "AppendixDocumentResponse": {
+        "required": ["id", "galleryPhotoId", "documentId", "displaySequence"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "galleryPhotoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displaySequence": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
       "AppointmentDto": {
         "required": ["appointmentDateTime", "appointmentLocation"],
         "type": "object",
@@ -9875,6 +10430,48 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          }
+        }
+      },
+      "AppraisalAppendixResponse": {
+        "required": [
+          "id",
+          "appendixTypeId",
+          "appendixTypeCode",
+          "appendixTypeName",
+          "sortOrder",
+          "layoutColumns",
+          "documents"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "appendixTypeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "appendixTypeCode": {
+            "type": "string"
+          },
+          "appendixTypeName": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "layoutColumns": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppendixDocumentResponse"
+            }
           }
         }
       },
@@ -10270,27 +10867,192 @@
         }
       },
       "AssignPhotoToTopicRequest": {
-        "required": ["photoTopicId"],
+        "required": ["photoTopicIds"],
         "type": "object",
         "properties": {
-          "photoTopicId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
+          "photoTopicIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         }
       },
       "AssignPhotoToTopicResult": {
-        "required": ["photoId", "photoTopicId"],
+        "required": ["photoId", "photoTopicIds"],
         "type": "object",
         "properties": {
           "photoId": {
             "type": "string",
             "format": "uuid"
           },
-          "photoTopicId": {
+          "photoTopicIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "BuildingAppraisalDepreciationDetailDto": {
+        "required": [
+          "id",
+          "areaDescription",
+          "area",
+          "pricePerSqMBeforeDepreciation",
+          "priceBeforeDepreciation",
+          "year",
+          "isBuilding",
+          "depreciationMethod",
+          "depreciationYearPct",
+          "totalDepreciationPct",
+          "priceDepreciation",
+          "pricePerSqMAfterDepreciation",
+          "priceAfterDepreciation",
+          "depreciationPeriods"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
             "type": "string",
-            "format": "uuid",
+            "format": "uuid"
+          },
+          "areaDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "area": {
+            "type": "number",
+            "format": "double"
+          },
+          "pricePerSqMBeforeDepreciation": {
+            "type": "number",
+            "format": "double"
+          },
+          "priceBeforeDepreciation": {
+            "type": "number",
+            "format": "double"
+          },
+          "year": {
+            "type": "integer",
+            "format": "int16"
+          },
+          "isBuilding": {
+            "type": "boolean"
+          },
+          "depreciationMethod": {
+            "type": "string"
+          },
+          "depreciationYearPct": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalDepreciationPct": {
+            "type": "number",
+            "format": "double"
+          },
+          "priceDepreciation": {
+            "type": "number",
+            "format": "double"
+          },
+          "pricePerSqMAfterDepreciation": {
+            "type": "number",
+            "format": "double"
+          },
+          "priceAfterDepreciation": {
+            "type": "number",
+            "format": "double"
+          },
+          "depreciationPeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAppraisalDepreciationPeriodDto"
+            }
+          }
+        }
+      },
+      "BuildingAppraisalDepreciationPeriodDto": {
+        "required": [
+          "id",
+          "atYear",
+          "toYear",
+          "depreciationPerYear",
+          "totalDepreciationPct",
+          "priceDepreciation"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "atYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "toYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "depreciationPerYear": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalDepreciationPct": {
+            "type": "number",
+            "format": "double"
+          },
+          "priceDepreciation": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "BuildingAppraisalSurfaceDto": {
+        "required": [
+          "id",
+          "fromFloorNumber",
+          "toFloorNumber",
+          "floorType",
+          "floorStructureType",
+          "floorStructureTypeOther",
+          "floorSurfaceType",
+          "floorSurfaceTypeOther"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fromFloorNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "toFloorNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "floorType": {
+            "type": "string",
+            "nullable": true
+          },
+          "floorStructureType": {
+            "type": "string",
+            "nullable": true
+          },
+          "floorStructureTypeOther": {
+            "type": "string",
+            "nullable": true
+          },
+          "floorSurfaceType": {
+            "type": "string",
+            "nullable": true
+          },
+          "floorSurfaceTypeOther": {
+            "type": "string",
             "nullable": true
           }
         }
@@ -11017,6 +11779,26 @@
           }
         }
       },
+      "CondoAppraisalAreaDetailDto": {
+        "required": ["id", "areaDescription", "areaSize"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "areaDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "areaSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        }
+      },
       "ContactDto": {
         "required": ["contactPersonName", "contactPersonPhone", "dealerCode"],
         "type": "object",
@@ -11422,6 +12204,22 @@
             "type": "string",
             "default": null,
             "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepreciationItemData"
+            },
+            "default": null,
+            "nullable": true
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceItemData"
+            },
+            "default": null,
+            "nullable": true
           }
         }
       },
@@ -11795,6 +12593,14 @@
           },
           "roofTypeOther": {
             "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
             "default": null,
             "nullable": true
           },
@@ -12518,7 +13324,7 @@
             "default": null,
             "nullable": true
           },
-          "buildingCondition": {
+          "buildingConditionType": {
             "type": "string",
             "default": null,
             "nullable": true
@@ -12578,12 +13384,12 @@
             "default": null,
             "nullable": true
           },
-          "buildingMaterial": {
+          "buildingMaterialType": {
             "type": "string",
             "default": null,
             "nullable": true
           },
-          "buildingStyle": {
+          "buildingStyleType": {
             "type": "string",
             "default": null,
             "nullable": true
@@ -12792,6 +13598,22 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/LandTitleItemRequest"
+            },
+            "default": null,
+            "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepreciationItemData"
+            },
+            "default": null,
+            "nullable": true
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceItemData"
             },
             "default": null,
             "nullable": true
@@ -13507,7 +14329,7 @@
         }
       },
       "CreateMarketComparableRequest": {
-        "required": ["comparableNumber", "propertyType", "province", "dataSource", "surveyDate"],
+        "required": ["comparableNumber", "propertyType", "surveyName"],
         "type": "object",
         "properties": {
           "comparableNumber": {
@@ -13516,72 +14338,16 @@
           "propertyType": {
             "type": "string"
           },
-          "province": {
+          "surveyName": {
             "type": "string"
           },
-          "dataSource": {
-            "type": "string"
-          },
-          "surveyDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "district": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "subDistrict": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "address": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "latitude": {
-            "type": "number",
-            "format": "double",
-            "default": null,
-            "nullable": true
-          },
-          "longitude": {
-            "type": "number",
-            "format": "double",
-            "default": null,
-            "nullable": true
-          },
-          "transactionType": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "transactionDate": {
+          "infoDateTime": {
             "type": "string",
             "format": "date-time",
             "default": null,
             "nullable": true
           },
-          "transactionPrice": {
-            "type": "number",
-            "format": "double",
-            "default": null,
-            "nullable": true
-          },
-          "pricePerUnit": {
-            "type": "number",
-            "format": "double",
-            "default": null,
-            "nullable": true
-          },
-          "unitType": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "description": {
+          "sourceInfo": {
             "type": "string",
             "default": null,
             "nullable": true
@@ -14391,6 +15157,15 @@
           }
         }
       },
+      "DeleteMarketComparableResponse": {
+        "required": ["isSuccess"],
+        "type": "object",
+        "properties": {
+          "isSuccess": {
+            "type": "boolean"
+          }
+        }
+      },
       "DeletePermissionResponse": {
         "required": ["isSuccess"],
         "type": "object",
@@ -14427,6 +15202,114 @@
           }
         }
       },
+      "DepreciationItemData": {
+        "required": ["id", "depreciationMethod"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "depreciationMethod": {
+            "type": "string"
+          },
+          "areaDescription": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "area": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "year": {
+            "type": "integer",
+            "format": "int16",
+            "default": 0
+          },
+          "isBuilding": {
+            "type": "boolean",
+            "default": true
+          },
+          "pricePerSqMBeforeDepreciation": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "priceBeforeDepreciation": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "pricePerSqMAfterDepreciation": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "priceAfterDepreciation": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "depreciationYearPct": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "totalDepreciationPct": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "priceDepreciation": {
+            "type": "number",
+            "format": "double",
+            "default": 0
+          },
+          "depreciationPeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepreciationPeriodItemData"
+            },
+            "default": null,
+            "nullable": true
+          }
+        }
+      },
+      "DepreciationPeriodItemData": {
+        "required": [
+          "atYear",
+          "toYear",
+          "depreciationPerYear",
+          "totalDepreciationPct",
+          "priceDepreciation"
+        ],
+        "type": "object",
+        "properties": {
+          "atYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "toYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "depreciationPerYear": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalDepreciationPct": {
+            "type": "number",
+            "format": "double"
+          },
+          "priceDepreciation": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
       "DocumentChecklistItemDto": {
         "type": "object",
         "properties": {
@@ -14449,6 +15332,64 @@
           },
           "notes": {
             "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DocumentItemDto": {
+        "required": [
+          "id",
+          "documentId",
+          "documentType",
+          "fileName",
+          "filePath",
+          "notes",
+          "isRequired",
+          "uploadedBy",
+          "uploadedByName",
+          "uploadedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "documentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "filePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean"
+          },
+          "uploadedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "uploadedByName": {
+            "type": "string",
+            "nullable": true
+          },
+          "uploadedAt": {
+            "type": "string",
+            "format": "date-time",
             "nullable": true
           }
         }
@@ -14523,6 +15464,46 @@
           }
         }
       },
+      "DocumentSectionDto": {
+        "required": [
+          "titleId",
+          "titleIdentifier",
+          "collateralType",
+          "totalDocuments",
+          "uploadedDocuments",
+          "documents"
+        ],
+        "type": "object",
+        "properties": {
+          "titleId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "titleIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "collateralType": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalDocuments": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "uploadedDocuments": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentItemDto"
+            }
+          }
+        }
+      },
       "DocumentTypeDto": {
         "type": "object",
         "properties": {
@@ -14574,6 +15555,32 @@
             "type": "string",
             "format": "uuid"
           },
+          "factorCode": {
+            "type": "string"
+          },
+          "factorName": {
+            "type": "string"
+          },
+          "fieldName": {
+            "type": "string"
+          },
+          "dataType": {
+            "$ref": "#/components/schemas/FactorDataType"
+          },
+          "fieldLength": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fieldDecimal": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "parameterGroup": {
+            "type": "string",
+            "nullable": true
+          },
           "value": {
             "type": "string",
             "nullable": true
@@ -14602,6 +15609,9 @@
             "nullable": true
           }
         }
+      },
+      "FactorDataType": {
+        "enum": ["Text", "Numeric", "Dropdown", "Checkbox", "Date", "Radio"]
       },
       "FactorScoreDto": {
         "required": [
@@ -14764,7 +15774,7 @@
           "uploadedAt",
           "isUsedInReport",
           "reportSection",
-          "photoTopicId"
+          "photoTopicIds"
         ],
         "type": "object",
         "properties": {
@@ -14817,10 +15827,12 @@
             "type": "string",
             "nullable": true
           },
-          "photoTopicId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
+          "photoTopicIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         }
       },
@@ -14832,6 +15844,18 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AppointmentDto2"
+            }
+          }
+        }
+      },
+      "GetAppraisalAppendicesResponse": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppraisalAppendixResponse"
             }
           }
         }
@@ -15008,7 +16032,9 @@
           "buildingInsurancePrice",
           "sellingPrice",
           "forcedSalePrice",
-          "remark"
+          "remark",
+          "depreciationDetails",
+          "surfaces"
         ],
         "type": "object",
         "properties": {
@@ -15273,6 +16299,18 @@
           "remark": {
             "type": "string",
             "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAppraisalDepreciationDetailDto"
+            }
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAppraisalSurfaceDto"
+            }
           }
         }
       },
@@ -15460,6 +16498,7 @@
           "bathroomFloorMaterialTypeOther",
           "roofType",
           "roofTypeOther",
+          "areaDetails",
           "totalBuildingArea",
           "isExpropriated",
           "expropriationRemark",
@@ -15708,6 +16747,13 @@
             "type": "string",
             "nullable": true
           },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
+            "nullable": true
+          },
           "totalBuildingArea": {
             "type": "number",
             "format": "double",
@@ -15919,6 +16965,7 @@
           "pondDepth",
           "hasBuilding",
           "hasBuildingOther",
+          "titles",
           "buildingNumber",
           "modelName",
           "builtOnTitleNumber",
@@ -15967,7 +17014,9 @@
           "sellingPrice",
           "forcedSalePrice",
           "landRemark",
-          "buildingRemark"
+          "buildingRemark",
+          "depreciationDetails",
+          "surfaces"
         ],
         "type": "object",
         "properties": {
@@ -16340,6 +17389,13 @@
             "type": "string",
             "nullable": true
           },
+          "titles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandTitleItemData"
+            },
+            "nullable": true
+          },
           "buildingNumber": {
             "type": "string",
             "nullable": true
@@ -16566,6 +17622,18 @@
           "buildingRemark": {
             "type": "string",
             "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAppraisalDepreciationDetailDto"
+            }
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAppraisalSurfaceDto"
+            }
           }
         }
       },
@@ -16950,6 +18018,18 @@
               "$ref": "#/components/schemas/LandTitleItemData"
             },
             "nullable": true
+          }
+        }
+      },
+      "GetLawAndRegulationsResult": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LawAndRegulationDto"
+            }
           }
         }
       },
@@ -17597,6 +18677,26 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RequestCommentDto"
+            }
+          }
+        }
+      },
+      "GetRequestDocumentsByRequestIdResponse": {
+        "required": ["totalDocuments", "totalUploaded", "sections"],
+        "type": "object",
+        "properties": {
+          "totalDocuments": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalUploaded": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentSectionDto"
             }
           }
         }
@@ -18755,6 +19855,134 @@
           }
         }
       },
+      "LawAndRegulationDto": {
+        "required": ["id", "headerCode", "remark", "images"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "headerCode": {
+            "type": "string"
+          },
+          "remark": {
+            "type": "string",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LawAndRegulationImageDto"
+            }
+          }
+        }
+      },
+      "LawAndRegulationImageDto": {
+        "required": [
+          "id",
+          "documentId",
+          "displaySequence",
+          "fileName",
+          "filePath",
+          "title",
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displaySequence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LawAndRegulationImageInput": {
+        "required": [
+          "id",
+          "documentId",
+          "displaySequence",
+          "fileName",
+          "filePath",
+          "title",
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displaySequence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LawAndRegulationItemInput": {
+        "required": ["id", "headerCode", "remark", "images"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "headerCode": {
+            "type": "string"
+          },
+          "remark": {
+            "type": "string",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LawAndRegulationImageInput"
+            }
+          }
+        }
+      },
       "LinkComparableRequest": {
         "required": ["marketComparableId", "displaySequence"],
         "type": "object",
@@ -18906,92 +20134,15 @@
           "propertyType": {
             "type": "string"
           },
-          "province": {
+          "surveyName": {
             "type": "string"
           },
-          "district": {
-            "type": "string",
-            "nullable": true
-          },
-          "subDistrict": {
-            "type": "string",
-            "nullable": true
-          },
-          "address": {
-            "type": "string",
-            "nullable": true
-          },
-          "latitude": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "longitude": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "transactionType": {
-            "type": "string",
-            "nullable": true
-          },
-          "transactionDate": {
+          "infoDateTime": {
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
-          "transactionPrice": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "pricePerUnit": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "unitType": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataSource": {
-            "type": "string"
-          },
-          "dataConfidence": {
-            "type": "string",
-            "nullable": true
-          },
-          "isVerified": {
-            "type": "boolean"
-          },
-          "verifiedAt": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "verifiedBy": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "status": {
-            "type": "string"
-          },
-          "expiryDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "surveyDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "surveyedBy": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "description": {
+          "sourceInfo": {
             "type": "string",
             "nullable": true
           },
@@ -19049,60 +20200,21 @@
           "propertyType": {
             "type": "string"
           },
-          "province": {
+          "surveyName": {
             "type": "string"
           },
-          "district": {
-            "type": "string",
-            "nullable": true
-          },
-          "subDistrict": {
-            "type": "string",
-            "nullable": true
-          },
-          "address": {
-            "type": "string",
-            "nullable": true
-          },
-          "transactionType": {
-            "type": "string",
-            "nullable": true
-          },
-          "transactionDate": {
+          "infoDateTime": {
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
-          "transactionPrice": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "pricePerUnit": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "unitType": {
+          "sourceInfo": {
             "type": "string",
             "nullable": true
           },
-          "dataSource": {
-            "type": "string"
-          },
-          "dataConfidence": {
+          "notes": {
             "type": "string",
             "nullable": true
-          },
-          "isVerified": {
-            "type": "boolean"
-          },
-          "status": {
-            "type": "string"
-          },
-          "surveyDate": {
-            "type": "string",
-            "format": "date-time"
           },
           "createdOn": {
             "type": "string",
@@ -19632,6 +20744,55 @@
           }
         }
       },
+      "ParameterDto": {
+        "required": [
+          "parId",
+          "group",
+          "country",
+          "language",
+          "code",
+          "description",
+          "isActive",
+          "seqNo"
+        ],
+        "type": "object",
+        "properties": {
+          "parId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "group": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "seqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
       "PaymentHistoryDto": {
         "type": "object",
         "properties": {
@@ -20069,6 +21230,15 @@
           },
           "reason": {
             "type": "string"
+          }
+        }
+      },
+      "RemoveAppendixDocumentResponse": {
+        "required": ["success"],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
           }
         }
       },
@@ -20683,6 +21853,35 @@
           }
         }
       },
+      "SaveLawAndRegulationsRequest": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LawAndRegulationItemInput"
+            }
+          }
+        }
+      },
+      "SaveLawAndRegulationsResponse": {
+        "required": ["appraisalId", "itemCount", "success"],
+        "type": "object",
+        "properties": {
+          "appraisalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "itemCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        }
+      },
       "SelectMethodResponse": {
         "required": ["id", "methodType", "status"],
         "type": "object",
@@ -21035,6 +22234,50 @@
           }
         }
       },
+      "SurfaceItemData": {
+        "required": ["id", "fromFloorNumber", "toFloorNumber"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "fromFloorNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "toFloorNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "floorType": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "floorStructureType": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "floorStructureTypeOther": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "floorSurfaceType": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "floorSurfaceTypeOther": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          }
+        }
+      },
       "TaskItem": {
         "required": [
           "id",
@@ -21339,6 +22582,30 @@
           "mappingId": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "UpdateAppendixLayoutRequest": {
+        "required": ["layoutColumns"],
+        "type": "object",
+        "properties": {
+          "layoutColumns": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "UpdateAppendixLayoutResponse": {
+        "required": ["appendixId", "layoutColumns"],
+        "type": "object",
+        "properties": {
+          "appendixId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "layoutColumns": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -21681,6 +22948,22 @@
           },
           "remark": {
             "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepreciationItemData"
+            },
+            "default": null,
+            "nullable": true
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceItemData"
+            },
             "default": null,
             "nullable": true
           }
@@ -22210,6 +23493,14 @@
           },
           "roofTypeOther": {
             "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
             "default": null,
             "nullable": true
           },
@@ -23419,6 +24710,22 @@
             "type": "string",
             "default": null,
             "nullable": true
+          },
+          "depreciationDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepreciationItemData"
+            },
+            "default": null,
+            "nullable": true
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceItemData"
+            },
+            "default": null,
+            "nullable": true
           }
         }
       },
@@ -24063,6 +25370,49 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "UpdateMarketComparableRequest": {
+        "required": ["propertyType", "surveyName"],
+        "type": "object",
+        "properties": {
+          "propertyType": {
+            "type": "string"
+          },
+          "surveyName": {
+            "type": "string"
+          },
+          "infoDateTime": {
+            "type": "string",
+            "format": "date-time",
+            "default": null,
+            "nullable": true
+          },
+          "sourceInfo": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "templateId": {
+            "type": "string",
+            "format": "uuid",
+            "default": null,
+            "nullable": true
+          }
+        }
+      },
+      "UpdateMarketComparableResponse": {
+        "required": ["success"],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
           }
         }
       },
@@ -24823,12 +26173,22 @@
         }
       },
       "UploadDocumentResponse": {
-        "required": ["isSuccess", "documentId", "fileName", "fileSize"],
+        "required": [
+          "documentId",
+          "fileName",
+          "fileExtension",
+          "fileSize",
+          "mimeType",
+          "storageUrl",
+          "documentType",
+          "documentCategory",
+          "description",
+          "uploadedBy",
+          "uploadedByName",
+          "uploadedAt"
+        ],
         "type": "object",
         "properties": {
-          "isSuccess": {
-            "type": "boolean"
-          },
           "documentId": {
             "type": "string",
             "format": "uuid"
@@ -24836,9 +26196,38 @@
           "fileName": {
             "type": "string"
           },
+          "fileExtension": {
+            "type": "string"
+          },
           "fileSize": {
             "type": "integer",
             "format": "int64"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "storageUrl": {
+            "type": "string"
+          },
+          "documentType": {
+            "type": "string"
+          },
+          "documentCategory": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "uploadedBy": {
+            "type": "string"
+          },
+          "uploadedByName": {
+            "type": "string"
+          },
+          "uploadedAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -24947,6 +26336,9 @@
       "name": "Requests"
     },
     {
+      "name": "Request Documents"
+    },
+    {
       "name": "Request Comments"
     },
     {
@@ -24969,6 +26361,9 @@
     },
     {
       "name": "GetUserNotificationsEndpoint"
+    },
+    {
+      "name": "Parameter"
     },
     {
       "name": "Documents"
@@ -25032,6 +26427,12 @@
     },
     {
       "name": "AppraisalGallery"
+    },
+    {
+      "name": "Appendix"
+    },
+    {
+      "name": "LawAndRegulation"
     },
     {
       "name": "Appointment"

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -341,6 +341,37 @@ const CreateDraftRequestRequest = z
   })
   .passthrough();
 const CreateDraftRequestResponse = z.object({ id: z.string().uuid() }).passthrough();
+const DocumentItemDto = z
+  .object({
+    id: z.string().uuid(),
+    documentId: z.string().uuid().nullable(),
+    documentType: z.string().nullable(),
+    fileName: z.string().nullable(),
+    filePath: z.string().nullable(),
+    notes: z.string().nullable(),
+    isRequired: z.boolean(),
+    uploadedBy: z.string().nullable(),
+    uploadedByName: z.string().nullable(),
+    uploadedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .passthrough();
+const DocumentSectionDto = z
+  .object({
+    titleId: z.string().uuid().nullable(),
+    titleIdentifier: z.string().nullable(),
+    collateralType: z.string().nullable(),
+    totalDocuments: z.number().int(),
+    uploadedDocuments: z.number().int(),
+    documents: z.array(DocumentItemDto),
+  })
+  .passthrough();
+const GetRequestDocumentsByRequestIdResponse = z
+  .object({
+    totalDocuments: z.number().int(),
+    totalUploaded: z.number().int(),
+    sections: z.array(DocumentSectionDto),
+  })
+  .passthrough();
 const UpdateRequestCommentRequest = z.object({ comment: z.string() }).passthrough();
 const UpdateRequestCommentResponse = z.object({ isSuccess: z.boolean() }).passthrough();
 const RemoveRequestCommentResponse = z.object({ isSuccess: z.boolean() }).passthrough();
@@ -520,6 +551,18 @@ const NotificationDto = z
 const GetUserNotificationsResponse = z
   .object({ notifications: z.array(NotificationDto) })
   .passthrough();
+const ParameterDto = z
+  .object({
+    parId: z.number().int().nullable(),
+    group: z.string().nullable(),
+    country: z.string().nullable(),
+    language: z.string().nullable(),
+    code: z.string().nullable(),
+    description: z.string().nullable(),
+    isActive: z.boolean().nullable(),
+    seqNo: z.number().int().nullable(),
+  })
+  .passthrough();
 const DocumentLink = z
   .object({
     entityType: z.string(),
@@ -537,10 +580,18 @@ const CreateUploadSessionResponse = z
   .passthrough();
 const UploadDocumentResponse = z
   .object({
-    isSuccess: z.boolean(),
     documentId: z.string().uuid(),
     fileName: z.string(),
+    fileExtension: z.string(),
     fileSize: z.number().int(),
+    mimeType: z.string(),
+    storageUrl: z.string(),
+    documentType: z.string(),
+    documentCategory: z.string(),
+    description: z.string().nullable(),
+    uploadedBy: z.string(),
+    uploadedByName: z.string(),
+    uploadedAt: z.string().datetime({ offset: true }),
   })
   .passthrough();
 const KickstartWorkflowRequest = z.object({ requestId: z.number().int() }).passthrough();
@@ -810,7 +861,6 @@ const UpdateCollateralRequest = z
     landTitles: z.array(LandTitleDto).nullable(),
   })
   .passthrough();
-
 const UpdateCollateralResponse = z.object({ isSuccess: z.boolean() }).passthrough();
 const CollateralEngagementDto = z
   .object({
@@ -1397,78 +1447,29 @@ const AddFactorToTemplateRequest = z
   })
   .passthrough();
 const AddFactorToTemplateResponse = z.object({ templateFactorId: z.string().uuid() }).passthrough();
-const FactorDataItem = z
+const UpdateMarketComparableRequest = z
   .object({
-    factorId: z.string().uuid(),
-    value: z.string().nullable(),
-    otherRemarks: z.string().nullish().default(null),
-  })
-  .passthrough();
-const SetMarketComparableFactorDataRequest = z
-  .object({ factorData: z.array(FactorDataItem) })
-  .passthrough();
-const SetMarketComparableFactorDataResponse = z.object({ success: z.boolean() }).passthrough();
-const MarketComparableDto = z
-  .object({
-    id: z.string().uuid(),
-    comparableNumber: z.string(),
     propertyType: z.string(),
-    province: z.string(),
-    district: z.string().nullable(),
-    subDistrict: z.string().nullable(),
-    address: z.string().nullable(),
-    transactionType: z.string().nullable(),
-    transactionDate: z.string().datetime({ offset: true }).nullable(),
-    transactionPrice: z.number().nullable(),
-    pricePerUnit: z.number().nullable(),
-    unitType: z.string().nullable(),
-    dataSource: z.string(),
-    dataConfidence: z.string().nullable(),
-    isVerified: z.boolean(),
-    status: z.string(),
-    surveyDate: z.string().datetime({ offset: true }),
-    createdOn: z.string().datetime({ offset: true }).nullable(),
-  })
-  .partial()
-  .passthrough();
-const PaginatedResultOfMarketComparableDto = z
-  .object({
-    items: z.array(MarketComparableDto),
-    count: z.number().int(),
-    pageNumber: z.number().int(),
-    pageSize: z.number().int(),
-  })
-  .passthrough();
-const GetMarketComparablesResponse = z
-  .object({ result: PaginatedResultOfMarketComparableDto })
-  .passthrough();
-const CreateMarketComparableRequest = z
-  .object({
-    comparableNumber: z.string(),
-    propertyType: z.string(),
-    province: z.string(),
-    dataSource: z.string(),
-    surveyDate: z.string().datetime({ offset: true }),
-    district: z.string().nullish().default(null),
-    subDistrict: z.string().nullish().default(null),
-    address: z.string().nullish().default(null),
-    latitude: z.number().nullish().default(null),
-    longitude: z.number().nullish().default(null),
-    transactionType: z.string().nullish().default(null),
-    transactionDate: z.string().datetime({ offset: true }).nullish().default(null),
-    transactionPrice: z.number().nullish().default(null),
-    pricePerUnit: z.number().nullish().default(null),
-    unitType: z.string().nullish().default(null),
-    description: z.string().nullish().default(null),
+    surveyName: z.string(),
+    infoDateTime: z.string().datetime({ offset: true }).nullish().default(null),
+    sourceInfo: z.string().nullish().default(null),
     notes: z.string().nullish().default(null),
     templateId: z.string().uuid().nullish().default(null),
   })
   .passthrough();
-const CreateMarketComparableResponse = z.object({ id: z.string().uuid() }).passthrough();
+const UpdateMarketComparableResponse = z.object({ success: z.boolean() }).passthrough();
+const FactorDataType = z.unknown();
 const FactorDataDto = z
   .object({
     id: z.string().uuid(),
     factorId: z.string().uuid(),
+    factorCode: z.string(),
+    factorName: z.string(),
+    fieldName: z.string(),
+    dataType: FactorDataType,
+    fieldLength: z.number().int().nullable(),
+    fieldDecimal: z.number().int().nullable(),
+    parameterGroup: z.string().nullable(),
     value: z.string().nullable(),
     otherRemarks: z.string().nullable(),
   })
@@ -1489,27 +1490,9 @@ const MarketComparableDetailDto = z
     id: z.string().uuid(),
     comparableNumber: z.string(),
     propertyType: z.string(),
-    province: z.string(),
-    district: z.string().nullable(),
-    subDistrict: z.string().nullable(),
-    address: z.string().nullable(),
-    latitude: z.number().nullable(),
-    longitude: z.number().nullable(),
-    transactionType: z.string().nullable(),
-    transactionDate: z.string().datetime({ offset: true }).nullable(),
-    transactionPrice: z.number().nullable(),
-    pricePerUnit: z.number().nullable(),
-    unitType: z.string().nullable(),
-    dataSource: z.string(),
-    dataConfidence: z.string().nullable(),
-    isVerified: z.boolean(),
-    verifiedAt: z.string().datetime({ offset: true }).nullable(),
-    verifiedBy: z.string().uuid().nullable(),
-    status: z.string(),
-    expiryDate: z.string().datetime({ offset: true }).nullable(),
-    surveyDate: z.string().datetime({ offset: true }),
-    surveyedBy: z.string().uuid().nullable(),
-    description: z.string().nullable(),
+    surveyName: z.string(),
+    infoDateTime: z.string().datetime({ offset: true }).nullable(),
+    sourceInfo: z.string().nullable(),
     notes: z.string().nullable(),
     templateId: z.string().uuid().nullable(),
     createdOn: z.string().datetime({ offset: true }).nullable(),
@@ -1524,6 +1507,54 @@ const MarketComparableDetailDto = z
 const GetMarketComparableByIdResponse = z
   .object({ marketComparable: MarketComparableDetailDto })
   .passthrough();
+const FactorDataItem = z
+  .object({
+    factorId: z.string().uuid(),
+    value: z.string().nullable(),
+    otherRemarks: z.string().nullish().default(null),
+  })
+  .passthrough();
+const SetMarketComparableFactorDataRequest = z
+  .object({ factorData: z.array(FactorDataItem) })
+  .passthrough();
+const SetMarketComparableFactorDataResponse = z.object({ success: z.boolean() }).passthrough();
+const MarketComparableDto = z
+  .object({
+    id: z.string().uuid(),
+    comparableNumber: z.string(),
+    propertyType: z.string(),
+    surveyName: z.string(),
+    infoDateTime: z.string().datetime({ offset: true }).nullable(),
+    sourceInfo: z.string().nullable(),
+    notes: z.string().nullable(),
+    createdOn: z.string().datetime({ offset: true }).nullable(),
+  })
+  .partial()
+  .passthrough();
+const PaginatedResultOfMarketComparableDto = z
+  .object({
+    items: z.array(MarketComparableDto),
+    count: z.number().int(),
+    pageNumber: z.number().int(),
+    pageSize: z.number().int(),
+  })
+  .passthrough();
+const GetMarketComparablesResponse = z
+  .object({ result: PaginatedResultOfMarketComparableDto })
+  .passthrough();
+const CreateMarketComparableRequest = z
+  .object({
+    comparableNumber: z.string(),
+    propertyType: z.string(),
+    surveyName: z.string(),
+    infoDateTime: z.string().datetime({ offset: true }).nullish().default(null),
+    sourceInfo: z.string().nullish().default(null),
+    notes: z.string().nullish().default(null),
+    templateId: z.string().uuid().nullish().default(null),
+  })
+  .passthrough();
+const CreateMarketComparableResponse = z.object({ id: z.string().uuid() }).passthrough();
+const DeleteMarketComparableResponse = z.object({ isSuccess: z.boolean() }).passthrough();
 const AddMarketComparableImageRequest = z
   .object({
     documentId: z.string().uuid(),
@@ -2369,6 +2400,45 @@ const GetLandPropertyResponse = z
   })
   .partial()
   .passthrough();
+const DepreciationPeriodItemData = z
+  .object({
+    atYear: z.number().int(),
+    toYear: z.number().int(),
+    depreciationPerYear: z.number(),
+    totalDepreciationPct: z.number(),
+    priceDepreciation: z.number(),
+  })
+  .passthrough();
+const DepreciationItemData = z
+  .object({
+    id: z.string().uuid().nullable(),
+    depreciationMethod: z.string(),
+    areaDescription: z.string().nullish().default(null),
+    area: z.number().optional().default(0),
+    year: z.number().int().optional().default(0),
+    isBuilding: z.boolean().optional().default(true),
+    pricePerSqMBeforeDepreciation: z.number().optional().default(0),
+    priceBeforeDepreciation: z.number().optional().default(0),
+    pricePerSqMAfterDepreciation: z.number().optional().default(0),
+    priceAfterDepreciation: z.number().optional().default(0),
+    depreciationYearPct: z.number().optional().default(0),
+    totalDepreciationPct: z.number().optional().default(0),
+    priceDepreciation: z.number().optional().default(0),
+    depreciationPeriods: z.array(DepreciationPeriodItemData).nullish().default(null),
+  })
+  .passthrough();
+const SurfaceItemData = z
+  .object({
+    id: z.string().uuid().nullable(),
+    fromFloorNumber: z.number().int(),
+    toFloorNumber: z.number().int(),
+    floorType: z.string().nullish().default(null),
+    floorStructureType: z.string().nullish().default(null),
+    floorStructureTypeOther: z.string().nullish().default(null),
+    floorSurfaceType: z.string().nullish().default(null),
+    floorSurfaceTypeOther: z.string().nullish().default(null),
+  })
+  .passthrough();
 const UpdateLandAndBuildingPropertyRequest = z
   .object({
     propertyName: z.string().nullable().default(null),
@@ -2500,8 +2570,50 @@ const UpdateLandAndBuildingPropertyRequest = z
     forcedSalePrice: z.number().nullable().default(null),
     landRemark: z.string().nullable().default(null),
     buildingRemark: z.string().nullable().default(null),
+    depreciationDetails: z.array(DepreciationItemData).nullable().default(null),
+    surfaces: z.array(SurfaceItemData).nullable().default(null),
   })
   .partial()
+  .passthrough();
+const BuildingAppraisalDepreciationPeriodDto = z
+  .object({
+    id: z.string().uuid(),
+    atYear: z.number().int(),
+    toYear: z.number().int(),
+    depreciationPerYear: z.number(),
+    totalDepreciationPct: z.number(),
+    priceDepreciation: z.number(),
+  })
+  .passthrough();
+const BuildingAppraisalDepreciationDetailDto = z
+  .object({
+    id: z.string().uuid(),
+    areaDescription: z.string().nullable(),
+    area: z.number(),
+    pricePerSqMBeforeDepreciation: z.number(),
+    priceBeforeDepreciation: z.number(),
+    year: z.number().int(),
+    isBuilding: z.boolean(),
+    depreciationMethod: z.string(),
+    depreciationYearPct: z.number(),
+    totalDepreciationPct: z.number(),
+    priceDepreciation: z.number(),
+    pricePerSqMAfterDepreciation: z.number(),
+    priceAfterDepreciation: z.number(),
+    depreciationPeriods: z.array(BuildingAppraisalDepreciationPeriodDto),
+  })
+  .passthrough();
+const BuildingAppraisalSurfaceDto = z
+  .object({
+    id: z.string().uuid(),
+    fromFloorNumber: z.number().int(),
+    toFloorNumber: z.number().int(),
+    floorType: z.string().nullable(),
+    floorStructureType: z.string().nullable(),
+    floorStructureTypeOther: z.string().nullable(),
+    floorSurfaceType: z.string().nullable(),
+    floorSurfaceTypeOther: z.string().nullable(),
+  })
   .passthrough();
 const GetLandAndBuildingPropertyResponse = z
   .object({
@@ -2588,6 +2700,7 @@ const GetLandAndBuildingPropertyResponse = z
     pondDepth: z.number().nullable(),
     hasBuilding: z.boolean().nullable(),
     hasBuildingOther: z.string().nullable(),
+    titles: z.array(LandTitleItemData).nullable(),
     buildingNumber: z.string().nullable(),
     modelName: z.string().nullable(),
     builtOnTitleNumber: z.string().nullable(),
@@ -2637,6 +2750,8 @@ const GetLandAndBuildingPropertyResponse = z
     forcedSalePrice: z.number().nullable(),
     landRemark: z.string().nullable(),
     buildingRemark: z.string().nullable(),
+    depreciationDetails: z.array(BuildingAppraisalDepreciationDetailDto),
+    surfaces: z.array(BuildingAppraisalSurfaceDto),
   })
   .passthrough();
 const UpdateGalleryPhotoRequest = z
@@ -2649,14 +2764,13 @@ const UpdateGalleryPhotoRequest = z
   })
   .passthrough();
 const UpdateGalleryPhotoResponse = z.object({ id: z.string().uuid() }).passthrough();
-const AreaDetailDto = z
+const CondoAppraisalAreaDetailDto = z
   .object({
-    appraisalPropertyId: z.string().uuid(),
+    id: z.string().uuid().nullable(),
     areaDescription: z.string().nullable(),
-    areaSize: z.coerce.number().nullable(),
+    areaSize: z.number().nullable(),
   })
   .passthrough();
-
 const UpdateCondoPropertyRequest = z
   .object({
     propertyName: z.string().nullable().default(null),
@@ -2708,6 +2822,7 @@ const UpdateCondoPropertyRequest = z
     bathroomFloorMaterialTypeOther: z.string().nullable().default(null),
     roofType: z.string().nullable().default(null),
     roofTypeOther: z.string().nullable().default(null),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable().default(null),
     totalBuildingArea: z.number().nullable().default(null),
     isExpropriated: z.boolean().nullable().default(null),
     expropriationRemark: z.string().nullable().default(null),
@@ -2782,7 +2897,7 @@ const GetCondoPropertyResponse = z
     bathroomFloorMaterialTypeOther: z.string().nullable(),
     roofType: z.string().nullable(),
     roofTypeOther: z.string().nullable(),
-    condoAreaDetails: z.array(AreaDetailDto).nullable(),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable(),
     totalBuildingArea: z.number().nullable(),
     isExpropriated: z.boolean().nullable(),
     expropriationRemark: z.string().nullable(),
@@ -2859,6 +2974,8 @@ const UpdateBuildingPropertyRequest = z
     sellingPrice: z.number().nullable().default(null),
     forcedSalePrice: z.number().nullable().default(null),
     remark: z.string().nullable().default(null),
+    depreciationDetails: z.array(DepreciationItemData).nullable().default(null),
+    surfaces: z.array(SurfaceItemData).nullable().default(null),
   })
   .partial()
   .passthrough();
@@ -2923,16 +3040,68 @@ const GetBuildingPropertyResponse = z
     sellingPrice: z.number().nullable(),
     forcedSalePrice: z.number().nullable(),
     remark: z.string().nullable(),
+    depreciationDetails: z.array(BuildingAppraisalDepreciationDetailDto),
+    surfaces: z.array(BuildingAppraisalSurfaceDto),
   })
+  .passthrough();
+const UpdateAppendixLayoutRequest = z.object({ layoutColumns: z.number().int() }).passthrough();
+const UpdateAppendixLayoutResponse = z
+  .object({ appendixId: z.string().uuid(), layoutColumns: z.number().int() })
   .passthrough();
 const UnsetPropertyThumbnailResult = z.object({ mappingId: z.string().uuid() }).passthrough();
 const UnmarkPhotoFromReportResult = z.object({ id: z.string().uuid() }).passthrough();
 const SetPropertyThumbnailResult = z.object({ mappingId: z.string().uuid() }).passthrough();
+const LawAndRegulationImageInput = z
+  .object({
+    id: z.string().uuid().nullable(),
+    documentId: z.string().uuid(),
+    displaySequence: z.number().int(),
+    fileName: z.string(),
+    filePath: z.string(),
+    title: z.string().nullable(),
+    description: z.string().nullable(),
+  })
+  .passthrough();
+const LawAndRegulationItemInput = z
+  .object({
+    id: z.string().uuid().nullable(),
+    headerCode: z.string(),
+    remark: z.string().nullable(),
+    images: z.array(LawAndRegulationImageInput),
+  })
+  .passthrough();
+const SaveLawAndRegulationsRequest = z
+  .object({ items: z.array(LawAndRegulationItemInput) })
+  .passthrough();
+const SaveLawAndRegulationsResponse = z
+  .object({ appraisalId: z.string().uuid(), itemCount: z.number().int(), success: z.boolean() })
+  .passthrough();
+const LawAndRegulationImageDto = z
+  .object({
+    id: z.string().uuid(),
+    documentId: z.string().uuid(),
+    displaySequence: z.number().int(),
+    fileName: z.string(),
+    filePath: z.string(),
+    title: z.string().nullable(),
+    description: z.string().nullable(),
+  })
+  .passthrough();
+const LawAndRegulationDto = z
+  .object({
+    id: z.string().uuid(),
+    headerCode: z.string(),
+    remark: z.string().nullable(),
+    images: z.array(LawAndRegulationImageDto),
+  })
+  .passthrough();
+const GetLawAndRegulationsResult = z.object({ items: z.array(LawAndRegulationDto) }).passthrough();
 const ReorderPropertiesInGroupRequest = z
   .object({ orderedPropertyIds: z.array(z.string().uuid()) })
   .passthrough();
 const ReorderPropertiesInGroupResponse = z.object({ success: z.boolean() }).passthrough();
 const RemovePropertyFromGroupResponse = z.object({ success: z.boolean() }).passthrough();
+const RemoveAppendixDocumentResponse = z.object({ success: z.boolean() }).passthrough();
 const MovePropertyToGroupRequest = z
   .object({ targetGroupId: z.string().uuid(), targetPosition: z.number().int().nullable() })
   .passthrough();
@@ -3006,7 +3175,7 @@ const GalleryPhotoDto = z
     uploadedAt: z.string().datetime({ offset: true }),
     isUsedInReport: z.boolean(),
     reportSection: z.string().nullable(),
-    photoTopicId: z.string().uuid().nullable(),
+    photoTopicIds: z.array(z.string().uuid()),
   })
   .passthrough();
 const GetGalleryPhotosResult = z.object({ photos: z.array(GalleryPhotoDto) }).passthrough();
@@ -3020,7 +3189,7 @@ const AddGalleryPhotoRequest = z
     latitude: z.number().nullish().default(null),
     longitude: z.number().nullish().default(null),
     capturedAt: z.string().datetime({ offset: true }).nullish().default(null),
-    photoTopicId: z.string().uuid().nullish().default(null),
+    photoTopicIds: z.array(z.string().uuid()).nullish().default(null),
   })
   .passthrough();
 const AddGalleryPhotoResponse = z
@@ -3087,6 +3256,28 @@ const GetAppraisalByIdResponse = z
     updatedBy: z.string().nullable(),
   })
   .partial()
+  .passthrough();
+const AppendixDocumentResponse = z
+  .object({
+    id: z.string().uuid(),
+    galleryPhotoId: z.string().uuid(),
+    documentId: z.string().uuid(),
+    displaySequence: z.number().int(),
+  })
+  .passthrough();
+const AppraisalAppendixResponse = z
+  .object({
+    id: z.string().uuid(),
+    appendixTypeId: z.string().uuid(),
+    appendixTypeCode: z.string(),
+    appendixTypeName: z.string(),
+    sortOrder: z.number().int(),
+    layoutColumns: z.number().int(),
+    documents: z.array(AppendixDocumentResponse),
+  })
+  .passthrough();
+const GetAppraisalAppendicesResponse = z
+  .object({ items: z.array(AppraisalAppendixResponse) })
   .passthrough();
 const CreateVesselPropertyRequest = z
   .object({
@@ -3409,7 +3600,7 @@ const CreateLandAndBuildingPropertyRequest = z
     buildingAge: z.number().int().nullable().default(null),
     constructionYear: z.number().int().nullable().default(null),
     residentialRemark: z.string().nullable().default(null),
-    buildingCondition: z.string().nullable().default(null),
+    buildingConditionType: z.string().nullable().default(null),
     isUnderConstruction: z.boolean().nullable().default(null),
     constructionCompletionPercent: z.number().nullable().default(null),
     constructionLicenseExpirationDate: z
@@ -3424,8 +3615,8 @@ const CreateLandAndBuildingPropertyRequest = z
     buildingAreaUnit: z.string().nullable().default(null),
     usableArea: z.number().nullable().default(null),
     numberOfFloors: z.number().int().nullable().default(null),
-    buildingMaterial: z.string().nullable().default(null),
-    buildingStyle: z.string().nullable().default(null),
+    buildingMaterialType: z.string().nullable().default(null),
+    buildingStyleType: z.string().nullable().default(null),
     isResidential: z.boolean().nullable().default(null),
     constructionStyleType: z.string().nullable().default(null),
     constructionStyleRemark: z.string().nullable().default(null),
@@ -3462,6 +3653,8 @@ const CreateLandAndBuildingPropertyRequest = z
     landRemark: z.string().nullable().default(null),
     buildingRemark: z.string().nullable().default(null),
     titles: z.array(LandTitleItemRequest).nullable().default(null),
+    depreciationDetails: z.array(DepreciationItemData).nullable().default(null),
+    surfaces: z.array(SurfaceItemData).nullable().default(null),
   })
   .partial()
   .passthrough();
@@ -3519,7 +3712,7 @@ const CreateCondoPropertyRequest = z
     bathroomFloorMaterialTypeOther: z.string().nullable().default(null),
     roofType: z.string().nullable().default(null),
     roofTypeOther: z.string().nullable().default(null),
-    condoAreaDetail: z.array(AreaDetailDto).nullable(),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable().default(null),
     totalBuildingArea: z.number().nullable().default(null),
     isExpropriated: z.boolean().nullable().default(null),
     expropriationRemark: z.string().nullable().default(null),
@@ -3600,6 +3793,8 @@ const CreateBuildingPropertyRequest = z
     sellingPrice: z.number().nullable().default(null),
     forcedSalePrice: z.number().nullable().default(null),
     remark: z.string().nullable().default(null),
+    depreciationDetails: z.array(DepreciationItemData).nullable().default(null),
+    surfaces: z.array(SurfaceItemData).nullable().default(null),
   })
   .partial()
   .passthrough();
@@ -3607,13 +3802,19 @@ const CreateBuildingPropertyResponse = z
   .object({ propertyId: z.string().uuid(), detailId: z.string().uuid() })
   .passthrough();
 const AssignPhotoToTopicRequest = z
-  .object({ photoTopicId: z.string().uuid().nullable() })
+  .object({ photoTopicIds: z.array(z.string().uuid()) })
   .passthrough();
 const AssignPhotoToTopicResult = z
-  .object({ photoId: z.string().uuid(), photoTopicId: z.string().uuid().nullable() })
+  .object({ photoId: z.string().uuid(), photoTopicIds: z.array(z.string().uuid()) })
   .passthrough();
 const AddPropertyToGroupRequest = z.object({ propertyId: z.string().uuid() }).passthrough();
 const AddPropertyToGroupResponse = z.object({ success: z.boolean() }).passthrough();
+const AddAppendixDocumentRequest = z
+  .object({ galleryPhotoId: z.string().uuid(), displaySequence: z.number().int() })
+  .passthrough();
+const AddAppendixDocumentResponse = z
+  .object({ documentId: z.string().uuid(), appendixId: z.string().uuid() })
+  .passthrough();
 const RescheduleAppointmentRequest = z
   .object({
     changedBy: z.string(),
@@ -3721,6 +3922,9 @@ export const schemas = {
   CreateRequestResponse,
   CreateDraftRequestRequest,
   CreateDraftRequestResponse,
+  DocumentItemDto,
+  DocumentSectionDto,
+  GetRequestDocumentsByRequestIdResponse,
   UpdateRequestCommentRequest,
   UpdateRequestCommentResponse,
   RemoveRequestCommentResponse,
@@ -3757,6 +3961,7 @@ export const schemas = {
   NotificationType,
   NotificationDto,
   GetUserNotificationsResponse,
+  ParameterDto,
   DocumentLink,
   Input,
   CreateUploadSessionResponse,
@@ -3866,6 +4071,13 @@ export const schemas = {
   CreateMarketComparableTemplateResponse,
   AddFactorToTemplateRequest,
   AddFactorToTemplateResponse,
+  UpdateMarketComparableRequest,
+  UpdateMarketComparableResponse,
+  FactorDataType,
+  FactorDataDto,
+  ImageDto,
+  MarketComparableDetailDto,
+  GetMarketComparableByIdResponse,
   FactorDataItem,
   SetMarketComparableFactorDataRequest,
   SetMarketComparableFactorDataResponse,
@@ -3874,10 +4086,7 @@ export const schemas = {
   GetMarketComparablesResponse,
   CreateMarketComparableRequest,
   CreateMarketComparableResponse,
-  FactorDataDto,
-  ImageDto,
-  MarketComparableDetailDto,
-  GetMarketComparableByIdResponse,
+  DeleteMarketComparableResponse,
   AddMarketComparableImageRequest,
   AddMarketComparableImageResponse,
   UpdateMarketComparableFactorRequest,
@@ -3949,20 +4158,37 @@ export const schemas = {
   LandTitleItemData,
   UpdateLandPropertyRequest,
   GetLandPropertyResponse,
+  DepreciationPeriodItemData,
+  DepreciationItemData,
+  SurfaceItemData,
   UpdateLandAndBuildingPropertyRequest,
+  BuildingAppraisalDepreciationPeriodDto,
+  BuildingAppraisalDepreciationDetailDto,
+  BuildingAppraisalSurfaceDto,
   GetLandAndBuildingPropertyResponse,
   UpdateGalleryPhotoRequest,
   UpdateGalleryPhotoResponse,
+  CondoAppraisalAreaDetailDto,
   UpdateCondoPropertyRequest,
   GetCondoPropertyResponse,
   UpdateBuildingPropertyRequest,
   GetBuildingPropertyResponse,
+  UpdateAppendixLayoutRequest,
+  UpdateAppendixLayoutResponse,
   UnsetPropertyThumbnailResult,
   UnmarkPhotoFromReportResult,
   SetPropertyThumbnailResult,
+  LawAndRegulationImageInput,
+  LawAndRegulationItemInput,
+  SaveLawAndRegulationsRequest,
+  SaveLawAndRegulationsResponse,
+  LawAndRegulationImageDto,
+  LawAndRegulationDto,
+  GetLawAndRegulationsResult,
   ReorderPropertiesInGroupRequest,
   ReorderPropertiesInGroupResponse,
   RemovePropertyFromGroupResponse,
+  RemoveAppendixDocumentResponse,
   MovePropertyToGroupRequest,
   MovePropertyToGroupResponse,
   MarkPhotoForReportRequest,
@@ -3988,6 +4214,9 @@ export const schemas = {
   CreateAppraisalRequest,
   CreateAppraisalResponse,
   GetAppraisalByIdResponse,
+  AppendixDocumentResponse,
+  AppraisalAppendixResponse,
+  GetAppraisalAppendicesResponse,
   CreateVesselPropertyRequest,
   CreateVesselPropertyResponse,
   CreateVehiclePropertyRequest,
@@ -4007,6 +4236,8 @@ export const schemas = {
   AssignPhotoToTopicResult,
   AddPropertyToGroupRequest,
   AddPropertyToGroupResponse,
+  AddAppendixDocumentRequest,
+  AddAppendixDocumentResponse,
   RescheduleAppointmentRequest,
   AppointmentDto2,
   GetAppointmentsResponse,
@@ -4048,7 +4279,7 @@ export type GetLandAndBuildingPropertyResponseType = z.infer<
 >;
 
 // CondoAppraisalAreaDetail Type
-export type AreaDetailDtoType = z.infer<typeof AreaDetailDto>;
+export type CondoAppraisalAreaDetailDtoType = z.infer<typeof CondoAppraisalAreaDetailDto>;
 
 // Property Update response types
 // export type UpdateBuildingPropertyResponseType = z.infer<typeof UpdateBuildingPropertyResponse>;


### PR DESCRIPTION
## Summary
- Rename `condoAreaDetails` to `areaDetails` in form schema, defaults, and mappers to align with API
- Add `id` field to `AreaDetailDto` schema
- Update API client schema and v1 types

## Test plan
- [ ] Verify area details data loads and saves correctly with the renamed field
- [ ] Verify no regression in condo appraisal form

🤖 Generated with [Claude Code](https://claude.com/claude-code)