### PR TITLE
Fix FormStringToggle visual state swapped from actual form value

### DIFF
--- a/src/shared/components/inputs/FormStringToggle.tsx
+++ b/src/shared/components/inputs/FormStringToggle.tsx
@@ -43,11 +43,11 @@ const FormStringToggle = ({ name, label, group, options, size, disabled, classNa
       options={[resolvedOptions[0].label, resolvedOptions[1].label]}
       size={size}
       error={error?.message?.toString()}
-      checked={field.value === resolvedOptions[0].name}
+      checked={field.value === resolvedOptions[1].name}
       disabled={disabled}
       className={className}
       required={required}
-      onChange={checked => field.onChange(checked ? resolvedOptions[0].name : resolvedOptions[1].name)}
+      onChange={checked => field.onChange(checked ? resolvedOptions[1].name : resolvedOptions[0].name)}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Fixed `FormStringToggle` where the `checked` prop and `onChange` handler had inverted option index references, causing the toggle to visually highlight the **opposite** option from the stored form value
- The `Toggle` primitive treats `checked=true` as "right (index 1) is active", but `checked` was comparing against `resolvedOptions[0]` — now correctly compares against `resolvedOptions[1]`
- Affects all usages of `FormStringToggle` across the app (e.g. depreciation method toggle in `BuildingDetailPopUpModal`)

## Test plan
- [ ] Open BuildingDetailPopUpModal — toggle should default to "Gross" visually highlighted (left)
- [ ] Click "Period" — right side highlights, form value becomes `"Period"`
- [ ] Click "Gross" — left side highlights, form value becomes `"Gross"`
- [ ] Check other `FormStringToggle` usages in the app to confirm correct display

🤖 Generated with [Claude Code](https://claude.com/claude-code)