### PR TITLE
fix: requiredWhen should reject 0 for numeric fields

### DIFF
--- a/src/shared/components/form/schemaBuilder.ts
+++ b/src/shared/components/form/schemaBuilder.ts
@@ -319,7 +319,8 @@ function buildConditionalRefinement(fields: FormField[]) {
       // 5. Enforce required — resolve dotted paths
       if (isRequired) {
         const value = getNestedValue(data, field.name);
-        if (value == null || value === '') {
+        const isNumberField = field.type === 'number-input';
+        if (value == null || value === '' || (isNumberField && value === 0)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: field.name.split('.'),

--- a/src/shared/components/form/schemaBuilder.ts
+++ b/src/shared/components/form/schemaBuilder.ts
@@ -320,7 +320,11 @@ function buildConditionalRefinement(fields: FormField[]) {
       if (isRequired) {
         const value = getNestedValue(data, field.name);
         const isNumberField = field.type === 'number-input';
-        if (value == null || value === '' || (isNumberField && value === 0)) {
+        if (
+          value == null ||
+          value === '' ||
+          (isNumberField && value === 0 && field.min == null)
+        ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: field.name.split('.'),


### PR DESCRIPTION
## Summary
- `requiredWhen` validation now rejects `0` for `number-input` fields, matching the behavior of static `required: true`
- Previously `requiredWhen` only checked `null/undefined/''`, allowing `0` through for numeric fields

## Test plan
- [x] Existing schema builder tests pass (41/41)
- [ ] Manually test a `requiredWhen` number field (e.g. in land titles) — entering 0 should trigger validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)