### PR TITLE
Add manual entry mode for pricing analysis and UI enhancements

### DIFF
--- a/src/app/AppraisalLayout.tsx
+++ b/src/app/AppraisalLayout.tsx
@@ -19,8 +19,12 @@ import { useDisclosure } from '@shared/hooks/useDisclosure';
 import { useUIStore } from '@shared/store';
 
 const userNavigation = [
-  { name: 'Your profile', href: '#' },
-  { name: 'Sign out', href: '#' },
+  { name: 'Your profile', nameKey: 'userMenu.yourProfile', href: '#' },
+  {
+    name: 'Sign out',
+    nameKey: 'userMenu.signOut',
+    href: `${import.meta.env.VITE_API_URL}/connect/logout?client_id=spa&post_logout_redirect_uri=${import.meta.env.VITE_APP_URL}/`,
+  },
 ];
 
 // Map route segments to page labels

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -24,7 +24,7 @@ const userNavigation = [
   {
     name: 'Sign out',
     nameKey: 'userMenu.signOut',
-    href: 'https://localhost:7111/connect/logout?client_id=spa&post_logout_redirect_uri=https://localhost:3000/',
+    href: `${import.meta.env.VITE_API_URL}/connect/logout?client_id=spa&post_logout_redirect_uri=${import.meta.env.VITE_APP_URL}/`,
   },
 ];
 

--- a/src/features/appraisal/components/AppraisalRightMenu.tsx
+++ b/src/features/appraisal/components/AppraisalRightMenu.tsx
@@ -9,6 +9,7 @@ import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { useAppraisalContext, useAppraisalReadOnly } from '../context/AppraisalContext';
 import { MapPreview } from './MapPreview';
 import { useAuthStore } from '@/features/auth/store';
+import { useAddressStore } from '@/shared/store';
 import {
   useAddComment,
   useUpdateComment,
@@ -58,6 +59,15 @@ const AppraisalRightMenu = ({ onClose }: AppraisalRightMenuProps) => {
     if (fees.length === 0) return null;
     return fees[0];
   }, [fees]);
+
+  // Resolve province code to name via address store
+  const titleAddresses = useAddressStore(state => state.titleAddresses);
+  const provinceName = useMemo(() => {
+    const code = (requestData as any)?.detail?.address?.province;
+    if (!code) return null;
+    const match = titleAddresses.find(a => a.provinceCode === code);
+    return match?.provinceName ?? null;
+  }, [requestData, titleAddresses]);
 
   // API queries and mutations for comments
   const { data: commentsData, isLoading: isCommentsLoading } = useGetComments(requestId);
