### PR TITLE
Improve payment validation and fee payment type

### DIFF
--- a/src/features/appraisal/components/AddPaymentModal.tsx
+++ b/src/features/appraisal/components/AddPaymentModal.tsx
@@ -16,6 +16,7 @@ interface AddPaymentModalProps {
   onSubmit: (data: AddPaymentFormData) => void;
   defaultValues?: { paymentDate: string; amount: number } | null;
   isEditing?: boolean;
+  maxAmount?: number;
 }
 
 /**
@@ -27,12 +28,14 @@ export default function AddPaymentModal({
   onSubmit,
   defaultValues,
   isEditing = false,
+  maxAmount,
 }: AddPaymentModalProps) {
   const {
     handleSubmit,
     formState: { errors, isSubmitting },
     reset,
     setValue,
+    setError,
     watch,
   } = useForm<AddPaymentFormData>({
     resolver: zodResolver(AddPaymentFormSchema),
@@ -57,12 +60,22 @@ export default function AddPaymentModal({
   };
 
   const handleFormSubmit = (data: AddPaymentFormData) => {
+    if (maxAmount == 0 || (maxAmount && data.amount > maxAmount)) {
+      setError('amount', { type: 'manual', message: `Amount cannot exceed ${maxAmount}` });
+      return;
+    }
+
     onSubmit(data);
     handleClose();
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title={isEditing ? 'Edit Payment' : 'Add Payment'} size="sm">
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={isEditing ? 'Edit Payment' : 'Add Payment'}
+      size="sm"
+    >
       <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
         {/* Payment Date */}
         <DateInput

--- a/src/features/appraisal/components/FeeInformationSection.tsx
+++ b/src/features/appraisal/components/FeeInformationSection.tsx
@@ -4,7 +4,7 @@ import Icon from '@shared/components/Icon';
 import Dropdown from '@shared/components/inputs/Dropdown';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import type { FeeItem } from '../types/appointmentAndFee';
-import { FEE_ITEM_TYPE_OPTIONS, FEE_TYPE_OPTIONS, VAT_PERCENTAGE, } from '../types/appointmentAndFee';
+import { FEE_ITEM_TYPE_OPTIONS, VAT_PERCENTAGE } from '../types/appointmentAndFee';
 import type { AppraisalFeeItemDtoType } from '@shared/schemas/v1';
 import AddFeeModal from './AddFeeModal';
 
@@ -172,7 +172,7 @@ export default function FeeInformationSection({
         name="feePaymentType"
         label="Fee Payment Type"
         required
-        options={FEE_TYPE_OPTIONS.map(opt => ({ value: opt.value, label: opt.label }))}
+        group="FeePaymentMethod"
         value={feePaymentType || ''}
         onChange={value => onUpdateFeePaymentType?.(value)}
         disabled={isFeePaymentTypeUpdating}

--- a/src/features/appraisal/components/PaymentInformationSection.tsx
+++ b/src/features/appraisal/components/PaymentInformationSection.tsx
@@ -58,7 +58,7 @@ export default function PaymentInformationSection({
   // Determine payment status
   const getPaymentStatus = () => {
     if (fee) {
-      switch (fee.paymentStatus.toLowerCase()) {
+      switch (fee?.paymentStatus?.toLowerCase()) {
         case 'paid':
           return { label: 'Paid', color: 'success' };
         case 'partial':
@@ -371,6 +371,7 @@ export default function PaymentInformationSection({
             : null
         }
         isEditing={editingPaymentId !== null}
+        maxAmount={remaining}
       />
 
       {/* Delete Confirmation Dialog */}


### PR DESCRIPTION
## Summary
- Add `maxAmount` validation to `AddPaymentModal` to prevent payments exceeding the remaining balance
- Switch fee payment type dropdown from hardcoded options to group-based lookup (`group="FeePaymentMethod"`)
- Fix optional chaining on `paymentStatus` to prevent runtime crash when value is undefined

## Test plan
- [ ] Verify payment modal rejects amounts exceeding remaining balance
- [ ] Verify fee payment type dropdown loads options from group lookup
- [ ] Verify payment status displays correctly when `paymentStatus` is undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)