### PR TITLE
Fix unsaved changes blocker on LawAndRegulation save

### DIFF
--- a/src/features/appraisal/pages/CreateLawAndRegulationPage.tsx
+++ b/src/features/appraisal/pages/CreateLawAndRegulationPage.tsx
@@ -72,7 +72,7 @@ const CreateLawAndRegulationPage = () => {
   });
 
   const { formState: { isDirty } } = methods;
-  const { blocker } = useUnsavedChangesWarning(isDirty);
+  const { blocker, skipWarning } = useUnsavedChangesWarning(isDirty);
 
   // Image & UI state
   const [images, setImages] = useState<LocalImage[]>([]);
@@ -447,6 +447,7 @@ const CreateLawAndRegulationPage = () => {
           onSuccess: () => {
             toast.success(action === 'draft' ? 'Draft saved' : 'Saved successfully');
             setSaveAction(null);
+            skipWarning();
             navigateBack();
           },
           onError: () => {


### PR DESCRIPTION
## Summary
- Call `skipWarning()` before `navigateBack()` in the save `onSuccess` callback on `CreateLawAndRegulationPage`
- Matches the existing pattern used by Land, Building, Condo, and other pages
- Prevents the unsaved changes dialog from incorrectly appearing after a successful save

## Test plan
- [ ] Edit the LawAndRegulation form (change header or remark), click Save → should redirect without showing the unsaved changes dialog
- [ ] Edit the form, then navigate away WITHOUT saving → should still show the blocker dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)