### PR TITLE
Fix request listing cache not invalidated after mutations

### DIFF
--- a/.claude/design/workflow-definition.json
+++ b/.claude/design/workflow-definition.json
@@ -1,0 +1,512 @@
+{
+  "name": "Collateral Appraisal Workflow",
+  "description": "Complete appraisal workflow from request submission through verification",
+  "category": "Appraisal",
+  "createdBy": "system-admin",
+  "workflowSchema": {
+    "id": "appraisal-workflow",
+    "name": "Collateral Appraisal Workflow",
+    "description": "Complete appraisal workflow from request submission through verification",
+    "category": "Appraisal",
+    "activities": [
+      {
+        "id": "start",
+        "name": "Workflow Start",
+        "type": "StartActivity",
+        "description": "Initial workflow entry point",
+        "properties": {},
+        "position": {
+          "x": 100,
+          "y": 100
+        },
+        "requiredRoles": [],
+        "isStartActivity": true,
+        "isEndActivity": false
+      },
+      {
+        "id": "initial-routing",
+        "name": "Initial Routing",
+        "type": "RoutingActivity",
+        "description": "Evaluates routing conditions to determine workflow path — auto-assign to external company or route to internal admin",
+        "properties": {
+          "routingConditions": {
+            "admin_review": "amount > 50000"
+          },
+          "defaultDecision": "auto_assign_external"
+        },
+        "position": {
+          "x": 200,
+          "y": 100
+        },
+        "requiredRoles": [],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "admin",
+        "name": "Admin",
+        "type": "TaskActivity",
+        "description": "Admin reviews the submitted request and decides next action",
+        "properties": {
+          "activityName": "Admin",
+          "assigneeRole": "Admin",
+          "assigneeGroup": "Admin",
+          "assignmentStrategies": "started_by",
+          "initialAssignmentStrategies": ["started_by"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT72H",
+          "decisionConditions": {
+            "proceed": "admin_decisionTaken == 'P'",
+            "reject": "admin_decisionTaken == 'REJ'",
+            "request_more_info": "admin_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 100
+        },
+        "requiredRoles": ["Admin"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "ext-appraisal-staff",
+        "name": "External Appraisal Staff",
+        "type": "TaskActivity",
+        "description": "External appraisal staff conducts the property appraisal",
+        "properties": {
+          "activityName": "External Appraisal Staff",
+          "assigneeRole": "ExtAppraisalStaff",
+          "assigneeGroup": "ExtAppraisalStaff",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT72H",
+          "decisionConditions": {
+            "proceed": "ext_appraisal_staff_decisionTaken == 'P'",
+            "route_back": "ext_appraisal_staff_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 250
+        },
+        "requiredRoles": ["ExtAppraisalStaff"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "ext-appraisal-checker",
+        "name": "External Appraisal Checker",
+        "type": "TaskActivity",
+        "description": "External checker reviews the appraisal work for accuracy and completeness",
+        "properties": {
+          "activityName": "External Appraisal Checker",
+          "assigneeRole": "ExtAppraisalChecker",
+          "assigneeGroup": "ExtAppraisalChecker",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT48H",
+          "decisionConditions": {
+            "proceed": "ext_appraisal_checker_decisionTaken == 'P'",
+            "route_back": "ext_appraisal_checker_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 400
+        },
+        "requiredRoles": ["ExtAppraisalChecker"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "ext-appraisal-verifier",
+        "name": "External Appraisal Verifier",
+        "type": "TaskActivity",
+        "description": "External verifier performs final verification before handoff to internal",
+        "properties": {
+          "activityName": "External Appraisal Verifier",
+          "assigneeRole": "ExtAppraisalVerifier",
+          "assigneeGroup": "ExtAppraisalVerifier",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT24H",
+          "decisionConditions": {
+            "proceed": "ext_appraisal_verifier_decisionTaken == 'P'",
+            "route_back": "ext_appraisal_verifier_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 550
+        },
+        "requiredRoles": ["ExtAppraisalVerifier"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "int-appraisal-staff",
+        "name": "Internal Appraisal Staff",
+        "type": "TaskActivity",
+        "description": "Internal appraisal staff reviews or conducts the property appraisal",
+        "properties": {
+          "activityName": "Internal Appraisal Staff",
+          "assigneeRole": "IntAppraisalStaff",
+          "assigneeGroup": "IntAppraisalStaff",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT72H",
+          "decisionConditions": {
+            "proceed": "int_appraisal_staff_decisionTaken == 'P'",
+            "route_back": "int_appraisal_staff_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 700
+        },
+        "requiredRoles": ["IntAppraisalStaff"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "int-appraisal-checker",
+        "name": "Internal Appraisal Checker",
+        "type": "TaskActivity",
+        "description": "Internal checker reviews the appraisal work for accuracy and completeness",
+        "properties": {
+          "activityName": "Internal Appraisal Checker",
+          "assigneeRole": "IntAppraisalChecker",
+          "assigneeGroup": "IntAppraisalChecker",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT48H",
+          "decisionConditions": {
+            "proceed": "int_appraisal_checker_decisionTaken == 'P'",
+            "route_back": "int_appraisal_checker_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 850
+        },
+        "requiredRoles": ["IntAppraisalChecker"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "int-appraisal-verifier",
+        "name": "Internal Appraisal Verifier",
+        "type": "TaskActivity",
+        "description": "Internal verifier performs final verification and sign-off",
+        "properties": {
+          "activityName": "Internal Appraisal Verifier",
+          "assigneeRole": "IntAppraisalVerifier",
+          "assigneeGroup": "IntAppraisalVerifier",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT24H",
+          "decisionConditions": {
+            "proceed": "int_appraisal_verifier_decisionTaken == 'P'",
+            "route_back": "int_appraisal_verifier_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 1000
+        },
+        "requiredRoles": ["IntAppraisalVerifier"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "pending-approval",
+        "name": "Pending Approval",
+        "type": "TaskActivity",
+        "description": "Appraisal committee reviews and approves or sends back for rework",
+        "properties": {
+          "activityName": "Pending Approval",
+          "assigneeRole": "AppraisalCommittee",
+          "assigneeGroup": "AppraisalCommittee",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT48H",
+          "decisionConditions": {
+            "approve": "pending_approval_decisionTaken == 'APP'",
+            "route_back": "pending_approval_decisionTaken == 'R'"
+          }
+        },
+        "position": {
+          "x": 300,
+          "y": 1150
+        },
+        "requiredRoles": ["AppraisalCommittee"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "request-maker",
+        "name": "Request Maker",
+        "type": "TaskActivity",
+        "description": "Request maker submits appraisal request and may need to provide additional information",
+        "properties": {
+          "activityName": "Request Maker",
+          "assigneeRole": "RequestMaker",
+          "assigneeGroup": "RequestMaker",
+          "assignmentStrategies": "round_robin",
+          "initialAssignmentStrategies": ["round_robin"],
+          "revisitAssignmentStrategies": ["previous_owner"],
+          "timeoutDuration": "PT48H"
+        },
+        "position": {
+          "x": 700,
+          "y": 200
+        },
+        "requiredRoles": ["RequestMaker"],
+        "isStartActivity": false,
+        "isEndActivity": false
+      },
+      {
+        "id": "workflow-completed",
+        "name": "Appraisal Completed",
+        "type": "EndActivity",
+        "description": "Appraisal process successfully completed",
+        "properties": {
+          "completionMessage": "Appraisal has been successfully completed and approved"
+        },
+        "position": {
+          "x": 300,
+          "y": 1300
+        },
+        "requiredRoles": [],
+        "isStartActivity": false,
+        "isEndActivity": true
+      },
+      {
+        "id": "workflow-rejected",
+        "name": "Request Rejected",
+        "type": "EndActivity",
+        "description": "Request has been rejected",
+        "properties": {
+          "completionMessage": "Request has been rejected and workflow terminated"
+        },
+        "position": {
+          "x": 700,
+          "y": 900
+        },
+        "requiredRoles": [],
+        "isStartActivity": false,
+        "isEndActivity": true
+      }
+    ],
+    "transitions": [
+      {
+        "id": "start-to-routing",
+        "from": "start",
+        "to": "initial-routing",
+        "condition": null,
+        "properties": {},
+        "type": "Normal"
+      },
+      {
+        "id": "routing-to-admin",
+        "from": "initial-routing",
+        "to": "admin",
+        "condition": "decision == 'admin_review'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "routing-to-admin-external",
+        "from": "initial-routing",
+        "to": "admin",
+        "condition": "decision == 'auto_assign_external'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "admin-proceed-external",
+        "from": "admin",
+        "to": "ext-appraisal-staff",
+        "condition": "decision == 'proceed' && routingPath == 'external'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "admin-proceed-internal",
+        "from": "admin",
+        "to": "int-appraisal-staff",
+        "condition": "decision == 'proceed' && routingPath == 'internal'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "admin-reject",
+        "from": "admin",
+        "to": "workflow-rejected",
+        "condition": "decision == 'reject'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "admin-request-info",
+        "from": "admin",
+        "to": "request-maker",
+        "condition": "decision == 'request_more_info'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "info-back-to-admin",
+        "from": "request-maker",
+        "to": "admin",
+        "condition": null,
+        "properties": {},
+        "type": "Normal"
+      },
+      {
+        "id": "ext-staff-proceed",
+        "from": "ext-appraisal-staff",
+        "to": "ext-appraisal-checker",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "ext-staff-back-to-admin",
+        "from": "ext-appraisal-staff",
+        "to": "admin",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "ext-checker-proceed",
+        "from": "ext-appraisal-checker",
+        "to": "ext-appraisal-verifier",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "ext-checker-back-to-staff",
+        "from": "ext-appraisal-checker",
+        "to": "ext-appraisal-staff",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "ext-verifier-proceed",
+        "from": "ext-appraisal-verifier",
+        "to": "int-appraisal-staff",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "ext-verifier-back-to-checker",
+        "from": "ext-appraisal-verifier",
+        "to": "ext-appraisal-checker",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-staff-proceed",
+        "from": "int-appraisal-staff",
+        "to": "int-appraisal-checker",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-staff-back-to-ext-staff",
+        "from": "int-appraisal-staff",
+        "to": "ext-appraisal-staff",
+        "condition": "decision == 'route_back' && routingPath == 'external'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-staff-back-to-admin",
+        "from": "int-appraisal-staff",
+        "to": "admin",
+        "condition": "decision == 'route_back' && routingPath == 'internal'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-checker-proceed",
+        "from": "int-appraisal-checker",
+        "to": "int-appraisal-verifier",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-checker-back-to-staff",
+        "from": "int-appraisal-checker",
+        "to": "int-appraisal-staff",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-verifier-proceed",
+        "from": "int-appraisal-verifier",
+        "to": "pending-approval",
+        "condition": "decision == 'proceed'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "int-verifier-back-to-checker",
+        "from": "int-appraisal-verifier",
+        "to": "int-appraisal-checker",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "approval-complete",
+        "from": "pending-approval",
+        "to": "workflow-completed",
+        "condition": "decision == 'approve'",
+        "properties": {},
+        "type": "Conditional"
+      },
+      {
+        "id": "approval-back-to-int-staff",
+        "from": "pending-approval",
+        "to": "int-appraisal-staff",
+        "condition": "decision == 'route_back'",
+        "properties": {},
+        "type": "Conditional"
+      }
+    ],
+    "variables": {
+      "decisionTaken": "",
+      "routingPath": "",
+      "other_variable": "Other value"
+    },
+    "metadata": {
+      "author": "System Admin",
+      "createdDate": "2024-01-15T00:00:00Z",
+      "version": "2.0",
+      "tags": ["appraisal", "workflow"],
+      "customProperties": {
+        "department": "Appraisal",
+        "businessProcess": "Collateral Valuation",
+        "slaHours": 999
+      }
+    }
+  }
+}

--- a/src/features/request/api/requests.ts
+++ b/src/features/request/api/requests.ts
@@ -56,7 +56,7 @@ export const useCreateRequest = () => {
     },
     onSuccess: data => {
       console.log(data);
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
     },
     onError: (error: any) => {
       console.log(error);
@@ -149,7 +149,7 @@ export const useUpdateRequest = () => {
     },
     onSuccess: (data, variables) => {
       console.log('Request updated successfully:', data);
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
       queryClient.invalidateQueries({ queryKey: ['request', variables.id] });
     },
     onError: (error: any) => {
@@ -171,7 +171,7 @@ export const useDeleteRequest = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
     },
   });
 };
@@ -189,7 +189,7 @@ export const useCreateDraftRequest = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
     },
   });
 };
@@ -213,7 +213,7 @@ export const useUpdateDraftRequest = () => {
       return data;
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
       queryClient.invalidateQueries({ queryKey: ['request', variables.id] });
     },
   });
@@ -232,7 +232,7 @@ export const useSubmitRequest = () => {
       return data;
     },
     onSuccess: (_, id) => {
-      queryClient.invalidateQueries({ queryKey: ['requests'] });
+      queryClient.invalidateQueries({ queryKey: ['my-requests'] });
       queryClient.invalidateQueries({ queryKey: ['request', id] });
     },
   });


### PR DESCRIPTION
## Summary
- All request mutations (`create`, `update`, `delete`, `saveDraft`, `updateDraft`, `submit`) were invalidating query key `['requests']`, but the listing page (`useGetRequests`) uses `['my-requests']`
- This caused the listing page to show stale data after any mutation until the 30s staleTime expired
- Fixed by changing all invalidation keys from `['requests']` to `['my-requests']`

## Test plan
- [ ] Create a new request → listing page should show it immediately on navigate back
- [ ] Save a draft → listing should reflect the new draft
- [ ] Delete a request → listing should remove it without needing a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)