### PR TITLE
Fix dropdown click in editing row triggering unsaved changes warning

### DIFF
--- a/src/features/request/components/tables/FormTable.tsx
+++ b/src/features/request/components/tables/FormTable.tsx
@@ -278,6 +278,8 @@ const FormTable = ({ name, columns, sumColumns = [], totalFieldName }: FormTable
     if (e.relatedTarget && row.contains(e.relatedTarget as Node)) return;
     requestAnimationFrame(() => {
       if (suppressBlurRef.current || row.contains(document.activeElement)) return;
+      // Skip blur if a dropdown inside this row is open (options render outside the row via portal)
+      if (row.querySelector('[data-headlessui-state*="open"]')) return;
       suppressBlurRef.current = true;
       setBlurConfirm(true);
     });


### PR DESCRIPTION
## Summary
- When clicking a HeadlessUI dropdown (Property Type, Building Type) in an editing row on the Request page, the "Unsaved Changes" dialog incorrectly appeared
- Root cause: HeadlessUI `ListboxOptions` renders outside the `<tr>` via a portal, so `handleRowBlur` fires when focus moves to the dropdown panel
- Fix: Check for `data-headlessui-state*="open"` on elements inside the row before triggering the warning

## Test plan
- [ ] Edit a property row, click Property Type dropdown — no warning
- [ ] Edit a property row, click Building Type dropdown — no warning
- [ ] Select an option from the dropdown — applies without warning
- [ ] Click outside the row entirely — unsaved changes warning appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)