### PR TITLE
Update API schemas and add condo area detail fields

### DIFF
--- a/src/shared/schemas/api.client.json
+++ b/src/shared/schemas/api.client.json
@@ -7423,7 +7423,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateAppendixLayoutResult"
+                  "$ref": "#/components/schemas/UpdateAppendixLayoutResponse"
                 }
               }
             }
@@ -7952,7 +7952,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RemoveAppendixDocumentResult"
+                  "$ref": "#/components/schemas/RemoveAppendixDocumentResponse"
                 }
               }
             }
@@ -8631,7 +8631,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetAppraisalAppendicesResult"
+                  "$ref": "#/components/schemas/GetAppraisalAppendicesResponse"
                 }
               }
             }
@@ -9300,7 +9300,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AddAppendixDocumentResult"
+                  "$ref": "#/components/schemas/AddAppendixDocumentResponse"
                 }
               }
             }
@@ -9746,7 +9746,7 @@
           }
         }
       },
-      "AddAppendixDocumentResult": {
+      "AddAppendixDocumentResponse": {
         "required": ["documentId", "appendixId"],
         "type": "object",
         "properties": {
@@ -10319,8 +10319,8 @@
         },
         "nullable": true
       },
-      "AppendixDocumentDto": {
-        "required": ["id", "galleryPhotoId", "displaySequence"],
+      "AppendixDocumentResponse": {
+        "required": ["id", "galleryPhotoId", "documentId", "displaySequence"],
         "type": "object",
         "properties": {
           "id": {
@@ -10328,6 +10328,10 @@
             "format": "uuid"
           },
           "galleryPhotoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
             "type": "string",
             "format": "uuid"
           },
@@ -10429,7 +10433,7 @@
           }
         }
       },
-      "AppraisalAppendixDto": {
+      "AppraisalAppendixResponse": {
         "required": [
           "id",
           "appendixTypeId",
@@ -10466,7 +10470,7 @@
           "documents": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/AppendixDocumentDto"
+              "$ref": "#/components/schemas/AppendixDocumentResponse"
             }
           }
         }
@@ -11775,6 +11779,26 @@
           }
         }
       },
+      "CondoAppraisalAreaDetailDto": {
+        "required": ["id", "areaDescription", "areaSize"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "areaDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "areaSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        }
+      },
       "ContactDto": {
         "required": ["contactPersonName", "contactPersonPhone", "dealerCode"],
         "type": "object",
@@ -12569,6 +12593,14 @@
           },
           "roofTypeOther": {
             "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
             "default": null,
             "nullable": true
           },
@@ -15816,14 +15848,14 @@
           }
         }
       },
-      "GetAppraisalAppendicesResult": {
+      "GetAppraisalAppendicesResponse": {
         "required": ["items"],
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/AppraisalAppendixDto"
+              "$ref": "#/components/schemas/AppraisalAppendixResponse"
             }
           }
         }
@@ -16466,6 +16498,7 @@
           "bathroomFloorMaterialTypeOther",
           "roofType",
           "roofTypeOther",
+          "areaDetails",
           "totalBuildingArea",
           "isExpropriated",
           "expropriationRemark",
@@ -16712,6 +16745,13 @@
           },
           "roofTypeOther": {
             "type": "string",
+            "nullable": true
+          },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
             "nullable": true
           },
           "totalBuildingArea": {
@@ -21193,7 +21233,7 @@
           }
         }
       },
-      "RemoveAppendixDocumentResult": {
+      "RemoveAppendixDocumentResponse": {
         "required": ["success"],
         "type": "object",
         "properties": {
@@ -22555,7 +22595,7 @@
           }
         }
       },
-      "UpdateAppendixLayoutResult": {
+      "UpdateAppendixLayoutResponse": {
         "required": ["appendixId", "layoutColumns"],
         "type": "object",
         "properties": {
@@ -23453,6 +23493,14 @@
           },
           "roofTypeOther": {
             "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "areaDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CondoAppraisalAreaDetailDto"
+            },
             "default": null,
             "nullable": true
           },

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -2764,6 +2764,13 @@ const UpdateGalleryPhotoRequest = z
   })
   .passthrough();
 const UpdateGalleryPhotoResponse = z.object({ id: z.string().uuid() }).passthrough();
+const CondoAppraisalAreaDetailDto = z
+  .object({
+    id: z.string().uuid().nullable(),
+    areaDescription: z.string().nullable(),
+    areaSize: z.number().nullable(),
+  })
+  .passthrough();
 const UpdateCondoPropertyRequest = z
   .object({
     propertyName: z.string().nullable().default(null),
@@ -2815,6 +2822,7 @@ const UpdateCondoPropertyRequest = z
     bathroomFloorMaterialTypeOther: z.string().nullable().default(null),
     roofType: z.string().nullable().default(null),
     roofTypeOther: z.string().nullable().default(null),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable().default(null),
     totalBuildingArea: z.number().nullable().default(null),
     isExpropriated: z.boolean().nullable().default(null),
     expropriationRemark: z.string().nullable().default(null),
@@ -2889,6 +2897,7 @@ const GetCondoPropertyResponse = z
     bathroomFloorMaterialTypeOther: z.string().nullable(),
     roofType: z.string().nullable(),
     roofTypeOther: z.string().nullable(),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable(),
     totalBuildingArea: z.number().nullable(),
     isExpropriated: z.boolean().nullable(),
     expropriationRemark: z.string().nullable(),
@@ -3036,7 +3045,7 @@ const GetBuildingPropertyResponse = z
   })
   .passthrough();
 const UpdateAppendixLayoutRequest = z.object({ layoutColumns: z.number().int() }).passthrough();
