### PR TITLE
Derive collateral type from group properties

### DIFF
--- a/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
@@ -18,6 +18,7 @@ import {
 } from '@features/pricingAnalysis/adapters/buildDirectComparisonDerivedRules';
 import { DirectComparisonSecondRevision } from './DirectComparisonSecondRevision';
 import { qualitativeDefault } from '../domain/qualitativeDefault';
+import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
 import { getFactorDesciption } from '@features/pricingAnalysis/domain/getFactorDescription';
 import { useLocaleStore } from '@shared/store';
 import type {
@@ -80,6 +81,7 @@ export const DirectComparisonScoringSection = ({
   } = directComparisonPath;
 
   const serverData = useContext(ServerDataCtx);
+  const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
   const language = useLocaleStore(s => s.language);
   const { control, getValues, setValue } = useFormContext();
   const {
@@ -564,10 +566,10 @@ export const DirectComparisonScoringSection = ({
             </tr>
 
             {/* 2nd revision */}
-            {(template?.collateralType === 'LB' || template?.collateralType === 'C') && (
+            {(groupCollateralType === 'LB' || groupCollateralType === 'C') && (
               <DirectComparisonSecondRevision
                 comparativeSurveys={comparativeSurveys}
-                collateralType={template.collateralType}
+                collateralType={groupCollateralType}
               />
             )}
 

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
@@ -25,6 +25,7 @@ import type {
 import { FactorValueDisplay } from './FactorValueDisplay';
 import { SaleAdjustmentGridSecondRevision } from '@features/pricingAnalysis/components/SaleAdjustmentGridSecondRevision.tsx';
 import { qualitativeDefault } from '@features/pricingAnalysis/domain/qualitativeDefault.ts';
+import { deriveGroupCollateralType } from '@features/pricingAnalysis/domain/deriveGroupCollateralType';
 import { getFactorDesciption } from '@features/pricingAnalysis/domain/getFactorDescription.ts';
 import { useLocaleStore } from '@shared/store';
 import { ScrollableTableContainer } from './ScrollableTableContainer';
@@ -77,6 +78,7 @@ export const SaleAdjustmentGridScoringSection = ({
   } = saleGridFieldPath;
 
   const serverData = useContext(ServerDataCtx);
+  const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
   const language = useLocaleStore(s => s.language);
   const { control, getValues, setValue } = useFormContext();
   const {
@@ -563,10 +565,10 @@ export const SaleAdjustmentGridScoringSection = ({
             </tr>
 
             {/* 2nd revision */}
-            {(template?.collateralType === 'LB' || template?.collateralType === 'C') && (
+            {(groupCollateralType === 'LB' || groupCollateralType === 'C') && (
               <SaleAdjustmentGridSecondRevision
                 comparativeSurveys={comparativeSurveys}
-                collateralType={template.collateralType}
+                collateralType={groupCollateralType}
               />
             )}
 

--- a/src/features/pricingAnalysis/domain/deriveGroupCollateralType.ts
+++ b/src/features/pricingAnalysis/domain/deriveGroupCollateralType.ts
@@ -1,8 +1,8 @@
 export function deriveGroupCollateralType(
-  properties: Array<{ propertyType?: string | null }>
+  properties: Array<{ propertyType?: string | null }>,
 ): string {
   const types = properties.map(p => p.propertyType ?? '');
-  if (types.includes('C')) return 'C';
+  if (types.includes('U')) return 'U';
   if (types.includes('LB')) return 'LB';
   if (types.includes('L')) return 'L';
   return types[0] ?? '';

--- a/src/features/pricingAnalysis/domain/deriveGroupCollateralType.ts
+++ b/src/features/pricingAnalysis/domain/deriveGroupCollateralType.ts
@@ -1,0 +1,9 @@
+export function deriveGroupCollateralType(
+  properties: Array<{ propertyType?: string | null }>
+): string {
+  const types = properties.map(p => p.propertyType ?? '');
+  if (types.includes('C')) return 'C';
+  if (types.includes('LB')) return 'LB';
+  if (types.includes('L')) return 'L';
+  return types[0] ?? '';
+}


### PR DESCRIPTION
## Summary
- Add `deriveGroupCollateralType` utility that infers collateral type from actual group properties instead of relying on the template's `collateralType`
- Update `DirectComparisonScoringSection` and `SaleAdjustmentGridScoringSection` to use the new utility
- Fixes 2nd revision rendering logic where template collateral type didn't match actual properties

## Test plan
- [ ] Verify DirectComparison scoring renders correctly for different collateral types
- [ ] Verify SaleAdjustmentGrid scoring renders correctly for different collateral types
- [ ] Verify 2nd revision properties display the correct scoring sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)