### PR TITLE
feat: add image annotation editor with sticker support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.9.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "fabric": "^6.9.1",
         "i18next": "^25.8.14",
         "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.1.0",
@@ -1245,6 +1246,152 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
@@ -2157,6 +2304,16 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/aria-query": {
@@ -3169,16 +3326,42 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3188,6 +3371,32 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3210,7 +3419,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3229,6 +3438,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/argparse": {
@@ -3496,13 +3727,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3627,6 +3858,22 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -3730,6 +3977,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3746,7 +4003,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3782,6 +4046,33 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -3925,6 +4216,21 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3996,7 +4302,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4009,11 +4315,31 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4064,6 +4390,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4103,6 +4436,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4138,6 +4485,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4380,6 +4740,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -4719,6 +5101,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -4747,7 +5143,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4766,7 +5162,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4785,6 +5181,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fabric": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-6.9.1.tgz",
+      "integrity": "sha512-TqG08Xbt4rtlPsXgCjSUcZz/RsyEP57Qo21nCVRkw7zz9nR0co4SLkL9Q/zQh3tC1Yxap6M5jKFHUKV6SgPovg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "jsdom": "^20.0.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4957,6 +5366,46 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5006,6 +5455,35 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -5076,6 +5554,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -5257,6 +5757,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5275,6 +5782,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5289,6 +5809,35 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/i18next": {
@@ -5329,6 +5878,19 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -5384,6 +5946,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5563,7 +6144,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5654,6 +6235,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -5898,6 +6486,68 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsesc": {
@@ -6368,6 +7018,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6382,7 +7045,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6436,7 +7099,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/msw": {
       "version": "2.12.4",
@@ -6493,6 +7156,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6516,17 +7186,100 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6648,6 +7401,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6731,6 +7494,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6738,6 +7514,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -6959,14 +7745,34 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7171,6 +7977,21 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
@@ -7282,6 +8103,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -7332,6 +8160,23 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -7414,6 +8259,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7447,6 +8313,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -7460,6 +8346,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
@@ -7625,6 +8518,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7677,11 +8615,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7696,7 +8644,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -7810,7 +8758,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7876,6 +8824,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/synckit": {
       "version": "0.11.8",
@@ -8068,6 +9023,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8357,6 +9325,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
@@ -8406,6 +9384,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -8414,6 +9403,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/uuid": {
       "version": "13.0.0",
@@ -8648,12 +9644,63 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -8775,6 +9822,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8798,6 +9855,52 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "fabric": "^6.9.1",
     "i18next": "^25.8.14",
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.1.0",

--- a/src/assets/stickers/directional/arrow-down.svg
+++ b/src/assets/stickers/directional/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="16,30 28,12 22,12 22,2 10,2 10,12 4,12" fill="#E53935" stroke="#B71C1C" stroke-width="1"/>
+</svg>

--- a/src/assets/stickers/directional/arrow-left.svg
+++ b/src/assets/stickers/directional/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="2,16 20,4 20,10 30,10 30,22 20,22 20,28" fill="#E53935" stroke="#B71C1C" stroke-width="1"/>
+</svg>

--- a/src/assets/stickers/directional/arrow-right.svg
+++ b/src/assets/stickers/directional/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="30,16 12,4 12,10 2,10 2,22 12,22 12,28" fill="#E53935" stroke="#B71C1C" stroke-width="1"/>
+</svg>

--- a/src/assets/stickers/directional/arrow-up.svg
+++ b/src/assets/stickers/directional/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="16,2 28,20 22,20 22,30 10,30 10,20 4,20" fill="#E53935" stroke="#B71C1C" stroke-width="1"/>
+</svg>

--- a/src/assets/stickers/directional/camera-down.svg
+++ b/src/assets/stickers/directional/camera-down.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1E88E5" stroke="#1565C0" stroke-width="1.5"/>
+  <path d="M10 12h12l-2 4h-2l-2 6-2-6h-2z" fill="white"/>
+  <polygon points="16,26 12,20 20,20" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/camera-left.svg
+++ b/src/assets/stickers/directional/camera-left.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1E88E5" stroke="#1565C0" stroke-width="1.5"/>
+  <path d="M20 10v12l-4-2v-2l-6-2 6-2v-2z" fill="white"/>
+  <polygon points="6,16 12,12 12,20" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/camera-right.svg
+++ b/src/assets/stickers/directional/camera-right.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1E88E5" stroke="#1565C0" stroke-width="1.5"/>
+  <path d="M12 10v12l4-2v-2l6-2-6-2v-2z" fill="white"/>
+  <polygon points="26,16 20,12 20,20" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/camera-up.svg
+++ b/src/assets/stickers/directional/camera-up.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1E88E5" stroke="#1565C0" stroke-width="1.5"/>
+  <path d="M10 20h12l-2-4h-2l-2-6-2 6h-2z" fill="white"/>
+  <polygon points="16,6 12,12 20,12" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/compass-rose.svg
+++ b/src/assets/stickers/directional/compass-rose.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- North -->
+  <polygon points="16,2 18.5,13 16,11 13.5,13" fill="#333"/>
+  <!-- South -->
+  <polygon points="16,30 18.5,19 16,21 13.5,19" fill="#999"/>
+  <!-- East -->
+  <polygon points="30,16 19,13.5 21,16 19,18.5" fill="#999"/>
+  <!-- West -->
+  <polygon points="2,16 13,13.5 11,16 13,18.5" fill="#999"/>
+  <!-- North dark -->
+  <polygon points="16,2 13.5,13 16,11" fill="#222"/>
+  <!-- Center -->
+  <circle cx="16" cy="16" r="2" fill="#333"/>
+  <!-- Labels -->
+  <text x="16" y="7" text-anchor="middle" font-family="Arial, sans-serif" font-size="5" font-weight="bold" fill="#E53935">N</text>
+</svg>

--- a/src/assets/stickers/directional/north-arrow.svg
+++ b/src/assets/stickers/directional/north-arrow.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="16,2 22,18 16,14 10,18" fill="#333" stroke="#111" stroke-width="0.5"/>
+  <polygon points="16,14 22,18 16,30 10,18" fill="#999" stroke="#111" stroke-width="0.5"/>
+  <text x="16" y="12" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" font-weight="bold" fill="white">N</text>
+</svg>

--- a/src/assets/stickers/directional/photo-angle.svg
+++ b/src/assets/stickers/directional/photo-angle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#43A047" stroke="#2E7D32" stroke-width="1.5"/>
+  <path d="M16 8 L8 24 L24 24 Z" fill="none" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="16" cy="20" r="2.5" fill="white"/>
+  <line x1="16" y1="8" x2="16" y2="14" stroke="white" stroke-width="2"/>
+</svg>

--- a/src/assets/stickers/directional/photo-spot.svg
+++ b/src/assets/stickers/directional/photo-spot.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#9C27B0" stroke="#7B1FA2" stroke-width="1.5"/>
+  <rect x="8" y="11" width="16" height="12" rx="2" fill="white"/>
+  <circle cx="16" cy="17" r="4" fill="#9C27B0"/>
+  <circle cx="16" cy="17" r="2" fill="white"/>
+  <rect x="13" y="9" width="6" height="3" rx="1" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/viewpoint-down.svg
+++ b/src/assets/stickers/directional/viewpoint-down.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="2" y="2" width="28" height="28" rx="4" fill="#FF6600" stroke="#E65100" stroke-width="1"/>
+  <circle cx="16" cy="13" r="5" fill="white" stroke="white" stroke-width="1.5"/>
+  <circle cx="16" cy="13" r="2" fill="#FF6600"/>
+  <polygon points="16,28 11,20 21,20" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/viewpoint-left.svg
+++ b/src/assets/stickers/directional/viewpoint-left.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="2" y="2" width="28" height="28" rx="4" fill="#FF6600" stroke="#E65100" stroke-width="1"/>
+  <circle cx="19" cy="16" r="5" fill="white" stroke="white" stroke-width="1.5"/>
+  <circle cx="19" cy="16" r="2" fill="#FF6600"/>
+  <polygon points="4,16 12,11 12,21" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/viewpoint-right.svg
+++ b/src/assets/stickers/directional/viewpoint-right.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="2" y="2" width="28" height="28" rx="4" fill="#FF6600" stroke="#E65100" stroke-width="1"/>
+  <circle cx="13" cy="16" r="5" fill="white" stroke="white" stroke-width="1.5"/>
+  <circle cx="13" cy="16" r="2" fill="#FF6600"/>
+  <polygon points="28,16 20,11 20,21" fill="white"/>
+</svg>

--- a/src/assets/stickers/directional/viewpoint-up.svg
+++ b/src/assets/stickers/directional/viewpoint-up.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="2" y="2" width="28" height="28" rx="4" fill="#FF6600" stroke="#E65100" stroke-width="1"/>
+  <circle cx="16" cy="19" r="5" fill="white" stroke="white" stroke-width="1.5"/>
+  <circle cx="16" cy="19" r="2" fill="#FF6600"/>
+  <polygon points="16,4 11,12 21,12" fill="white"/>
+</svg>

--- a/src/assets/stickers/markers/number-1.svg
+++ b/src/assets/stickers/markers/number-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">1</text>
+</svg>

--- a/src/assets/stickers/markers/number-10.svg
+++ b/src/assets/stickers/markers/number-10.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white">10</text>
+</svg>

--- a/src/assets/stickers/markers/number-2.svg
+++ b/src/assets/stickers/markers/number-2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">2</text>
+</svg>

--- a/src/assets/stickers/markers/number-3.svg
+++ b/src/assets/stickers/markers/number-3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">3</text>
+</svg>

--- a/src/assets/stickers/markers/number-4.svg
+++ b/src/assets/stickers/markers/number-4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">4</text>
+</svg>

--- a/src/assets/stickers/markers/number-5.svg
+++ b/src/assets/stickers/markers/number-5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">5</text>
+</svg>

