### PR TITLE
fix: auth flow login gate and logout reliability

### DIFF
--- a/src/app/queryClient.ts
+++ b/src/app/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -48,34 +48,24 @@ const AppraisalIndexRedirect = () => {
   return null;
 };
 
-// Placeholder component for pages not yet implemented
-const PlaceholderPage = ({ title }: { title: string }) => (
-  <div className="flex flex-col items-center justify-center h-full gap-4">
-    <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center">
-      <span className="text-2xl">🚧</span>
-    </div>
-    <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
-    <p className="text-gray-500">This page is coming soon</p>
-  </div>
-);
-
 export const router = createBrowserRouter([
+  // Auth routes — outside Layout (no sidebar/navbar)
+  {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
+    path: '/callback',
+    element: <CallbackPage />,
+  },
   {
     path: '/',
-    element: <Layout />,
+    element: <ProtectedRoute component={<Layout />} />,
     errorElement: <ErrorPage />,
     children: [
       {
         index: true,
-        element: <ProtectedRoute component={<HomePage />} />,
-      },
-      {
-        path: 'login',
-        element: <LoginPage />,
-      },
-      {
-        path: 'callback',
-        element: <CallbackPage />,
+        element: <HomePage />,
       },
       // Request Routes
       {
@@ -173,7 +163,7 @@ export const router = createBrowserRouter([
   // Appraisal Application Routes (separate layout with application sidebar)
   {
     path: 'appraisals/:appraisalId',
-    element: <AppraisalLayout />,
+    element: <ProtectedRoute component={<AppraisalLayout />} />,
     errorElement: <ErrorPage />,
     children: [
       {

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,12 +1,26 @@
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '../store.ts';
+import { useCurrentUser } from '../api.ts';
 import type { JSX } from 'react';
 
 export function ProtectedRoute({ component }: { component: JSX.Element }) {
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
+  const hasToken = !!localStorage.getItem('auth_token');
+  const { isLoading } = useCurrentUser();
 
-  if (!isAuthenticated && !localStorage.getItem('auth_token')) {
+  // No token and not authenticated → go to login
+  if (!hasToken && !isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
+
+  // Has token but still validating → show spinner
+  if (!isAuthenticated && isLoading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+      </div>
+    );
+  }
+
   return component;
 }

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -17,7 +17,11 @@ export function ProtectedRoute({ component }: { component: JSX.Element }) {
   if (!isAuthenticated && isLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+        <div
+          className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary"
+          role="status"
+          aria-label="Authenticating"
+        />
       </div>
     );
   }

--- a/src/features/auth/pages/CallbackPage.tsx
+++ b/src/features/auth/pages/CallbackPage.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from '@features/auth/store.ts';
 import { useNavigate } from 'react-router-dom';
 
 function CallbackPage() {
-  const login = useAuthStore(state => state.login);
+  const setToken = useAuthStore(state => state.setToken);
   const navigate = useNavigate();
   const isProcessing = useRef(false);
 
@@ -45,29 +45,14 @@ function CallbackPage() {
         return res.json();
       })
       .then(tokens => {
-        login(
-          {
-            id: '',
-            name: '',
-            firstName: '',
-            lastName: '',
-            email: '',
-            username: '',
-            avatarUrl: '',
-            position: '',
-            department: '',
-            roles: [],
-            permissions: [],
-          },
-          tokens.accessToken,
-        );
+        setToken(tokens.accessToken);
         navigate('/');
       })
       .catch(error => {
         console.error('Token exchange error:', error);
         navigate('/login');
       });
-  }, [login, navigate]);
+  }, [setToken, navigate]);
 
   return <p>Processing login...</p>;
 }

--- a/src/features/auth/pages/CallbackPage.tsx
+++ b/src/features/auth/pages/CallbackPage.tsx
@@ -25,7 +25,7 @@ function CallbackPage() {
 
     if (state !== storedState || !code || !codeVerifier) {
       console.error('Invalid state or missing code');
-      navigate('/login');
+      navigate('/login', { replace: true });
       return;
     }
 
@@ -46,11 +46,11 @@ function CallbackPage() {
       })
       .then(tokens => {
         setToken(tokens.accessToken);
-        navigate('/');
+        navigate('/', { replace: true });
       })
       .catch(error => {
         console.error('Token exchange error:', error);
-        navigate('/login');
+        navigate('/login', { replace: true });
       });
   }, [setToken, navigate]);
 

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -7,6 +7,7 @@ type AuthStore = {
   isLoading: boolean;
   error: string | null;
   setUser: (user: User | null) => void;
+  setToken: (token: string) => void;
   setLoading: (isLoading: boolean) => void;
   setError: (error: string | null) => void;
   login: (user: User, token: string) => void;
@@ -19,7 +20,10 @@ export const useAuthStore = create<AuthStore>(set => ({
   isLoading: false,
   error: null,
 
-  setUser: user => set({ user }),
+  setUser: user => set({ user, isAuthenticated: !!user }),
+  setToken: token => {
+    localStorage.setItem('auth_token', token);
+  },
   setLoading: isLoading => set({ isLoading }),
   setError: error => set({ error }),
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import './i18n';
 import './index.css'; // Import global CSS which includes Tailwind
 import App from '@app/App';
+import { queryClient } from '@app/queryClient';
 import { AuthProvider } from '@features/auth/components';
-
-// Create React Query client
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 5, // 5 minutes
-      refetchOnWindowFocus: false,
-    },
-  },
-});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosError } from 'axios';
+import { queryClient } from '@app/queryClient';
 import { extractApiError } from '../utils/errorUtils';
 import type { ProblemDetails } from '../types/api';
 
@@ -46,6 +47,7 @@ axiosInstance.interceptors.response.use(
     // Handle authentication errors
     if (response && response.status === 401) {
       localStorage.removeItem('auth_token');
+      queryClient.clear();
       window.location.href = '/login';
       return Promise.reject(error);
     }

--- a/src/shared/components/Navbar.tsx
+++ b/src/shared/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Icon from '@shared/components/Icon';
 import { useUIStore } from '@shared/store';
 import clsx from 'clsx';
 import { useAuthStore } from '@features/auth/store.ts';
+import { queryClient } from '@app/queryClient';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@shared/components/LanguageSwitcher';
 import Avatar from '@shared/components/Avatar';
@@ -27,7 +28,12 @@ const filterColorStyles: Record<string, { bg: string; text: string; activeBg: st
 };
 
 function handleLogout(href: string) {
-  useAuthStore.getState().logout();
+  // Navigate FIRST — clearing Zustand state would trigger ProtectedRoute
+  // to redirect to /login, which cancels the server logout navigation.
+  // Clear storage directly without triggering React re-renders.
+  localStorage.removeItem('auth_token');
+  queryClient.clear();
+  sessionStorage.clear();
   window.location.replace(href);
 }
 


### PR DESCRIPTION
## Summary
- **Login gate**: Added loading spinner to `ProtectedRoute` while token is being validated — prevents dashboard flash before auth completes
- **Route protection**: Moved `/login` and `/callback` outside `Layout`; wrapped all app routes with `ProtectedRoute` so no pages are unprotected
- **Logout reliability**: Fixed race condition where Zustand state update triggered `ProtectedRoute` redirect to `/login`, cancelling the server logout navigation. Now clears localStorage/cache directly without triggering React re-renders
- **No more "unknown user" flash**: `CallbackPage` now stores only the token (not a dummy empty user object); real user data loads via `useCurrentUser` behind the spinner
- **401 handling**: Clears React Query cache on 401 to prevent stale data

## Test plan
- [ ] Clear localStorage, visit `/` — should see login page immediately (no dashboard flash)
- [ ] Set expired token, visit `/` — spinner briefly, then redirect to login
- [ ] Visit `/requests` or `/tasks` without auth — redirects to login
- [ ] Complete OAuth login — lands on dashboard with correct user info (no "unknown user" flash)
- [ ] Click Sign out — server logout completes (no cancelled request), redirects to login
- [ ] After logout, no stale user data visible on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)