### PR TITLE
feat: construction inspection tab with API integration

### DIFF
--- a/src/features/appraisal/components/construction/ConstructionDetailTable.tsx
+++ b/src/features/appraisal/components/construction/ConstructionDetailTable.tsx
@@ -66,6 +66,7 @@ function AddSubItemDropdown({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const availableItems = group.items.filter(
     item => !existingItemIds.includes(item.id),
@@ -73,7 +74,6 @@ function AddSubItemDropdown({
 
   if (availableItems.length === 0) return null;
 
-  const menuRef = useRef<HTMLDivElement>(null);
   const rect = btnRef.current?.getBoundingClientRect();
 
   // Check if dropdown would overflow below the viewport


### PR DESCRIPTION
## Summary
- Add Construction Inspection tab for building properties when `isUnderConstruction = true`
- Two modes: **Full Detail** (grouped work items table) and **Summary** (simple form with document upload)
- Fetch work groups/items from `GET /construction-work-groups` API with infinite cache
- Nested `constructionInspection` payload on building/land-and-building endpoints
- User inputs `proportionPct` and `currentProgressPct`; server computes derived values
- Real document upload via standard `POST /documents` flow with metadata (fileName, filePath, fileExtension, mimeType, fileSizeBytes)
- Validation: blocks save when total proportion exceeds 100%
- Tab auto-resets when `isUnderConstruction` toggled to false

## Key files
- `src/features/appraisal/api/constructionWorkGroups.ts` — new API hook
- `src/features/appraisal/components/tabs/ConstructionInspectionTab.tsx` — main tab
- `src/features/appraisal/components/construction/ConstructionDetailTable.tsx` — detail mode
- `src/features/appraisal/components/construction/ConstructionSummaryForm.tsx` — summary mode
- `src/features/appraisal/schemas/form.ts` — form schema + validation
- `src/features/appraisal/utils/mappers.ts` — API ↔ form mapping

## Test plan
- [ ] Toggle `isUnderConstruction = Yes` → Construction Inspection tab appears
- [ ] Full Detail mode: add work items, enter proportion/progress → values auto-calculate
- [ ] Total proportion > 100% → warning banner + save blocked
- [ ] Summary mode: enter detail/progress, upload document, add remark
- [ ] Save → verify nested `constructionInspection` payload in network tab
- [ ] Reload → verify data loads from API response
- [ ] Toggle `isUnderConstruction = No` → tab disappears, `constructionInspection: null` sent
- [ ] Switch property via dropdown → tab preserved with `tab=construction` URL param

🤖 Generated with [Claude Code](https://claude.com/claude-code)