--- a/src/assets/stickers/markers/number-6.svg
+++ b/src/assets/stickers/markers/number-6.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">6</text>
+</svg>

--- a/src/assets/stickers/markers/number-7.svg
+++ b/src/assets/stickers/markers/number-7.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">7</text>
+</svg>

--- a/src/assets/stickers/markers/number-8.svg
+++ b/src/assets/stickers/markers/number-8.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">8</text>
+</svg>

--- a/src/assets/stickers/markers/number-9.svg
+++ b/src/assets/stickers/markers/number-9.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E53935" stroke="#B71C1C" stroke-width="1.5"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white">9</text>
+</svg>

--- a/src/assets/stickers/markers/pin-blue.svg
+++ b/src/assets/stickers/markers/pin-blue.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 2C10.48 2 6 6.48 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.52-4.48-10-10-10z" fill="#1E88E5" stroke="#1565C0" stroke-width="1"/>
+  <circle cx="16" cy="12" r="4" fill="white"/>
+</svg>

--- a/src/assets/stickers/markers/pin-green.svg
+++ b/src/assets/stickers/markers/pin-green.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 2C10.48 2 6 6.48 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.52-4.48-10-10-10z" fill="#43A047" stroke="#2E7D32" stroke-width="1"/>
+  <circle cx="16" cy="12" r="4" fill="white"/>
+</svg>

--- a/src/assets/stickers/markers/pin-red.svg
+++ b/src/assets/stickers/markers/pin-red.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 2C10.48 2 6 6.48 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.52-4.48-10-10-10z" fill="#E53935" stroke="#B71C1C" stroke-width="1"/>
+  <circle cx="16" cy="12" r="4" fill="white"/>
+</svg>

--- a/src/assets/stickers/stamps/approved.svg
+++ b/src/assets/stickers/stamps/approved.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#E8F5E9" stroke="#43A047" stroke-width="2"/>
+  <polyline points="10,16 14,20 22,12" fill="none" stroke="#43A047" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/stickers/stamps/boundary.svg
+++ b/src/assets/stickers/stamps/boundary.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="3" y="3" width="26" height="26" rx="1" fill="none" stroke="#F57C00" stroke-width="2" stroke-dasharray="4 2"/>
+  <circle cx="3" cy="3" r="1.5" fill="#F57C00"/>
+  <circle cx="29" cy="3" r="1.5" fill="#F57C00"/>
+  <circle cx="3" cy="29" r="1.5" fill="#F57C00"/>
+  <circle cx="29" cy="29" r="1.5" fill="#F57C00"/>
+</svg>

--- a/src/assets/stickers/stamps/inspected.svg
+++ b/src/assets/stickers/stamps/inspected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="none" stroke="#1565C0" stroke-width="2"/>
+  <circle cx="16" cy="16" r="11" fill="none" stroke="#1565C0" stroke-width="0.5"/>
+  <polyline points="10,16 14,20 22,12" fill="none" stroke="#1565C0" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/stickers/symbols/area-mark.svg
+++ b/src/assets/stickers/symbols/area-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <pattern id="hatch" patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#1E88E5" stroke-width="1" stroke-opacity="0.5"/>
+    </pattern>
+  </defs>
+  <rect x="4" y="4" width="24" height="24" rx="1" fill="url(#hatch)" stroke="#1E88E5" stroke-width="1.5"/>
+  <text x="16" y="19" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" font-weight="bold" fill="#1565C0">A</text>
+</svg>

--- a/src/assets/stickers/symbols/measurement.svg
+++ b/src/assets/stickers/symbols/measurement.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ruler body -->
+  <rect x="2" y="10" width="28" height="12" rx="1" fill="#FFB300" stroke="#F57F17" stroke-width="1"/>
+  <!-- Tick marks -->
+  <line x1="6" y1="10" x2="6" y2="16" stroke="#F57F17" stroke-width="0.8"/>
+  <line x1="10" y1="10" x2="10" y2="14" stroke="#F57F17" stroke-width="0.8"/>
+  <line x1="14" y1="10" x2="14" y2="16" stroke="#F57F17" stroke-width="0.8"/>
+  <line x1="18" y1="10" x2="18" y2="14" stroke="#F57F17" stroke-width="0.8"/>
+  <line x1="22" y1="10" x2="22" y2="16" stroke="#F57F17" stroke-width="0.8"/>
+  <line x1="26" y1="10" x2="26" y2="14" stroke="#F57F17" stroke-width="0.8"/>
+</svg>

--- a/src/features/appraisal/components/tabs/DocumentChecklistTab.tsx
+++ b/src/features/appraisal/components/tabs/DocumentChecklistTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import Icon from '@shared/components/Icon';
 import Button from '@shared/components/Button';
 import clsx from 'clsx';
@@ -16,9 +16,24 @@ import {
   useRemoveAppendixDocument,
   useUpdateAppendixLayout,
 } from '@features/appraisal/api';
-import { createUploadSession, useUploadDocument } from '@features/request/api/documents';
+import {
+  createUploadSession,
+  useDownloadDocument,
+  useUploadDocument,
+} from '@features/request/api/documents';
 import { useGetGalleryPhotos } from '../../api/gallery';
