### PR TITLE
Update schemas: draft endpoint and roofType

### DIFF
--- a/src/shared/schemas/api.client.json
+++ b/src/shared/schemas/api.client.json
@@ -241,7 +241,7 @@
       }
     },
     "/requests/{id}/draft": {
-      "patch": {
+      "put": {
         "tags": ["Requests"],
         "summary": "Update a draft request",
         "description": "Updates an existing draft request.",
@@ -18268,7 +18268,10 @@
             "nullable": true
           },
           "roofType": {
-            "type": "string",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
             "nullable": true
           },
           "roofTypeOther": {

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -3117,7 +3117,7 @@ const GetCondoPropertyResponse = z
     upperFloorMaterialTypeOther: z.string().nullable(),
     bathroomFloorMaterialType: z.string().nullable(),
     bathroomFloorMaterialTypeOther: z.string().nullable(),
-    roofType: z.string().nullable(),
+    roofType: z.array(z.string()).nullable(),
     roofTypeOther: z.string().nullable(),
     areaDetails: z.array(CondoAppraisalAreaDetailDto).nullable(),
     totalBuildingArea: z.number().nullable(),


### PR DESCRIPTION
## Summary
- Change `/requests/{id}/draft` endpoint from PATCH to PUT
- Change `roofType` field from `string` to `array of strings` in condo property schema (both `api.client.json` and `v1.ts`)

## Test plan
- [ ] Verify draft save functionality works with PUT method
- [ ] Verify roofType field handles array values correctly in condo forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)