### PR TITLE
Fix in/notIn operator in FormFields condition evaluator

### DIFF
--- a/src/shared/components/form/FormFields.tsx
+++ b/src/shared/components/form/FormFields.tsx
@@ -1,10 +1,4 @@
-import {
-  type Control,
-  type FieldValues,
-  useController,
-  useFormContext,
-  useWatch,
-} from 'react-hook-form';
+import { type Control, type FieldValues, useController, useFormContext, useWatch, } from 'react-hook-form';
 import { useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 import type { z } from 'zod';
@@ -138,9 +132,9 @@ function evaluateCondition(
     case 'notEquals':
       return value !== target;
     case 'in':
-      return Array.isArray(target) && target.includes(value);
+      return Array.isArray(value) && value.includes(target);
     case 'notIn':
-      return Array.isArray(target) && !target.includes(value);
+      return Array.isArray(value) && !value.includes(target);
     case 'isEmpty':
       return value == null || value === '';
     case 'isNotEmpty':

--- a/src/shared/components/form/types.ts
+++ b/src/shared/components/form/types.ts
@@ -12,8 +12,8 @@ import type { AtLeastOne } from '@/shared/types';
 export type ConditionOperator =
   | 'equals' // value === target (default)
   | 'notEquals' // value !== target
-  | 'in' // target array includes value
-  | 'notIn' // target array doesn't include value
+  | 'in' // value array includes target
+  | 'notIn' // value array doesn't include target
   | 'isEmpty' // value is null/undefined/''
   | 'isNotEmpty' // value is truthy
   | 'gt' // value > target (number)


### PR DESCRIPTION
## Summary
- **Bug:** The `in`/`notIn` operators in `evaluateCondition` checked `Array.isArray(target)` instead of `Array.isArray(value)`, so they always returned `false` for checkbox-group fields (where the form value is the array and `is` is a scalar)
- **Impact:** All ~17 conditional visibility/disabled rules depending on checkbox-group selections across LandDetailForm, CondoDetailForm, and BuildingDetailForm were silently broken
- **Fix:** Swap to `Array.isArray(value) && value.includes(target)` and update type comments to match

## Test plan
- [ ] Verify checkbox-group-dependent `showWhen`/`hideWhen` conditions work in LandDetailForm
- [ ] Verify checkbox-group-dependent `disableWhen` conditions work in CondoDetailForm and BuildingDetailForm
- [ ] Confirm no regressions on `equals`/`notEquals`/`isEmpty`/`isNotEmpty` operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)