### PR TITLE
Price analysis/fix related area

### DIFF
--- a/src/features/pricingAnalysis/adapters/buildDirectComparisonDerivedRules.ts
+++ b/src/features/pricingAnalysis/adapters/buildDirectComparisonDerivedRules.ts
@@ -46,6 +46,8 @@ export function buildDirectComparisonCalculationDerivedRules(args: {
     calculationSumFactorAmt: calculationSumFactorAmtPath,
     calculationTotalAdjustedSellingPrice: calculationTotalAdjustedSellingPricePath,
     calculationUsableAreaPrice: calculationUsableAreaPricePath,
+    landArea: landAreaPath,
+    usableArea: usableAreaPath,
   } = directComparisonPath;
 
   const rules: DerivedFieldRule[] = surveys
@@ -103,9 +105,9 @@ export function buildDirectComparisonCalculationDerivedRules(args: {
         {
           targetPath: calculationLandAreaDiffPath({ column: columnIndex }),
           deps: [],
-          compute: () => {
-            const propertyLandArea = getPropertyValueByFactorCode('05', property, allFactors) ?? 0;
-            const findSurveyLandArea = (survey.factorData ?? []).find(f => f.factorCode === '05');
+          compute: ({ getValues }) => {
+            const propertyLandArea = getValues(landAreaPath());
+            const findSurveyLandArea = (survey.factorData ?? []).find(f => f.factorCode === '02');
             const surveyLandArea = findSurveyLandArea
               ? readFactorValue({
                   dataType: findSurveyLandArea.dataType,
@@ -121,7 +123,7 @@ export function buildDirectComparisonCalculationDerivedRules(args: {
           targetPath: calculationLandValueIncreaseDecreasePath({ column: columnIndex }),
           deps: [calculationLandPricePath()],
           compute: ({ getValues }) => {
-            const landPrice = getValues('landPrice') ?? 0;
+            const landPrice = getValues(calculationLandPricePath()) ?? 0;
             const landDiff = getValues(calculationLandAreaDiffPath({ column: columnIndex })) ?? 0;
             const landValueIncreaseDecrease = calcIncreaseDecrease(landPrice, landDiff);
             return landValueIncreaseDecrease;
@@ -130,9 +132,9 @@ export function buildDirectComparisonCalculationDerivedRules(args: {
         {
           targetPath: calculationUsableAreaDiffPath({ column: columnIndex }),
           deps: [],
-          compute: () => {
-            const propertyUsableArea = getPropertyValueByFactorCode('12', property, allFactors) ?? 0;
-            const findSurveyUsableArea = survey.factorData?.find(f => f.factorCode === '12');
+          compute: ({ getValues }) => {
+            const propertyUsableArea = getValues(usableAreaPath()) ?? 0;
+            const findSurveyUsableArea = survey.factorData?.find(f => f.factorCode === '14');
             const surveyUsableArea = findSurveyUsableArea
               ? readFactorValue({
                   dataType: findSurveyUsableArea.dataType,
@@ -149,7 +151,7 @@ export function buildDirectComparisonCalculationDerivedRules(args: {
           targetPath: calculationBuildingValueIncreaseDecreasePath({ column: columnIndex }),
           deps: [calculationUsableAreaPricePath()],
           compute: ({ getValues }) => {
-            const usableAreaPrice = getValues('usableAreaPrice') ?? 0;
+            const usableAreaPrice = getValues(calculationUsableAreaPricePath()) ?? 0;
             const usableAreaDiff =
               getValues(calculationUsableAreaDiffPath({ column: columnIndex })) ?? 0;
             const buildingValueIncreaseDecrease = calcIncreaseDecrease(

--- a/src/features/pricingAnalysis/adapters/buildSaleAdjustmentGridDerivedRules.ts
+++ b/src/features/pricingAnalysis/adapters/buildSaleAdjustmentGridDerivedRules.ts
@@ -47,6 +47,8 @@ export function buildSaleGridCalculationDerivedRules(args: {
     calculationWeight: calculationWeightPath,
     calculationWeightAdjustValue: calculationWeightAdjustValuePath,
     calculationUsableAreaPrice: calculationUsableAreaPricePath,
+    landArea: landAreaPath,
+    usableArea: usableAreaPath,
   } = saleGridFieldPath;
 
   const rules: DerivedFieldRule[] = surveys
@@ -104,9 +106,9 @@ export function buildSaleGridCalculationDerivedRules(args: {
         {
           targetPath: calculationLandAreaDiffPath({ column: columnIndex }),
           deps: [],
-          compute: ({ ctx }) => {
-            const propertyLandArea = ctx.property?.area ?? 0;
-            const findSurveyLandArea = (survey.factorData ?? []).find(f => f.factorCode === '05');
+          compute: ({ getValues }) => {
+            const propertyLandArea = getValues(landAreaPath()) ?? 0;
+            const findSurveyLandArea = (survey.factorData ?? []).find(f => f.factorCode === '02');
             const surveyLandArea = findSurveyLandArea
               ? readFactorValue({
                   dataType: findSurveyLandArea.dataType,
@@ -122,7 +124,7 @@ export function buildSaleGridCalculationDerivedRules(args: {
           targetPath: calculationLandValueIncreaseDecreasePath({ column: columnIndex }),
           deps: [calculationLandPricePath()],
           compute: ({ getValues }) => {
-            const landPrice = getValues('landPrice') ?? 0;
+            const landPrice = getValues(calculationLandPricePath()) ?? 0;
             const landDiff = getValues(calculationLandAreaDiffPath({ column: columnIndex })) ?? 0;
             const landValueIncreaseDecrease = calcIncreaseDecrease(landPrice, landDiff);
             return landValueIncreaseDecrease;
@@ -131,9 +133,9 @@ export function buildSaleGridCalculationDerivedRules(args: {
         {
           targetPath: calculationUsableAreaDiffPath({ column: columnIndex }),
           deps: [],
-          compute: () => {
-            const propertyUsableArea = getPropertyValueByFactorCode('12', property, allFactors) ?? 0;
-            const findSurveyUsableArea = survey.factorData?.find(f => f.factorCode === '12');
+          compute: ({ getValues }) => {
+            const propertyUsableArea = getValues(usableAreaPath()) ?? 0;
+            const findSurveyUsableArea = survey.factorData?.find(f => f.factorCode === '14');
             const surveyUsableArea = findSurveyUsableArea
               ? readFactorValue({
                   dataType: findSurveyUsableArea.dataType,
@@ -150,7 +152,7 @@ export function buildSaleGridCalculationDerivedRules(args: {
           targetPath: calculationBuildingValueIncreaseDecreasePath({ column: columnIndex }),
           deps: [calculationUsableAreaPricePath()],
           compute: ({ getValues }) => {
-            const usableAreaPrice = getValues('usableAreaPrice') ?? 0;
+            const usableAreaPrice = getValues(calculationUsableAreaPricePath()) ?? 0;
             const usableAreaDiff =
               getValues(calculationUsableAreaDiffPath({ column: columnIndex })) ?? 0;
             const buildingValueIncreaseDecrease = calcIncreaseDecrease(

--- a/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
@@ -15,7 +15,6 @@ import {
   toNum,
   yearDiffFromToday,
 } from '@features/pricingAnalysis/domain/readFactorValue.ts';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface SetDirectComparisonInitialValueProps {
   collateralType: string;

--- a/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeDirectComparisonForm.ts
@@ -101,10 +101,12 @@ export function initializeDirectComparisonForm({
         },
         directComparisonAppraisalPrice: {
           includeLandArea: false,
-          landArea: property.titles
-            ? convertLandTitlesToLandArea({ titles: property.titles })
-            : undefined,
-          usableArea: property.usableArea ?? undefined,
+          landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+          usableArea: property.totalBuildingArea
+            ? Number(property.totalBuildingArea)
+            : property.usableArea
+              ? Number(property.usableArea)
+              : undefined,
           appraisalPrice: 0,
           appraisalPriceRounded: 0,
           priceDifferentiate: 0,
@@ -192,10 +194,12 @@ export function initializeDirectComparisonForm({
       },
       directComparisonAppraisalPrice: {
         includeLandArea: false,
-        landArea: property.titles
-          ? convertLandTitlesToLandArea({ titles: property.titles })
-          : undefined,
-        usableArea: property.usableArea ?? undefined,
+        landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+        usableArea: property.totalBuildingArea
+          ? Number(property.totalBuildingArea)
+          : property.usableArea
+            ? Number(property.usableArea)
+            : undefined,
         appraisalPrice: 0,
         appraisalPriceRounded: 0,
         priceDifferentiate: 0,

--- a/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
@@ -15,7 +15,6 @@ import {
   toNum,
   yearDiffFromToday,
 } from '@features/pricingAnalysis/domain/readFactorValue';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface SetSaleAdjustmentGridInitialValueProps {
   collateralType: string;

--- a/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeSaleAdjustmentGridForm.ts
@@ -104,10 +104,12 @@ export function initializeSaleAdjustmentGridForm({
         },
         saleAdjustmentGridAppraisalPrice: {
           includeLandArea: false,
-          landArea: property.titles
-            ? convertLandTitlesToLandArea({ titles: property.titles })
-            : undefined,
-          usableArea: property.usableArea ?? undefined,
+          landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+          usableArea: property.totalBuildingArea
+            ? Number(property.totalBuildingArea)
+            : property.usableArea
+              ? Number(property.usableArea)
+              : undefined,
           appraisalPrice: 0,
           appraisalPriceRounded: 0,
           priceDifferentiate: 0,
@@ -198,10 +200,12 @@ export function initializeSaleAdjustmentGridForm({
       },
       saleAdjustmentGridAppraisalPrice: {
         includeLandArea: false,
-        landArea: property.titles
-          ? convertLandTitlesToLandArea({ titles: property.titles })
-          : undefined,
-        usableArea: property.usableArea ?? undefined,
+        landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+        usableArea: property.totalBuildingArea
+          ? Number(property.totalBuildingArea)
+          : property.usableArea
+            ? Number(property.usableArea)
+            : undefined,
         appraisalPrice: 0,
         appraisalPriceRounded: 0,
         priceDifferentiate: 0,

--- a/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
@@ -1,7 +1,6 @@
 import type { UseFormReset } from 'react-hook-form';
 import type { WQSCalculationType, WQSFormType } from '../schemas/wqsForm';
 import type { FactorDataType, MarketComparableDetailType, TemplateDetailType } from '../schemas';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 import { readFactorValue, toNum, yearDiffFromToday } from '../domain/readFactorValue';
 
 interface setWQSInitialValueProps {
@@ -48,10 +47,12 @@ function buildCalculations(comparativeSurveys: MarketComparableDetailType[]): WQ
 
 function buildFinalValue(property: Record<string, unknown>) {
   return {
-    landArea: property.titles
-      ? convertLandTitlesToLandArea({ titles: property.titles })
-      : undefined,
-    usableArea: property?.usableArea ?? undefined,
+    landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+    usableArea: property.totalBuildingArea
+      ? Number(property.totalBuildingArea)
+      : property.usableArea
+        ? Number(property.usableArea)
+        : undefined,
     finalValue: 0,
     finalValueRounded: 0,
     coefficientOfDecision: 0,

--- a/src/features/pricingAnalysis/adapters/restoreDirectComparisonFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreDirectComparisonFromSavedData.ts
@@ -12,7 +12,6 @@ import type {
   MarketComparableDetailType,
 } from '../schemas';
 import { readFactorValue, toNum, yearDiffFromToday } from '../domain/readFactorValue';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface RestoreDirectComparisonFromSavedDataProps {
   methodId: string;

--- a/src/features/pricingAnalysis/adapters/restoreDirectComparisonFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreDirectComparisonFromSavedData.ts
@@ -51,19 +51,18 @@ export function restoreDirectComparisonFromSavedData({
   }
 
   // Restore comparativeFactors — ALL factors for the top table
-  const allComparativeFactors = [...savedComparativeFactors]
-    .sort((a, b) => a.displaySequence - b.displaySequence);
+  const allComparativeFactors = [...savedComparativeFactors].sort(
+    (a, b) => a.displaySequence - b.displaySequence,
+  );
 
-  const comparativeFactors = allComparativeFactors
-    .map(cf => ({
-      id: cf.id,
-      factorId: cf.factorId,
-      factorCode: cf.factorCode ?? factorCodeMap.get(cf.factorId) ?? '',
-    }));
+  const comparativeFactors = allComparativeFactors.map(cf => ({
+    id: cf.id,
+    factorId: cf.factorId,
+    factorCode: cf.factorCode ?? factorCodeMap.get(cf.factorId) ?? '',
+  }));
 
   // Scoring factors: only isSelectedForScoring for calculation section
-  const scoringFactors = allComparativeFactors
-    .filter(cf => cf.isSelectedForScoring);
+  const scoringFactors = allComparativeFactors.filter(cf => cf.isSelectedForScoring);
 
   // Build factor score lookups: factorId → marketComparableId → FactorScoreType
   const scoreMap = new Map<string, Map<string, FactorScoreType>>();
@@ -118,7 +117,14 @@ export function restoreDirectComparisonFromSavedData({
     const surveyMap = new Map<string, unknown>();
     for (const s of survey.factorData ?? []) {
       if (s.factorCode) {
-        surveyMap.set(s.factorCode, readFactorValue({ dataType: s.dataType as string, value: s.value as string, fieldDecimal: s.fieldDecimal as number }));
+        surveyMap.set(
+          s.factorCode,
+          readFactorValue({
+            dataType: s.dataType as string,
+            value: s.value as string,
+            fieldDecimal: s.fieldDecimal as number,
+          }),
+        );
       }
     }
 
@@ -127,9 +133,12 @@ export function restoreDirectComparisonFromSavedData({
     return {
       marketId: survey.id,
       offeringPrice: saved?.offeringPrice ?? survey.offerPrice ?? 0,
-      offeringPriceMeasurementUnit: saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
-      offeringPriceAdjustmentPct: saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
-      offeringPriceAdjustmentAmt: saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
+      offeringPriceMeasurementUnit:
+        saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
+      offeringPriceAdjustmentPct:
+        saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
+      offeringPriceAdjustmentAmt:
+        saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: saved?.sellingPrice ?? survey.salePrice ?? 0,
       sellingPriceMeasurementUnit: (surveyMap.get('20') as string) ?? '',
       sellingDate: survey.saleDate ?? '',
@@ -172,10 +181,12 @@ export function restoreDirectComparisonFromSavedData({
         finalValueRounded: 0,
       },
       directComparisonAppraisalPrice: {
-        landArea: property.titles
-          ? convertLandTitlesToLandArea({ titles: property.titles })
-          : undefined,
-        usableArea: (property.usableArea as number) ?? undefined,
+        landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+        usableArea: property.totalBuildingArea
+          ? Number(property.totalBuildingArea)
+          : property.usableArea
+            ? Number(property.usableArea)
+            : undefined,
         appraisalPrice: 0,
         appraisalPriceRounded: 0,
         priceDifferentiate: 0,

--- a/src/features/pricingAnalysis/adapters/restoreSaleAdjustmentGridFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreSaleAdjustmentGridFromSavedData.ts
@@ -51,19 +51,18 @@ export function restoreSaleAdjustmentGridFromSavedData({
   }
 
   // Restore comparativeFactors — ALL factors for the top table
-  const allComparativeFactors = [...savedComparativeFactors]
-    .sort((a, b) => a.displaySequence - b.displaySequence);
+  const allComparativeFactors = [...savedComparativeFactors].sort(
+    (a, b) => a.displaySequence - b.displaySequence,
+  );
 
-  const comparativeFactors = allComparativeFactors
-    .map(cf => ({
-      id: cf.id,
-      factorId: cf.factorId,
-      factorCode: cf.factorCode ?? factorCodeMap.get(cf.factorId) ?? '',
-    }));
+  const comparativeFactors = allComparativeFactors.map(cf => ({
+    id: cf.id,
+    factorId: cf.factorId,
+    factorCode: cf.factorCode ?? factorCodeMap.get(cf.factorId) ?? '',
+  }));
 
   // Scoring factors: only isSelectedForScoring for calculation section
-  const scoringFactors = allComparativeFactors
-    .filter(cf => cf.isSelectedForScoring);
+  const scoringFactors = allComparativeFactors.filter(cf => cf.isSelectedForScoring);
 
   // Build factor score lookups: factorId → marketComparableId → FactorScoreType
   const scoreMap = new Map<string, Map<string, FactorScoreType>>();
@@ -119,7 +118,14 @@ export function restoreSaleAdjustmentGridFromSavedData({
     const surveyMap = new Map<string, unknown>();
     for (const s of survey.factorData ?? []) {
       if (s.factorCode) {
-        surveyMap.set(s.factorCode, readFactorValue({ dataType: s.dataType as string, value: s.value as string, fieldDecimal: s.fieldDecimal as number }));
+        surveyMap.set(
+          s.factorCode,
+          readFactorValue({
+            dataType: s.dataType as string,
+            value: s.value as string,
+            fieldDecimal: s.fieldDecimal as number,
+          }),
+        );
       }
     }
 
@@ -128,9 +134,12 @@ export function restoreSaleAdjustmentGridFromSavedData({
     return {
       marketId: survey.id,
       offeringPrice: saved?.offeringPrice ?? survey.offerPrice ?? 0,
-      offeringPriceMeasurementUnit: saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
-      offeringPriceAdjustmentPct: saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
-      offeringPriceAdjustmentAmt: saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
+      offeringPriceMeasurementUnit:
+        saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
+      offeringPriceAdjustmentPct:
+        saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
+      offeringPriceAdjustmentAmt:
+        saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: saved?.sellingPrice ?? survey.salePrice ?? 0,
       sellingPriceMeasurementUnit: (surveyMap.get('20') as string) ?? '',
       sellingDate: survey.saleDate ?? '',
@@ -175,10 +184,12 @@ export function restoreSaleAdjustmentGridFromSavedData({
         finalValueRounded: 0,
       },
       saleAdjustmentGridAppraisalPrice: {
-        landArea: property.titles
-          ? convertLandTitlesToLandArea({ titles: property.titles })
-          : undefined,
-        usableArea: (property.usableArea as number) ?? undefined,
+        landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+        usableArea: property.totalBuildingArea
+          ? Number(property.totalBuildingArea)
+          : property.usableArea
+            ? Number(property.usableArea)
+            : undefined,
         appraisalPrice: 0,
         appraisalPriceRounded: 0,
         priceDifferentiate: 0,

--- a/src/features/pricingAnalysis/adapters/restoreSaleAdjustmentGridFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreSaleAdjustmentGridFromSavedData.ts
@@ -12,7 +12,6 @@ import type {
   MarketComparableDetailType,
 } from '../schemas';
 import { readFactorValue, toNum, yearDiffFromToday } from '../domain/readFactorValue';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 
 interface RestoreSaleAdjustmentGridFromSavedDataProps {
   methodId: string;

--- a/src/features/pricingAnalysis/adapters/restoreWQSFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreWQSFromSavedData.ts
@@ -8,7 +8,6 @@ import type {
   LinkedComparableType,
   MarketComparableDetailType,
 } from '../schemas';
-import { convertLandTitlesToLandArea } from '../domain/convertLandTitlesToLandArea';
 import { readFactorValue, toNum, yearDiffFromToday } from '../domain/readFactorValue';
 
 interface RestoreWQSFromSavedDataProps {
@@ -104,7 +103,14 @@ export function restoreWQSFromSavedData({
     const surveyMap = new Map<string, unknown>();
     for (const s of survey.factorData ?? []) {
       if (s.factorCode) {
-        surveyMap.set(s.factorCode, readFactorValue({ dataType: s.dataType as string, value: s.value as string, fieldDecimal: s.fieldDecimal as number }));
+        surveyMap.set(
+          s.factorCode,
+          readFactorValue({
+            dataType: s.dataType as string,
+            value: s.value as string,
+            fieldDecimal: s.fieldDecimal as number,
+          }),
+        );
       }
     }
 
@@ -113,9 +119,12 @@ export function restoreWQSFromSavedData({
     return {
       marketId: survey.id ?? '',
       offeringPrice: saved?.offeringPrice ?? survey.offerPrice ?? 0,
-      offeringPriceMeasurementUnit: saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
-      offeringPriceAdjustmentPct: saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
-      offeringPriceAdjustmentAmt: saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
+      offeringPriceMeasurementUnit:
+        saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
+      offeringPriceAdjustmentPct:
+        saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
+      offeringPriceAdjustmentAmt:
+        saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: saved?.sellingPrice ?? survey.salePrice ?? 0,
       sellingPriceMeasurementUnit: (surveyMap.get('20') as string) ?? '',
       sellingPriceAdjustmentYear: saved?.adjustedPeriodPct ?? toNum(surveyMap.get('23'), 3),
@@ -153,10 +162,12 @@ export function restoreWQSFromSavedData({
       },
       WQSCalculations,
       WQSFinalValue: {
-        landArea: property.titles
-          ? convertLandTitlesToLandArea({ titles: property.titles })
-          : undefined,
-        usableArea: (property?.usableArea as number) ?? undefined,
+        landArea: property.totalLandAreaInSqWa ? Number(property.totalLandAreaInSqWa) : undefined,
+        usableArea: property.totalBuildingArea
+          ? Number(property.totalBuildingArea)
+          : property.usableArea
+            ? Number(property.usableArea)
+            : undefined,
         finalValue: 0,
         finalValueRounded: 0,
         coefficientOfDecision: 0,

--- a/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
@@ -420,7 +420,9 @@ export const DirectComparisonScoringSection = ({
                       inputType="display"
                       accessor={({ value }) => {
                         if (!value) return '';
-                        const unit = survey.offerPriceUnit ? getParameterDescription('MeasurementUnits', survey.offerPriceUnit) : '';
+                        const unit = survey.offerPriceUnit
+                          ? getParameterDescription('MeasurementUnits', survey.offerPriceUnit)
+                          : '';
                         return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();
                       }}
                     />
@@ -504,7 +506,9 @@ export const DirectComparisonScoringSection = ({
                       inputType="display"
                       accessor={({ value }) => {
                         if (!value) return '';
-                        const unit = survey.salePriceUnit ? getParameterDescription('MeasurementUnits', survey.salePriceUnit) : '';
+                        const unit = survey.salePriceUnit
+                          ? getParameterDescription('MeasurementUnits', survey.salePriceUnit)
+                          : '';
                         return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();
                       }}
                     />
@@ -617,7 +621,7 @@ export const DirectComparisonScoringSection = ({
             </tr>
 
             {/* 2nd revision */}
-            {(groupCollateralType === 'LB' || groupCollateralType === 'C') && (
+            {(groupCollateralType === 'LB' || groupCollateralType === 'U') && (
               <DirectComparisonSecondRevision
                 comparativeSurveys={comparativeSurveys}
                 collateralType={groupCollateralType}

--- a/src/features/pricingAnalysis/components/DirectComparisonSecondRevision.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonSecondRevision.tsx
@@ -123,7 +123,7 @@ export function DirectComparisonSecondRevision({
           </tr>
         </>
       )}
-      {(collateralType === 'LB' || collateralType === 'C') && (
+      {(collateralType === 'LB' || collateralType === 'U') && (
         <>
           <tr>
             <td className={clsx('bg-white', leftColumnBody, bgGradient)}>

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
@@ -618,7 +618,7 @@ export const SaleAdjustmentGridScoringSection = ({
             </tr>
 
             {/* 2nd revision */}
-            {(groupCollateralType === 'LB' || groupCollateralType === 'C') && (
+            {(groupCollateralType === 'LB' || groupCollateralType === 'U') && (
               <SaleAdjustmentGridSecondRevision
                 comparativeSurveys={comparativeSurveys}
                 collateralType={groupCollateralType}

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridSecondRevision.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridSecondRevision.tsx
@@ -121,7 +121,7 @@ export function SaleAdjustmentGridSecondRevision({
           </tr>
         </>
       )}
-      {(collateralType === 'LB' || collateralType === 'C') && (
+      {(collateralType === 'LB' || collateralType === 'U') && (
         <>
           <tr>
             <td className={clsx('bg-white', leftColumnBody, bgGradient)}>

--- a/src/features/pricingAnalysis/components/WQSAdjustFinalValueSection.tsx
+++ b/src/features/pricingAnalysis/components/WQSAdjustFinalValueSection.tsx
@@ -3,7 +3,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { Icon } from '@/shared/components';
 import { RHFInputCell } from './table/RHFInputCell';
 import { wqsFieldPath } from '../adapters/wqsFieldPath';
-import { toFiniteNumber } from '@features/pricingAnalysis/domain/calculateWQS.ts';
+import { round2, toFiniteNumber } from '@features/pricingAnalysis/domain/calculateWQS.ts';
 import {
   type DerivedFieldRule,
   useDerivedFields,
@@ -17,6 +17,7 @@ export const AdjustFinalValueSection = ({ property }: { property: Record<string,
     finalValueLandArea: landAreaPath,
     finalValueUsableArea: usableAreaPath,
     finalValueFinalValueRounded: finalValueRoundedPath,
+    finalValueAppraisalPrice: finalValueAppraisalPricePath,
     finalValueAppraisalPriceRounded: appraisalPriceRoundedPath,
     finalValuePriceDifferentiate: priceDifferentiatePath,
   } = wqsFieldPath;
@@ -31,11 +32,31 @@ export const AdjustFinalValueSection = ({ property }: { property: Record<string,
 
   const rules: DerivedFieldRule[] = [
     {
-      targetPath: appraisalPriceRoundedPath(),
+      targetPath: finalValueAppraisalPricePath(),
       deps: [finalValueRoundedPath()],
-      compute: ({ getValues }) => Number(getValues(finalValueRoundedPath())) || 0,
+      compute: ({ getValues }) => {
+        const finalValueRounded = getValues(finalValueRoundedPath()) ?? 0;
+
+        const isIncludeLandArea = getValues(includeLandAreaPath());
+        const landArea = getValues(landAreaPath());
+        if (isIncludeLandArea && !!landArea) {
+          return round2(finalValueRounded * (landArea ?? 0));
+        }
+
+        const usableArea = getValues(usableAreaPath());
+        if (isIncludeLandArea && !!usableArea) {
+          return round2(finalValueRounded * (usableArea ?? 0));
+        }
+
+        return finalValueRounded;
+      },
+    },
+    {
+      targetPath: appraisalPriceRoundedPath(),
+      deps: [finalValueAppraisalPricePath()],
+      compute: ({ getValues }) => Number(getValues(finalValueAppraisalPricePath())) || 0,
       when: ({ getValues }) => {
-        const depValue = Number(getValues(finalValueRoundedPath())) || 0;
+        const depValue = Number(getValues(finalValueAppraisalPricePath())) || 0;
         const current = Number(getValues(appraisalPriceRoundedPath())) || 0;
 
         if (prevFinalValueRef.current === null) {
@@ -137,7 +158,9 @@ export const AdjustFinalValueSection = ({ property }: { property: Record<string,
               const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
               const icon = num > 0 ? 'arrow-up' : 'arrow-down';
               return (
-                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}>
+                <span
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
+                >
                   <Icon name={icon} style="solid" className="size-3" />
                   {Math.abs(num).toLocaleString()}
                 </span>
@@ -148,14 +171,14 @@ export const AdjustFinalValueSection = ({ property }: { property: Record<string,
       </div>
 
       {/* Include building cost toggle */}
-      <div className="flex items-center gap-4">
+      {/* <div className="flex items-center gap-4">
         <span className="w-44 text-gray-500">Include building cost</span>
         <RHFInputCell
           fieldName={hasBuildingCostPath()}
           inputType="toggle"
           toggle={{ checked: false, options: ['No', 'Yes'] }}
         />
-      </div>
+      </div> */}
     </div>
   );
 };


### PR DESCRIPTION
- Replace title-based area conversion with totalLandAreaInSqWa/totalBuildingArea (and fall back to usableArea) when initializing and restoring wqs, direct-comparison and sale-adjustment forms.
- Pass landArea and usableArea paths into derived-rule builders and switch derived computations to use getValues(...) for property area and price lookups (use calculationLandPricePath/calculationUsableAreaPricePath).
- Update survey factor codes used for land and usable area lookups (survey factor codes changed to '02' and '14').
- Apply minor formatting/refactorings in restore functions and sorting/mapping.
- Replace collateral-type checks to use 'U' instead of 'C' for rendering 2nd-revision sections in direct-comparison and sale-adjustment components.
- Update WQS final value logic.
- add finalValueAppraisalPrice derived field that multiplies finalValueRounded by land or usable area when includeLandArea is set, and wire appraisalPriceRounded to that derived value.
- comment out the "Include building cost" toggle.
- Remove usages and imports of convertLandTitlesToLandArea across pricingAnalysis adapters and switch to using explicit area fields (totalLandAreaInSqWa and totalBuildingArea) with fallbacks to usableArea where appropriate.
- Affected files: BuildDirectComparisonDerivedRule, InitializeDirectComparisonForm, DirectComparisonScoringSection, DirectComparisonSecondRevision, restoreDirectComparisonFromSavedData, InitializeSaleAdjustmentGridForm, BuildSaleAdjustmentGridDerivedRule, restoreSaleAdjustmentGridFromSavedDate, SaleAdjustmentGridScoringSection, SaleAdjustmentGridSecondRevision, InitializeWQSForm, WQSAdjustFinalValueSection, restoreWQSFromSavedData.