-import type { AppendixDocumentDto, AppraisalAppendixDto, DocumentItemDto, } from '../../types/documentChecklist';
+import type {
+  AppendixDocumentDto,
+  AppraisalAppendixDto,
+  DocumentItemDto,
+} from '../../types/documentChecklist';
+import type { AnnotationResult } from '@shared/components/ImageAnnotationEditor';
+
+const ImageAnnotationEditor = lazy(
+  () => import('@shared/components/ImageAnnotationEditor/ImageAnnotationEditor'),
+);
+
+const isImageFile = (file: File) => /\.(jpg|jpeg|png|gif|webp|bmp|svg)$/i.test(file.name);
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
@@ -80,10 +95,12 @@ const ProgressBar = ({ uploaded, total }: { uploaded: number; total: number }) =
 // Action Dropdown Component
 const ActionDropdown = ({
   onView,
+  onEdit,
   onDelete,
   isEditable = false,
 }: {
   onView?: () => void;
+  onEdit?: () => void;
   onDelete?: () => void;
   isEditable?: boolean;
 }) => {
@@ -114,6 +131,19 @@ const ActionDropdown = ({
               >
                 <Icon name="eye" className="text-gray-400" />
                 View
+              </button>
+            )}
+            {isEditable && onEdit && (
+              <button
+                type="button"
+                onClick={() => {
+                  onEdit();
+                  setIsOpen(false);
+                }}
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                <Icon name="pen-to-square" className="text-gray-400" />
+                Edit
               </button>
             )}
             {isEditable && onDelete && (
@@ -188,6 +218,36 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
   const updateAppendixLayout = useUpdateAppendixLayout();
   const { mutateAsync: uploadDocument } = useUploadDocument();
   const { mutateAsync: addGalleryPhoto } = useAddGalleryPhoto();
+  const { mutateAsync: downloadDocument } = useDownloadDocument();
+
+  // Annotation editor state — use refs alongside state to avoid stale closures in async callbacks
+  const [showAnnotationEditor, setShowAnnotationEditor] = useState(false);
+  const [pendingEditFiles, _setPendingEditFiles] = useState<File[]>([]);
+  const pendingEditFilesRef = useRef<File[]>([]);
+  const setPendingEditFiles = (files: File[]) => {
+    pendingEditFilesRef.current = files;
+    _setPendingEditFiles(files);
+  };
+  const [editingFileIndex, _setEditingFileIndex] = useState(0);
+  const editingFileIndexRef = useRef(0);
+  const setEditingFileIndex = (idx: number) => {
+    editingFileIndexRef.current = idx;
+    _setEditingFileIndex(idx);
+  };
+  const [editingDocument, _setEditingDocument] = useState<AppendixDocumentDto | null>(null);
+  const editingDocumentRef = useRef<AppendixDocumentDto | null>(null);
+  const setEditingDocument = (doc: AppendixDocumentDto | null) => {
+    editingDocumentRef.current = doc;
+    _setEditingDocument(doc);
+  };
+  const [_editingAppendixId, _setEditingAppendixId] = useState<string | null>(null);
+  const editingAppendixIdRef = useRef<string | null>(null);
+  const setEditingAppendixId = (id: string | null) => {
+    editingAppendixIdRef.current = id;
+    _setEditingAppendixId(id);
+  };
+  const [editingImageUrl, setEditingImageUrl] = useState<string | null>(null);
+  const [editingFileName, setEditingFileName] = useState<string | null>(null);
 
   // Local UI state
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
@@ -274,62 +334,187 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
     return sessionPromiseRef.current;
   }, []);
 
-  // Upload flow: getOrCreateSession → uploadDocument → addAppendixDocument
-  const processFiles = useCallback(
-    async (files: FileList, appendixId: string) => {
+  // Upload a single file through the 3-step flow
+  const uploadSingleFile = useCallback(
+    async (file: File, appendixId: string, displaySequence?: number) => {
       if (!appraisalId) return;
 
-      // Clone files immediately — the FileList is emptied when the input resets
-      const fileArray = Array.from(files);
-      if (fileArray.length === 0) return;
+      const sessionId = await getOrCreateSession();
 
+      const uploadResult = await uploadDocument({
+        uploadSessionId: sessionId,
+        file,
+        documentType: 'APPENDIX',
+        documentCategory: 'appendix',
+      });
+
+      const galleryPhoto = await addGalleryPhoto({
+        appraisalId,
+        documentId: uploadResult.documentId,
+        photoType: 'general',
+        uploadedBy: 'current-user',
+        photoCategory: null,
+        caption: null,
+        latitude: null,
+        longitude: null,
+        capturedAt: null,
+        photoTopicIds: null,
+        fileName: file.name,
+        filePath: null,
+        fileExtension: file.name.split('.').pop() ?? null,
+        mimeType: file.type || null,
+        fileSizeBytes: file.size,
+        uploadedByName: null,
+      });
+
+      const appendix = appendices.find(a => a.id === appendixId);
+      const nextSequence = displaySequence ?? (appendix?.documents.length ?? 0) + 1;
+
+      await addAppendixDocument.mutateAsync({
+        appraisalId,
+        appendixId,
+        body: {
+          galleryPhotoId: galleryPhoto.id,
+          displaySequence: nextSequence,
+        },
+      });
+    },
+    [
+      appraisalId,
+      appendices,
+      getOrCreateSession,
+      uploadDocument,
+      addGalleryPhoto,
+      addAppendixDocument,
+    ],
+  );
+
+  // Upload File[] (non-FileList variant)
+  const processFilesFromArray = useCallback(
+    async (files: File[], appendixId: string) => {
+      if (!appraisalId || files.length === 0) return;
       try {
-        const sessionId = await getOrCreateSession();
-
-        for (const file of fileArray) {
-          // Step 1: Upload document to get documentId
-          const uploadResult = await uploadDocument({
-            uploadSessionId: sessionId,
-            file,
-            documentType: 'APPENDIX',
-            documentCategory: 'appendix',
-          });
-
-          // Step 2: Register as gallery photo to get galleryPhotoId
-          const galleryPhoto = await addGalleryPhoto({
-            appraisalId,
-            documentId: uploadResult.documentId,
-            photoType: 'general',
-            uploadedBy: 'current-user',
-            photoCategory: null,
-            caption: null,
-            latitude: null,
-            longitude: null,
-            capturedAt: null,
-            photoTopicIds: null,
-          });
-
-          // Step 3: Attach to appendix using galleryPhotoId
-          const appendix = appendices.find(a => a.id === appendixId);
-          const nextSequence = (appendix?.documents.length ?? 0) + 1;
-
-          await addAppendixDocument.mutateAsync({
-            appraisalId,
-            appendixId,
-            body: {
-              galleryPhotoId: galleryPhoto.id,
-              displaySequence: nextSequence,
-            },
-          });
+        for (const file of files) {
+          await uploadSingleFile(file, appendixId);
         }
-
         toast.success('Files uploaded successfully');
       } catch (error) {
         console.error('Upload failed:', error);
         toast.error('Failed to upload files');
       }
     },
-    [appraisalId, appendices, getOrCreateSession, uploadDocument, addGalleryPhoto, addAppendixDocument],
+    [appraisalId, uploadSingleFile],
+  );
+
+  // Annotation editor handlers
+  const handleAnnotationSave = useCallback(
+    async (result: AnnotationResult) => {
+      const file = new File([result.imageBlob], result.fileName, { type: 'image/png' });
+      // Read from refs to avoid stale closures
+      const curEditingDoc = editingDocumentRef.current;
+      const curAppendixId = editingAppendixIdRef.current;
+      const curFileIndex = editingFileIndexRef.current;
+      const curPendingFiles = pendingEditFilesRef.current;
+
+      try {
+        if (curEditingDoc && curAppendixId) {
+          // Edit-after-upload: upload new annotated image, then remove old one
+          await uploadSingleFile(file, curAppendixId, curEditingDoc.displaySequence);
+          if (appraisalId) {
+            await removeAppendixDocument.mutateAsync({
+              appraisalId,
+              appendixId: curAppendixId,
+              documentId: curEditingDoc.id,
+            });
+          }
+          setEditingDocument(null);
+          setEditingAppendixId(null);
+          toast.success('Document updated');
+        } else {
+          // Edit-before-upload: upload annotated image
+          if (curAppendixId) {
+            await uploadSingleFile(file, curAppendixId);
+          }
+
+          // Advance to next pending file
+          const nextIndex = curFileIndex + 1;
+          if (nextIndex < curPendingFiles.length) {
+            setEditingFileIndex(nextIndex);
+            return; // Keep editor open
+          }
+
+          // All done
+          setPendingEditFiles([]);
+          setEditingFileIndex(0);
+          setActiveAppendixId(null);
+          toast.success('Files uploaded successfully');
+        }
+      } catch (error) {
+        console.error('Annotation save failed:', error);
+        toast.error('Failed to save annotated image');
+      }
+    },
+    [appraisalId, uploadSingleFile, removeAppendixDocument],
+  );
+
+  const handleAnnotationSkip = useCallback(() => {
+    // Read from refs to avoid stale closures
+    const curPendingFiles = pendingEditFilesRef.current;
+    const curFileIndex = editingFileIndexRef.current;
+    const curAppendixId = editingAppendixIdRef.current;
+
+    // Upload the current file without annotation
+    const currentFile = curPendingFiles[curFileIndex];
+
+    if (currentFile && curAppendixId) {
+      void uploadSingleFile(currentFile, curAppendixId).catch(() => {
+        toast.error('Failed to upload file');
+      });
+    }
+
+    // Advance to next file
+    const nextIndex = curFileIndex + 1;
+    if (nextIndex < curPendingFiles.length) {
+      setEditingFileIndex(nextIndex);
+    } else {
+      setShowAnnotationEditor(false);
+      setPendingEditFiles([]);
+      setEditingFileIndex(0);
+      setEditingAppendixId(null);
+    }
+  }, [uploadSingleFile]);
+
+  const handleAnnotationClose = useCallback(() => {
+    setShowAnnotationEditor(false);
+    setPendingEditFiles([]);
+    setEditingFileIndex(0);
+    setEditingDocument(null);
+    setEditingAppendixId(null);
+    setEditingFileName(null);
+    if (editingImageUrl) {
+      URL.revokeObjectURL(editingImageUrl);
+      setEditingImageUrl(null);
+    }
+    // Don't clear activeAppendixId if there are pending non-image files
+  }, [editingImageUrl]);
+
+  // Edit an existing appendix document
+  const handleEditDocument = useCallback(
+    async (appendixId: string, doc: AppendixDocumentDto) => {
+      try {
+        const { blob, fileName } = await downloadDocument(doc.documentId);
+        const url = URL.createObjectURL(blob);
+        setEditingDocument(doc);
+        setEditingAppendixId(appendixId);
+        setEditingImageUrl(url);
+        setEditingFileName(fileName);
+        setShowAnnotationEditor(true);
+      } catch (error) {
+        console.error('Failed to download document for editing:', error);
+        toast.error('Failed to load document for editing');
+      }
+    },
+    [downloadDocument],
   );
 
   const handleAddFiles = (appendixId: string) => {
@@ -340,8 +525,26 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
   const handleUploadFromDevice = (files: FileList) => {
     const appendixId = activeAppendixIdRef.current;
     if (!appendixId) return;
-    void processFiles(files, appendixId);
-    setActiveAppendixId(null);
+
+    const fileArray = Array.from(files);
+    const imageFiles = fileArray.filter(isImageFile);
+    const nonImageFiles = fileArray.filter(f => !isImageFile(f));
+
+    // Upload non-image files directly
+    if (nonImageFiles.length > 0) {
+      void processFilesFromArray(nonImageFiles, appendixId);
+    }
+
+    // Open editor for image files — save appendixId into editor state
+    // because activeAppendixIdRef will be cleared when PhotoSourceModal closes
+    if (imageFiles.length > 0) {
+      setEditingAppendixId(appendixId);
+      setPendingEditFiles(imageFiles);
+      setEditingFileIndex(0);
+      setShowAnnotationEditor(true);
+    } else {
+      setActiveAppendixId(null);
+    }
   };
 
   const transitionToGalleryRef = useRef(false);
@@ -417,8 +620,21 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
     e.preventDefault();
     setDragOverSection(null);
     const files = e.dataTransfer.files;
-    if (files.length > 0) {
-      void processFiles(files, appendixId);
+    if (files.length === 0) return;
+
+    const fileArray = Array.from(files);
+    const imageFiles = fileArray.filter(isImageFile);
+    const nonImageFiles = fileArray.filter(f => !isImageFile(f));
+
+    if (nonImageFiles.length > 0) {
+      void processFilesFromArray(nonImageFiles, appendixId);
+    }
+
+    if (imageFiles.length > 0) {
+      setEditingAppendixId(appendixId);
+      setPendingEditFiles(imageFiles);
+      setEditingFileIndex(0);
+      setShowAnnotationEditor(true);
     }
   };
 
@@ -710,6 +926,7 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
                               <div className="flex justify-end">
                                 <ActionDropdown
                                   onView={() => handleViewDocument(doc)}
+                                  onEdit={() => void handleEditDocument(appendix.id, doc)}
                                   onDelete={() => handleDeleteDocument(appendix.id, doc.id)}
                                   isEditable={!readOnly}
                                 />
@@ -781,6 +998,31 @@ export const DocumentChecklistTab = ({ readOnly }: { readOnly?: boolean }) => {
         images={galleryImages}
         multiSelect
       />
+
+      {/* Image Annotation Editor */}
+      {showAnnotationEditor && (
+        <Suspense
+          fallback={
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900">
+              <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+            </div>
+          }
+        >
+          <ImageAnnotationEditor
+            isOpen={showAnnotationEditor}
+            onClose={handleAnnotationClose}
+            imageFile={editingDocument ? undefined : pendingEditFiles[editingFileIndex]}
+            imageUrl={editingImageUrl ?? undefined}
+            onSave={handleAnnotationSave}
+            onSkip={editingDocument ? undefined : handleAnnotationSkip}
+            fileName={
+              editingDocument
+                ? (editingFileName ?? `document-${editingDocument.documentId}.png`)
+                : pendingEditFiles[editingFileIndex]?.name
+            }
+          />
+        </Suspense>
+      )}
     </div>
   );
 };

--- a/src/features/request/api/documents.ts
+++ b/src/features/request/api/documents.ts
@@ -82,14 +82,30 @@ export const useUploadDocumentLegacy = () => {
  * 3. Remove the mock implementation
  * 4. Ensure your API endpoint matches: GET /api/documents/{documentId}/download
  */
+export interface DownloadDocumentResult {
+  blob: Blob;
+  fileName: string | null;
+}
+
 export const useDownloadDocument = () => {
   return useMutation({
-    mutationFn: async (documentId: string): Promise<Blob> => {
-      const { data } = await axios.get(`/documents/${documentId}/download`, {
+    mutationFn: async (documentId: string): Promise<DownloadDocumentResult> => {
+      const response = await axios.get(`/documents/${documentId}/download`, {
         responseType: 'blob',
         params: { download: false },
       });
-      return data;
+
+      // Extract filename from Content-Disposition header if available
+      const disposition = response.headers?.['content-disposition'] as string | undefined;
+      let fileName: string | null = null;
+      if (disposition) {
+        const match = disposition.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
+        if (match) {
+          fileName = decodeURIComponent(match[1].replace(/"/g, ''));
+        }
+      }
+
+      return { blob: response.data, fileName };
     },
   });
 };

--- a/src/features/request/components/DocumentUploader.tsx
+++ b/src/features/request/components/DocumentUploader.tsx
@@ -664,7 +664,7 @@ const DocumentUploader: React.FunctionComponent<DocumentUploaderProps> = ({
     } else if (document.documentId) {
       // Download from server
       downloadDocument(document.documentId, {
-        onSuccess: blob => {
+        onSuccess: ({ blob }) => {
           const url = URL.createObjectURL(blob);
           window.open(url, '_blank');
         },

--- a/src/shared/components/ImageAnnotationEditor/ColorPicker.tsx
+++ b/src/shared/components/ImageAnnotationEditor/ColorPicker.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx';
+import { COLOR_PRESETS } from './constants';
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+  label?: string;
+}
+
+export default function ColorPicker({ value, onChange, label }: ColorPickerProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && <span className="text-xs text-gray-400 font-medium">{label}</span>}
+      <div className="flex flex-wrap gap-1.5">
+        {COLOR_PRESETS.map(color => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => onChange(color)}
+            className={clsx(
+              'w-6 h-6 rounded-full border-2 transition-transform hover:scale-110',
+              value === color ? 'border-white ring-2 ring-primary scale-110' : 'border-gray-600',
+            )}
+            style={{ backgroundColor: color }}
+            title={color}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/FabricCanvas.tsx
+++ b/src/shared/components/ImageAnnotationEditor/FabricCanvas.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useRef, useCallback } from 'react';
+import {
+  Canvas,
+  FabricImage,
+  Rect,
+  Circle,
+  Line,
+  IText,
+  Group,
+  FabricText,
+  PencilBrush,
+  FabricObject,
+  Triangle,
+} from 'fabric';
+import type { FabricCanvasProps, SelectedObjectInfo } from './types';
+import { NUMBER_MARKER_RADIUS, NUMBER_MARKER_COLORS } from './constants';
+
+function getObjectInfo(canvas: Canvas): SelectedObjectInfo | null {
+  const active = canvas.getActiveObject();
+  if (!active) return null;
+
+  const objects = canvas.getActiveObjects();
+  const count = objects.length;
+
+  if (count === 0) return null;
+
+  // Use the first object for style info
+  const obj = objects[0];
+
+  let type: SelectedObjectInfo['type'] = 'unknown';
+  if (obj instanceof IText || obj instanceof FabricText) {
+    type = 'text';
+  } else if (obj instanceof Group) {
+    type = 'group';
+  } else if (obj instanceof FabricImage) {
+    type = 'image';
+  } else if (obj instanceof Rect || obj instanceof Circle || obj instanceof Line || obj instanceof Triangle) {
+    type = 'shape';
+  }
+
+  return {
+    type,
+    strokeColor: (obj.stroke as string) || undefined,
+    fillColor: (obj.fill as string) || undefined,
+    strokeWidth: obj.strokeWidth,
+    fontSize: 'fontSize' in obj ? (obj as any).fontSize : undefined,
+    opacity: active.opacity ?? 1,
+    count,
+  };
+}
+
+export default function FabricCanvas({
+  imageFile,
+  imageUrl,
+  activeTool,
+  toolOptions,
+  numberCounter,
+  selectedSticker,
+  onNumberPlaced,
+  onCanvasReady,
+  onSelectionChange,
+}: FabricCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasElRef = useRef<HTMLCanvasElement>(null);
+  const fabricRef = useRef<Canvas | null>(null);
+  const drawingRef = useRef<{
+    isDrawing: boolean;
+    startX: number;
+    startY: number;
+    shape: FabricObject | null;
+  }>({ isDrawing: false, startX: 0, startY: 0, shape: null });
+
+  // Initialize canvas
+  useEffect(() => {
+    if (!canvasElRef.current || !containerRef.current) return;
+
+    const container = containerRef.current;
+    const canvas = new Canvas(canvasElRef.current, {
+      width: container.clientWidth,
+      height: container.clientHeight,
+      backgroundColor: '#1a1a1a',
+      selection: true,
+    });
+
+    fabricRef.current = canvas;
+    onCanvasReady(canvas);
+
+    // Track selection changes
+    const emitSelection = () => onSelectionChange(getObjectInfo(canvas));
+    canvas.on('selection:created', emitSelection);
+    canvas.on('selection:updated', emitSelection);
+    canvas.on('selection:cleared', () => onSelectionChange(null));
+
+    // Load background image — delay slightly to ensure container has layout dimensions
+    const loadImage = async () => {
+      let imgUrl: string;
+      let shouldRevoke = false;
+
+      if (imageFile) {
+        imgUrl = URL.createObjectURL(imageFile);
+        shouldRevoke = true;
+      } else if (imageUrl) {
+        imgUrl = imageUrl;
+      } else {
+        return;
+      }
+
+      try {
+        const img = await FabricImage.fromURL(imgUrl, { crossOrigin: 'anonymous' });
+
+        // Use container's current dimensions (flex layout should be resolved by now)
+        const containerW = container.clientWidth;
+        const containerH = container.clientHeight;
+        const imgW = img.width ?? 1;
+        const imgH = img.height ?? 1;
+        const scale = Math.min(containerW / imgW, containerH / imgH);
+
+        const canvasW = Math.round(imgW * scale);
+        const canvasH = Math.round(imgH * scale);
+
+        canvas.setDimensions({ width: canvasW, height: canvasH });
+
+        img.scaleX = scale;
+        img.scaleY = scale;
+        canvas.backgroundImage = img;
+        canvas.renderAll();
+      } finally {
+        if (shouldRevoke) {
+          URL.revokeObjectURL(imgUrl);
+        }
+      }
+    };
+
+    // Wait a frame so the flex container is fully laid out
+    requestAnimationFrame(() => void loadImage());
+
+    // Resize handler
+    const handleResize = () => {
+      if (!fabricRef.current || !container) return;
+      const bgImg = fabricRef.current.backgroundImage;
+      if (bgImg) {
+        const imgW = bgImg.width ?? 1;
+        const imgH = bgImg.height ?? 1;
+        const scale = Math.min(container.clientWidth / imgW, container.clientHeight / imgH);
+        fabricRef.current.setDimensions({
+          width: imgW * scale,
+          height: imgH * scale,
+        });
+        bgImg.scaleX = scale;
+        bgImg.scaleY = scale;
+        fabricRef.current.renderAll();
+      }
+    };
+
+    const observer = new ResizeObserver(handleResize);
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      canvas.dispose();
+      fabricRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imageFile, imageUrl]);
+
+  // Update drawing mode based on active tool
+  useEffect(() => {
+    const canvas = fabricRef.current;
+    if (!canvas) return;
+
+    if (activeTool === 'freehand') {
+      canvas.isDrawingMode = true;
+      const brush = new PencilBrush(canvas);
+      brush.color = toolOptions.strokeColor;
+      brush.width = toolOptions.strokeWidth;
+      canvas.freeDrawingBrush = brush;
+    } else {
+      canvas.isDrawingMode = false;
+    }
+
+    // Toggle selection
+    canvas.selection = activeTool === 'select' || activeTool === 'eraser';
+    canvas.forEachObject(obj => {
+      obj.selectable = activeTool === 'select' || activeTool === 'eraser';
+      obj.evented = activeTool === 'select' || activeTool === 'eraser';
+    });
+
+    canvas.defaultCursor =
+      activeTool === 'select' ? 'default' : activeTool === 'eraser' ? 'pointer' : 'crosshair';
+
+    canvas.renderAll();
+  }, [activeTool, toolOptions.strokeColor, toolOptions.strokeWidth]);
+
+  // Handle shape/tool mouse events
+  const handleMouseDown = useCallback(
+    (e: { e: MouseEvent; absolutePointer?: { x: number; y: number } }) => {
+      const canvas = fabricRef.current;
+      if (!canvas || activeTool === 'select' || activeTool === 'freehand') return;
+
+      const pointer = canvas.getScenePoint(e.e);
+      if (!pointer) return;
+
+      // Find object under pointer (works even when evented is false)
+      const hitTarget = canvas.getObjects().reverse().find(obj => obj.containsPoint(pointer));
+
+      if (activeTool === 'eraser') {
+        if (hitTarget) {
+          canvas.remove(hitTarget);
+          canvas.renderAll();
+        }
+        return;
+      }
+
+      // If clicking on an existing object, select it instead of creating a new one
+      if (hitTarget) {
+        hitTarget.selectable = true;
+        hitTarget.evented = true;
+        canvas.setActiveObject(hitTarget);
+        // Enter editing mode for text objects
+        if (hitTarget instanceof IText) {
+          hitTarget.enterEditing();
+        }
+        canvas.renderAll();
+        return;
+      }
+
+      if (activeTool === 'text') {
+        const text = new IText('Type here', {
+          left: pointer.x,
+          top: pointer.y,
+          fontSize: toolOptions.fontSize,
+          fill: toolOptions.strokeColor,
+          opacity: toolOptions.opacity,
+          fontFamily: 'Arial',
+        });
+        canvas.add(text);
+        canvas.setActiveObject(text);
+        text.enterEditing();
+        canvas.renderAll();
+        return;
+      }
+
+      if (activeTool === 'number') {
+        const colorIdx = (numberCounter - 1) % NUMBER_MARKER_COLORS.length;
+        const color = NUMBER_MARKER_COLORS[colorIdx];
+        // Scale circle radius based on font size (fontSize is the text size, circle wraps it)
+        const radius = Math.max(toolOptions.fontSize * 0.75, NUMBER_MARKER_RADIUS);
+
+        const circle = new Circle({
+          radius,
+          fill: color,
+          originX: 'center',
+          originY: 'center',
+        });
+
+        const text = new FabricText(String(numberCounter), {
+          fontSize: toolOptions.fontSize,
+          fill: '#FFFFFF',
+          fontWeight: 'bold',
+          fontFamily: 'Arial',
+          originX: 'center',
+          originY: 'center',
+        });
+
+        const group = new Group([circle, text], {
+          left: pointer.x - radius,
+          top: pointer.y - radius,
+          opacity: toolOptions.opacity,
+        });
+
+        canvas.add(group);
+        canvas.renderAll();
+        onNumberPlaced();
+        return;
+      }
+
+      if (activeTool === 'sticker' && selectedSticker) {
+        // Rasterize SVG to a temp canvas first, then create FabricImage
+        // This ensures SVG <text> and other elements render correctly
+        const targetSize = 80;
+        const renderSize = 160; // 2x for crisp rendering
+        const imgEl = new Image();
+        imgEl.crossOrigin = 'anonymous';
+        imgEl.onload = () => {
+          const offscreen = document.createElement('canvas');
+          offscreen.width = renderSize;
+          offscreen.height = renderSize;
+          const ctx = offscreen.getContext('2d')!;
+          ctx.drawImage(imgEl, 0, 0, renderSize, renderSize);
+
+          const fabricImg = new FabricImage(offscreen, {
+            left: pointer.x - targetSize / 2,
+            top: pointer.y - targetSize / 2,
+            scaleX: targetSize / renderSize,
+            scaleY: targetSize / renderSize,
+            opacity: toolOptions.opacity,
+          });
+          canvas.add(fabricImg);
+          canvas.renderAll();
+        };
+        imgEl.src = selectedSticker;
+        return;
+      }
+
+      // Shape drawing tools: line, arrow, rect, circle
+      drawingRef.current.isDrawing = true;
+      drawingRef.current.startX = pointer.x;
+      drawingRef.current.startY = pointer.y;
+
+      let shape: FabricObject | null = null;
+
+      if (activeTool === 'line' || activeTool === 'arrow') {
+        shape = new Line([pointer.x, pointer.y, pointer.x, pointer.y], {
+          stroke: toolOptions.strokeColor,
+          strokeWidth: toolOptions.strokeWidth,
+          opacity: toolOptions.opacity,
+          selectable: false,
+          evented: false,
+        });
+      } else if (activeTool === 'rect') {
+        shape = new Rect({
+          left: pointer.x,
+          top: pointer.y,
+          width: 0,
+          height: 0,
+          stroke: toolOptions.strokeColor,
+          strokeWidth: toolOptions.strokeWidth,
+          fill: toolOptions.fillColor === 'transparent' ? '' : toolOptions.fillColor,
+          opacity: toolOptions.opacity,
+          selectable: false,
+          evented: false,
+        });
+      } else if (activeTool === 'circle') {
+        shape = new Circle({
+          left: pointer.x,
+          top: pointer.y,
+          radius: 0,
+          stroke: toolOptions.strokeColor,
+          strokeWidth: toolOptions.strokeWidth,
+          fill: toolOptions.fillColor === 'transparent' ? '' : toolOptions.fillColor,
+          opacity: toolOptions.opacity,
+          selectable: false,
+          evented: false,
+        });
+      }
+
+      if (shape) {
+        drawingRef.current.shape = shape;
+        canvas.add(shape);
+      }
+    },
+    [activeTool, toolOptions, numberCounter, selectedSticker, onNumberPlaced],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: { e: MouseEvent }) => {
+      const canvas = fabricRef.current;
+      if (!canvas || !drawingRef.current.isDrawing || !drawingRef.current.shape) return;
+
+      const pointer = canvas.getScenePoint(e.e);
+      if (!pointer) return;
+
+      const { startX, startY, shape } = drawingRef.current;
+
+      if (activeTool === 'line' || activeTool === 'arrow') {
+        (shape as Line).set({ x2: pointer.x, y2: pointer.y });
+      } else if (activeTool === 'rect') {
+        const w = Math.abs(pointer.x - startX);
+        const h = Math.abs(pointer.y - startY);
+        (shape as Rect).set({
+          left: Math.min(startX, pointer.x),
+          top: Math.min(startY, pointer.y),
+          width: w,
+          height: h,
+        });
+      } else if (activeTool === 'circle') {
+        const radius =
+          Math.sqrt(Math.pow(pointer.x - startX, 2) + Math.pow(pointer.y - startY, 2)) / 2;
+        (shape as Circle).set({
+          left: (startX + pointer.x) / 2 - radius,
+          top: (startY + pointer.y) / 2 - radius,
+          radius,
+        });
+      }
+
+      canvas.renderAll();
+    },
+    [activeTool],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    const canvas = fabricRef.current;
+    if (!canvas || !drawingRef.current.isDrawing) return;
+
+    const { shape, startX, startY } = drawingRef.current;
+    drawingRef.current.isDrawing = false;
+
+    if (shape) {
+      // If arrow, add arrowhead
+      if (activeTool === 'arrow' && shape instanceof Line) {
+        const line = shape;
+        const x1 = line.x1 ?? startX;
+        const y1 = line.y1 ?? startY;
+        const x2 = line.x2 ?? startX;
+        const y2 = line.y2 ?? startY;
+        const angle = Math.atan2(y2 - y1, x2 - x1) * (180 / Math.PI);
+
+        const headSize = toolOptions.strokeWidth * 4;
+        const head = new Triangle({
+          width: headSize,
+          height: headSize,
+          fill: toolOptions.strokeColor,
+          left: x2,
+          top: y2,
+          angle: angle + 90,
+          originX: 'center',
+          originY: 'center',
+          opacity: toolOptions.opacity,
+          selectable: false,
+          evented: false,
+        });
+
+        canvas.remove(shape);
+        const group = new Group([line, head], {
+          opacity: toolOptions.opacity,
+        });
+        canvas.add(group);
+      }
+
+      // Make selectable after drawing
+      shape.set({ selectable: true, evented: true });
+      canvas.renderAll();
+    }
+
+    drawingRef.current.shape = null;
+  }, [activeTool, toolOptions]);
+
+  // Attach mouse event handlers
+  useEffect(() => {
+    const canvas = fabricRef.current;
+    if (!canvas) return;
+
+    canvas.on('mouse:down', handleMouseDown as any);
+    canvas.on('mouse:move', handleMouseMove as any);
+    canvas.on('mouse:up', handleMouseUp as any);
+
+    return () => {
+      canvas.off('mouse:down', handleMouseDown as any);
+      canvas.off('mouse:move', handleMouseMove as any);
+      canvas.off('mouse:up', handleMouseUp as any);
+    };
+  }, [handleMouseDown, handleMouseMove, handleMouseUp]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex-1 flex items-center justify-center bg-gray-900 overflow-hidden"
+    >
+      <canvas ref={canvasElRef} />
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/ImageAnnotationEditor.tsx
+++ b/src/shared/components/ImageAnnotationEditor/ImageAnnotationEditor.tsx
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Canvas } from 'fabric';
+import { IText, FabricText, Group, Line, ActiveSelection } from 'fabric';
+import type { ImageAnnotationEditorProps, EditorState, AnnotationTool, ToolOptions, SelectedObjectInfo } from './types';
+import { DEFAULT_TOOL_OPTIONS } from './constants';
+import Toolbar from './Toolbar';
+import FabricCanvas from './FabricCanvas';
+import ToolPanel from './ToolPanel';
+import { useAnnotationHistory } from './useAnnotationHistory';
+import { useCanvasExport } from './useCanvasExport';
+
+export default function ImageAnnotationEditor({
+  isOpen,
+  onClose,
+  imageFile,
+  imageUrl,
+  onSave,
+  onSkip,
+  fileName,
+}: ImageAnnotationEditorProps) {
+  const canvasRef = useRef<Canvas | null>(null);
+  const [state, setState] = useState<EditorState>({
+    activeTool: 'select',
+    toolOptions: DEFAULT_TOOL_OPTIONS,
+    numberCounter: 1,
+    selectedSticker: null,
+    isExporting: false,
+  });
+
+  const [selectedObjectInfo, setSelectedObjectInfo] = useState<SelectedObjectInfo | null>(null);
+
+  const { saveSnapshot, undo, redo, canUndo, canRedo, reset } = useAnnotationHistory(canvasRef);
+  const { exportCanvas, getCanvasJson } = useCanvasExport(canvasRef);
+
+  // Body scroll lock
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+  }, [isOpen]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Delete selected object(s)
+      if ((e.key === 'Delete' || e.key === 'Backspace') && !e.ctrlKey && !e.metaKey) {
+        const canvas = canvasRef.current;
+        if (canvas) {
+          const active = canvas.getActiveObject();
+          // Don't delete if we're editing text
+          if (active && !(active as any).isEditing) {
+            const objects = canvas.getActiveObjects();
+            canvas.discardActiveObject();
+            objects.forEach(obj => canvas.remove(obj));
+            canvas.renderAll();
+            saveSnapshot();
+          }
+        }
+      }
+
+      // Select all (Ctrl+A)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+        e.preventDefault();
+        const canvas = canvasRef.current;
+        if (canvas) {
+          const allObjects = canvas.getObjects();
+          if (allObjects.length > 0) {
+            const sel = new ActiveSelection(allObjects, { canvas });
+            canvas.setActiveObject(sel);
+            canvas.renderAll();
+          }
+        }
+      }
+
+      // Undo/Redo
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
+        e.preventDefault();
+        redo();
+      }
+
+      // Escape
+      if (e.key === 'Escape') {
+        const canvas = canvasRef.current;
+        if (canvas) {
+          canvas.discardActiveObject();
+          canvas.renderAll();
+        }
+      }
+
+      // Tool shortcuts
+      const toolKeys: Record<string, AnnotationTool> = {
+        v: 'select',
+        t: 'text',
+        n: 'number',
+        a: 'arrow',
+        l: 'line',
+        r: 'rect',
+        c: 'circle',
+        f: 'freehand',
+        s: 'sticker',
+        e: 'eraser',
+      };
+
+      if (!e.ctrlKey && !e.metaKey && !e.altKey && toolKeys[e.key]) {
+        // Don't change tool while editing text
+        const canvas = canvasRef.current;
+        const active = canvas?.getActiveObject();
+        if (active && (active as any).isEditing) return;
+
+        setState(prev => ({ ...prev, activeTool: toolKeys[e.key] }));
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, undo, redo, saveSnapshot]);
+
+  const handleCanvasReady = useCallback(
+    (canvas: Canvas) => {
+      canvasRef.current = canvas;
+
+      // Save initial snapshot after image loads
+      canvas.on('after:render', function initialSnapshot() {
+        if (canvas.backgroundImage) {
+          canvas.off('after:render', initialSnapshot);
+          setTimeout(() => saveSnapshot(), 100);
+        }
+      });
+
+      // Save snapshot on object modifications
+      canvas.on('object:added', () => saveSnapshot());
+      canvas.on('object:modified', () => saveSnapshot());
+      canvas.on('object:removed', () => saveSnapshot());
+    },
+    [saveSnapshot],
+  );
+
+  const handleToolChange = useCallback((tool: AnnotationTool) => {
+    setState(prev => ({ ...prev, activeTool: tool }));
+  }, []);
+
+  const handleToolOptionsChange = useCallback((opts: Partial<ToolOptions>) => {
+    setState(prev => ({
+      ...prev,
+      toolOptions: { ...prev.toolOptions, ...opts },
+    }));
+  }, []);
+
+  const handleSelectionChange = useCallback((info: SelectedObjectInfo | null) => {
+    setSelectedObjectInfo(info);
+  }, []);
+
+  const handleSelectedObjectStyleChange = useCallback((opts: Partial<ToolOptions>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const objects = canvas.getActiveObjects();
+    if (objects.length === 0) return;
+
+    for (const obj of objects) {
+      if (opts.strokeColor !== undefined) {
+        // For text objects, change fill (text color)
+        if (obj instanceof IText || obj instanceof FabricText) {
+          obj.set('fill', opts.strokeColor);
+        } else if (obj instanceof Group) {
+          // Groups: arrows (Line + Triangle) or number markers (Circle + Text)
+          const children = obj.getObjects();
+          for (const child of children) {
+            if (child instanceof FabricText) {
+              // keep text white for number markers
+            } else if (child instanceof Line) {
+              child.set('stroke', opts.strokeColor);
+            } else {
+              child.set('fill', opts.strokeColor);
+            }
+          }
+        } else {
+          obj.set('stroke', opts.strokeColor);
+        }
+      }
+      if (opts.fillColor !== undefined) {
+        if (!(obj instanceof IText) && !(obj instanceof FabricText)) {
+          obj.set('fill', opts.fillColor === 'transparent' ? '' : opts.fillColor);
+        }
+      }
+      if (opts.strokeWidth !== undefined) {
+        obj.set('strokeWidth', opts.strokeWidth);
+      }
+      if (opts.fontSize !== undefined) {
+        if (obj instanceof IText || obj instanceof FabricText) {
+          obj.set('fontSize', opts.fontSize);
+        } else if (obj instanceof Group) {
+          for (const child of obj.getObjects()) {
+            if (child instanceof FabricText) {
+              child.set('fontSize', opts.fontSize);
+            }
+          }
+        }
+      }
+      if (opts.opacity !== undefined) {
+        obj.set('opacity', opts.opacity);
+      }
+    }
+
+    canvas.renderAll();
+    saveSnapshot();
+    // Re-emit selection info with updated values
+    setSelectedObjectInfo(prev => prev ? { ...prev, ...opts } : prev);
+  }, [saveSnapshot]);
+
+  const handleStickerSelect = useCallback((stickerUrl: string) => {
+    setState(prev => ({
+      ...prev,
+      selectedSticker: stickerUrl,
+      activeTool: 'sticker',
+    }));
+  }, []);
+
+  const handleNumberPlaced = useCallback(() => {
+    setState(prev => ({ ...prev, numberCounter: prev.numberCounter + 1 }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setState(prev => ({ ...prev, isExporting: true }));
+    try {
+      const blob = await exportCanvas();
+      if (!blob) throw new Error('Failed to export canvas');
+
+      const json = getCanvasJson();
+      const resultFileName = fileName?.replace(/\.[^.]+$/, '.png') ?? 'annotated.png';
+
+      await onSave({
+        imageBlob: blob,
+        fabricJson: json,
+        fileName: resultFileName,
+      });
+
+      onClose();
+    } catch (error) {
+      console.error('Failed to save annotation:', error);
+    } finally {
+      setState(prev => ({ ...prev, isExporting: false }));
+    }
+  }, [exportCanvas, getCanvasJson, fileName, onSave, onClose]);
+
+  const handleCancel = useCallback(() => {
+    reset();
+    onClose();
+  }, [reset, onClose]);
+
+  const handleSkip = useCallback(() => {
+    reset();
+    onSkip?.();
+  }, [reset, onSkip]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-gray-900">
+      {/* Toolbar */}
+      <Toolbar
+        activeTool={state.activeTool}
+        onToolChange={handleToolChange}
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onSave={handleSave}
+        onSkip={onSkip ? handleSkip : undefined}
+        onCancel={handleCancel}
+        isSaving={state.isExporting}
+      />
+
+      {/* Main area */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Canvas */}
+        <FabricCanvas
+          imageFile={imageFile}
+          imageUrl={imageUrl}
+          activeTool={state.activeTool}
+          toolOptions={state.toolOptions}
+          numberCounter={state.numberCounter}
+          selectedSticker={state.selectedSticker}
+          onNumberPlaced={handleNumberPlaced}
+          onCanvasReady={handleCanvasReady}
+          onSelectionChange={handleSelectionChange}
+        />
+
+        {/* Right panel */}
+        <ToolPanel
+          activeTool={state.activeTool}
+          toolOptions={state.toolOptions}
+          onToolOptionsChange={handleToolOptionsChange}
+          selectedSticker={state.selectedSticker}
+          onStickerSelect={handleStickerSelect}
+          selectedObjectInfo={selectedObjectInfo}
+          onSelectedObjectStyleChange={handleSelectedObjectStyleChange}
+        />
+      </div>
+
+      {/* File name indicator */}
+      {fileName && (
+        <div className="px-4 py-1.5 bg-gray-800 border-t border-gray-700 text-xs text-gray-400 text-center">
+          {fileName}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/StickerPicker.tsx
+++ b/src/shared/components/ImageAnnotationEditor/StickerPicker.tsx
@@ -1,0 +1,99 @@
+import clsx from 'clsx';
+import { useState } from 'react';
+
+// Discover all sticker assets
+const stickerModules = import.meta.glob('/src/assets/stickers/**/*.svg', {
+  eager: true,
+  query: '?url',
+  import: 'default',
+}) as Record<string, string>;
+
+interface StickerCategory {
+  name: string;
+  path: string;
+  stickers: { name: string; url: string }[];
+}
+
+function buildCategories(): StickerCategory[] {
+  const categoryMap = new Map<string, { name: string; url: string }[]>();
+
+  for (const [path, url] of Object.entries(stickerModules)) {
+    // path like /src/assets/stickers/markers/pin-red.svg
+    const parts = path.split('/');
+    const category = parts[parts.length - 2]; // e.g. "markers"
+    const fileName = parts[parts.length - 1].replace('.svg', '');
+
+    if (!categoryMap.has(category)) {
+      categoryMap.set(category, []);
+    }
+    categoryMap.get(category)!.push({ name: fileName, url });
+  }
+
+  return Array.from(categoryMap.entries()).map(([name, stickers]) => ({
+    name,
+    path: name,
+    stickers,
+  }));
+}
+
+const categories = buildCategories();
+
+interface StickerPickerProps {
+  selectedSticker: string | null;
+  onSelect: (stickerUrl: string) => void;
+}
+
+export default function StickerPicker({ selectedSticker, onSelect }: StickerPickerProps) {
+  const [activeCategory, setActiveCategory] = useState(categories[0]?.name ?? '');
+
+  if (categories.length === 0) {
+    return <p className="text-xs text-gray-400">No stickers available</p>;
+  }
+
+  const activeCat = categories.find(c => c.name === activeCategory) ?? categories[0];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs text-gray-400 font-medium">Stickers</span>
+
+      {/* Category tabs */}
+      <div className="flex flex-wrap gap-1">
+        {categories.map(cat => (
+          <button
+            key={cat.name}
+            type="button"
+            onClick={() => setActiveCategory(cat.name)}
+            className={clsx(
+              'px-2 py-1 text-xs rounded capitalize transition-colors',
+              activeCategory === cat.name
+                ? 'bg-primary text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+            )}
+          >
+            {cat.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Sticker grid */}
+      <div className="grid grid-cols-4 gap-1.5 max-h-48 overflow-y-auto">
+        {activeCat.stickers.map(sticker => (
+          <button
+            key={sticker.url}
+            type="button"
+            onClick={() => onSelect(sticker.url)}
+            className={clsx(
+              'w-10 h-10 p-1 rounded-lg flex items-center justify-center transition-all hover:scale-110',
+              selectedSticker === sticker.url
+                ? 'bg-primary/20 ring-2 ring-primary'
+                : 'bg-gray-700 hover:bg-gray-600',
+            )}
+            title={sticker.name}
+          >
+            <img src={sticker.url} alt={sticker.name} className="w-full h-full object-contain" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/ToolPanel.tsx
+++ b/src/shared/components/ImageAnnotationEditor/ToolPanel.tsx
@@ -1,0 +1,234 @@
+import type { ToolPanelProps } from './types';
+import { STROKE_WIDTH_PRESETS, FONT_SIZE_PRESETS } from './constants';
+import ColorPicker from './ColorPicker';
+import StickerPicker from './StickerPicker';
+import clsx from 'clsx';
+
+export default function ToolPanel({
+  activeTool,
+  toolOptions,
+  onToolOptionsChange,
+  selectedSticker,
+  onStickerSelect,
+  selectedObjectInfo,
+  onSelectedObjectStyleChange,
+}: ToolPanelProps) {
+  // --- Tool-specific options (when drawing) ---
+  const showStroke = ['freehand', 'line', 'arrow', 'rect', 'circle'].includes(activeTool);
+  const showFill = ['rect', 'circle'].includes(activeTool);
+  const showTextColor = ['text', 'number'].includes(activeTool);
+  const showFontSize = ['text', 'number'].includes(activeTool);
+  const showStickers = activeTool === 'sticker';
+
+  // --- Selection-based options (when objects are selected) ---
+  const hasSelection = selectedObjectInfo !== null && selectedObjectInfo.count > 0;
+  const selType = selectedObjectInfo?.type;
+  const selIsText = selType === 'text';
+  const selIsShape = selType === 'shape';
+  const selIsGroup = selType === 'group';
+
+  const showToolOptions = showStroke || showFill || showTextColor || showFontSize || showStickers;
+
+  if (!showToolOptions && !hasSelection) {
+    return null;
+  }
+
+  return (
+    <div className="w-52 bg-gray-800 border-l border-gray-700 p-3 flex flex-col gap-4 overflow-y-auto">
+      {/* === Tool options (for new objects) === */}
+      {showStroke && (
+        <>
+          <ColorPicker
+            value={toolOptions.strokeColor}
+            onChange={color => onToolOptionsChange({ strokeColor: color })}
+            label="Stroke Color"
+          />
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs text-gray-400 font-medium">Stroke Width</span>
+            <div className="flex gap-1.5">
+              {STROKE_WIDTH_PRESETS.map(w => (
+                <button
+                  key={w}
+                  type="button"
+                  onClick={() => onToolOptionsChange({ strokeWidth: w })}
+                  className={clsx(
+                    'w-8 h-8 rounded-lg flex items-center justify-center text-xs transition-colors',
+                    toolOptions.strokeWidth === w
+                      ? 'bg-primary text-white'
+                      : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+                  )}
+                >
+                  {w}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {showFill && (
+        <ColorPicker
+          value={toolOptions.fillColor}
+          onChange={color => onToolOptionsChange({ fillColor: color })}
+          label="Fill Color"
+        />
+      )}
+
+      {showTextColor && (
+        <ColorPicker
+          value={toolOptions.strokeColor}
+          onChange={color => onToolOptionsChange({ strokeColor: color })}
+          label="Text Color"
+        />
+      )}
+
+      {showFontSize && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-gray-400 font-medium">Font Size</span>
+          <div className="flex gap-1.5">
+            {FONT_SIZE_PRESETS.map(s => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => onToolOptionsChange({ fontSize: s })}
+                className={clsx(
+                  'w-8 h-8 rounded-lg flex items-center justify-center text-xs transition-colors',
+                  toolOptions.fontSize === s
+                    ? 'bg-primary text-white'
+                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+                )}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {showStickers && (
+        <StickerPicker selectedSticker={selectedSticker} onSelect={onStickerSelect} />
+      )}
+
+      {showToolOptions && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs text-gray-400 font-medium">
+            Opacity: {Math.round(toolOptions.opacity * 100)}%
+          </span>
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.1}
+            value={toolOptions.opacity}
+            onChange={e => onToolOptionsChange({ opacity: parseFloat(e.target.value) })}
+            className="w-full accent-primary"
+          />
+        </div>
+      )}
+
+      {/* === Selected object options === */}
+      {hasSelection && (
+        <>
+          {showToolOptions && (
+            <div className="border-t border-gray-600 pt-3 -mx-3 px-3">
+              <span className="text-xs text-gray-500 font-medium uppercase tracking-wider">
+                Selected ({selectedObjectInfo.count})
+              </span>
+            </div>
+          )}
+
+          {!showToolOptions && (
+            <span className="text-xs text-gray-500 font-medium uppercase tracking-wider">
+              Selected ({selectedObjectInfo.count})
+            </span>
+          )}
+
+          {/* Color for selected objects */}
+          {(selIsText || selIsGroup) && (
+            <ColorPicker
+              value={selectedObjectInfo.fillColor ?? selectedObjectInfo.strokeColor ?? '#FFFFFF'}
+              onChange={color => onSelectedObjectStyleChange({ strokeColor: color })}
+              label="Color"
+            />
+          )}
+
+          {selIsShape && (
+            <>
+              <ColorPicker
+                value={selectedObjectInfo.strokeColor ?? '#FFFFFF'}
+                onChange={color => onSelectedObjectStyleChange({ strokeColor: color })}
+                label="Stroke Color"
+              />
+              <ColorPicker
+                value={selectedObjectInfo.fillColor ?? 'transparent'}
+                onChange={color => onSelectedObjectStyleChange({ fillColor: color })}
+                label="Fill Color"
+              />
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs text-gray-400 font-medium">Stroke Width</span>
+                <div className="flex gap-1.5">
+                  {STROKE_WIDTH_PRESETS.map(w => (
+                    <button
+                      key={w}
+                      type="button"
+                      onClick={() => onSelectedObjectStyleChange({ strokeWidth: w })}
+                      className={clsx(
+                        'w-8 h-8 rounded-lg flex items-center justify-center text-xs transition-colors',
+                        selectedObjectInfo.strokeWidth === w
+                          ? 'bg-primary text-white'
+                          : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+                      )}
+                    >
+                      {w}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* Font size for text / number markers */}
+          {(selIsText || selIsGroup) && selectedObjectInfo.fontSize !== undefined && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs text-gray-400 font-medium">Font Size</span>
+              <div className="flex gap-1.5">
+                {FONT_SIZE_PRESETS.map(s => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => onSelectedObjectStyleChange({ fontSize: s })}
+                    className={clsx(
+                      'w-8 h-8 rounded-lg flex items-center justify-center text-xs transition-colors',
+                      selectedObjectInfo.fontSize === s
+                        ? 'bg-primary text-white'
+                        : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+                    )}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Opacity for selected */}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs text-gray-400 font-medium">
+              Opacity: {Math.round((selectedObjectInfo.opacity ?? 1) * 100)}%
+            </span>
+            <input
+              type="range"
+              min={0.1}
+              max={1}
+              step={0.1}
+              value={selectedObjectInfo.opacity ?? 1}
+              onChange={e => onSelectedObjectStyleChange({ opacity: parseFloat(e.target.value) })}
+              className="w-full accent-primary"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/Toolbar.tsx
+++ b/src/shared/components/ImageAnnotationEditor/Toolbar.tsx
@@ -1,0 +1,109 @@
+import clsx from 'clsx';
+import Icon from '@shared/components/Icon';
+import type { ToolbarProps, AnnotationTool } from './types';
+import { TOOL_ICONS, TOOL_LABELS } from './constants';
+
+const TOOL_GROUPS: AnnotationTool[][] = [
+  ['select'],
+  ['freehand', 'line', 'arrow'],
+  ['rect', 'circle'],
+  ['text', 'number'],
+  ['sticker'],
+  ['eraser'],
+];
+
+export default function Toolbar({
+  activeTool,
+  onToolChange,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  onSave,
+  onSkip,
+  onCancel,
+  isSaving,
+}: ToolbarProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2 bg-gray-900 border-b border-gray-700">
+      {/* Tool groups */}
+      <div className="flex items-center gap-1">
+        {TOOL_GROUPS.map((group, gi) => (
+          <div key={gi} className="flex items-center">
+            {gi > 0 && <div className="w-px h-6 bg-gray-700 mx-1" />}
+            {group.map(tool => (
+              <button
+                key={tool}
+                type="button"
+                onClick={() => onToolChange(tool)}
+                className={clsx(
+                  'p-2 rounded-lg transition-colors',
+                  activeTool === tool
+                    ? 'bg-primary text-white'
+                    : 'text-gray-400 hover:text-white hover:bg-gray-700',
+                )}
+                title={`${TOOL_LABELS[tool]} (${tool[0].toUpperCase()})`}
+              >
+                <Icon name={TOOL_ICONS[tool]} className="text-sm" />
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Right side: undo/redo + actions */}
+      <div className="flex items-center gap-1">
+        {/* Undo/Redo */}
+        <button
+          type="button"
+          onClick={onUndo}
+          disabled={!canUndo}
+          className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          title="Undo (Ctrl+Z)"
+        >
+          <Icon name="rotate-left" className="text-sm" />
+        </button>
+        <button
+          type="button"
+          onClick={onRedo}
+          disabled={!canRedo}
+          className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          title="Redo (Ctrl+Y)"
+        >
+          <Icon name="rotate-right" className="text-sm" />
+        </button>
+
+        <div className="w-px h-6 bg-gray-700 mx-2" />
+
+        {/* Action buttons */}
+        {onSkip && (
+          <button
+            type="button"
+            onClick={onSkip}
+            className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            Skip
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={isSaving}
+          className="px-4 py-1.5 text-sm bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors flex items-center gap-2"
+        >
+          {isSaving && (
+            <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          )}
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/ImageAnnotationEditor/constants.ts
+++ b/src/shared/components/ImageAnnotationEditor/constants.ts
@@ -1,0 +1,57 @@
+import type { ToolOptions, AnnotationTool } from './types';
+
+export const DEFAULT_TOOL_OPTIONS: ToolOptions = {
+  strokeColor: '#FF0000',
+  fillColor: 'transparent',
+  strokeWidth: 3,
+  fontSize: 24,
+  opacity: 1,
+};
+
+export const COLOR_PRESETS = [
+  '#FF0000', // Red
+  '#FF6600', // Orange
+  '#FFCC00', // Yellow
+  '#00CC00', // Green
+  '#0066FF', // Blue
+  '#9933FF', // Purple
+  '#FF3399', // Pink
+  '#000000', // Black
+  '#666666', // Gray
+  '#FFFFFF', // White
+];
+
+export const STROKE_WIDTH_PRESETS = [1, 2, 3, 5, 8];
+
+export const FONT_SIZE_PRESETS = [14, 18, 24, 32, 48];
+
+export const TOOL_LABELS: Record<AnnotationTool, string> = {
+  select: 'Select',
+  text: 'Text',
+  number: 'Number',
+  arrow: 'Arrow',
+  line: 'Line',
+  rect: 'Rectangle',
+  circle: 'Circle',
+  freehand: 'Freehand',
+  sticker: 'Sticker',
+  eraser: 'Eraser',
+};
+
+export const TOOL_ICONS: Record<AnnotationTool, string> = {
+  select: 'arrow-pointer',
+  text: 'font',
+  number: 'hashtag',
+  arrow: 'arrow-right-long',
+  line: 'minus',
+  rect: 'square',
+  circle: 'circle',
+  freehand: 'pen',
+  sticker: 'note-sticky',
+  eraser: 'eraser',
+};
+
+export const MAX_HISTORY_SIZE = 50;
+
+export const NUMBER_MARKER_RADIUS = 16;
+export const NUMBER_MARKER_COLORS = ['#FF0000', '#0066FF', '#00CC00', '#FF6600', '#9933FF'];

--- a/src/shared/components/ImageAnnotationEditor/index.ts
+++ b/src/shared/components/ImageAnnotationEditor/index.ts
@@ -1,0 +1,7 @@
+import { lazy } from 'react';
+
+export type { AnnotationResult, ImageAnnotationEditorProps } from './types';
+
+const ImageAnnotationEditor = lazy(() => import('./ImageAnnotationEditor'));
+
+export default ImageAnnotationEditor;

--- a/src/shared/components/ImageAnnotationEditor/types.ts
+++ b/src/shared/components/ImageAnnotationEditor/types.ts
@@ -1,0 +1,90 @@
+import type { Canvas as FabricCanvas } from 'fabric';
+
+export type AnnotationTool =
+  | 'select'
+  | 'text'
+  | 'number'
+  | 'arrow'
+  | 'line'
+  | 'rect'
+  | 'circle'
+  | 'freehand'
+  | 'sticker'
+  | 'eraser';
+
+export interface ToolOptions {
+  strokeColor: string;
+  fillColor: string;
+  strokeWidth: number;
+  fontSize: number;
+  opacity: number;
+}
+
+export interface EditorState {
+  activeTool: AnnotationTool;
+  toolOptions: ToolOptions;
+  numberCounter: number;
+  selectedSticker: string | null;
+  isExporting: boolean;
+}
+
+export interface AnnotationResult {
+  imageBlob: Blob;
+  fabricJson: string;
+  fileName: string;
+}
+
+export interface ImageAnnotationEditorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageFile?: File;
+  imageUrl?: string;
+  onSave: (result: AnnotationResult) => Promise<void>;
+  onSkip?: () => void;
+  fileName?: string;
+}
+
+export interface SelectedObjectInfo {
+  type: 'text' | 'shape' | 'group' | 'image' | 'unknown';
+  strokeColor?: string;
+  fillColor?: string;
+  strokeWidth?: number;
+  fontSize?: number;
+  opacity?: number;
+  count: number;
+}
+
+export interface FabricCanvasProps {
+  imageFile?: File;
+  imageUrl?: string;
+  activeTool: AnnotationTool;
+  toolOptions: ToolOptions;
+  numberCounter: number;
+  selectedSticker: string | null;
+  onNumberPlaced: () => void;
+  onCanvasReady: (canvas: FabricCanvas) => void;
+  onSelectionChange: (info: SelectedObjectInfo | null) => void;
+}
+
+export interface ToolbarProps {
+  activeTool: AnnotationTool;
+  onToolChange: (tool: AnnotationTool) => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onSave: () => void;
+  onSkip?: () => void;
+  onCancel: () => void;
+  isSaving: boolean;
+}
+
+export interface ToolPanelProps {
+  activeTool: AnnotationTool;
+  toolOptions: ToolOptions;
+  onToolOptionsChange: (options: Partial<ToolOptions>) => void;
+  selectedSticker: string | null;
+  onStickerSelect: (stickerUrl: string) => void;
+  selectedObjectInfo: SelectedObjectInfo | null;
+  onSelectedObjectStyleChange: (options: Partial<ToolOptions>) => void;
+}

--- a/src/shared/components/ImageAnnotationEditor/useAnnotationHistory.ts
+++ b/src/shared/components/ImageAnnotationEditor/useAnnotationHistory.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react';
+import type { Canvas as FabricCanvas } from 'fabric';
+import { MAX_HISTORY_SIZE } from './constants';
+
+export function useAnnotationHistory(canvasRef: React.RefObject<FabricCanvas | null>) {
+  const historyRef = useRef<string[]>([]);
+  const currentIndexRef = useRef(-1);
+  const isRestoringRef = useRef(false);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const updateState = useCallback(() => {
+    setCanUndo(currentIndexRef.current > 0);
+    setCanRedo(currentIndexRef.current < historyRef.current.length - 1);
+  }, []);
+
+  const saveSnapshot = useCallback(() => {
+    if (isRestoringRef.current || !canvasRef.current) return;
+
+    const json = JSON.stringify(canvasRef.current.toJSON());
+
+    // Remove any redo states
+    historyRef.current = historyRef.current.slice(0, currentIndexRef.current + 1);
+
+    historyRef.current.push(json);
+
+    // Trim if exceeds max
+    if (historyRef.current.length > MAX_HISTORY_SIZE) {
+      historyRef.current = historyRef.current.slice(-MAX_HISTORY_SIZE);
+    }
+
+    currentIndexRef.current = historyRef.current.length - 1;
+    updateState();
+  }, [canvasRef, updateState]);
+
+  const restoreSnapshot = useCallback(
+    async (index: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas || index < 0 || index >= historyRef.current.length) return;
+
+      isRestoringRef.current = true;
+      const json = historyRef.current[index];
+
+      await canvas.loadFromJSON(json);
+      canvas.renderAll();
+
+      currentIndexRef.current = index;
+      isRestoringRef.current = false;
+      updateState();
+    },
+    [canvasRef, updateState],
+  );
+
+  const undo = useCallback(() => {
+    if (currentIndexRef.current > 0) {
+      void restoreSnapshot(currentIndexRef.current - 1);
+    }
+  }, [restoreSnapshot]);
+
+  const redo = useCallback(() => {
+    if (currentIndexRef.current < historyRef.current.length - 1) {
+      void restoreSnapshot(currentIndexRef.current + 1);
+    }
+  }, [restoreSnapshot]);
+
+  const reset = useCallback(() => {
+    historyRef.current = [];
+    currentIndexRef.current = -1;
+    updateState();
+  }, [updateState]);
+
+  return { saveSnapshot, undo, redo, canUndo, canRedo, reset, isRestoringRef };
+}

--- a/src/shared/components/ImageAnnotationEditor/useCanvasExport.ts
+++ b/src/shared/components/ImageAnnotationEditor/useCanvasExport.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import type { Canvas as FabricCanvas } from 'fabric';
+
+export function useCanvasExport(canvasRef: React.RefObject<FabricCanvas | null>) {
+  const exportCanvas = useCallback(async (): Promise<Blob | null> => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+
+    // Deselect all objects before export
+    canvas.discardActiveObject();
+    canvas.renderAll();
+
+    // Get the background image to calculate original resolution
+    const bgImage = canvas.backgroundImage;
+    let multiplier = 1;
+
+    if (bgImage) {
+      const origWidth = bgImage.width ?? canvas.width;
+      const displayWidth = canvas.width;
+      if (displayWidth && origWidth) {
+        multiplier = origWidth / displayWidth;
+      }
+    }
+
+    // Export at original resolution
+    const exportCanvas = canvas.toCanvasElement(multiplier);
+
+    return new Promise<Blob | null>(resolve => {
+      exportCanvas.toBlob(blob => resolve(blob), 'image/png', 1);
+    });
+  }, [canvasRef]);
+
+  const getCanvasJson = useCallback((): string => {
+    const canvas = canvasRef.current;
+    if (!canvas) return '{}';
+    return JSON.stringify(canvas.toJSON());
+  }, [canvasRef]);
+
+  return { exportCanvas, getCanvasJson };
+}


### PR DESCRIPTION
## Summary
- Add Fabric.js-based `ImageAnnotationEditor` shared component with drawing, text, shapes, stickers, color picker, and undo/redo
- Include SVG sticker assets (directional arrows, markers, stamps, symbols)
- Integrate annotation editor into `DocumentChecklistTab` for document image annotation workflow
- Update document API and uploader to support annotated images

## Test plan
- [ ] Open DocumentChecklistTab and verify annotation editor opens for document images
- [ ] Test drawing tools: freehand, line, rectangle, circle, text
- [ ] Test sticker placement from all categories (directional, markers, stamps, symbols)
- [ ] Test undo/redo and color picker
- [ ] Test export/save of annotated image

🤖 Generated with [Claude Code](https://claude.com/claude-code)