### PR TITLE
update collateral type constants in price analysis from C to U

### DIFF
--- a/src/features/pricingAnalysis/data/constants.ts
+++ b/src/features/pricingAnalysis/data/constants.ts
@@ -12,7 +12,7 @@ export const COLLATERAL_TYPE = [
     label: 'Land and Building',
   },
   {
-    value: 'C',
+    value: 'U',
     label: 'Condo',
   },
 ];


### PR DESCRIPTION
- update collateral type constants in price analysis from C to U because template parameter use U as condo template type. so, system could not find condo's template.