### PR TITLE
fix: update calculation area, input adjust offer value and default ad…

### DIFF
--- a/src/features/pricingAnalysis/adapters/directComparisonFieldPath.ts
+++ b/src/features/pricingAnalysis/adapters/directComparisonFieldPath.ts
@@ -78,6 +78,7 @@ export const directComparisonPath = {
   finalValueRounded: () => 'directComparisonFinalValue.finalValueRounded',
 
   /** Appraisal price */
+  includeLandArea: () => 'directComparisonAppraisalPrice.includeLandArea',
   landArea: () => 'directComparisonAppraisalPrice.landArea',
   usableArea: () => 'directComparisonAppraisalPrice.usableArea',
   appraisalPrice: () => 'directComparisonAppraisalPrice.appraisalPrice',

--- a/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
@@ -10,7 +10,11 @@ import type {
   DirectComparisonCalculationFormType,
   DirectComparisonType,
 } from '@features/pricingAnalysis/schemas/directComparisonForm';
-import { readFactorValue, toNum, yearDiffFromToday } from '@features/pricingAnalysis/domain/readFactorValue.ts';
+import {
+  readFactorValue,
+  toNum,
+  yearDiffFromToday,
+} from '@features/pricingAnalysis/domain/readFactorValue.ts';
 import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface SetDirectComparisonInitialValueProps {
@@ -74,7 +78,7 @@ export function initializeDirectComparisonForm({
               marketId: survey.id,
               offeringPrice: survey.offerPrice ?? 0,
               offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
-              offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 0,
+              offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
               offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
               sellingPrice: survey.salePrice ?? 0,
               sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
@@ -96,6 +100,7 @@ export function initializeDirectComparisonForm({
           finalValueRounded: 0,
         },
         directComparisonAppraisalPrice: {
+          includeLandArea: false,
           landArea: property.titles
             ? convertLandTitlesToLandArea({ titles: property.titles })
             : undefined,
@@ -155,7 +160,7 @@ export function initializeDirectComparisonForm({
             marketId: survey.id,
             offeringPrice: survey.offerPrice ?? 0,
             offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
-            offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 0,
+            offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
             offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
             sellingPrice: survey.salePrice ?? 0,
             sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
@@ -186,6 +191,7 @@ export function initializeDirectComparisonForm({
         finalValueRounded: 0,
       },
       directComparisonAppraisalPrice: {
+        includeLandArea: false,
         landArea: property.titles
           ? convertLandTitlesToLandArea({ titles: property.titles })
           : undefined,

--- a/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
@@ -10,7 +10,11 @@ import type {
   TemplateComparativeFactorType,
   TemplateDetailType,
 } from '@features/pricingAnalysis/schemas';
-import { readFactorValue, toNum, yearDiffFromToday } from '@features/pricingAnalysis/domain/readFactorValue';
+import {
+  readFactorValue,
+  toNum,
+  yearDiffFromToday,
+} from '@features/pricingAnalysis/domain/readFactorValue';
 import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface SetSaleAdjustmentGridInitialValueProps {
@@ -73,7 +77,7 @@ export function initializeSaleAdjustmentGridForm({
               marketId: survey.id,
               offeringPrice: survey.offerPrice ?? 0,
               offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
-              offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 0,
+              offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
               offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
               sellingPrice: survey.salePrice ?? 0,
               sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
@@ -99,6 +103,7 @@ export function initializeSaleAdjustmentGridForm({
           finalValueRounded: 0,
         },
         saleAdjustmentGridAppraisalPrice: {
+          includeLandArea: false,
           landArea: property.titles
             ? convertLandTitlesToLandArea({ titles: property.titles })
             : undefined,
@@ -158,7 +163,7 @@ export function initializeSaleAdjustmentGridForm({
             marketId: survey.id,
             offeringPrice: survey.offerPrice ?? 0,
             offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
-            offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 0,
+            offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
             offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
             sellingPrice: survey.salePrice ?? 0,
             sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
@@ -192,6 +197,7 @@ export function initializeSaleAdjustmentGridForm({
         finalValueRounded: 0,
       },
       saleAdjustmentGridAppraisalPrice: {
+        includeLandArea: false,
         landArea: property.titles
           ? convertLandTitlesToLandArea({ titles: property.titles })
           : undefined,

--- a/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
@@ -35,7 +35,7 @@ function buildCalculations(comparativeSurveys: MarketComparableDetailType[]): WQ
       marketId: survey.id ?? '',
       offeringPrice: survey.offerPrice ?? 0,
       offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
-      offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 0,
+      offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
       offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: survey.salePrice ?? 0,
       sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',

--- a/src/features/pricingAnalysis/adapters/saleAdjustmentGridFieldPath.ts
+++ b/src/features/pricingAnalysis/adapters/saleAdjustmentGridFieldPath.ts
@@ -84,6 +84,7 @@ export const saleGridFieldPath = {
   finalValueRounded: () => 'saleAdjustmentGridFinalValue.finalValueRounded',
 
   /** Appraisal price */
+  includeLandArea: () => 'saleAdjustmentGridAppraisalPrice.includeLandArea',
   landArea: () => 'saleAdjustmentGridAppraisalPrice.landArea',
   usableArea: () => 'saleAdjustmentGridAppraisalPrice.usableArea',
   appraisalPrice: () => 'saleAdjustmentGridAppraisalPrice.appraisalPrice',

--- a/src/features/pricingAnalysis/components/DirectComparisonAdjustAppraisalPriceSection.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonAdjustAppraisalPriceSection.tsx
@@ -5,8 +5,11 @@ import {
   type DerivedFieldRule,
 } from '@features/pricingAnalysis/adapters/useDerivedFieldArray.tsx';
 import { directComparisonPath } from '@features/pricingAnalysis/adapters/directComparisonFieldPath.ts';
-import { useRef } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useContext, useRef } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
+import { ServerDataCtx } from '../store/selectionContext';
+import { round2 } from '../domain/calculateDirectComparison';
 
 interface DirectComparisonAdjustAppraisalPriceSectionProps {
   property: Record<string, unknown>;
@@ -18,6 +21,7 @@ export function DirectComparisonAdjustAppraisalPriceSection({
 
   const {
     finalValueRounded: finalValueRoundedPath,
+    includeLandArea: includeLandAreaPath,
     landArea: landAreaPath,
     usableArea: usableAreaPath,
     appraisalPrice: appraisalPricePath,
@@ -32,19 +36,20 @@ export function DirectComparisonAdjustAppraisalPriceSection({
       targetPath: appraisalPricePath(),
       deps: [finalValueRoundedPath()],
       compute: ({ getValues }) => {
-        const finalValue = getValues(finalValueRoundedPath()) ?? 0;
+        const finalValueRounded = getValues(finalValueRoundedPath()) ?? 0;
 
+        const isIncludeLandArea = getValues(includeLandAreaPath());
         const landArea = getValues(landAreaPath());
-        if (landArea) {
-          return finalValue * landArea;
+        if (isIncludeLandArea && !!landArea) {
+          return round2(finalValueRounded * (landArea ?? 0));
         }
 
         const usableArea = getValues(usableAreaPath());
-        if (usableArea) {
-          return finalValue * usableArea;
+        if (isIncludeLandArea && !!usableArea) {
+          return round2(finalValueRounded * (usableArea ?? 0));
         }
 
-        return finalValue;
+        return finalValueRounded;
       },
     },
     {
@@ -81,18 +86,40 @@ export function DirectComparisonAdjustAppraisalPriceSection({
 
   useDerivedFields({ rules: rules });
 
+  const { control } = useFormContext();
+  const includeLandArea = useWatch({ control, name: includeLandAreaPath() });
+
+  const serverData = useContext(ServerDataCtx);
+  const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
+  const isLand = groupCollateralType === 'L';
+  const isUsable = groupCollateralType === 'U';
+  const areaUnit = isLand ? 'Sq. Wa' : 'Sq. m.';
+  const areaFieldPath = isLand ? landAreaPath() : usableAreaPath();
+
   return (
     <div className="flex flex-col gap-3 text-sm">
-      {property.propertyType === 'L' && (
+      {/* Include Area toggle */}
+      {(isLand || isUsable) && (
         <div className="flex items-center gap-4">
-          <span className="w-44 text-gray-500">Land Area</span>
-          <span className="font-medium text-gray-800">{(getValues(landAreaPath()) ?? 0).toLocaleString()}</span>
+          <span className="w-44 text-gray-500">Include Area</span>
+          <RHFInputCell
+            fieldName={includeLandAreaPath()}
+            inputType="toggle"
+            toggle={{ checked: includeLandArea, options: ['No', 'Yes'] }}
+          />
         </div>
       )}
-      {property.propertyType === 'U' && (
+      {includeLandArea && (
         <div className="flex items-center gap-4">
-          <span className="w-44 text-gray-500">Usable Area</span>
-          <span className="font-medium text-gray-800">{(getValues(usableAreaPath()) ?? 0).toLocaleString()}</span>
+          <span className="w-44 text-gray-500">Area</span>
+          <span className="font-medium text-gray-800">
+            <RHFInputCell
+              fieldName={areaFieldPath}
+              inputType="display"
+              accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
+            />
+          </span>
+          <span className="text-gray-500">{areaUnit}</span>
         </div>
       )}
       <div className="flex items-center gap-4">
@@ -125,7 +152,9 @@ export function DirectComparisonAdjustAppraisalPriceSection({
               const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
               const icon = num > 0 ? 'arrow-up' : 'arrow-down';
               return (
-                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}>
+                <span
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
+                >
                   <Icon name={icon} style="solid" className="size-3" />
                   {Math.abs(num).toLocaleString()}
                 </span>

--- a/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
@@ -248,7 +248,8 @@ export const DirectComparisonScoringSection = ({
                   cf => cf.factorCode === selected || !usedFactorCodes.includes(cf.factorCode),
                 )
                 .map(cf => ({
-                  label: getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ?? '',
+                  label:
+                    getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ?? '',
                   value: cf.factorCode,
                 }));
               const isTemplateFactor = (template?.calculationFactors ?? []).some(
@@ -265,7 +266,13 @@ export const DirectComparisonScoringSection = ({
                               fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                               inputType="display"
                               accessor={({ value }) =>
-                                value ? getFactorDesciption(value.toString(), serverData.allFactors ?? [], language) : ''
+                                value
+                                  ? getFactorDesciption(
+                                      value.toString(),
+                                      serverData.allFactors ?? [],
+                                      language,
+                                    )
+                                  : ''
                               }
                             />
                           ) : (
@@ -273,11 +280,16 @@ export const DirectComparisonScoringSection = ({
                               fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                               inputType="select"
                               options={options}
-                              onSelectChange={(value) => {
-                                const factor = serverData.allFactors?.find((f: FactorDataType) => f.factorCode === value);
+                              onSelectChange={value => {
+                                const factor = serverData.allFactors?.find(
+                                  (f: FactorDataType) => f.factorCode === value,
+                                );
                                 const fid = factor?.factorId ?? factor?.id ?? '';
                                 setValue(`directComparisonQualitatives.${rowIndex}.factorId`, fid);
-                                setValue(`directComparisonAdjustmentFactors.${rowIndex}.factorId`, fid);
+                                setValue(
+                                  `directComparisonAdjustmentFactors.${rowIndex}.factorId`,
+                                  fid,
+                                );
                               }}
                             />
                           )}
@@ -344,7 +356,9 @@ export const DirectComparisonScoringSection = ({
                       fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                       inputType="display"
                       accessor={({ value }) => {
-                        const factor = (serverData.allFactors ?? []).find((f: FactorDataType) => f.factorCode === value);
+                        const factor = (serverData.allFactors ?? []).find(
+                          (f: FactorDataType) => f.factorCode === value,
+                        );
                         const fieldName = factor?.fieldName as string | undefined;
                         const raw = fieldName ? property[fieldName] : null;
                         const rawStr = raw != null ? String(raw) : null;
@@ -358,7 +372,6 @@ export const DirectComparisonScoringSection = ({
                       }}
                     />
                   </td>
-
                 </tr>
               );
             })}
@@ -380,7 +393,15 @@ export const DirectComparisonScoringSection = ({
 
             {/* initial value */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Initial Price</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Initial Price
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -414,12 +435,18 @@ export const DirectComparisonScoringSection = ({
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex) => {
                 const hasOfferPrice = !!survey.offerPrice;
+                const hasAdjustAmt = !!(
+                  getValues(calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })) > 0
+                );
                 return (
                   <td key={survey.id} className={'border-b border-r border-gray-300'}>
                     {hasOfferPrice && (
                       <RHFInputCell
-                        fieldName={calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })}
+                        fieldName={calculationOfferingPriceAdjustmentPctPath({
+                          column: columnIndex,
+                        })}
                         inputType="number"
+                        disabled={hasAdjustAmt}
                       />
                     )}
                   </td>
@@ -436,12 +463,18 @@ export const DirectComparisonScoringSection = ({
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex) => {
                 const hasOfferPrice = !!survey.offerPrice;
+                const hasAdjustPct = !!(
+                  getValues(calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })) > 0
+                );
                 return (
                   <td key={survey.id} className={clsx(surveyColumnBody)}>
                     {hasOfferPrice && (
                       <RHFInputCell
-                        fieldName={calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })}
+                        fieldName={calculationOfferingPriceAdjustmentAmtPath({
+                          column: columnIndex,
+                        })}
                         inputType="number"
+                        disabled={hasAdjustPct}
                       />
                     )}
                   </td>
@@ -459,7 +492,10 @@ export const DirectComparisonScoringSection = ({
                 if (!hasSalePrice)
                   return <td key={survey.id} className={clsx(surveyColumnBody)}></td>;
                 return (
-                  <td key={survey.id} className={clsx(surveyColumnBody, 'text-right', hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(surveyColumnBody, 'text-right', hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -485,7 +521,14 @@ export const DirectComparisonScoringSection = ({
                   return `${format(d, 'MMM')} ${buddhistYear}`;
                 })();
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyColumnBody, (hasOfferPrice || !hasSalePrice) && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(
+                      'text-right',
+                      surveyColumnBody,
+                      (hasOfferPrice || !hasSalePrice) && 'opacity-50',
+                    )}
+                  >
                     <div className="flex flex-col items-end gap-0.5">
                       <RHFInputCell
                         fieldName={calculationNumberOfYearsPath({ column: columnIndex })}
@@ -534,7 +577,10 @@ export const DirectComparisonScoringSection = ({
                 if (!hasSalePrice)
                   return <td key={survey.id} className={clsx(surveyColumnBody)}></td>;
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyColumnBody, hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx('text-right', surveyColumnBody, hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationTotalAdjustedSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -575,7 +621,15 @@ export const DirectComparisonScoringSection = ({
 
             {/* adjust factors */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Adjusted Value</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Adjusted Value
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -590,7 +644,13 @@ export const DirectComparisonScoringSection = ({
                         fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                         inputType="display"
                         accessor={({ value }) =>
-                          value ? getFactorDesciption(value.toString(), serverData.allFactors ?? [], language) : ''
+                          value
+                            ? getFactorDesciption(
+                                value.toString(),
+                                serverData.allFactors ?? [],
+                                language,
+                              )
+                            : ''
                         }
                       />
                     }
@@ -726,7 +786,15 @@ export const DirectComparisonScoringSection = ({
 
             {/* final value */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Final Value</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Final Value
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -743,7 +811,13 @@ export const DirectComparisonScoringSection = ({
               </td>
             </tr>
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
                 {'Final Value (Rounded)'}
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {

--- a/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
@@ -3,9 +3,7 @@ import { SaleAdjustmentGridPanel } from '@features/pricingAnalysis/components/Sa
 import { DirectComparisonPanel } from '@features/pricingAnalysis/components/DirectComparisonPanel.tsx';
 import { WQSPanel } from '@features/pricingAnalysis/components/WQSPanel.tsx';
 import type { PricingServerData } from '../types/selection';
-import type {
-  GetComparativeFactorsResponseType,
-} from '../schemas';
+import type { GetComparativeFactorsResponseType } from '../schemas';
 import type { TemplateDtoType } from '@/shared/schemas/v1';
 
 interface MethodSectionRendererProps {
@@ -15,7 +13,11 @@ interface MethodSectionRendererProps {
     comparativeFactors: GetComparativeFactorsResponseType | undefined;
     templateList: TemplateDtoType[] | undefined;
   };
-  onCalculationSave: (payload: { approachType: string; methodType: string; appraisalValue: number }) => void;
+  onCalculationSave: (payload: {
+    approachType: string;
+    methodType: string;
+    appraisalValue: number;
+  }) => void;
   onCalculationMethodDirty: (check: boolean) => void;
   onCancelCalculationMethod: () => void;
 }
@@ -38,7 +40,8 @@ export function MethodSectionRenderer({
     savedComparativeFactors: calculationMethodData.comparativeFactors?.comparativeFactors,
     savedFactorScores: calculationMethodData.comparativeFactors?.factorScores,
     savedCalculations: calculationMethodData.comparativeFactors?.calculations,
-    savedComparativeAnalysisTemplateId: calculationMethodData.comparativeFactors?.comparativeAnalysisTemplateId,
+    savedComparativeAnalysisTemplateId:
+      calculationMethodData.comparativeFactors?.comparativeAnalysisTemplateId,
     savedMethodValue: calculationMethodData.comparativeFactors?.methodValue ?? null,
     onCalculationSave,
     onCalculationMethodDirty,

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridAdjustAppraisalPriceSection.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridAdjustAppraisalPriceSection.tsx
@@ -5,8 +5,11 @@ import {
   useDerivedFields,
 } from '@features/pricingAnalysis/adapters/useDerivedFieldArray.tsx';
 import { RHFInputCell } from '@features/pricingAnalysis/components/table/RHFInputCell.tsx';
-import { useRef } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useContext, useRef } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { round2, toFiniteNumber } from '../domain/calculateSaleAdjustmentGrid';
+import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
+import { ServerDataCtx } from '../store/selectionContext';
 
 interface SaleAdjustmentGridAdjustAppraisalPriceSectionProps {
   property: Record<string, unknown>;
@@ -18,6 +21,7 @@ export function SaleAdjustmentGridAdjustAppraisalPriceSection({
 
   const {
     finalValueRounded: finalValueRoundedPath,
+    includeLandArea: includeLandAreaPath,
     landArea: landAreaPath,
     usableArea: usableAreaPath,
     appraisalPrice: appraisalPricePath,
@@ -32,19 +36,20 @@ export function SaleAdjustmentGridAdjustAppraisalPriceSection({
       targetPath: appraisalPricePath(),
       deps: [finalValueRoundedPath()],
       compute: ({ getValues }) => {
-        const finalValue = getValues(finalValueRoundedPath()) ?? 0;
+        const finalValueRounded = getValues(finalValueRoundedPath()) ?? 0;
 
+        const isIncludeLandArea = getValues(includeLandAreaPath());
         const landArea = getValues(landAreaPath());
-        if (landArea) {
-          return finalValue * landArea;
+        if (isIncludeLandArea && !!landArea) {
+          return round2(finalValueRounded * (landArea ?? 0));
         }
 
         const usableArea = getValues(usableAreaPath());
-        if (usableArea) {
-          return finalValue * usableArea;
+        if (isIncludeLandArea && !!usableArea) {
+          return round2(finalValueRounded * (usableArea ?? 0));
         }
 
-        return finalValue;
+        return finalValueRounded;
       },
     },
     {
@@ -81,57 +86,83 @@ export function SaleAdjustmentGridAdjustAppraisalPriceSection({
 
   useDerivedFields({ rules: rules });
 
+  const { control } = useFormContext();
+  const includeLandArea = useWatch({ control, name: includeLandAreaPath() });
+
+  const serverData = useContext(ServerDataCtx);
+  const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
+  const isLand = groupCollateralType === 'L';
+  const isUsable = groupCollateralType === 'U';
+  const areaUnit = isLand ? 'Sq. Wa' : 'Sq. m.';
+  const areaFieldPath = isLand ? landAreaPath() : usableAreaPath();
+
   return (
     <div className="flex flex-col gap-3 text-sm">
-      {property.propertyType === 'L' && (
+      <div className="flex flex-col gap-3 text-sm py-2">
+        {/* Include Area toggle */}
+        {(isLand || isUsable) && (
+          <div className="flex items-center gap-4">
+            <span className="w-44 text-gray-500">Include Area</span>
+            <RHFInputCell
+              fieldName={includeLandAreaPath()}
+              inputType="toggle"
+              toggle={{ checked: includeLandArea, options: ['No', 'Yes'] }}
+            />
+          </div>
+        )}
+        {includeLandArea && (
+          <div className="flex items-center gap-4">
+            <span className="w-44 text-gray-500">Area</span>
+            <span className="font-medium text-gray-800">
+              <RHFInputCell
+                fieldName={areaFieldPath}
+                inputType="display"
+                accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
+              />
+            </span>
+            <span className="text-gray-500">{areaUnit}</span>
+          </div>
+        )}
         <div className="flex items-center gap-4">
-          <span className="w-44 text-gray-500">Land Area</span>
-          <span className="font-medium text-gray-800">{(getValues(landAreaPath()) ?? 0).toLocaleString()}</span>
+          <span className="w-44 text-gray-500">Final Value (Rounded)</span>
+          <span className="font-medium text-gray-800">
+            <RHFInputCell
+              fieldName={finalValueRoundedPath()}
+              inputType={'display'}
+              accessor={({ value }) => {
+                return value?.toLocaleString() ?? '0';
+              }}
+            />
+          </span>
+          <span className="text-gray-500">Baht</span>
         </div>
-      )}
-      {property.propertyType === 'U' && (
-        <div className="flex items-center gap-4">
-          <span className="w-44 text-gray-500">Usable Area</span>
-          <span className="font-medium text-gray-800">{(getValues(usableAreaPath()) ?? 0).toLocaleString()}</span>
-        </div>
-      )}
-      <div className="flex items-center gap-4">
-        <span className="w-44 text-gray-500">Final Value (Rounded)</span>
-        <span className="font-medium text-gray-800">
-          <RHFInputCell
-            fieldName={finalValueRoundedPath()}
-            inputType={'display'}
-            accessor={({ value }) => {
-              return value?.toLocaleString() ?? '0';
-            }}
-          />
-        </span>
-        <span className="text-gray-500">Baht</span>
-      </div>
-      <div className="flex items-center gap-4 rounded-lg bg-primary/5 border border-primary/20 px-4 py-3 -mx-4">
-        <span className="w-44 shrink-0 font-semibold text-gray-800">Appraisal Price</span>
-        <div className="w-40">
-          <RHFInputCell fieldName={appraisalPriceRoundedPath()} inputType={'number'} />
-        </div>
-        <span className="text-gray-500">Baht</span>
-        <div className="flex items-center">
-          <RHFInputCell
-            fieldName={priceDifferentiatePath()}
-            inputType={'display'}
-            accessor={({ value }) => {
-              const num = Number(value) || 0;
-              if (num === 0) return <span className="text-gray-400">-</span>;
-              const color = num > 0 ? 'text-green-600' : 'text-red-600';
-              const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
-              const icon = num > 0 ? 'arrow-up' : 'arrow-down';
-              return (
-                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}>
-                  <Icon name={icon} style="solid" className="size-3" />
-                  {Math.abs(num).toLocaleString()}
-                </span>
-              );
-            }}
-          />
+        <div className="flex items-center gap-4 rounded-lg bg-primary/5 border border-primary/20 px-4 py-3 -mx-4">
+          <span className="w-44 shrink-0 font-semibold text-gray-800">Appraisal Price</span>
+          <div className="w-40">
+            <RHFInputCell fieldName={appraisalPriceRoundedPath()} inputType={'number'} />
+          </div>
+          <span className="text-gray-500">Baht</span>
+          <div className="flex items-center">
+            <RHFInputCell
+              fieldName={priceDifferentiatePath()}
+              inputType={'display'}
+              accessor={({ value }) => {
+                const num = Number(value) || 0;
+                if (num === 0) return <span className="text-gray-400">-</span>;
+                const color = num > 0 ? 'text-green-600' : 'text-red-600';
+                const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
+                const icon = num > 0 ? 'arrow-up' : 'arrow-down';
+                return (
+                  <span
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
+                  >
+                    <Icon name={icon} style="solid" className="size-3" />
+                    {Math.abs(num).toLocaleString()}
+                  </span>
+                );
+              }}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
@@ -246,7 +246,8 @@ export const SaleAdjustmentGridScoringSection = ({
                   cf => cf.factorCode === selected || !usedFactorCodes.includes(cf.factorCode),
                 )
                 .map(cf => ({
-                  label: getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ?? '',
+                  label:
+                    getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ?? '',
                   value: cf.factorCode,
                 }));
               const isTemplateFactor = (template?.calculationFactors ?? []).some(
@@ -263,7 +264,13 @@ export const SaleAdjustmentGridScoringSection = ({
                               fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                               inputType="display"
                               accessor={({ value }) =>
-                                value ? getFactorDesciption(value.toString(), serverData.allFactors ?? [], language) : ''
+                                value
+                                  ? getFactorDesciption(
+                                      value.toString(),
+                                      serverData.allFactors ?? [],
+                                      language,
+                                    )
+                                  : ''
                               }
                             />
                           ) : (
@@ -271,11 +278,19 @@ export const SaleAdjustmentGridScoringSection = ({
                               fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                               inputType="select"
                               options={options}
-                              onSelectChange={(value) => {
-                                const factor = serverData.allFactors?.find((f: FactorDataType) => f.factorCode === value);
+                              onSelectChange={value => {
+                                const factor = serverData.allFactors?.find(
+                                  (f: FactorDataType) => f.factorCode === value,
+                                );
                                 const fid = factor?.factorId ?? factor?.id ?? '';
-                                setValue(`saleAdjustmentGridQualitatives.${rowIndex}.factorId`, fid);
-                                setValue(`saleAdjustmentGridAdjustmentFactors.${rowIndex}.factorId`, fid);
+                                setValue(
+                                  `saleAdjustmentGridQualitatives.${rowIndex}.factorId`,
+                                  fid,
+                                );
+                                setValue(
+                                  `saleAdjustmentGridAdjustmentFactors.${rowIndex}.factorId`,
+                                  fid,
+                                );
                               }}
                             />
                           )}
@@ -341,7 +356,9 @@ export const SaleAdjustmentGridScoringSection = ({
                       fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                       inputType="display"
                       accessor={({ value }) => {
-                        const factor = (serverData.allFactors ?? []).find((f: FactorDataType) => f.factorCode === value);
+                        const factor = (serverData.allFactors ?? []).find(
+                          (f: FactorDataType) => f.factorCode === value,
+                        );
                         const fieldName = factor?.fieldName as string | undefined;
                         const raw = fieldName ? property[fieldName] : null;
                         const rawStr = raw != null ? String(raw) : null;
@@ -376,7 +393,15 @@ export const SaleAdjustmentGridScoringSection = ({
 
             {/* initial value */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Initial Price</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Initial Price
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -410,6 +435,9 @@ export const SaleAdjustmentGridScoringSection = ({
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex) => {
                 const hasOfferPrice = !!survey.offerPrice;
+                const hasAdjustAmt = !!(
+                  getValues(calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })) > 0
+                );
                 if (!hasOfferPrice)
                   return <td key={survey.id} className={'border-b border-r border-gray-300'}></td>;
                 return (
@@ -417,6 +445,7 @@ export const SaleAdjustmentGridScoringSection = ({
                     <RHFInputCell
                       fieldName={calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })}
                       inputType="number"
+                      disabled={hasAdjustAmt}
                     />
                   </td>
                 );
@@ -432,14 +461,20 @@ export const SaleAdjustmentGridScoringSection = ({
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex) => {
                 const hasOfferPrice = !!survey.offerPrice;
-                if (!hasOfferPrice)
-                  return <td key={survey.id} className={'border-b border-r border-gray-300'}></td>;
+                const hasAdjustPct = !!(
+                  getValues(calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })) > 0
+                );
                 return (
                   <td key={survey.id} className={clsx(surveyColumnBody)}>
-                    <RHFInputCell
-                      fieldName={calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })}
-                      inputType="number"
-                    />
+                    {hasOfferPrice && (
+                      <RHFInputCell
+                        fieldName={calculationOfferingPriceAdjustmentAmtPath({
+                          column: columnIndex,
+                        })}
+                        inputType="number"
+                        disabled={hasAdjustPct}
+                      />
+                    )}
                   </td>
                 );
               })}
@@ -455,7 +490,10 @@ export const SaleAdjustmentGridScoringSection = ({
                 if (!hasSalePrice)
                   return <td key={survey.id} className={clsx(surveyColumnBody)}></td>;
                 return (
-                  <td key={survey.id} className={clsx(surveyColumnBody, 'text-right', hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(surveyColumnBody, 'text-right', hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -481,7 +519,14 @@ export const SaleAdjustmentGridScoringSection = ({
                   return `${format(d, 'MMM')} ${buddhistYear}`;
                 })();
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyColumnBody, (hasOfferPrice || !hasSalePrice) && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(
+                      'text-right',
+                      surveyColumnBody,
+                      (hasOfferPrice || !hasSalePrice) && 'opacity-50',
+                    )}
+                  >
                     <div className="flex flex-col items-end gap-0.5">
                       <RHFInputCell
                         fieldName={calculationNumberOfYearsPath({ column: columnIndex })}
@@ -533,7 +578,10 @@ export const SaleAdjustmentGridScoringSection = ({
                 if (!hasSalePrice)
                   return <td key={survey.id} className={clsx(surveyColumnBody)}></td>;
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyColumnBody, hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx('text-right', surveyColumnBody, hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationTotalAdjustedSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -574,7 +622,15 @@ export const SaleAdjustmentGridScoringSection = ({
 
             {/* adjust factors */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Adjusted Value</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Adjusted Value
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -589,7 +645,13 @@ export const SaleAdjustmentGridScoringSection = ({
                         fieldName={qualitativeFactorCodePath({ row: rowIndex })}
                         inputType="display"
                         accessor={({ value }) =>
-                          value ? getFactorDesciption(value.toString(), serverData.allFactors ?? [], language) : ''
+                          value
+                            ? getFactorDesciption(
+                                value.toString(),
+                                serverData.allFactors ?? [],
+                                language,
+                              )
+                            : ''
                         }
                       />
                     }
@@ -725,7 +787,15 @@ export const SaleAdjustmentGridScoringSection = ({
 
             {/* adjust weighted */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Adjust Weight</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Adjust Weight
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -771,7 +841,15 @@ export const SaleAdjustmentGridScoringSection = ({
 
             {/* final value */}
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>Final Value</td>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
+                Final Value
+              </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {
                 return <td key={survey.id} className={clsx('bg-gray-100', surveyColumnBody)}></td>;
               })}
@@ -788,7 +866,13 @@ export const SaleAdjustmentGridScoringSection = ({
               </td>
             </tr>
             <tr>
-              <td className={clsx('bg-gray-100 !font-semibold !text-gray-700', leftColumnBody, bgGradient)}>
+              <td
+                className={clsx(
+                  'bg-gray-100 !font-semibold !text-gray-700',
+                  leftColumnBody,
+                  bgGradient,
+                )}
+              >
                 {'Final Value (Rounded)'}
               </td>
               {comparativeSurveys.map((survey: MarketComparableDetailType) => {

--- a/src/features/pricingAnalysis/components/WQSScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/WQSScoringSection.tsx
@@ -261,7 +261,9 @@ export function WQSScoringSection({
                     cf => cf.factorCode === selected || !usedFactorCodes.includes(cf.factorCode),
                   )
                   .map(cf => ({
-                    label: getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ?? '',
+                    label:
+                      getFactorDesciption(cf.factorCode, serverData.allFactors ?? [], language) ??
+                      '',
                     value: cf.factorCode,
                   }));
                 const isTemplateFactor = (template?.calculationFactors ?? []).some(
@@ -277,7 +279,13 @@ export function WQSScoringSection({
                               fieldName={scoringFactorCodePath({ row: rowIndex })}
                               inputType="display"
                               accessor={({ value }) =>
-                                value ? getFactorDesciption(value.toString(), serverData.allFactors ?? [], language) : ''
+                                value
+                                  ? getFactorDesciption(
+                                      value.toString(),
+                                      serverData.allFactors ?? [],
+                                      language,
+                                    )
+                                  : ''
                               }
                             />
                           ) : (
@@ -285,9 +293,14 @@ export function WQSScoringSection({
                               fieldName={scoringFactorCodePath({ row: rowIndex })}
                               inputType="select"
                               options={options}
-                              onSelectChange={(value) => {
-                                const factor = serverData.allFactors?.find((f: FactorDataType) => f.factorCode === value);
-                                setValue(`WQSScores.${rowIndex}.factorId`, factor?.factorId ?? factor?.id ?? '');
+                              onSelectChange={value => {
+                                const factor = serverData.allFactors?.find(
+                                  (f: FactorDataType) => f.factorCode === value,
+                                );
+                                setValue(
+                                  `WQSScores.${rowIndex}.factorId`,
+                                  factor?.factorId ?? factor?.id ?? '',
+                                );
                               }}
                             />
                           )}
@@ -613,12 +626,18 @@ export function WQSScoringSection({
               ></td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex: number) => {
                 const hasOfferPrice = !!survey.offerPrice;
+                const hasAdjustAmt = !!(
+                  getValues(calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })) > 0
+                );
                 return (
                   <td key={survey.id} className={'border-b border-r border-gray-300'}>
                     {hasOfferPrice && (
                       <RHFInputCell
-                        fieldName={calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })}
+                        fieldName={calculationOfferingPriceAdjustmentPctPath({
+                          column: columnIndex,
+                        })}
                         inputType="number"
+                        disabled={hasAdjustAmt}
                       />
                     )}
                   </td>
@@ -645,12 +664,18 @@ export function WQSScoringSection({
               ></td>
               {comparativeSurveys.map((survey: MarketComparableDetailType, columnIndex: number) => {
                 const hasOfferPrice = !!survey.offerPrice;
+                const hasAdjustPct = !!(
+                  getValues(calculationOfferingPriceAdjustmentPctPath({ column: columnIndex })) > 0
+                );
                 return (
                   <td key={survey.id} className={clsx(surveyStyle)}>
                     {hasOfferPrice && (
                       <RHFInputCell
-                        fieldName={calculationOfferingPriceAdjustmentAmtPath({ column: columnIndex })}
+                        fieldName={calculationOfferingPriceAdjustmentAmtPath({
+                          column: columnIndex,
+                        })}
                         inputType="number"
+                        disabled={hasAdjustPct}
                       />
                     )}
                   </td>
@@ -679,7 +704,10 @@ export function WQSScoringSection({
                 const hasOfferPrice = !!survey.offerPrice;
                 if (!hasSalePrice) return <td key={survey.id} className={clsx(surveyStyle)}></td>;
                 return (
-                  <td key={survey.id} className={clsx(surveyStyle, 'text-right', hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(surveyStyle, 'text-right', hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -717,7 +745,14 @@ export function WQSScoringSection({
                   return `${format(d, 'MMM')} ${buddhistYear}`;
                 })();
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyStyle, (hasOfferPrice || !hasSalePrice) && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx(
+                      'text-right',
+                      surveyStyle,
+                      (hasOfferPrice || !hasSalePrice) && 'opacity-50',
+                    )}
+                  >
                     <div className="flex flex-col items-end gap-0.5">
                       <RHFInputCell
                         fieldName={calculationNumberOfYearsPath({ column: columnIndex })}
@@ -789,7 +824,10 @@ export function WQSScoringSection({
                 const hasOfferPrice = !!survey.offerPrice;
                 if (!hasSalePrice) return <td key={survey.id} className={clsx(surveyStyle)}></td>;
                 return (
-                  <td key={survey.id} className={clsx('text-right', surveyStyle, hasOfferPrice && 'opacity-50')}>
+                  <td
+                    key={survey.id}
+                    className={clsx('text-right', surveyStyle, hasOfferPrice && 'opacity-50')}
+                  >
                     <RHFInputCell
                       fieldName={calculationTotalAdjustedSellingPricePath({ column: columnIndex })}
                       inputType="display"
@@ -837,13 +875,26 @@ export function WQSScoringSection({
               <td className={clsx('bg-gray-100 border-r font-semibold', leftColumnBody)}>
                 Final Value
               </td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[250px] z-30')}></td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[350px] z-30')}></td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[450px] z-30', bgGradient)}></td>
+              <td
+                className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[250px] z-30')}
+              ></td>
+              <td
+                className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[350px] z-30')}
+              ></td>
+              <td
+                className={clsx(
+                  'bg-gray-100 border-b border-gray-300 sticky left-[450px] z-30',
+                  bgGradient,
+                )}
+              ></td>
               {comparativeSurveys.map(survey => (
                 <td key={survey.id} className={clsx('bg-gray-100', surveyStyle)}></td>
               ))}
-              <td className={clsx('bg-gray-100 border-b border-gray-300 px-3 py-1.5 text-right font-semibold')}>
+              <td
+                className={clsx(
+                  'bg-gray-100 border-b border-gray-300 px-3 py-1.5 text-right font-semibold',
+                )}
+              >
                 <RHFInputCell
                   fieldName={finalValueFinalValuePath()}
                   inputType="display"
@@ -857,17 +908,23 @@ export function WQSScoringSection({
               <td className={clsx('bg-gray-100 border-r font-semibold', leftColumnBody)}>
                 {'Final Value (Rounded)'}
               </td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[250px] z-30')}></td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[350px] z-30')}></td>
-              <td className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[450px] z-30', bgGradient)}></td>
+              <td
+                className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[250px] z-30')}
+              ></td>
+              <td
+                className={clsx('bg-gray-100 border-b border-gray-300 sticky left-[350px] z-30')}
+              ></td>
+              <td
+                className={clsx(
+                  'bg-gray-100 border-b border-gray-300 sticky left-[450px] z-30',
+                  bgGradient,
+                )}
+              ></td>
               {comparativeSurveys.map(survey => (
                 <td key={survey.id} className={clsx('bg-gray-100', surveyStyle)}></td>
               ))}
               <td className={clsx('bg-gray-100 border-b border-gray-300 px-1 py-1')}>
-                <RHFInputCell
-                  fieldName={finalValueFinalValueRoundedPath()}
-                  inputType="number"
-                />
+                <RHFInputCell fieldName={finalValueFinalValueRoundedPath()} inputType="number" />
               </td>
             </tr>
           </tbody>

--- a/src/features/pricingAnalysis/domain/calculateSaleAdjustmentGrid.ts
+++ b/src/features/pricingAnalysis/domain/calculateSaleAdjustmentGrid.ts
@@ -8,6 +8,26 @@ export function floorToTenThousands(num) {
   return Math.floor(num / 10000) * 10000;
 }
 
+export const toFiniteNumber = (v: unknown, fallback = 0): number => {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : fallback;
+
+  if (typeof v === 'string') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  // If RHF gives you an array (or someone stored a tuple), take the first usable number.
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      const n = toFiniteNumber(item, NaN);
+      if (Number.isFinite(n)) return n;
+    }
+    return fallback;
+  }
+
+  return fallback;
+};
+
 /**
  * Adjusted value from offering price:
  * - pct > 0 => offeringPrice - offeringPrice * pct/100

--- a/src/features/pricingAnalysis/schemas/directComparisonForm.ts
+++ b/src/features/pricingAnalysis/schemas/directComparisonForm.ts
@@ -89,6 +89,7 @@ const DirectComparisonAdjustmentFactor = z
 
 const DirectComparisonAppraisalPrice = z
   .object({
+    includeLandArea: z.boolean(),
     landArea: z.number().nullable().optional(),
     usableArea: z.number().nullable().optional(),
     appraisalPrice: z.number(),

--- a/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
@@ -93,6 +93,7 @@ const SaleAdjustmentGridAdjustmentFactor = z
 
 const SaleAdjustmentGridAppraisalPrice = z
   .object({
+    includeLandArea: z.boolean(),
     landArea: z.number().nullable().optional(),
     usableArea: z.number().nullable().optional(),
     appraisalPrice: z.number(),


### PR DESCRIPTION
- add 'include area' toggle to sale grid and direct
- update calculation appraisal value condition to check whether 'includeLandArea' is true or not
- update input adjusted offering price to key in either pct or amt
- update initial value of adjusted offering price pct to 5%