### PR TITLE
Add read-only mode for terminal appraisal statuses

### DIFF
--- a/src/features/appraisal/context/AppraisalContext.tsx
+++ b/src/features/appraisal/context/AppraisalContext.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, type ReactNode } from 'react';
+import { isTerminalStatus } from '@shared/config/navigation';
+import { canEditAppraisalPage } from '@shared/config/appraisalNavigation';
+import { useUserStore } from '@shared/store';
 
 /**
  * Appraisal data returned from the backend
@@ -70,4 +73,36 @@ export function useAppraisalRequestId(): string | undefined {
 export function useAppraisalIsPma(): boolean {
   const context = useContext(AppraisalContext);
   return context?.appraisal?.isPma ?? false;
+}
+
+/**
+ * Hook to get the appraisal status
+ * Returns undefined if not in appraisal context or still loading
+ */
+export function useAppraisalStatus(): string | undefined {
+  const context = useContext(AppraisalContext);
+  return context?.appraisal?.status;
+}
+
+/**
+ * Hook to determine if the appraisal is in read-only mode.
+ * Combines terminal status check with per-page role-based edit permission.
+ * @param pageName - Optional page name to also check role-based edit permission
+ */
+export function useAppraisalReadOnly(pageName?: string): {
+  isReadOnly: boolean;
+  isTerminalStatus: boolean;
+  status: string | undefined;
+} {
+  const context = useContext(AppraisalContext);
+  const role = useUserStore(state => state.user?.role ?? 'viewer');
+  const status = context?.appraisal?.status;
+  const terminal = isTerminalStatus(status);
+
+  let isReadOnly = terminal;
+  if (!isReadOnly && pageName) {
+    isReadOnly = !canEditAppraisalPage(pageName, role, { status });
+  }
+
+  return { isReadOnly, isTerminalStatus: terminal, status };
 }

--- a/src/shared/components/AppraisalSidebar.tsx
+++ b/src/shared/components/AppraisalSidebar.tsx
@@ -6,12 +6,12 @@ import Icon from './Icon';
 import clsx from 'clsx';
 import type { NavItem } from '@shared/config/navigation';
 import {
-  getAppraisalNavigationByRole,
+  getAppraisalNavigationWithAccess,
   getGeneralNavigationByRole,
   getCollapsibleNavigationByRole,
   getFooterNavigationByRole,
 } from '@shared/config/appraisalNavigation';