-const UpdateAppendixLayoutResult = z
+const UpdateAppendixLayoutResponse = z
   .object({ appendixId: z.string().uuid(), layoutColumns: z.number().int() })
   .passthrough();
 const UnsetPropertyThumbnailResult = z.object({ mappingId: z.string().uuid() }).passthrough();
@@ -3092,7 +3101,7 @@ const ReorderPropertiesInGroupRequest = z
   .passthrough();
 const ReorderPropertiesInGroupResponse = z.object({ success: z.boolean() }).passthrough();
 const RemovePropertyFromGroupResponse = z.object({ success: z.boolean() }).passthrough();
-const RemoveAppendixDocumentResult = z.object({ success: z.boolean() }).passthrough();
+const RemoveAppendixDocumentResponse = z.object({ success: z.boolean() }).passthrough();
 const MovePropertyToGroupRequest = z
   .object({ targetGroupId: z.string().uuid(), targetPosition: z.number().int().nullable() })
   .passthrough();
@@ -3248,7 +3257,7 @@ const GetAppraisalByIdResponse = z
   })
   .partial()
   .passthrough();
-const AppendixDocumentDto = z
+const AppendixDocumentResponse = z
   .object({
     id: z.string().uuid(),
     galleryPhotoId: z.string().uuid(),
@@ -3256,7 +3265,7 @@ const AppendixDocumentDto = z
     displaySequence: z.number().int(),
   })
   .passthrough();
-const AppraisalAppendixDto = z
+const AppraisalAppendixResponse = z
   .object({
     id: z.string().uuid(),
     appendixTypeId: z.string().uuid(),
@@ -3264,11 +3273,11 @@ const AppraisalAppendixDto = z
     appendixTypeName: z.string(),
     sortOrder: z.number().int(),
     layoutColumns: z.number().int(),
-    documents: z.array(AppendixDocumentDto),
+    documents: z.array(AppendixDocumentResponse),
   })
   .passthrough();
 const GetAppraisalAppendicesResponse = z
-  .object({ items: z.array(AppraisalAppendixDto) })
+  .object({ items: z.array(AppraisalAppendixResponse) })
   .passthrough();
 const CreateVesselPropertyRequest = z
   .object({
@@ -3703,6 +3712,7 @@ const CreateCondoPropertyRequest = z
     bathroomFloorMaterialTypeOther: z.string().nullable().default(null),
     roofType: z.string().nullable().default(null),
     roofTypeOther: z.string().nullable().default(null),
+    areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable().default(null),
     totalBuildingArea: z.number().nullable().default(null),
     isExpropriated: z.boolean().nullable().default(null),
     expropriationRemark: z.string().nullable().default(null),
@@ -3802,7 +3812,7 @@ const AddPropertyToGroupResponse = z.object({ success: z.boolean() }).passthroug
 const AddAppendixDocumentRequest = z
   .object({ galleryPhotoId: z.string().uuid(), displaySequence: z.number().int() })
   .passthrough();
-const AddAppendixDocumentResult = z
+const AddAppendixDocumentResponse = z
   .object({ documentId: z.string().uuid(), appendixId: z.string().uuid() })
   .passthrough();
 const RescheduleAppointmentRequest = z
@@ -4158,12 +4168,13 @@ export const schemas = {
   GetLandAndBuildingPropertyResponse,
   UpdateGalleryPhotoRequest,
   UpdateGalleryPhotoResponse,
+  CondoAppraisalAreaDetailDto,
   UpdateCondoPropertyRequest,
   GetCondoPropertyResponse,
   UpdateBuildingPropertyRequest,
   GetBuildingPropertyResponse,
   UpdateAppendixLayoutRequest,
-  UpdateAppendixLayoutResult,
+  UpdateAppendixLayoutResponse,
   UnsetPropertyThumbnailResult,
   UnmarkPhotoFromReportResult,
   SetPropertyThumbnailResult,
@@ -4177,7 +4188,7 @@ export const schemas = {
   ReorderPropertiesInGroupRequest,
   ReorderPropertiesInGroupResponse,
   RemovePropertyFromGroupResponse,
-  RemoveAppendixDocumentResult,
+  RemoveAppendixDocumentResponse,
   MovePropertyToGroupRequest,
   MovePropertyToGroupResponse,
   MarkPhotoForReportRequest,
@@ -4203,8 +4214,8 @@ export const schemas = {
   CreateAppraisalRequest,
   CreateAppraisalResponse,
   GetAppraisalByIdResponse,
-  AppendixDocumentDto,
-  AppraisalAppendixDto,
+  AppendixDocumentResponse,
+  AppraisalAppendixResponse,
   GetAppraisalAppendicesResponse,
   CreateVesselPropertyRequest,
   CreateVesselPropertyResponse,
@@ -4226,7 +4237,7 @@ export const schemas = {
   AddPropertyToGroupRequest,
   AddPropertyToGroupResponse,
   AddAppendixDocumentRequest,
-  AddAppendixDocumentResult,
+  AddAppendixDocumentResponse,
   RescheduleAppointmentRequest,
   AppointmentDto2,
   GetAppointmentsResponse,


### PR DESCRIPTION
## Summary
- Rename appendix-related `*Dto` / `*Result` types to `*Response` naming convention (`AppendixDocumentDto` → `AppendixDocumentResponse`, `AppraisalAppendixDto` → `AppraisalAppendixResponse`, etc.)
- Add `CondoAppraisalAreaDetailDto` schema and `areaDetails` field to condo property request/response schemas
- Add `documentId` field to `AppendixDocumentResponse`

## Test plan
- [ ] Verify existing appendix features still work with renamed schema types
- [ ] Verify condo property forms handle `areaDetails` field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)