@@ -268,13 +278,81 @@ const AppraisalRightMenu = ({ onClose }: AppraisalRightMenuProps) => {
       >
         {activeTab === 'overview' ? (
           <div className="flex flex-col gap-5">
-            {/* Status & Type */}
+            {/* Appraisal Info */}
             <div>
-              <SidebarLabel>Status</SidebarLabel>
+              <SidebarLabel>Appraisal Info</SidebarLabel>
               <div className="mt-2 space-y-2">
-                <div className="flex items-center gap-2">
-                  <Badge type="status" value={appraisal.status || 'draft'} />
-                </div>
+                <InfoRow
+                  icon="hashtag"
+                  label="Appraisal No."
+                  value={appraisal.appraisalReportNo || 'Not set'}
+                  muted={!appraisal.appraisalReportNo}
+                />
+                <InfoRow
+                  icon="user"
+                  label="Customer"
+                  value={(requestData as any)?.customers?.[0]?.name || 'Not set'}
+                  muted={!(requestData as any)?.customers?.[0]?.name}
+                />
+                <InfoRow
+                  icon="bullseye"
+                  label="Purpose"
+                  value={
+                    requestData?.purpose ? (
+                      <ParameterDisplay group="AppraisalPurpose" code={requestData?.purpose} />
+                    ) : (
+                      'Not set'
+                    )
+                  }
+                  muted={!requestData?.purpose}
+                />
+                <InfoRow
+                  icon="circle-check"
+                  label="Status"
+                  value={<Badge type="status" value={appraisal.status || 'draft'} />}
+                />
+                <InfoRow
+                  icon="baht-sign"
+                  label="Selling Price"
+                  value={formatCurrency((requestData as any)?.detail?.loanDetail?.totalSellingPrice)}
+                  muted={(requestData as any)?.detail?.loanDetail?.totalSellingPrice == null}
+                />
+                <InfoRow
+                  icon="book"
+                  label="Customer's Own Book"
+                  value={
+                    (requestData as any)?.detail?.hasAppraisalBook != null
+                      ? (requestData as any)?.detail?.hasAppraisalBook
+                        ? 'Yes'
+                        : 'No'
+                      : 'Not set'
+                  }
+                  muted={(requestData as any)?.detail?.hasAppraisalBook == null}
+                />
+                <InfoRow
+                  icon="location-dot"
+                  label="Province"
+                  value={provinceName || 'Not set'}
+                  muted={!provinceName}
+                />
+                <InfoRow
+                  icon="calendar"
+                  label="Requested At"
+                  value={formatDateTime((requestData as any)?.requestedAt)}
+                  muted={!(requestData as any)?.requestedAt}
+                />
+                <InfoRow
+                  icon="flag"
+                  label="Priority"
+                  value={<Badge type="priority" value={appraisal.priority || 'normal'} />}
+                />
+              </div>
+            </div>
+
+            {/* Workflow Progress */}
+            <div>
+              <SidebarLabel>Workflow Progress</SidebarLabel>
+              <div className="mt-2">
                 <InfoRow
                   icon="diagram-project"
                   label="Type"
@@ -287,33 +365,6 @@ const AppraisalRightMenu = ({ onClose }: AppraisalRightMenuProps) => {
                   }
                   muted={!appraisal.appraisalType}
                 />
-              </div>
-            </div>
-
-            {/* Purpose (from request) */}
-            <div>
-              <SidebarLabel>Purpose</SidebarLabel>
-              <div className="mt-2">
-                <InfoRow
-                  icon="bullseye"
-                  label="Type"
-                  value={
-                    requestData?.purpose ? (
-                      <ParameterDisplay group="AppraisalPurpose" code={requestData?.purpose} />
-                    ) : (
-                      'Not set'
-                    )
-                  }
-                  muted={!requestData?.purpose}
-                />
-              </div>
-            </div>
-
-            {/* Priority */}
-            <div>
-              <SidebarLabel>Priority</SidebarLabel>
-              <div className="mt-2">
-                <Badge type="priority" value={appraisal.priority || 'normal'} />
               </div>
             </div>
 

--- a/src/features/appraisal/components/GroupContainer.tsx
+++ b/src/features/appraisal/components/GroupContainer.tsx
@@ -142,14 +142,11 @@ export const GroupContainer = React.memo(
           </div>
           <div className="flex items-center gap-2">
             <button
-              className="px-2 py-1 bg-orange-100 text-orange-700 hover:text-red-500 hover:bg-red-50 cursor-pointer rounded text-[14px] font-medium"
+              className="p-2 text-gray-500 hover:text-orange-600 hover:bg-orange-50 cursor-pointer rounded-md transition-colors"
               onClick={() => handleOnClickPricingButton()}
-              title="Appraise Collateral"
+              title="Pricing Analysis"
             >
-              <div className="flex flex-row items-center justify-center gap-1">
-                <Icon name="badge-dollar" className="text-xl" />
-                AP
-              </div>
+              <Icon name="badge-dollar" className="text-lg" />
             </button>
           </div>
         </div>

--- a/src/features/appraisal/components/PropertyCardContent.tsx
+++ b/src/features/appraisal/components/PropertyCardContent.tsx
@@ -2,7 +2,7 @@ import type { PropertyItem } from '../types';
 import Icon from '@shared/components/Icon';
 import ParameterDisplay from '@shared/components/ParameterDisplay';
 
-type CardSize = 'sm' | 'md';
+type CardSize = 'xs' | 'sm' | 'md';
 
 interface PropertyCardContentProps {
   property: PropertyItem;
@@ -14,6 +14,14 @@ interface PropertyCardContentProps {
 }
 
 const sizeConfig = {
+  xs: {
+    image: 'w-10 h-10',
+    title: 'text-[11px] line-clamp-1',
+    text: 'text-[10px]',
+    iconSize: 'text-[8px]',
+    padding: 'px-2 py-1',
+    gap: 'gap-1',
+  },
   sm: {
     image: 'w-20 min-h-[80px]',
     title: 'text-xs line-clamp-2',
@@ -50,56 +58,76 @@ export function PropertyCardContent({
       className={`flex flex-1 ${onClick ? 'cursor-pointer hover:bg-gray-50/50' : ''} transition-colors`}
     >
       {/* Property Image */}
-      <div className={`relative ${cfg.image} bg-gray-100 flex-shrink-0`}>
+      <div className={`relative ${cfg.image} bg-gray-100 flex-shrink-0 ${size === 'xs' ? 'rounded' : ''}`}>
         {property.image ? (
           <img
             src={property.image}
             alt={property.address}
             loading="lazy"
             decoding="async"
-            className="w-full h-full object-cover"
+            className={`w-full h-full object-cover ${size === 'xs' ? 'rounded' : ''}`}
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
-            <Icon name="image" className="text-gray-400 text-2xl" />
+            <Icon name="image" className={`text-gray-400 ${size === 'xs' ? 'text-sm' : 'text-2xl'}`} />
           </div>
         )}
-        <div className="absolute top-2 left-2 bg-white rounded-full p-1 shadow-sm">
-          <Icon name="location-dot" className="text-green-500 text-[10px]" style="solid" />
-        </div>
+        {size !== 'xs' && (
+          <div className="absolute top-2 left-2 bg-white rounded-full p-1 shadow-sm">
+            <Icon name="location-dot" className="text-green-500 text-[10px]" style="solid" />
+          </div>
+        )}
       </div>
 
       {/* Property Details */}
-      <div className={`flex-1 ${cfg.padding} flex flex-col justify-between min-w-0`}>
-        <div>
-          <h3
-            className={`font-medium text-gray-900 ${cfg.title}`}
-            title={property.address}
-          >
-            {property.address}
-          </h3>
-
-          <ParameterDisplay
-            group="PropertyType"
-            code={property.type}
-            fallback={property.type}
-            className={`${cfg.text} text-gray-500`}
-          />
-
-          <div className={`flex items-center ${cfg.gap} ${cfg.text} text-gray-500 mt-1`}>
-            <div className="flex items-center gap-1">
+      <div className={`flex-1 ${cfg.padding} flex ${size === 'xs' ? 'flex-row items-center gap-2' : 'flex-col justify-between'} min-w-0`}>
+        {size === 'xs' ? (
+          <>
+            <h3 className={`font-medium text-gray-900 ${cfg.title}`} title={property.address}>
+              {property.address}
+            </h3>
+            <ParameterDisplay
+              group="PropertyType"
+              code={property.type}
+              fallback={property.type}
+              className={`${cfg.text} text-gray-500 shrink-0`}
+            />
+            <div className={`flex items-center gap-1 ${cfg.text} text-gray-500 shrink-0`}>
               <Icon name="ruler-combined" className={`text-gray-400 ${cfg.iconSize}`} style="solid" />
               <span>{property.area}</span>
             </div>
-          </div>
+          </>
+        ) : (
+          <div>
+            <h3
+              className={`font-medium text-gray-900 ${cfg.title}`}
+              title={property.address}
+            >
+              {property.address}
+            </h3>
 
-          <div className={`flex items-center gap-1 ${cfg.text} text-gray-400 mt-0.5`}>
-            <Icon name="location-dot" className={cfg.iconSize} style="solid" />
-            <span className="truncate" title={property.location}>
-              {property.location}
-            </span>
+            <ParameterDisplay
+              group="PropertyType"
+              code={property.type}
+              fallback={property.type}
+              className={`${cfg.text} text-gray-500`}
+            />
+
+            <div className={`flex items-center ${cfg.gap} ${cfg.text} text-gray-500 mt-1`}>
+              <div className="flex items-center gap-1">
+                <Icon name="ruler-combined" className={`text-gray-400 ${cfg.iconSize}`} style="solid" />
+                <span>{property.area}</span>
+              </div>
+            </div>
+
+            <div className={`flex items-center gap-1 ${cfg.text} text-gray-400 mt-0.5`}>
+              <Icon name="location-dot" className={cfg.iconSize} style="solid" />
+              <span className="truncate" title={property.location}>
+                {property.location}
+              </span>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Arrow indicator */}

--- a/src/features/appraisal/components/tables/BuildingDetailPopUpModal.tsx
+++ b/src/features/appraisal/components/tables/BuildingDetailPopUpModal.tsx
@@ -237,7 +237,7 @@ function BuildingDetailPopUpModal({
                   <div className="col-span-3">
                     <FormBooleanToggle
                       label="Is Building"
-                      options={['Yes', 'No']}
+                      options={['No', 'Yes']}
                       name="isBuilding"
                     />
                   </div>

--- a/src/features/appraisal/forms/MarketComparableForm.tsx
+++ b/src/features/appraisal/forms/MarketComparableForm.tsx
@@ -2,10 +2,7 @@ import { type FormField, FormFields } from '@/shared/components/form';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
-import {
-  useGetMarketComparableTemplate,
-  useGetMarketComparableTemplateById,
-} from '../api/marketComparable';
+import { useGetMarketComparableTemplate, useGetMarketComparableTemplateById, } from '../api/marketComparable';
 import { useSearchParams } from 'react-router-dom';
 import Icon from '@/shared/components/Icon';
 import { getTranslatedFactorName } from '@shared/utils/translationUtils';
@@ -59,7 +56,7 @@ const FactorsSkeleton = () => (
 );
 
 const MarketComparableForm = () => {
-  const language = useLocaleStore((s) => s.language);
+  const language = useLocaleStore(s => s.language);
   const { getValues, setValue, reset } = useFormContext();
   const [isTemplateChanged, setIsTemplateChanged] = useState(false);
   const isInitialSetup = useRef(true);
@@ -185,6 +182,8 @@ const MarketComparableForm = () => {
       wrapperClassName: 'col-span-8',
       maxIntegerDigits: 15,
       decimalPlaces: 2,
+      disableWhen: { field: 'salePrice', operator: 'isNotEmpty' },
+      disabledValue: null,
     },
     {
       type: 'dropdown',
@@ -192,6 +191,8 @@ const MarketComparableForm = () => {
       label: '',
       group: 'MeasurementUnits',
       wrapperClassName: 'col-span-4',
+      disableWhen: { field: 'salePrice', operator: 'isNotEmpty' },
+      disabledValue: null,
     },
     {
       type: 'number-input',
@@ -200,6 +201,8 @@ const MarketComparableForm = () => {
       wrapperClassName: 'col-span-8',
       maxIntegerDigits: 15,
       decimalPlaces: 2,
+      disableWhen: { field: 'offerPrice', operator: 'isNotEmpty' },
+      disabledValue: null,
     },
     {
       type: 'dropdown',
@@ -207,12 +210,16 @@ const MarketComparableForm = () => {
       label: '',
       group: 'MeasurementUnits',
       wrapperClassName: 'col-span-4',
+      disableWhen: { field: 'offerPrice', operator: 'isNotEmpty' },
+      disabledValue: null,
     },
     {
       type: 'date-input',
       name: 'saleDate',
       label: '',
       wrapperClassName: 'col-span-12',
+      disableWhen: { field: 'offerPrice', operator: 'isNotEmpty' },
+      disabledValue: null,
     },
   ];
 
@@ -284,7 +291,11 @@ const MarketComparableForm = () => {
               {factors.map((fac: any, index: number) => {
                 const fields: FormField[] = [buildFormField(fac, index)];
                 return (
-                  <SectionRow key={fac.factorCode} title={getTranslatedFactorName(fac.translations, language)} icon="sliders">
+                  <SectionRow
+                    key={fac.factorCode}
+                    title={getTranslatedFactorName(fac.translations, language)}
+                    icon="sliders"
+                  >
                     <FormFields fields={fields} />
                   </SectionRow>
                 );

--- a/src/features/appraisal/pages/PropertyInformationPage.tsx
+++ b/src/features/appraisal/pages/PropertyInformationPage.tsx
@@ -25,7 +25,7 @@ const TABS: Tab[] = [
   { id: 'markets', label: 'Markets', icon: 'chart-line' },
   { id: 'gallery', label: 'Gallery', icon: 'images' },
   { id: 'photos', label: 'Photos', icon: 'camera' },
-  { id: 'laws', label: 'Laws', icon: 'gavel' },
+  { id: 'laws', label: 'Laws & Regulations', icon: 'gavel' },
 ];
 
 const VALID_TABS: TabId[] = ['properties', 'markets', 'gallery', 'photos', 'laws'];
@@ -42,7 +42,9 @@ export default function PropertyInformationPage() {
   const renderTabContent = () => {
     switch (activeTab) {
       case 'properties':
-        return <PropertiesTab viewMode={viewMode} onViewModeChange={setViewMode} readOnly={isReadOnly} />;
+        return (
+          <PropertiesTab viewMode={viewMode} onViewModeChange={setViewMode} readOnly={isReadOnly} />
+        );
       case 'markets':
         return <MarketsTab readOnly={isReadOnly} />;
       case 'gallery':

--- a/src/features/pricingAnalysis/components/DirectComparisonPanel.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonPanel.tsx
@@ -101,8 +101,6 @@ export function DirectComparisonPanel({
   const selectedTemplateId = (templateList ?? []).find(t => t.templateCode === selectedTemplateCode)?.id;
   const templateDetailQuery = useGetComparativeAnalysisTemplateById(selectedTemplateId);
 
-  /** cancel calculation dialog state */
-  const [isShowCanceledDialog, setisShowCanceledDialog] = useState<boolean>(false);
   const [isShowResetDialog, setIsShowResetDialog] = useState<boolean>(false);
 
   const saveMutation = useSaveComparativeAnalysis();
@@ -182,20 +180,6 @@ export function DirectComparisonPanel({
 
   const handleOnSelectTemplate = (templateCode: string) => {
     setSelectedTemplateCode(templateCode);
-  };
-
-  /** cancel calculation handler */
-  const handleOnCancelCalculationMethod = () => {
-    setisShowCanceledDialog(true);
-  };
-
-  const handleOnConfirmCancelCalculationMethod = () => {
-    onCancelCalculationMethod();
-    setisShowCanceledDialog(false);
-  };
-
-  const handleOnDenyCancelCalculationMethod = () => {
-    setisShowCanceledDialog(false);
   };
 
   /** reset handler */
@@ -372,19 +356,13 @@ export function DirectComparisonPanel({
               />
             </div>
             <MethodFooterActions
-              onCancel={handleOnCancelCalculationMethod}
+              onCancel={onCancelCalculationMethod}
               onReset={handleOnReset}
               showReset={!!savedComparativeFactors && savedComparativeFactors.length > 0}
               isSubmitting={saveMutation.isPending}
             />
           </>
         )}
-        <ConfirmDialog
-          isOpen={isShowCanceledDialog}
-          onClose={handleOnDenyCancelCalculationMethod}
-          onConfirm={handleOnConfirmCancelCalculationMethod}
-          message={`Are you sure? If you confirm the calculation value of this method will be removed.`}
-        />
         <ConfirmDialog
           isOpen={isShowResetDialog}
           onClose={() => setIsShowResetDialog(false)}

--- a/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonScoringSection.tsx
@@ -1,5 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { format } from 'date-fns';
 import { ServerDataCtx } from '@features/pricingAnalysis/store/selectionContext';
 import { Icon } from '@/shared/components';
@@ -35,6 +35,8 @@ import type {
 } from '@features/pricingAnalysis/schemas';
 import { FactorValueDisplay } from './FactorValueDisplay';
 import { ScrollableTableContainer } from './ScrollableTableContainer';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+import { MarketComparableDetailModal } from './MarketComparableDetailModal';
 
 interface DirectComparisonScoringSectionProps {
   comparativeSurveys: MarketComparableDetailType[];
@@ -83,6 +85,9 @@ export const DirectComparisonScoringSection = ({
 
   const serverData = useContext(ServerDataCtx);
   const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
+  const [selectedSurveyId, setSelectedSurveyId] = useState<string | null>(null);
+  const { isOpen: isModalOpen, onOpen: onModalOpen, onClose: onModalClose } = useDisclosure();
+
   const language = useLocaleStore(s => s.language);
   const { control, getValues, setValue } = useFormContext();
   const {
@@ -232,7 +237,17 @@ export const DirectComparisonScoringSection = ({
                       'bg-gray-50 font-medium text-center px-3 py-2.5 border-r border-b border-gray-300 sticky top-[32px] h-[32px] min-h-[32px] max-h-[32px] z-23 whitespace-nowrap min-w-[250px]'
                     }
                   >
-                    <div>{survey.surveyName}</div>
+                    <div className="flex items-center justify-center gap-1.5">
+                      <span>{survey.surveyName}</span>
+                      <button
+                        type="button"
+                        className="text-gray-500 hover:text-primary-600 transition-colors"
+                        onClick={() => { setSelectedSurveyId(survey.id ?? null); onModalOpen(); }}
+                        title="View market comparable detail"
+                      >
+                        <Icon name="arrow-up-right-from-square" style="solid" className="size-3.5" />
+                      </button>
+                    </div>
                   </th>
                 );
               })}
@@ -839,6 +854,11 @@ export const DirectComparisonScoringSection = ({
           </tbody>
         </table>
       </ScrollableTableContainer>
+      <MarketComparableDetailModal
+        isOpen={isModalOpen}
+        onClose={onModalClose}
+        marketComparableId={selectedSurveyId}
+      />
     </div>
   );
 };

--- a/src/features/pricingAnalysis/components/MarketComparableDetailModal.tsx
+++ b/src/features/pricingAnalysis/components/MarketComparableDetailModal.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import Modal from '@/shared/components/Modal';
+import { FormReadOnlyContext } from '@/shared/components/form/context';
+import {
+  useGetMarketComparableById,
+  useGetMarketComparableTemplateById,
+} from '@/features/appraisal/api/marketComparable';
+import MarketComparableForm from '@/features/appraisal/forms/MarketComparableForm';
+import {
+  createMarketComparableForm,
+  createMarketComparableFormDefault,
+  type createMarketComparableFormType,
+} from '@/features/appraisal/schemas/form';
+
+interface MarketComparableDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  marketComparableId: string | null;
+}
+
+export function MarketComparableDetailModal({
+  isOpen,
+  onClose,
+  marketComparableId,
+}: MarketComparableDetailModalProps) {
+  const { data: marketComparable, isLoading: isLoadingComparable } =
+    useGetMarketComparableById(marketComparableId ?? undefined);
+  const { data: template, isLoading: isLoadingTemplate } =
+    useGetMarketComparableTemplateById(
+      marketComparable?.marketComparable.templateId ?? undefined,
+    );
+
+  const isLoading = isLoadingComparable || isLoadingTemplate;
+
+  const mapComparableToForm = useMemo(() => {
+    if (!marketComparable || !template) return null;
+
+    const factorDataValue = template.template.factors
+      .map((factor: any) => {
+        const found = marketComparable.marketComparable.factorData.find(
+          (ed: any) => ed.factorId === factor.factorId,
+        );
+        if (!found) return undefined;
+        if (factor.dataType === 'Checkbox') {
+          return { ...found, value: found.value === true || found.value === 'true' };
+        }
+        if (factor.dataType === 'CheckboxGroup') {
+          let parsed = found.value;
+          if (typeof found.value === 'string') {
+            try {
+              parsed = JSON.parse(found.value);
+            } catch {
+              parsed = [];
+            }
+          }
+          return { ...found, value: Array.isArray(parsed) ? parsed : [] };
+        }
+        return found;
+      })
+      .filter(Boolean);
+
+    return {
+      surveyName: marketComparable.marketComparable.surveyName,
+      propertyType: marketComparable.marketComparable.propertyType,
+      templateCode: template.template.templateCode,
+      infoDateTime: marketComparable.marketComparable.infoDateTime,
+      notes: marketComparable.marketComparable.notes,
+      sourceInfo: marketComparable.marketComparable.sourceInfo,
+      templateId: marketComparable.marketComparable.templateId,
+      offerPrice: marketComparable.marketComparable.offerPrice ?? null,
+      offerPriceUnit: marketComparable.marketComparable.offerPriceUnit ?? null,
+      salePrice: marketComparable.marketComparable.salePrice ?? null,
+      salePriceUnit: marketComparable.marketComparable.salePriceUnit ?? null,
+      saleDate: marketComparable.marketComparable.saleDate ?? null,
+      factorData: factorDataValue,
+    };
+  }, [marketComparable, template]);
+
+  const methods = useForm<createMarketComparableFormType>({
+    defaultValues: createMarketComparableFormDefault,
+    resolver: zodResolver(createMarketComparableForm),
+  });
+
+  useEffect(() => {
+    if (mapComparableToForm) {
+      methods.reset(mapComparableToForm);
+    }
+  }, [mapComparableToForm, methods]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Market Comparable Detail" size="3xl">
+      <div className="max-h-[75vh] overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary-600" />
+          </div>
+        ) : (
+          <div key={marketComparableId}>
+            <FormProvider {...methods}>
+              <FormReadOnlyContext.Provider value={true}>
+                <MarketComparableForm />
+              </FormReadOnlyContext.Provider>
+            </FormProvider>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
@@ -5,6 +5,7 @@ import { WQSPanel } from '@features/pricingAnalysis/components/WQSPanel.tsx';
 import type { PricingServerData } from '../types/selection';
 import type { GetComparativeFactorsResponseType } from '../schemas';
 import type { TemplateDtoType } from '@/shared/schemas/v1';
+import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
 
 interface MethodSectionRendererProps {
   state: SelectionState;
@@ -30,10 +31,20 @@ export function MethodSectionRenderer({
   onCalculationMethodDirty,
   onCancelCalculationMethod,
 }: MethodSectionRendererProps) {
+  const groupCollateralType = deriveGroupCollateralType(
+    serverData.groupDetail?.properties ?? [],
+  );
+
+  const filteredMarketSurveys = groupCollateralType
+    ? serverData.marketSurveyDetails.filter(
+        s => s.propertyType === groupCollateralType,
+      )
+    : serverData.marketSurveyDetails;
+
   const panelProps = {
     activeMethod: state.activeMethod,
     property: serverData.properties,
-    marketSurveys: serverData.marketSurveyDetails,
+    marketSurveys: filteredMarketSurveys,
     allFactors: serverData.allFactors,
     templateList: calculationMethodData.templateList,
     linkedComparables: calculationMethodData.comparativeFactors?.linkedComparables,

--- a/src/features/pricingAnalysis/components/PricingAnalysisTemplateSelector.tsx
+++ b/src/features/pricingAnalysis/components/PricingAnalysisTemplateSelector.tsx
@@ -30,7 +30,7 @@ export function PricingAnalysisTemplateSelector({
         </div>
         <h2 className="text-lg font-semibold text-gray-900">{methodName}</h2>
       </div>
-      <div className="flex items-end gap-4 rounded-lg border border-gray-200 bg-gray-50/50 p-4">
+      <div className="flex items-center gap-4 rounded-lg border border-gray-200 bg-gray-50/50 p-4">
         <div className="flex h-full items-center text-sm font-medium text-gray-600 shrink-0">
           Pricing Analysis Template
         </div>

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridPanel.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridPanel.tsx
@@ -104,8 +104,6 @@ export function SaleAdjustmentGridPanel({
   const selectedTemplateId = (templateList ?? []).find(t => t.templateCode === selectedTemplateCode)?.id;
   const templateDetailQuery = useGetComparativeAnalysisTemplateById(selectedTemplateId);
 
-  /** cancel calculation dialog state */
-  const [isShowCanceledDialog, setisShowCanceledDialog] = useState<boolean>(false);
   const [isShowResetDialog, setIsShowResetDialog] = useState<boolean>(false);
 
   const saveMutation = useSaveComparativeAnalysis();
@@ -186,20 +184,6 @@ export function SaleAdjustmentGridPanel({
 
   const handleOnSelectTemplate = (templateCode: string) => {
     setSelectedTemplateCode(templateCode);
-  };
-
-  /** cancel calculation handler */
-  const handleOnCancelCalculationMethod = () => {
-    setisShowCanceledDialog(true);
-  };
-
-  const handleOnConfirmCancelCalculationMethod = () => {
-    onCancelCalculationMethod();
-    setisShowCanceledDialog(false);
-  };
-
-  const handleOnDenyCancelCalculationMethod = () => {
-    setisShowCanceledDialog(false);
   };
 
   /** reset handler */
@@ -368,19 +352,13 @@ export function SaleAdjustmentGridPanel({
               />
             </div>
             <MethodFooterActions
-              onCancel={handleOnCancelCalculationMethod}
+              onCancel={onCancelCalculationMethod}
               onReset={handleOnReset}
               showReset={!!savedComparativeFactors && savedComparativeFactors.length > 0}
               isSubmitting={saveMutation.isPending}
             />
           </>
         )}
-        <ConfirmDialog
-          isOpen={isShowCanceledDialog}
-          onClose={handleOnDenyCancelCalculationMethod}
-          onConfirm={handleOnConfirmCancelCalculationMethod}
-          message={`Are you sure? If you confirm the calculation value of this method will be removed.`}
-        />
         <ConfirmDialog
           isOpen={isShowResetDialog}
           onClose={() => setIsShowResetDialog(false)}

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridScoringSection.tsx
@@ -1,5 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { format } from 'date-fns';
 import { ServerDataCtx } from '@features/pricingAnalysis/store/selectionContext';
 import { Icon } from '@/shared/components';
@@ -30,6 +30,8 @@ import { deriveGroupCollateralType } from '@features/pricingAnalysis/domain/deri
 import { getFactorDesciption } from '@features/pricingAnalysis/domain/getFactorDescription.ts';
 import { useLocaleStore } from '@shared/store';
 import { ScrollableTableContainer } from './ScrollableTableContainer';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+import { MarketComparableDetailModal } from './MarketComparableDetailModal';
 
 interface SaleAdjustmentGridScoringSectionProps {
   comparativeSurveys: MarketComparableDetailType[];
@@ -77,6 +79,9 @@ export const SaleAdjustmentGridScoringSection = ({
     finalValue: finalValuePath,
     finalValueRounded: finalValueRoundedPath,
   } = saleGridFieldPath;
+
+  const [selectedSurveyId, setSelectedSurveyId] = useState<string | null>(null);
+  const { isOpen: isModalOpen, onOpen: onModalOpen, onClose: onModalClose } = useDisclosure();
 
   const serverData = useContext(ServerDataCtx);
   const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
@@ -230,7 +235,17 @@ export const SaleAdjustmentGridScoringSection = ({
                       'bg-gray-50 font-medium text-center px-3 py-2.5 border-r border-b border-gray-300 sticky top-[32px] h-[32px] min-h-[32px] max-h-[32px] z-23 whitespace-nowrap min-w-[250px]'
                     }
                   >
-                    <div>{survey.surveyName}</div>
+                    <div className="flex items-center justify-center gap-1.5">
+                      <span>{survey.surveyName}</span>
+                      <button
+                        type="button"
+                        className="text-gray-500 hover:text-primary-600 transition-colors"
+                        onClick={() => { setSelectedSurveyId(survey.id ?? null); onModalOpen(); }}
+                        title="View market comparable detail"
+                      >
+                        <Icon name="arrow-up-right-from-square" style="solid" className="size-3.5" />
+                      </button>
+                    </div>
                   </th>
                 );
               })}
@@ -890,6 +905,11 @@ export const SaleAdjustmentGridScoringSection = ({
           </tbody>
         </table>
       </ScrollableTableContainer>
+      <MarketComparableDetailModal
+        isOpen={isModalOpen}
+        onClose={onModalClose}
+        marketComparableId={selectedSurveyId}
+      />
     </div>
   );
 };

--- a/src/features/pricingAnalysis/components/WQSPanel.tsx
+++ b/src/features/pricingAnalysis/components/WQSPanel.tsx
@@ -102,8 +102,6 @@ export function WQSPanel({
   const selectedTemplateId = (templateList ?? []).find(t => t.templateCode === selectedTemplateCode)?.id;
   const templateDetailQuery = useGetComparativeAnalysisTemplateById(selectedTemplateId);
 
-  /** cancel calculation dialog state */
-  const [isShowCanceledDialog, setisShowCanceledDialog] = useState<boolean>(false);
   const [isShowResetDialog, setIsShowResetDialog] = useState<boolean>(false);
 
   const saveMutation = useSaveComparativeAnalysis();
@@ -184,20 +182,6 @@ export function WQSPanel({
 
   const handleOnSelectTemplate = (templateCode: string) => {
     setSelectedTemplateCode(templateCode);
-  };
-
-  /** cancel calculation handler */
-  const handleOnCancelCalculationMethod = () => {
-    setisShowCanceledDialog(true);
-  };
-
-  const handleOnConfirmCancelCalculationMethod = () => {
-    onCancelCalculationMethod();
-    setisShowCanceledDialog(false);
-  };
-
-  const handleOnDenyCancelCalculationMethod = () => {
-    setisShowCanceledDialog(false);
   };
 
   /** reset handler */
@@ -379,19 +363,13 @@ export function WQSPanel({
               />
             </div>
             <MethodFooterActions
-              onCancel={handleOnCancelCalculationMethod}
+              onCancel={onCancelCalculationMethod}
               onReset={handleOnReset}
               showReset={!!savedComparativeFactors && savedComparativeFactors.length > 0}
               isSubmitting={saveMutation.isPending}
             />
           </>
         )}
-        <ConfirmDialog
-          isOpen={isShowCanceledDialog}
-          onClose={handleOnDenyCancelCalculationMethod}
-          onConfirm={handleOnConfirmCancelCalculationMethod}
-          message={`Are you sure? If you confirm the calculation value of this method will be removed.`}
-        />
         <ConfirmDialog
           isOpen={isShowResetDialog}
           onClose={() => setIsShowResetDialog(false)}

--- a/src/features/pricingAnalysis/components/WQSScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/WQSScoringSection.tsx
@@ -1,5 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { ServerDataCtx } from '@features/pricingAnalysis/store/selectionContext';
 import { wqsFieldPath } from '../adapters/wqsFieldPath';
 import clsx from 'clsx';
@@ -27,6 +27,8 @@ import { getFactorDesciption } from '@features/pricingAnalysis/domain/getFactorD
 import { useLocaleStore } from '@shared/store';
 import { format } from 'date-fns';
 import { ScrollableTableContainer } from './ScrollableTableContainer';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+import { MarketComparableDetailModal } from './MarketComparableDetailModal';
 
 interface WQSScoringSectionProps {
   comparativeSurveys: MarketComparableDataType[];
@@ -80,6 +82,9 @@ export function WQSScoringSection({
     finalValueFinalValue: finalValueFinalValuePath,
     finalValueFinalValueRounded: finalValueFinalValueRoundedPath,
   } = wqsFieldPath;
+
+  const [selectedSurveyId, setSelectedSurveyId] = useState<string | null>(null);
+  const { isOpen: isModalOpen, onOpen: onModalOpen, onClose: onModalClose } = useDisclosure();
 
   const serverData = useContext(ServerDataCtx);
   const language = useLocaleStore(s => s.language);
@@ -240,7 +245,17 @@ export function WQSScoringSection({
                     }
                   >
                     <div className="flex flex-col">
-                      <div className="p-1">{survey.surveyName}</div>
+                      <div className="p-1 flex items-center justify-center gap-1.5">
+                        <span>{survey.surveyName}</span>
+                        <button
+                          type="button"
+                          className="text-gray-500 hover:text-primary-600 transition-colors"
+                          onClick={() => { setSelectedSurveyId(survey.id ?? null); onModalOpen(); }}
+                          title="View market comparable detail"
+                        >
+                          <Icon name="arrow-up-right-from-square" style="solid" className="size-3.5" />
+                        </button>
+                      </div>
                       <div className="flex flex-row justify-between items-center">
                         <span>Score</span>
                         <span>Weighted Score</span>
@@ -937,6 +952,11 @@ export function WQSScoringSection({
           </tbody>
         </table>
       </ScrollableTableContainer>
+      <MarketComparableDetailModal
+        isOpen={isModalOpen}
+        onClose={onModalClose}
+        marketComparableId={selectedSurveyId}
+      />
     </div>
   );
 }

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@/shared/components';
+import Badge from '@/shared/components/Badge';
 import clsx from 'clsx';
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { PricingAnalysisApproachMethodSelector } from './PricingAnalysisApproachMethodSelector';
@@ -35,7 +36,6 @@ interface PricingAnalysisAccordionProps {
   onCancelDeselectMethod: () => void;
   onSystemCalculationChange: (check: boolean) => void;
   systemCalculationMode: string;
-  onCancelPricingAccordion: () => void;
 
   onSelectCandidateMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCandidateApproach: (approachType: string) => void;
@@ -50,6 +50,7 @@ interface PricingAnalysisAccordionProps {
     confirmDelete: () => void;
     cancelDelete: () => void;
   };
+  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
 }
 
 export const PricingAnalysisAccordion = ({
@@ -70,7 +71,6 @@ export const PricingAnalysisAccordion = ({
   onCancelDeselectMethod,
   onSystemCalculationChange,
   systemCalculationMode,
-  onCancelPricingAccordion,
 
   onSelectCandidateMethod,
   onSelectCandidateApproach,
@@ -79,6 +79,7 @@ export const PricingAnalysisAccordion = ({
   onDeleteMethod,
   pricingConfiguration,
   deleteConfirm,
+  onManualValueChange,
 }: PricingAnalysisAccordionProps) => {
   /** Map group properties to PropertyItem for rendering */
   const propertyItems = useMemo(
@@ -89,6 +90,9 @@ export const PricingAnalysisAccordion = ({
         .map(mapGroupItemToPropertyItem),
     [group.properties],
   );
+
+  /** Find selected approach name for header badge */
+  const selectedApproach = state.summarySelected?.find(appr => appr.isSelected);
 
   /** accordion effect */
   const detailInnerRef = useRef<HTMLDivElement>(null);
@@ -114,8 +118,20 @@ export const PricingAnalysisAccordion = ({
     <div className="rounded-xl border border-gray-200 bg-white px-2">
       {/* header */}
       <div className="grid grid-cols-12 justify-between items-center h-12">
-        <div className="col-span-8">
-          <span>{`Group: ${group?.number ?? ''} ${group?.name ?? ''} ( ${group?.properties?.length ?? 0} item(s) )`}</span>
+        <div className="col-span-8 flex items-center gap-2">
+          <span className="font-semibold">{`Group: ${group?.number ?? ''} ${group?.name ?? ''}`}</span>
+          <span className="text-sm text-gray-400">{`${group?.properties?.length ?? 0} item(s)`}</span>
+          {selectedApproach && (
+            <Badge
+              size="xs"
+              badgeStyle="soft"
+              type="status"
+              value="inprogress"
+              dot={false}
+            >
+              {selectedApproach.label}
+            </Badge>
+          )}
         </div>
         <div className="col-span-4 flex items-center justify-end gap-1">
           <div className="flex flex-row gap-1 items-center justify-end">
@@ -191,7 +207,6 @@ export const PricingAnalysisAccordion = ({
                 onSummaryModeSave={onSummaryModeSave}
                 onToggleMethod={onToggleMethod}
                 onSelectCalculationMethod={onSelectCalculationMethod}
-                onCancelPricingAccordion={onCancelPricingAccordion}
                 onCancelEditMode={onCancelEditMode}
                 onSelectCandidateMethod={onSelectCandidateMethod}
                 onSelectCandidateApproach={onSelectCandidateApproach}
@@ -199,6 +214,7 @@ export const PricingAnalysisAccordion = ({
                 onDeleteMethod={onDeleteMethod}
                 pricingConfiguration={pricingConfiguration}
                 deleteConfirm={deleteConfirm}
+                onManualValueChange={onManualValueChange}
               />
             </div>
           </div>

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachAccordion.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachAccordion.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { PricingAnalysisApproachCard } from './PricingAnalysisApproachCard';
 import { PricingAnalysisMethodCard } from './PricingAnalysisMethodCard';
+import type { ViewLayout } from './PricingAnalysisMethodCard';
 import { Icon } from '@/shared/components';
 import type { Approach } from '../../types/selection';
 import type { PricingAnalysisConfigType } from '../../schemas';
@@ -9,6 +10,7 @@ import { useState } from 'react';
 
 interface PricingAnalysisApproachAccordionProps {
   viewMode: ViewMode;
+  viewLayout?: ViewLayout;
   approach: Approach;
   onToggleMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCalculationMethod: (arg: { approachType: string; methodType: string }) => void;
@@ -19,10 +21,14 @@ interface PricingAnalysisApproachAccordionProps {
   onAddMethod?: (arg: { approachType: string; methodType: string }) => void;
   onDeleteMethod?: (arg: { approachType: string; methodType: string }) => void;
   configMethods?: PricingAnalysisConfigType['methods'];
+  onViewLayoutChange?: (layout: ViewLayout) => void;
+  isManualMode?: boolean;
+  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
 }
 
 export const PricingAnalysisApproachAccordion = ({
   viewMode,
+  viewLayout = 'grid',
   approach,
   onToggleMethod,
   onSelectCalculationMethod,
@@ -33,6 +39,9 @@ export const PricingAnalysisApproachAccordion = ({
   onAddMethod,
   onDeleteMethod,
   configMethods,
+  onViewLayoutChange,
+  isManualMode,
+  onManualValueChange,
 }: PricingAnalysisApproachAccordionProps) => {
   const hasSelectedMethods = approach.methods.some(m => m.isIncluded);
   const [isOpen, setIsOpen] = useState(viewMode === 'editing' ? true : false);
@@ -44,6 +53,8 @@ export const PricingAnalysisApproachAccordion = ({
   );
   const availableMethods = (configMethods ?? []).filter(cm => !selectedMethodTypes.has(cm.methodType));
 
+  const includedMethods = approach.methods.filter(m => m.isIncluded);
+
   if (viewMode === 'editing') {
     return (
       <div>
@@ -54,29 +65,25 @@ export const PricingAnalysisApproachAccordion = ({
           onToggle={() => setIsOpen(!isOpen)}
           onSelectCandidateApproach={onSelectCandidateApproach}
         />
-        <div
+        {isOpen && <div
           className={clsx(
-            'flex flex-col gap-1 ml-4 pl-4 border-l-2',
-            'transition-all ease-in-out duration-300 overflow-hidden',
+            'flex flex-col gap-1 ml-4 pl-4 border-l-2 mt-2',
             hasSelectedMethods ? 'border-primary/30' : 'border-gray-200',
-            isOpen ? 'max-h-[1000px] opacity-100 mt-2' : 'max-h-0 opacity-0',
           )}
         >
-          {approach.methods
-            .filter(m => m.isIncluded)
-            .map(method => (
-              <PricingAnalysisMethodCard
-                key={method.methodType}
-                viewMode={viewMode}
-                approachId={approach.id}
-                approachType={approach.approachType}
-                method={method}
-                onToggleMethod={onToggleMethod}
-                onSelectCalculationMethod={onSelectCalculationMethod}
-                onSelectCandidateMethod={onSelectCandidateMethod}
-                onDeleteMethod={onDeleteMethod}
-              />
-            ))}
+          {includedMethods.map(method => (
+            <PricingAnalysisMethodCard
+              key={method.methodType}
+              viewMode={viewMode}
+              approachId={approach.id}
+              approachType={approach.approachType}
+              method={method}
+              onToggleMethod={onToggleMethod}
+              onSelectCalculationMethod={onSelectCalculationMethod}
+              onSelectCandidateMethod={onSelectCandidateMethod}
+              onDeleteMethod={onDeleteMethod}
+            />
+          ))}
 
           {/* + Add Method inline list */}
           {onAddMethod && availableMethods.length > 0 && (
@@ -109,40 +116,69 @@ export const PricingAnalysisApproachAccordion = ({
               )}
             </div>
           )}
-        </div>
+        </div>}
       </div>
     );
   }
+
+  // Summary mode — grid or list layout for methods
+  const methodCount = approach.methods.length;
+  const gridCols = methodCount >= 3 ? 'grid-cols-3' : 'grid-cols-2';
 
   return (
     <div>
       <PricingAnalysisApproachCard
         viewMode={viewMode}
+        viewLayout={viewLayout}
         approach={approach}
         isOpen={isOpen}
         onToggle={() => setIsOpen(!isOpen)}
         onSelectCandidateApproach={onSelectCandidateApproach}
+        onViewLayoutChange={onViewLayoutChange}
       />
       <div
         className={clsx(
-          'flex flex-col gap-1 ml-4 pl-4 border-l-2',
-          'transition-all ease-in-out duration-300 overflow-hidden',
+          'mt-2 ml-4 pl-4 border-l-2',
           approach.isSelected ? 'border-primary/30' : 'border-gray-200',
-          'max-h-96 mt-2',
         )}
       >
-        {approach.methods.map(method => (
-          <PricingAnalysisMethodCard
-            key={method.methodType}
-            viewMode={viewMode}
-            approachId={approach.id}
-            approachType={approach.approachType}
-            method={method}
-            onToggleMethod={onToggleMethod}
-            onSelectCandidateMethod={onSelectCandidateMethod}
-            onSelectCalculationMethod={onSelectCalculationMethod}
-          />
-        ))}
+        {viewLayout === 'grid' ? (
+          <div className={clsx('grid gap-2', gridCols)}>
+            {approach.methods.map(method => (
+              <PricingAnalysisMethodCard
+                key={method.methodType}
+                viewMode={viewMode}
+                viewLayout="grid"
+                approachId={approach.id}
+                approachType={approach.approachType}
+                method={method}
+                onToggleMethod={onToggleMethod}
+                onSelectCandidateMethod={onSelectCandidateMethod}
+                onSelectCalculationMethod={onSelectCalculationMethod}
+                isManualMode={isManualMode}
+                onManualValueChange={onManualValueChange}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {approach.methods.map(method => (
+              <PricingAnalysisMethodCard
+                key={method.methodType}
+                viewMode={viewMode}
+                viewLayout="list"
+                approachId={approach.id}
+                approachType={approach.approachType}
+                method={method}
+                onToggleMethod={onToggleMethod}
+                onSelectCandidateMethod={onSelectCandidateMethod}
+                onSelectCalculationMethod={onSelectCalculationMethod}
+                isManualMode={isManualMode}
+                onManualValueChange={onManualValueChange}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachCard.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachCard.tsx
@@ -2,21 +2,27 @@ import { Icon } from '@/shared/components';
 import clsx from 'clsx';
 import type { Approach } from '../../types/selection';
 import type { ViewMode } from '@features/pricingAnalysis/store/selectionReducer';
+import type { ViewLayout } from './PricingAnalysisMethodCard';
 
-interface PricingAnalysisApproachCard {
+interface PricingAnalysisApproachCardProps {
   viewMode: ViewMode;
+  viewLayout?: ViewLayout;
   approach: Approach;
   isOpen: boolean;
   onToggle: () => void;
   onSelectCandidateApproach: (approachType: string) => void;
+  onViewLayoutChange?: (layout: ViewLayout) => void;
 }
+
 export const PricingAnalysisApproachCard = ({
   viewMode,
+  viewLayout = 'grid',
   approach,
   isOpen,
   onToggle,
   onSelectCandidateApproach,
-}: PricingAnalysisApproachCard) => {
+  onViewLayoutChange,
+}: PricingAnalysisApproachCardProps) => {
   const hasSelectedMethods = approach.methods.some(m => m.isIncluded);
 
   if (viewMode === 'editing') {
@@ -26,13 +32,13 @@ export const PricingAnalysisApproachCard = ({
           type="button"
           onClick={onToggle}
           className={clsx(
-            'cursor-pointer text-sm rounded-lg border transition-all duration-200',
+            'cursor-pointer text-sm rounded-lg border-l-4 border transition-all duration-200',
             hasSelectedMethods
-              ? 'border-primary bg-primary/5 text-primary'
-              : 'border-gray-200 text-gray-500 hover:border-gray-300',
+              ? 'border-l-primary border-primary bg-primary/5 text-primary'
+              : 'border-l-gray-300 border-gray-200 text-gray-500 hover:border-gray-300',
           )}
         >
-          <div className="flex items-center gap-3 h-14 px-4">
+          <div className="flex items-center gap-3 h-12 px-4">
             <Icon
               name={approach.icon}
               style="solid"
@@ -43,7 +49,7 @@ export const PricingAnalysisApproachCard = ({
               name="chevron-down"
               style="solid"
               className={clsx(
-                'size-2 transition-transform duration-300 ease-in-out shrink-0',
+                'size-2 shrink-0',
                 isOpen ? 'rotate-180' : '',
               )}
             />
@@ -57,10 +63,10 @@ export const PricingAnalysisApproachCard = ({
     <div className="flex flex-col">
       <div
         className={clsx(
-          'flex items-center gap-3 h-14 px-3 text-sm rounded-lg',
+          'flex items-center gap-3 h-12 px-3 text-sm rounded-lg border-l-4',
           approach.isSelected
-            ? 'bg-primary/5 border border-primary'
-            : 'border border-transparent',
+            ? 'bg-primary/5 border border-primary border-l-primary'
+            : 'border border-transparent border-l-gray-300',
         )}
       >
         <button
@@ -106,6 +112,34 @@ export const PricingAnalysisApproachCard = ({
           <span>{Number(approach.appraisalValue).toLocaleString()}</span>
           <Icon name="baht-sign" style="light" className="size-2" />
         </div>
+
+        {/* View toggle */}
+        {onViewLayoutChange && (
+          <div className="flex items-center gap-0.5 ml-1 border-l border-gray-200 pl-2">
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onViewLayoutChange('grid'); }}
+              className={clsx(
+                'p-1 rounded transition-colors cursor-pointer',
+                viewLayout === 'grid' ? 'bg-primary/10 text-primary' : 'text-gray-400 hover:text-gray-600',
+              )}
+              title="Grid view"
+            >
+              <Icon name="grid-2" style="solid" className="size-3" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onViewLayoutChange('list'); }}
+              className={clsx(
+                'p-1 rounded transition-colors cursor-pointer',
+                viewLayout === 'list' ? 'bg-primary/10 text-primary' : 'text-gray-400 hover:text-gray-600',
+              )}
+              title="List view"
+            >
+              <Icon name="list" style="solid" className="size-3" />
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
@@ -1,9 +1,21 @@
 import { Icon, Toggle } from '@/shared/components';
-import Modal from '@/shared/components/Modal';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
+import { Textarea } from '@/shared/components/inputs';
 import { PricingAnalysisApproachAccordion } from './PricingAnalysisApproachAccordion';
+import type { ViewLayout } from './PricingAnalysisMethodCard';
 import type { SelectionState } from '@features/pricingAnalysis/store/selectionReducer';
 import type { PricingAnalysisConfigType } from '../../schemas';
+import { useState, useCallback, useRef } from 'react';
+
+const VIEW_LAYOUT_KEY = 'pricing-analysis-view-layout';
+
+function getStoredLayout(): ViewLayout {
+  try {
+    const stored = localStorage.getItem(VIEW_LAYOUT_KEY);
+    if (stored === 'grid' || stored === 'list') return stored;
+  } catch { /* ignore */ }
+  return 'grid';
+}
 
 interface DeleteConfirmState {
   isOpen: boolean;
@@ -23,7 +35,6 @@ interface PricingAnalysisApproachMethodSelectorProps {
   onSummaryModeSave: () => void;
   onToggleMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCalculationMethod: (arg: { approachType: string; methodType: string }) => void;
-  onCancelPricingAccordion: () => void;
 
   onSelectCandidateMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCandidateApproach: (approachType: string) => void;
@@ -32,6 +43,7 @@ interface PricingAnalysisApproachMethodSelectorProps {
   onDeleteMethod?: (arg: { approachType: string; methodType: string }) => void;
   pricingConfiguration?: PricingAnalysisConfigType[];
   deleteConfirm?: DeleteConfirmState;
+  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
 }
 
 export const PricingAnalysisApproachMethodSelector = ({
@@ -39,12 +51,9 @@ export const PricingAnalysisApproachMethodSelector = ({
   isSystemCalculation,
   onSystemCalculationChange,
   onEnterEdit,
-  onEditModeSave,
   onCancelEditMode,
-  onSummaryModeSave,
   onToggleMethod,
   onSelectCalculationMethod,
-  onCancelPricingAccordion,
 
   onSelectCandidateMethod,
   onSelectCandidateApproach,
@@ -53,116 +62,211 @@ export const PricingAnalysisApproachMethodSelector = ({
   onDeleteMethod,
   pricingConfiguration,
   deleteConfirm,
+  onManualValueChange,
 }: PricingAnalysisApproachMethodSelectorProps) => {
+  const [viewLayout, setViewLayout] = useState<ViewLayout>(getStoredLayout);
+  const [pdfFiles, setPdfFiles] = useState<File[]>([]);
+  const [remark, setRemark] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleViewLayoutChange = useCallback((layout: ViewLayout) => {
+    setViewLayout(layout);
+    try { localStorage.setItem(VIEW_LAYOUT_KEY, layout); } catch { /* ignore */ }
+  }, []);
+
   // Build a lookup of config methods per approach type
   const configMethodsByApproach = new Map(
     (pricingConfiguration ?? []).map(conf => [conf.approachType, conf.methods]),
   );
+
+  const isEditing = state.viewMode === 'editing';
+
+  const isManualMode = isSystemCalculation !== 'System';
+
   return (
     <div className="flex flex-col overflow-hidden gap-4 h-full">
-      {/* System Calculation */}
-      <div className="flex items-center gap-4 justify-center">
-        <span>Use System Calculation: </span>
-        <Toggle
-          options={['No', 'Yes']}
-          checked={isSystemCalculation === 'System'}
-          onChange={onSystemCalculationChange}
-        ></Toggle>
-      </div>
-      {isSystemCalculation ? (
-        <div className="flex flex-col min-h-0 h-full">
-          {/* Edit modal */}
-          <Modal
-            isOpen={state.viewMode === 'editing'}
-            onClose={() => { if (!deleteConfirm?.isOpen) onCancelEditMode(); }}
-            title="Edit Approach & Method"
-            size="lg"
-          >
-            <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto">
-              {state.editDraft?.map(appr => (
-                <PricingAnalysisApproachAccordion
-                  key={appr.id}
-                  viewMode={state.viewMode}
-                  approach={appr}
-                  onToggleMethod={onToggleMethod}
-                  onSelectCalculationMethod={onSelectCalculationMethod}
-                  onSelectCandidateApproach={onSelectCandidateApproach}
-                  onSelectCandidateMethod={onSelectCandidateMethod}
-                  onAddMethod={onAddMethod}
-                  onDeleteMethod={onDeleteMethod}
-                  configMethods={configMethodsByApproach.get(appr.approachType)}
-                />
-              ))}
-            </div>
-
-            {/* Footer Actions */}
-            <div className="flex items-center justify-end pt-4 mt-4 border-t border-gray-200">
-              <button type="button" className="btn btn-primary" onClick={() => onCancelEditMode()}>
-                Close
-              </button>
-            </div>
-
-            {/* Delete confirmation — must be inside Modal to be within Headless UI focus trap */}
-            {deleteConfirm && (
-              <ConfirmDialog
-                isOpen={deleteConfirm.isOpen}
-                onClose={deleteConfirm.cancelDelete}
-                onConfirm={deleteConfirm.confirmDelete}
-                title="Delete Method"
-                message={
-                  deleteConfirm.hasData
-                    ? 'This method has calculated data. Deleting will permanently remove all results.'
-                    : 'Are you sure you want to delete this method?'
-                }
-                confirmText="Delete"
-                variant={deleteConfirm.hasData ? 'danger' : 'warning'}
-                isLoading={deleteConfirm.isDeleting}
-              />
-            )}
-          </Modal>
-
-          {/* Summary view (always visible when not editing) */}
-          <div className="flex flex-col w-full h-full min-h-0 gap-4">
-            {/* Approach and methods */}
-            <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
-              <button
-                type="button"
-                className="flex justify-center items-center gap-2 w-full p-3 border border-dashed border-primary text-primary rounded-lg hover:bg-primary/10 duration-200 transition-all cursor-pointer font-medium"
-                onClick={() => onEnterEdit()}
-              >
-                <Icon name="pen-to-square" style="regular" className="size-4" />
-                Edit Approach & Method
-              </button>
-              {state.summarySelected?.map(appr => (
-                <PricingAnalysisApproachAccordion
-                  key={appr.id}
-                  viewMode="summary"
-                  approach={{
-                    ...appr,
-                    methods: appr.methods.filter(method => method.isIncluded),
-                  }}
-                  onToggleMethod={onToggleMethod}
-                  onSelectCalculationMethod={onSelectCalculationMethod}
-                  onSelectCandidateApproach={onSelectCandidateApproach}
-                  onSelectCandidateMethod={onSelectCandidateMethod}
-                />
-              ))}
-            </div>
-
-            {/* Footer */}
-            <div className="shrink-0 min-h-14 flex items-center py-2">
-              <button
-                type="button"
-                className="btn btn-ghost"
-                onClick={() => onCancelPricingAccordion()}
-              >
-                Cancel
-              </button>
-            </div>
+      {/* Calculation Mode Banner */}
+      <div className="flex items-center justify-between bg-gray-50 rounded-xl border border-gray-200 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Icon name={isManualMode ? 'pen-field' : 'microchip'} style="solid" className="size-5 text-primary" />
+          <div>
+            <p className="text-sm font-medium text-gray-700">
+              {isManualMode ? 'Manual Entry' : 'System Calculation'}
+            </p>
+            <p className="text-xs text-gray-400">
+              {isManualMode
+                ? 'Enter appraisal values directly for each method'
+                : 'System auto-calculates appraisal values'}
+            </p>
           </div>
         </div>
-      ) : (
-        <div></div>
+        <Toggle
+          size="sm"
+          options={['Manual', 'System']}
+          checked={isSystemCalculation === 'System'}
+          onChange={onSystemCalculationChange}
+        />
+      </div>
+
+      {/* Section header with Edit button — shared by both modes */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-600">
+          {isEditing ? 'Editing Approaches & Methods' : 'Approaches & Methods'}
+        </span>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium cursor-pointer ${
+            isEditing
+              ? 'bg-primary text-white hover:bg-primary/90'
+              : 'text-primary border border-primary/30 hover:bg-primary/5'
+          }`}
+          onClick={() => {
+            if (isEditing) {
+              onCancelEditMode();
+            } else {
+              onEnterEdit();
+            }
+          }}
+        >
+          <Icon
+            name={isEditing ? 'check' : 'pen-to-square'}
+            style={isEditing ? 'solid' : 'regular'}
+            className="size-3.5"
+          />
+          {isEditing ? 'Done' : 'Edit Approaches'}
+        </button>
+      </div>
+
+      {/* Inline edit view — shared by both modes */}
+      {isEditing && (
+        <div className="flex flex-col gap-3 p-3 bg-gray-50 rounded-xl border border-gray-200">
+          {state.editDraft?.map(appr => (
+            <PricingAnalysisApproachAccordion
+              key={appr.id}
+              viewMode={state.viewMode}
+              approach={appr}
+              onToggleMethod={onToggleMethod}
+              onSelectCalculationMethod={onSelectCalculationMethod}
+              onSelectCandidateApproach={onSelectCandidateApproach}
+              onSelectCandidateMethod={onSelectCandidateMethod}
+              onAddMethod={onAddMethod}
+              onDeleteMethod={onDeleteMethod}
+              configMethods={configMethodsByApproach.get(appr.approachType)}
+            />
+          ))}
+
+          {/* Delete confirmation */}
+          {deleteConfirm && (
+            <ConfirmDialog
+              isOpen={deleteConfirm.isOpen}
+              onClose={deleteConfirm.cancelDelete}
+              onConfirm={deleteConfirm.confirmDelete}
+              title="Delete Method"
+              message={
+                deleteConfirm.hasData
+                  ? 'This method has calculated data. Deleting will permanently remove all results.'
+                  : 'Are you sure you want to delete this method?'
+              }
+              confirmText="Delete"
+              variant={deleteConfirm.hasData ? 'danger' : 'warning'}
+              isLoading={deleteConfirm.isDeleting}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Summary view */}
+      {!isEditing && (
+        <div className="flex flex-col w-full h-full min-h-0 gap-4">
+          <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2">
+            {state.summarySelected?.map(appr => (
+              <PricingAnalysisApproachAccordion
+                key={appr.id}
+                viewMode="summary"
+                viewLayout={viewLayout}
+                approach={{
+                  ...appr,
+                  methods: appr.methods.filter(method => method.isIncluded),
+                }}
+                onToggleMethod={onToggleMethod}
+                onSelectCalculationMethod={onSelectCalculationMethod}
+                onSelectCandidateApproach={onSelectCandidateApproach}
+                onSelectCandidateMethod={onSelectCandidateMethod}
+                onViewLayoutChange={handleViewLayoutChange}
+                isManualMode={isManualMode}
+                onManualValueChange={isManualMode ? onManualValueChange : undefined}
+              />
+            ))}
+          </div>
+
+          {/* Manual mode: PDF uploader & Remark */}
+          {isManualMode && (
+            <div className="flex flex-col gap-4">
+              {/* PDF File Uploader */}
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-medium text-gray-600">Upload PDF</label>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf"
+                  className="hidden"
+                  onChange={e => {
+                    const file = e.target.files?.[0];
+                    if (file) setPdfFiles(prev => [...prev, file]);
+                    e.target.value = '';
+                  }}
+                />
+                <button
+                  type="button"
+                  className="flex items-center justify-center gap-2 px-4 py-3 border border-dashed border-gray-300 rounded-xl bg-gray-50 text-sm text-gray-500 hover:bg-gray-100 hover:border-gray-400 cursor-pointer transition-colors"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Icon name="file-pdf" style="regular" className="size-4" />
+                  Click to upload PDF
+                </button>
+                {pdfFiles.length > 0 && (
+                  <ul className="flex flex-col gap-1.5">
+                    {pdfFiles.map((file, idx) => (
+                      <li
+                        key={`${file.name}-${idx}`}
+                        className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg border border-gray-200 text-sm"
+                      >
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 text-gray-700 truncate hover:text-primary cursor-pointer"
+                          onClick={() => {
+                            const url = URL.createObjectURL(file);
+                            window.open(url, '_blank');
+                          }}
+                          title="Open PDF"
+                        >
+                          <Icon name="file-pdf" style="solid" className="size-4 text-red-500 shrink-0" />
+                          <span className="truncate underline underline-offset-2">{file.name}</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="text-gray-400 hover:text-red-500 cursor-pointer"
+                          onClick={() => setPdfFiles(prev => prev.filter((_, i) => i !== idx))}
+                        >
+                          <Icon name="xmark" style="solid" className="size-3.5" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              {/* Remark Textarea */}
+              <Textarea
+                label="Remark"
+                rows={3}
+                placeholder="Add any remarks or notes for this manual appraisal..."
+                value={remark}
+                onChange={e => setRemark(e.target.value)}
+              />
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
@@ -1,9 +1,15 @@
 import { Icon } from '@/shared/components';
+import Badge from '@/shared/components/Badge';
+import { NumberInput } from '@/shared/components/inputs';
 import clsx from 'clsx';
+import { useRef, useState } from 'react';
 import type { Method } from '../../types/selection';
+
+export type ViewLayout = 'grid' | 'list';
 
 interface PricingAnalysisMethodCardProps {
   viewMode: 'editing' | 'summary';
+  viewLayout?: ViewLayout;
   approachId?: string;
   approachType: string;
   method: Method;
@@ -11,18 +17,52 @@ interface PricingAnalysisMethodCardProps {
   onSelectCalculationMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCandidateMethod: (arg: { approachType: string; methodType: string }) => void;
   onDeleteMethod?: (arg: { approachType: string; methodType: string }) => void;
+  isManualMode?: boolean;
+  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
+}
+
+function getMethodStatus(method: Method): { label: string; color: 'emerald' | 'amber' | 'gray' } {
+  if (method.appraisalValue > 0) return { label: 'Calculated', color: 'emerald' };
+  if (method.isIncluded) return { label: 'Pending', color: 'amber' };
+  return { label: 'Not included', color: 'gray' };
 }
 
 export const PricingAnalysisMethodCard = ({
   viewMode,
-  approachId,
+  viewLayout = 'grid',
   approachType,
   method,
-  onToggleMethod,
   onSelectCalculationMethod,
   onSelectCandidateMethod,
   onDeleteMethod,
+  isManualMode,
+  onManualValueChange,
 }: PricingAnalysisMethodCardProps) => {
+  const [manualInput, setManualInput] = useState<number | null>(method.appraisalValue || null);
+  const isEscapingRef = useRef(false);
+
+  const handleManualChange = (e: { target: { name?: string; value: number | null } }) => {
+    setManualInput(e.target.value);
+  };
+
+  const handleManualBlur = () => {
+    if (isEscapingRef.current) {
+      isEscapingRef.current = false;
+      return;
+    }
+    const num = manualInput ?? 0;
+    if (num >= 0 && onManualValueChange) {
+      onManualValueChange({ approachType, methodType: method.methodType, value: num });
+    }
+  };
+
+  const handleManualKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      isEscapingRef.current = true;
+      setManualInput(method.appraisalValue || null);
+      (e.target as HTMLInputElement).blur();
+    }
+  };
   if (viewMode === 'editing') {
     return (
       <div
@@ -53,20 +93,118 @@ export const PricingAnalysisMethodCard = ({
     );
   }
 
+  const status = getMethodStatus(method);
+
+  // Grid tile view — card with hero value
+  if (viewLayout === 'grid') {
+    const Wrapper = isManualMode ? 'div' : 'button';
+    const wrapperProps = isManualMode
+      ? {}
+      : { type: 'button' as const, onClick: () => onSelectCalculationMethod({ approachType, methodType: method.methodType }) };
+
+    return (
+      <Wrapper
+        {...wrapperProps}
+        className={clsx(
+          'flex flex-col gap-2 p-4 rounded-xl border transition-all duration-200 text-left w-full',
+          isManualMode ? '' : 'cursor-pointer',
+          method.isSelected
+            ? 'ring-2 ring-primary bg-primary/5 border-primary'
+            : 'border-gray-200 hover:border-gray-300 hover:shadow-sm bg-white',
+        )}
+      >
+        {/* Header: icon + label + candidate checkbox */}
+        <div className="flex items-center gap-2 w-full">
+          <Icon
+            name={method.icon}
+            style="solid"
+            className={clsx('size-4 shrink-0', method.isSelected ? 'text-primary' : 'text-gray-400')}
+          />
+          <span className={clsx('flex-1 text-sm font-medium', method.isSelected ? 'text-primary' : 'text-gray-700')}>
+            {method.label}
+          </span>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelectCandidateMethod({ approachType, methodType: method.methodType });
+            }}
+            className="cursor-pointer shrink-0"
+          >
+            <div
+              className={clsx(
+                'size-4 rounded border-2 flex items-center justify-center transition-all',
+                method.isSelected
+                  ? 'bg-primary border-primary'
+                  : 'border-gray-300 hover:border-gray-400',
+              )}
+            >
+              {method.isSelected && (
+                <Icon name="check" style="solid" className="size-2.5 text-white" />
+              )}
+            </div>
+          </button>
+        </div>
+
+        {/* Hero value or manual input */}
+        {isManualMode ? (
+          <NumberInput
+            value={manualInput}
+            onChange={handleManualChange}
+            onBlur={handleManualBlur}
+            onKeyDown={handleManualKeyDown}
+            decimalPlaces={2}
+            placeholder="0.00"
+            rightIcon={<Icon name="baht-sign" style="light" className="size-3.5" />}
+            className="text-xl font-semibold"
+          />
+        ) : (
+          <div className="flex items-baseline gap-1">
+            <span className={clsx('text-xl font-semibold', method.isSelected ? 'text-primary' : 'text-gray-800')}>
+              {Number(method.appraisalValue).toLocaleString()}
+            </span>
+            <Icon name="baht-sign" style="light" className={clsx('size-3.5', method.isSelected ? 'text-primary/70' : 'text-gray-400')} />
+          </div>
+        )}
+
+        {/* Status badge */}
+        <Badge
+          size="xs"
+          dot
+          badgeStyle="soft"
+          type="status"
+          value={status.label === 'Calculated' ? 'completed' : status.label === 'Pending' ? 'draft' : 'cancelled'}
+        >
+          {status.label}
+        </Badge>
+      </Wrapper>
+    );
+  }
+
+  // List view — compact row
+  const ListWrapper = isManualMode ? 'div' : 'button';
+  const listWrapperProps = isManualMode
+    ? {}
+    : { type: 'button' as const, onClick: () => onSelectCalculationMethod({ approachType, methodType: method.methodType }) };
+
   return (
-    <div
+    <ListWrapper
+      {...listWrapperProps}
       className={clsx(
-        'flex items-center gap-3 px-3 py-3 rounded-lg transition-all duration-200',
-        'hover:bg-gray-50',
-        method.isSelected ? 'text-primary' : 'text-gray-500',
+        'flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 w-full',
+        isManualMode ? '' : 'cursor-pointer',
+        method.isSelected
+          ? 'bg-primary/5 ring-1 ring-primary/30'
+          : 'hover:bg-gray-50',
       )}
     >
       {/* Candidate checkbox */}
       <button
         type="button"
-        onClick={() =>
-          onSelectCandidateMethod({ approachType, methodType: method.methodType })
-        }
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelectCandidateMethod({ approachType, methodType: method.methodType });
+        }}
         className="cursor-pointer shrink-0"
       >
         <div
@@ -82,27 +220,41 @@ export const PricingAnalysisMethodCard = ({
           )}
         </div>
       </button>
-      <Icon name={method.icon} style="solid" className="size-4 shrink-0" />
-      <div className="flex-1 flex flex-col min-w-0">
-        <span className={clsx('text-sm', method.isSelected && 'font-medium')}>
-          {method.label}
-        </span>
-        <div className="flex items-center gap-1 text-xs text-gray-400">
-          <Icon name="baht-sign" style="light" className="size-3" />
-          <span className="truncate">{Number(method.appraisalValue).toLocaleString()}</span>
-        </div>
-      </div>
-      <button
-        type="button"
-        onClick={() => onSelectCalculationMethod({ approachType, methodType: method.methodType })}
-        className="cursor-pointer shrink-0 p-1 rounded hover:bg-gray-100"
-      >
-        <Icon
-          name="pen"
-          style="solid"
-          className="size-3.5 text-gray-500 hover:text-primary transition-colors"
+      <Icon name={method.icon} style="solid" className={clsx('size-4 shrink-0', method.isSelected ? 'text-primary' : 'text-gray-400')} />
+      <span className={clsx('flex-1 text-sm text-left', method.isSelected ? 'font-medium text-primary' : 'text-gray-700')}>
+        {method.label}
+      </span>
+      {isManualMode ? (
+        <NumberInput
+          value={manualInput}
+          onChange={handleManualChange}
+          onBlur={handleManualBlur}
+          onKeyDown={handleManualKeyDown}
+          decimalPlaces={2}
+          placeholder="0.00"
+          fullWidth={false}
+          className="w-40"
+          rightIcon={<Icon name="baht-sign" style="light" className="size-3" />}
         />
-      </button>
-    </div>
+      ) : (
+        <div className={clsx('flex items-center gap-1 text-sm font-semibold', method.isSelected ? 'text-primary' : 'text-gray-600')}>
+          <span>{Number(method.appraisalValue).toLocaleString()}</span>
+          <Icon name="baht-sign" style="light" className="size-3" />
+        </div>
+      )}
+      <Badge
+        size="xs"
+        dot
+        badgeStyle="soft"
+        type="status"
+        value={status.label === 'Calculated' ? 'completed' : status.label === 'Pending' ? 'draft' : 'cancelled'}
+        className="shrink-0"
+      >
+        {status.label}
+      </Badge>
+      {!isManualMode && (
+        <Icon name="chevron-right" style="solid" className="size-3 text-gray-300 shrink-0" />
+      )}
+    </ListWrapper>
   );
 };

--- a/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
+++ b/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
@@ -1,10 +1,8 @@
 import { Icon } from '@/shared/components';
 import clsx from 'clsx';
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import MarketsTab from '@features/appraisal/components/tabs/MarketsTab';
-import GalleryTab from '@features/appraisal/components/tabs/GalleryTab';
-import LawsRegulationTab from '@features/appraisal/components/tabs/LawsRegulationTab';
 import {
   DispatchCtx,
   ServerDataCtx,
@@ -20,9 +18,12 @@ import { useSelectionActions } from '@features/pricingAnalysis/hooks/useSelectio
 import { useCalculationFlow } from '@features/pricingAnalysis/hooks/useCalculationFlow';
 import { createInitialState } from '@features/pricingAnalysis/store/createInitialState';
 import { useDisclosure } from '@/shared/hooks/useDisclosure';
+import toast from 'react-hot-toast';
+import { useSetFinalValue } from '@features/pricingAnalysis/api';
 import { PricingAnalysisAccordion } from '@features/pricingAnalysis/components/selection/PricingAnalysisAccordion';
 import { MethodSectionRenderer } from '@features/pricingAnalysis/components/MethodSectionRenderer';
 import type { PricingServerData } from '@features/pricingAnalysis/types/selection';
+import type { SetFinalValueRequestType } from '@features/pricingAnalysis/schemas';
 import { propertyGroupKeys } from '@features/appraisal/api/propertyGroup';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from '@shared/api/axiosInstance';
@@ -38,8 +39,6 @@ interface Tab {
 const TABS: Tab[] = [
   { id: 'properties', label: 'Properties', icon: 'buildings' },
   { id: 'markets', label: 'Markets', icon: 'chart-line' },
-  { id: 'gallery', label: 'Gallery', icon: 'images' },
-  { id: 'laws', label: 'Laws', icon: 'gavel' },
 ];
 
 const initialState: SelectionState = {
@@ -189,7 +188,11 @@ function PricingAnalysisContent({
 
     dispatch({
       type: 'INIT',
-      payload: { pricingAnalysisId, approaches },
+      payload: {
+        pricingAnalysisId,
+        approaches,
+        useSystemCalc: (pricingSelection as any)?.useSystemCalc,
+      },
     });
 
     // If user was in editing mode (e.g. after add/delete mutation), stay in editing mode
@@ -247,6 +250,33 @@ function PricingAnalysisContent({
     setIsDirty(check);
   };
 
+  // (8b) Manual mode — set final value on blur
+  const setFinalValueMutation = useSetFinalValue();
+  const handleManualValueChange = useCallback(
+    ({ approachType, methodType, value }: { approachType: string; methodType: string; value: number }) => {
+      // Find the method's server ID from summarySelected
+      const approach = state.summarySelected?.find(a => a.approachType === approachType);
+      const method = approach?.methods.find(m => m.methodType === methodType);
+      if (!method?.id) return;
+
+      setFinalValueMutation.mutate(
+        {
+          pricingAnalysisId,
+          methodId: method.id,
+          request: {
+            finalValue: value,
+            finalValueRounded: value,
+          } as SetFinalValueRequestType,
+        },
+        {
+          onSuccess: () => toast.success('Value saved'),
+          onError: () => toast.error('Failed to save value'),
+        },
+      );
+    },
+    [state.summarySelected, pricingAnalysisId, setFinalValueMutation],
+  );
+
   // (9) Assemble server data for context
   const serverData: PricingServerData = {
     groupDetail,
@@ -287,7 +317,6 @@ function PricingAnalysisContent({
                         isPricingAnalysisAccordionOpen={isPricingAnalysisAccordionOpen}
                         onSystemCalculationChange={selectionActions.changeSystemCalculation}
                         systemCalculationMode={state.systemCalculationMode}
-                        onCancelPricingAccordion={selectionActions.cancelPricingAccordion}
                         isConfirmDeselectedMethodOpen={selectionActions.confirm.isOpen}
                         onConfirmDeselectMethod={selectionActions.confirm.confirmDeselect}
                         onCancelDeselectMethod={selectionActions.confirm.cancelDeselect}
@@ -299,6 +328,7 @@ function PricingAnalysisContent({
                         onDeleteMethod={selectionActions.requestDeleteMethod}
                         pricingConfiguration={pricingConfiguration}
                         deleteConfirm={selectionActions.deleteConfirm}
+                        onManualValueChange={handleManualValueChange}
                       />
                       {!isCalcLoading && (
                         <MethodSectionRenderer
@@ -320,10 +350,6 @@ function PricingAnalysisContent({
       }
       case 'markets':
         return <MarketsTab />;
-      case 'gallery':
-        return <GalleryTab />;
-      case 'laws':
-        return <LawsRegulationTab />;
       default:
         return null;
     }
@@ -331,8 +357,16 @@ function PricingAnalysisContent({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {/* Tab Navigation - Compact */}
-      <div className="shrink-0 pb-4">
+      {/* Page header — back + tabs */}
+      <div className="shrink-0 pb-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => selectionActions.cancelPricingAccordion()}
+          className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors cursor-pointer shrink-0"
+        >
+          <Icon name="arrow-left" style="solid" className="size-3.5" />
+          <span className="font-medium">Back</span>
+        </button>
         <nav className="flex gap-0.5 bg-gray-50/80 p-0.5 rounded-lg border border-gray-100">
           {TABS.map(tab => {
             const isActive = activeTab === tab.id;

--- a/src/features/pricingAnalysis/store/selectionReducer.ts
+++ b/src/features/pricingAnalysis/store/selectionReducer.ts
@@ -44,6 +44,7 @@ export type SelectionAction =
       payload: {
         pricingAnalysisId?: string;
         approaches: Approach[];
+        useSystemCalc?: boolean;
       };
     }
   | {
@@ -136,7 +137,7 @@ export function approachMethodReducer(
         editSaved: cloneApproaches(approaches),
         editDraft: cloneApproaches(approaches),
         summarySelected: cloneApproaches(visibleApproach),
-        systemCalculationMode: 'System',
+        systemCalculationMode: action.payload.useSystemCalc === false ? 'FillIn' : 'System',
         pricingAnalysisId: action.payload.pricingAnalysisId,
       };
     }

--- a/src/i18n/locales/en/nav.json
+++ b/src/i18n/locales/en/nav.json
@@ -1,6 +1,7 @@
 {
   "sidebar": {
     "menu": "Menu",
+    "general": "General",
     "system": "System",
     "dashboard": "Dashboard",
     "requests": "Requests",

--- a/src/i18n/locales/th/nav.json
+++ b/src/i18n/locales/th/nav.json
@@ -1,6 +1,7 @@
 {
   "sidebar": {
     "menu": "เมนู",
+    "general": "ทั่วไป",
     "system": "ระบบ",
     "dashboard": "แดชบอร์ด",
     "requests": "คำขอ",

--- a/src/i18n/locales/zh/nav.json
+++ b/src/i18n/locales/zh/nav.json
@@ -1,6 +1,7 @@
 {
   "sidebar": {
     "menu": "菜单",
+    "general": "一般的",
     "system": "系统",
     "dashboard": "仪表盘",
     "requests": "请求",

--- a/src/shared/components/Navbar.tsx
+++ b/src/shared/components/Navbar.tsx
@@ -25,6 +25,11 @@ const filterColorStyles: Record<string, { bg: string; text: string; activeBg: st
   amber: { bg: 'bg-amber-50', text: 'text-amber-500', activeBg: 'bg-amber-100' },
 };
 
+function handleLogout(href: string) {
+  useAuthStore.getState().logout();
+  window.location.replace(href);
+}
+
 export default function Navbar({
   userNavigation,
 }: {
@@ -244,27 +249,44 @@ export default function Navbar({
                   <p className="text-sm font-medium text-gray-900">{`${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`}</p>
                   <p className="text-xs text-gray-500 truncate">{currentUser?.email}</p>
                 </div>
-                {userNavigation.map(item => (
-                  <MenuItem key={item.name}>
-                    <a
-                      href={item.href}
-                      className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 data-focus:bg-gray-50 data-focus:outline-hidden transition-colors"
+                {userNavigation.map(item =>
+                  item.name === 'Sign out' ? (
+                    <MenuItem
+                      key={item.name}
+                      as="button"
+                      type="button"
+                      onClick={() => handleLogout(item.href)}
+                      className="flex w-full items-center gap-3 px-4 py-2 text-sm text-gray-700 data-focus:bg-gray-50 data-focus:outline-hidden transition-colors"
                     >
                       <Icon
-                        name={
-                          item.name === 'Your profile'
-                            ? 'user'
-                            : item.name === 'Settings'
-                              ? 'gear'
-                              : 'arrow-right-from-bracket'
-                        }
+                        name="arrow-right-from-bracket"
                         style="regular"
                         className="size-4 text-gray-400"
                       />
                       {item.nameKey ? t(item.nameKey as never) : item.name}
-                    </a>
-                  </MenuItem>
-                ))}
+                    </MenuItem>
+                  ) : (
+                    <MenuItem key={item.name}>
+                      <a
+                        href={item.href}
+                        className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 data-focus:bg-gray-50 data-focus:outline-hidden transition-colors"
+                      >
+                        <Icon
+                          name={
+                            item.name === 'Your profile'
+                              ? 'user'
+                              : item.name === 'Settings'
+                                ? 'gear'
+                                : 'arrow-right-from-bracket'
+                          }
+                          style="regular"
+                          className="size-4 text-gray-400"
+                        />
+                        {item.nameKey ? t(item.nameKey as never) : item.name}
+                      </a>
+                    </MenuItem>
+                  ),
+                )}
               </MenuItems>
             </Menu>
           </div>

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -12,12 +12,26 @@ type SidebarProps = {
   logo: string;
 };
 
-function MenuItem({ item, isChild = false, collapsed = false }: { item: NavItem; isChild?: boolean; collapsed?: boolean }) {
+function MenuItem({
+  item,
+  isChild = false,
+  collapsed = false,
+}: {
+  item: NavItem;
+  isChild?: boolean;
+  collapsed?: boolean;
+}) {
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   const isActive = location.pathname === item.href;
   const hasChildren = item.children && item.children.length > 0;
-  const iconStyle = (item.iconStyle || 'solid') as 'solid' | 'regular' | 'light' | 'thin' | 'duotone' | 'brands';
+  const iconStyle = (item.iconStyle || 'solid') as
+    | 'solid'
+    | 'regular'
+    | 'light'
+    | 'thin'
+    | 'duotone'
+    | 'brands';
 
   // Get background color class based on icon color
   const getIconBgClass = (iconColor: string | undefined) => {
@@ -51,7 +65,11 @@ function MenuItem({ item, isChild = false, collapsed = false }: { item: NavItem;
                 'group-hover:scale-105',
               )}
             >
-              <Icon name={item.icon} style={iconStyle} className={clsx('size-4', item.iconColor || 'text-gray-500')} />
+              <Icon
+                name={item.icon}
+                style={iconStyle}
+                className={clsx('size-4', item.iconColor || 'text-gray-500')}
+              />
             </div>
           </div>
         </li>
@@ -78,9 +96,18 @@ function MenuItem({ item, isChild = false, collapsed = false }: { item: NavItem;
                 'group-hover:scale-105',
               )}
             >
-              <Icon name={item.icon} style={iconStyle} className={clsx('size-4', item.iconColor || 'text-gray-500')} />
+              <Icon
+                name={item.icon}
+                style={iconStyle}
+                className={clsx('size-4', item.iconColor || 'text-gray-500')}
+              />
             </div>
-            <span className={clsx('text-sm font-medium', isChildActive ? 'text-primary' : 'text-gray-700')}>
+            <span
+              className={clsx(
+                'text-sm font-medium',
+                isChildActive ? 'text-primary' : 'text-gray-700',
+              )}
+            >
               {item.name}
             </span>
           </span>
@@ -99,9 +126,7 @@ function MenuItem({ item, isChild = false, collapsed = false }: { item: NavItem;
             isOpen ? 'max-h-96 opacity-100 mt-1' : 'max-h-0 opacity-0',
           )}
         >
-          {item.children?.map(child => (
-            <MenuItem key={child.href} item={child} isChild />
-          ))}
+          {item.children?.map(child => <MenuItem key={child.href} item={child} isChild />)}
         </ul>
       </li>
     );
@@ -211,7 +236,10 @@ export function MobileSidebar({ navigation, logo }: SidebarProps): React.ReactNo
                   </span>
                   <div
                     className="w-12 h-1 rounded-full my-0.5"
-                    style={{ background: 'linear-gradient(to right, #CED629, #47B9C0, #8B3F92, #ED8068, #0080BE, #F5BF0E, #F08D1D)' }}
+                    style={{
+                      background:
+                        'linear-gradient(to right, #CED629, #47B9C0, #8B3F92, #ED8068, #0080BE, #F5BF0E, #F08D1D)',
+                    }}
                   />
                   <span className="text-[10px] font-medium text-gray-400">
                     Collateral Appraisal System
@@ -223,7 +251,9 @@ export function MobileSidebar({ navigation, logo }: SidebarProps): React.ReactNo
             {/* Navigation */}
             <nav className="flex flex-1 flex-col px-4 py-4">
               <div className="px-3 mb-2">
-                <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{t('sidebar.menu')}</span>
+                <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                  {t('sidebar.general')}
+                </span>
               </div>
 
               <ul className="flex flex-col gap-1">
@@ -234,7 +264,9 @@ export function MobileSidebar({ navigation, logo }: SidebarProps): React.ReactNo
 
               <div className="mt-auto pt-4 border-t border-gray-100">
                 <div className="px-3 mb-2">
-                  <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{t('sidebar.system')}</span>
+                  <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    {t('sidebar.system')}
+                  </span>
                 </div>
                 <ul className="flex flex-col gap-1">
                   <li>
@@ -245,7 +277,9 @@ export function MobileSidebar({ navigation, logo }: SidebarProps): React.ReactNo
                       <div className="w-9 h-9 rounded-xl bg-gray-100 flex items-center justify-center transition-all duration-200 shadow-sm group-hover:scale-105">
                         <Icon name="gear" style="solid" className="size-4 text-gray-500" />
                       </div>
-                      <span className="text-sm font-medium text-gray-700">{t('sidebar.settings')}</span>
+                      <span className="text-sm font-medium text-gray-700">
+                        {t('sidebar.settings')}
+                      </span>
                     </Link>
                   </li>
                 </ul>
@@ -274,7 +308,9 @@ export default function Sidebar({ navigation, logo }: SidebarProps): React.React
     >
       <div className="flex grow flex-col overflow-y-auto border-r border-gray-100 bg-white shadow-sm">
         {/* Logo Area */}
-        <div className={clsx('py-5 transition-all duration-300', sidebarCollapsed ? 'px-2' : 'px-5')}>
+        <div
+          className={clsx('py-5 transition-all duration-300', sidebarCollapsed ? 'px-2' : 'px-5')}
+        >
           <div className={clsx('flex items-center', sidebarCollapsed ? 'justify-center' : 'gap-4')}>
             <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-gray-50 to-white border border-gray-100 flex items-center justify-center shadow-sm shrink-0">
               <img alt="LHBank" src={logo} className="h-7 w-auto" />
@@ -286,7 +322,10 @@ export default function Sidebar({ navigation, logo }: SidebarProps): React.React
                 </span>
                 <div
                   className="w-12 h-1 rounded-full my-0.5"
-                  style={{ background: 'linear-gradient(to right, #CED629, #47B9C0, #8B3F92, #ED8068, #0080BE, #F5BF0E, #F08D1D)' }}
+                  style={{
+                    background:
+                      'linear-gradient(to right, #CED629, #47B9C0, #8B3F92, #ED8068, #0080BE, #F5BF0E, #F08D1D)',
+                  }}
                 />
                 <span className="text-[10px] font-medium text-gray-400">
                   Collateral Appraisal System
@@ -297,10 +336,17 @@ export default function Sidebar({ navigation, logo }: SidebarProps): React.React
         </div>
 
         {/* Navigation */}
-        <nav className={clsx('flex flex-1 flex-col py-4 transition-all duration-300', sidebarCollapsed ? 'px-1' : 'px-4')}>
+        <nav
+          className={clsx(
+            'flex flex-1 flex-col py-4 transition-all duration-300',
+            sidebarCollapsed ? 'px-1' : 'px-4',
+          )}
+        >
           {!sidebarCollapsed && (
             <div className="px-3 mb-2">
-              <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{t('sidebar.menu')}</span>
+              <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                {t('sidebar.general')}
+              </span>
             </div>
           )}
 
@@ -314,7 +360,9 @@ export default function Sidebar({ navigation, logo }: SidebarProps): React.React
           <div className={clsx('mt-auto pt-4', !sidebarCollapsed && 'border-t border-gray-100')}>
             {!sidebarCollapsed && (
               <div className="px-3 mb-2">
-                <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">{t('sidebar.system')}</span>
+                <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                  {t('sidebar.system')}
+                </span>
               </div>
             )}
             <ul className="flex flex-col gap-1">
@@ -332,7 +380,9 @@ export default function Sidebar({ navigation, logo }: SidebarProps): React.React
                     <Icon name="gear" style="solid" className="size-4 text-gray-500" />
                   </div>
                   {!sidebarCollapsed && (
-                    <span className="text-sm font-medium text-gray-700">{t('sidebar.settings')}</span>
+                    <span className="text-sm font-medium text-gray-700">
+                      {t('sidebar.settings')}
+                    </span>
                   )}
                 </Link>
               </li>

--- a/src/shared/components/inputs/NumberInput.tsx
+++ b/src/shared/components/inputs/NumberInput.tsx
@@ -46,6 +46,7 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       value,
       onChange,
       onBlur,
+      onKeyDown,
       placeholder,
       ...props
     },
@@ -176,6 +177,8 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           },
         });
       }
+
+      onKeyDown?.(e);
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/shared/components/inputs/Toggle.tsx
+++ b/src/shared/components/inputs/Toggle.tsx
@@ -70,8 +70,7 @@ const Toggle = ({
           {/* Sliding pill */}
           <span
             className={clsx(
-              'absolute inset-y-1 w-[calc(50%-2px)] rounded-full',
-              'transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
+              'absolute inset-y-1 w-[calc(50%-2px)] rounded-full transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
               error ? 'bg-danger' : 'bg-primary shadow-md shadow-primary/25',
               activeIndex === 0 ? 'translate-x-0' : 'translate-x-[calc(100%+4px)]',
             )}
@@ -89,8 +88,7 @@ const Toggle = ({
                 disabled={isDisabled}
                 onClick={() => handleClick(index)}
                 className={clsx(
-                  'relative z-10 flex items-center justify-center rounded-full select-none font-medium whitespace-nowrap',
-                  'transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
+                  'relative z-10 flex items-center justify-center rounded-full select-none font-medium whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
                   sizeStyles[size].option,
                   isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
                   isActive


### PR DESCRIPTION
## Summary
- **Pricing Analysis Manual Mode**: Support manual entry alongside system calculation with grid/list view layouts, inline value editing, PDF upload, and calculation mode banner
- **Market Comparable Detail Modal**: New modal to view full survey details from scoring sections (WQS, SAG, DC)
- **Appraisal Right Menu**: Enhanced sidebar with province resolution, status, selling price, dates, and priority
- **UI Polish**: xs card size for compact property display, logout flow fix, conditional price field disabling, i18n sidebar labels

## Changes by Area

### Pricing Analysis (13 files)
- Manual entry mode with `FillIn` vs `System` calculation toggle
- Grid/list view layouts with localStorage persistence
- `MarketComparableDetailModal` (new file) for read-only survey viewing
- Market survey filtering by property type in `MethodSectionRenderer`
- Removed redundant cancel confirmation dialogs from WQS/SAG/DC panels
- Inline method card editing with NumberInput (onBlur save, Escape revert)

### Appraisal Feature (6 files)
- Richer `AppraisalRightMenu` with "Appraisal Info" section
- `PropertyCardContent` xs size for compact horizontal layout
- `GroupContainer` button refinement (icon-only pricing button)
- `MarketComparableForm` conditional field disabling
- `BuildingDetailPopUpModal` toggle option order fix

### Shared Components & Auth (5 files)
- `Navbar` logout properly clears auth state before redirect
- Environment-aware redirect URLs (`VITE_API_URL`, `VITE_APP_URL`)
- `NumberInput` onKeyDown prop forwarding
- `Toggle` class cleanup
- `Sidebar` formatting

### i18n (3 files)
- Added `sidebar.general` key in en/th/zh

## Test plan
- [ ] Verify pricing analysis loads in both manual and system calculation modes
- [ ] Test grid/list view toggle and layout persistence across page reloads
- [ ] Test manual value entry: type value, blur to save, Escape to revert
- [ ] Open market comparable detail modal from scoring section headers
- [ ] Verify market surveys are filtered by property type in calculation panels
- [ ] Check appraisal right menu displays province name, status, dates correctly
- [ ] Test logout flow clears auth state and redirects properly
- [ ] Verify xs property card renders correctly in compact layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)