-import { useAppraisalRequestId, useAppraisalIsPma } from '@features/appraisal/context/AppraisalContext';
+import { useAppraisalRequestId, useAppraisalIsPma, useAppraisalStatus } from '@features/appraisal/context/AppraisalContext';
 
 type AppraisalSidebarProps = {
   appraisalId: string;
@@ -36,9 +36,10 @@ const getIconBgClass = (iconColor: string | undefined) => {
   return colorMap[iconColor] || 'bg-gray-100';
 };
 
-function CompactMenuItem({ item, collapsed = false }: { item: NavItem; collapsed?: boolean }) {
+function CompactMenuItem({ item, collapsed = false }: { item: NavItem & { canEdit?: boolean }; collapsed?: boolean }) {
   const location = useLocation();
   const isActive = location.pathname === item.href;
+  const isReadOnly = item.canEdit === false;
   const iconStyle = (item.iconStyle || 'solid') as
     | 'solid'
     | 'regular'
@@ -46,6 +47,27 @@ function CompactMenuItem({ item, collapsed = false }: { item: NavItem; collapsed
     | 'thin'
     | 'duotone'
     | 'brands';
+
+  const iconWithBadge = (
+    <div
+      className={clsx(
+        'relative w-7 h-7 rounded-lg flex items-center justify-center transition-all duration-200',
+        isActive ? 'bg-primary/10' : getIconBgClass(item.iconColor),
+        'group-hover:scale-105',
+      )}
+    >
+      <Icon
+        name={item.icon}
+        style={iconStyle}
+        className={clsx('size-3.5', item.iconColor || 'text-gray-500')}
+      />
+      {isReadOnly && (
+        <div className="absolute -bottom-0.5 -right-0.5 size-3 rounded-full bg-white flex items-center justify-center">
+          <Icon name="lock" style="solid" className="size-1.5 text-gray-400" />
+        </div>
+      )}
+    </div>
+  );
 
   if (collapsed) {
     return (
@@ -57,19 +79,7 @@ function CompactMenuItem({ item, collapsed = false }: { item: NavItem; collapsed
           isActive ? 'bg-primary/10' : 'hover:bg-gray-50',
         )}
       >
-        <div
-          className={clsx(
-            'w-7 h-7 rounded-lg flex items-center justify-center transition-all duration-200',
-            isActive ? 'bg-primary/10' : getIconBgClass(item.iconColor),
-            'group-hover:scale-105',
-          )}
-        >
-          <Icon
-            name={item.icon}
-            style={iconStyle}
-            className={clsx('size-3.5', item.iconColor || 'text-gray-500')}
-          />
-        </div>
+        {iconWithBadge}
       </Link>
     );
   }
@@ -82,19 +92,7 @@ function CompactMenuItem({ item, collapsed = false }: { item: NavItem; collapsed
         isActive ? 'bg-primary/10' : 'hover:bg-gray-50',
       )}
     >
-      <div
-        className={clsx(
-          'w-7 h-7 rounded-lg flex items-center justify-center transition-all duration-200',
-          isActive ? 'bg-primary/10' : getIconBgClass(item.iconColor),
-          'group-hover:scale-105',
-        )}
-      >
-        <Icon
-          name={item.icon}
-          style={iconStyle}
-          className={clsx('size-3.5', item.iconColor || 'text-gray-500')}
-        />
-      </div>
+      {iconWithBadge}
       <span className={clsx('text-sm font-medium', isActive ? 'text-primary' : 'text-gray-700')}>
         {item.name}
       </span>
@@ -181,14 +179,15 @@ export function MobileAppraisalSidebar({
   const setSidebarOpen = useUIStore(state => state.setSidebarOpen);
   const requestId = useAppraisalRequestId();
   const isPma = useAppraisalIsPma();
+  const status = useAppraisalStatus();
   const user = useUserStore(state => state.user);
   const role = user?.role ?? 'viewer';
 
-  const navContext = useMemo(() => ({ isPma }), [isPma]);
+  const navContext = useMemo(() => ({ isPma, status }), [isPma, status]);
 
-  // Get role-filtered navigation
+  // Get role-filtered navigation with access levels
   const applicationNav = useMemo(
-    () => getAppraisalNavigationByRole({ appraisalId, requestId }, role, navContext),
+    () => getAppraisalNavigationWithAccess({ appraisalId, requestId }, role, navContext),
     [appraisalId, requestId, role, navContext],
   );
   const generalItems = useMemo(
@@ -288,16 +287,17 @@ export default function AppraisalSidebar({
 }: AppraisalSidebarProps): React.ReactNode {
   const requestId = useAppraisalRequestId();
   const isPma = useAppraisalIsPma();
+  const status = useAppraisalStatus();
   const user = useUserStore(state => state.user);
   const role = user?.role ?? 'viewer';
   const sidebarCollapsed = useUIStore(state => state.sidebarCollapsed);
   const toggleSidebar = useUIStore(state => state.toggleSidebar);
 
-  const navContext = useMemo(() => ({ isPma }), [isPma]);
+  const navContext = useMemo(() => ({ isPma, status }), [isPma, status]);
 
-  // Get role-filtered navigation
+  // Get role-filtered navigation with access levels
   const applicationNav = useMemo(
-    () => getAppraisalNavigationByRole({ appraisalId, requestId }, role, navContext),
+    () => getAppraisalNavigationWithAccess({ appraisalId, requestId }, role, navContext),
     [appraisalId, requestId, role, navContext],
   );
   const generalItems = useMemo(

--- a/src/shared/config/appraisalNavigation.ts
+++ b/src/shared/config/appraisalNavigation.ts
@@ -1,4 +1,5 @@
 import type { NavContext, NavItem, NavItemWithAccess, WorkflowActivity } from './navigation';
+import { isTerminalStatus } from './navigation';
 
 /**
  * Application-specific navigation for appraisal detail pages.
@@ -212,7 +213,9 @@ function canRoleView(item: NavItem, role: WorkflowActivity): boolean {
 /**
  * Check if a role can edit a navigation item's content
  */
-function canRoleEdit(item: NavItem, role: WorkflowActivity): boolean {
+function canRoleEdit(item: NavItem, role: WorkflowActivity, context?: NavContext): boolean {
+  // Read-only status overrides role
+  if (context && isTerminalStatus(context.status)) return false;
   // Must be able to view first
   if (!canRoleView(item, role)) {
     return false;
@@ -247,7 +250,7 @@ function getNavItemsWithAccess(items: NavItem[], role: WorkflowActivity, context
     .map(item => ({
       ...item,
       canView: true, // Already filtered for viewable items
-      canEdit: canRoleEdit(item, role),
+      canEdit: canRoleEdit(item, role, context),
     }));
 }
 
@@ -315,10 +318,10 @@ export const getAppraisalNavigationWithAccess = (
  * @param pageName - The page name (e.g., 'Administration', 'Appointment & Fee')
  * @param role - User's workflow activity role
  */
-export const canEditAppraisalPage = (pageName: string, role: WorkflowActivity): boolean => {
+export const canEditAppraisalPage = (pageName: string, role: WorkflowActivity, context?: NavContext): boolean => {
   const item = applicationNavigation.find(nav => nav.name === pageName);
   if (!item) return false;
-  return canRoleEdit(item, role);
+  return canRoleEdit(item, role, context);
 };
 
 /**
@@ -339,6 +342,7 @@ export const canViewAppraisalPage = (pageName: string, role: WorkflowActivity): 
 export const getPageAccessByPath = (
   path: string,
   role: WorkflowActivity,
+  context?: NavContext,
 ): { canView: boolean; canEdit: boolean } => {
   // Extract the page segment from paths like /appraisal/:id/administration
   const pathSegments = path.split('/').filter(Boolean);
@@ -361,6 +365,6 @@ export const getPageAccessByPath = (
 
   return {
     canView: canViewAppraisalPage(pageName, role),
-    canEdit: canEditAppraisalPage(pageName, role),
+    canEdit: canEditAppraisalPage(pageName, role, context),
   };
 };

--- a/src/shared/config/navigation.ts
+++ b/src/shared/config/navigation.ts
@@ -19,7 +19,21 @@ export type WorkflowActivity =
  */
 export type NavContext = {
   isPma?: boolean;
+  status?: string;
 };
+
+/** Configurable list of statuses that make all menus read-only. Add/remove as needed. */
+export const TERMINAL_STATUSES: string[] = [
+  'completed',
+  'approved',
+  'rejected',
+  'cancelled',
+];
+
+export function isTerminalStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return TERMINAL_STATUSES.some(s => s.toLowerCase() === status.toLowerCase());
+}
 
 /**
  * Navigation item with role-based access control


### PR DESCRIPTION
## Summary
- Add `TERMINAL_STATUSES` set and `isTerminalStatus()` helper to navigation config
- Wire terminal status checks into `appraisalNavigation` access control so sidebar items show as read-only
- Show lock badge on sidebar items when appraisal is in a terminal status (completed, approved, rejected, cancelled)
- Add `useAppraisalStatus()` and `useAppraisalReadOnly()` hooks to `AppraisalContext`

## Test plan
- [ ] Verify sidebar items show lock icon for appraisals in terminal statuses
- [ ] Verify editable appraisals (draft, in-progress) do not show lock icon
- [ ] Verify navigation still works correctly for read-only items
- [ ] Verify `useAppraisalReadOnly()` returns correct boolean

🤖 Generated with [Claude Code](https://claude.com/claude-code)