### PR TITLE
Move auth tokens to memory with silent refresh

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,18 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <!-- Shield background -->
-  <path d="M32 4L8 16v16c0 14.4 10.24 27.84 24 32 13.76-4.16 24-17.6 24-32V16L32 4z" fill="#1E40AF"/>
-  <path d="M32 8L12 18v14c0 12.6 8.96 24.36 20 28 11.04-3.64 20-15.4 20-28V18L32 8z" fill="#3B82F6"/>
-  <!-- Building -->
-  <rect x="22" y="24" width="20" height="22" rx="1" fill="white"/>
-  <rect x="25" y="28" width="5" height="4" rx="0.5" fill="#1E40AF"/>
-  <rect x="34" y="28" width="5" height="4" rx="0.5" fill="#1E40AF"/>
-  <rect x="25" y="35" width="5" height="4" rx="0.5" fill="#1E40AF"/>
-  <rect x="34" y="35" width="5" height="4" rx="0.5" fill="#1E40AF"/>
-  <!-- Door -->
-  <rect x="29" y="40" width="6" height="6" rx="0.5" fill="#1E40AF"/>
-  <!-- Roof -->
-  <polygon points="20,24 32,16 44,24" fill="white"/>
-  <!-- Checkmark circle -->
-  <circle cx="44" cy="20" r="8" fill="#10B981"/>
-  <path d="M40 20l3 3 5-5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3B82F6"/>
+      <stop offset="50%" stop-color="#8B5CF6"/>
+      <stop offset="100%" stop-color="#EC4899"/>
+    </linearGradient>
+  </defs>
+  <text x="32" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="900" font-size="24" fill="url(#g)">CAS</text>
 </svg>

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -7,6 +7,7 @@ import { useAuthStore } from './store';
 // Function to get the current user profile
 export const useCurrentUser = () => {
   const { setUser } = useAuthStore();
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated);
 
   return useQuery<User, Error, User, string[]>({
     queryKey: ['currentUser'],
@@ -20,12 +21,10 @@ export const useCurrentUser = () => {
       return user;
     },
     onError: () => {
-      // If we can't get the user, they're not authenticated
-      localStorage.removeItem('auth_token');
       setUser(null);
     },
-    // Only run if we have a token
-    enabled: !!localStorage.getItem('auth_token'),
+    // Only run if we have an authenticated session
+    enabled: isAuthenticated,
   } as UseQueryOptions<User, Error, User, string[]>);
 };
 

--- a/src/features/auth/components/AuthInitializer.tsx
+++ b/src/features/auth/components/AuthInitializer.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { setAccessToken, refreshClient } from '@shared/api/axiosInstance';
+import { useAuthStore } from '../store';
+
+export function AuthInitializer({ children }: { children: React.ReactNode }) {
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    refreshClient
+      .post('/auth/refresh')
+      .then(({ data }) => {
+        setAccessToken(data.accessToken);
+        useAuthStore.setState({ isAuthenticated: true });
+      })
+      .catch(() => {
+        // No valid refresh cookie — user will be redirected to login by ProtectedRoute
+      })
+      .finally(() => {
+        setIsInitialized(true);
+      });
+  }, []);
+
+  if (!isInitialized) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <div
+          className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary"
+          role="status"
+          aria-label="Initializing"
+        />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/features/auth/components/AuthInitializer.tsx
+++ b/src/features/auth/components/AuthInitializer.tsx
@@ -9,11 +9,19 @@ export function AuthInitializer({ children }: { children: React.ReactNode }) {
     refreshClient
       .post('/auth/refresh')
       .then(({ data }) => {
-        setAccessToken(data.accessToken);
-        useAuthStore.setState({ isAuthenticated: true });
+        if (data?.accessToken) {
+          setAccessToken(data.accessToken);
+          useAuthStore.setState({ isAuthenticated: true });
+          return;
+        }
+        // Refresh succeeded (2xx) but no token in the body — treat as unauthenticated.
+        setAccessToken(null);
+        useAuthStore.setState({ isAuthenticated: false });
       })
       .catch(() => {
-        // No valid refresh cookie — user will be redirected to login by ProtectedRoute
+        // No valid refresh cookie — clear state; ProtectedRoute will redirect to /login.
+        setAccessToken(null);
+        useAuthStore.setState({ isAuthenticated: false });
       })
       .finally(() => {
         setIsInitialized(true);

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,11 +1,12 @@
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '../store.ts';
 import { useCurrentUser } from '../api.ts';
+import { getAccessToken } from '@shared/api/axiosInstance';
 import type { JSX } from 'react';
 
 export function ProtectedRoute({ component }: { component: JSX.Element }) {
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
-  const hasToken = !!localStorage.getItem('auth_token');
+  const hasToken = !!getAccessToken();
   const { isLoading } = useCurrentUser();
 
   // No token and not authenticated → go to login

--- a/src/features/auth/components/index.ts
+++ b/src/features/auth/components/index.ts
@@ -1,3 +1,4 @@
+export { AuthInitializer } from './AuthInitializer';
 export { AuthProvider } from './AuthProvider';
 export { default as LoginForm } from './LoginForm';
 export { ProtectedRoute } from './ProtectedRoute';

--- a/src/features/auth/pages/CallbackPage.tsx
+++ b/src/features/auth/pages/CallbackPage.tsx
@@ -32,6 +32,7 @@ function CallbackPage() {
     fetch(`${baseApiUrl}/auth/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({
         grantType: 'authorization_code',
         clientId: 'spa',

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { setAccessToken } from '@shared/api/axiosInstance';
 import type { User } from './types';
 
 type AuthStore = {
@@ -22,18 +23,19 @@ export const useAuthStore = create<AuthStore>(set => ({
 
   setUser: user => set({ user, isAuthenticated: !!user }),
   setToken: token => {
-    localStorage.setItem('auth_token', token);
+    setAccessToken(token);
+    set({ isAuthenticated: true });
   },
   setLoading: isLoading => set({ isLoading }),
   setError: error => set({ error }),
 
   login: (user, token) => {
-    localStorage.setItem('auth_token', token);
+    setAccessToken(token);
     set({ user, isAuthenticated: true, error: null });
   },
 
   logout: () => {
-    localStorage.removeItem('auth_token');
+    setAccessToken(null);
     set({ user: null, isAuthenticated: false });
   },
 }));

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { setAccessToken } from '@shared/api/axiosInstance';
+import { broadcastLogout, setAccessToken } from '@shared/api/axiosInstance';
 import type { User } from './types';
 
 type AuthStore = {
@@ -35,7 +35,8 @@ export const useAuthStore = create<AuthStore>(set => ({
   },
 
   logout: () => {
-    setAccessToken(null);
+    // Broadcast an explicit logout so other tabs clear auth + redirect.
+    broadcastLogout();
     set({ user: null, isAuthenticated: false });
   },
 }));

--- a/src/features/notification/hooks/useNotificationHub.tsx
+++ b/src/features/notification/hooks/useNotificationHub.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { HubConnectionBuilder, LogLevel, HubConnectionState } from '@microsoft/signalr';
+import { getAccessToken } from '@shared/api/axiosInstance';
 import { useNotificationStore } from '../store';
 import { showNotificationToast } from '../components/NotificationToast';
 import type { Notification } from '../types';
@@ -14,12 +15,12 @@ export function useNotificationHub() {
   const addNotification = useNotificationStore(s => s.addNotification);
 
   useEffect(() => {
-    const token = localStorage.getItem('auth_token');
+    const token = getAccessToken();
     if (!token) return;
 
     const connection = new HubConnectionBuilder()
       .withUrl(getHubUrl(), {
-        accessTokenFactory: () => localStorage.getItem('auth_token') ?? '',
+        accessTokenFactory: () => getAccessToken() ?? '',
       })
       .withAutomaticReconnect()
       .configureLogging(LogLevel.Warning)

--- a/src/features/userManagement/api/users.ts
+++ b/src/features/userManagement/api/users.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from '@shared/api/axiosInstance';
+import { useAuthStore } from '@features/auth/store';
 import type {
   UserProfile,
   AdminUserListResult,
@@ -16,13 +17,15 @@ const USERS_KEY = 'users';
 
 /** Current user's own profile */
 export const useGetMe = () => {
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated);
+
   return useQuery({
     queryKey: ME_KEY,
     queryFn: async (): Promise<UserProfile> => {
       const { data } = await axios.get<UserProfile>('/auth/me');
       return data;
     },
-    enabled: !!localStorage.getItem('auth_token'),
+    enabled: isAuthenticated,
   });
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,14 +5,16 @@ import './i18n';
 import './index.css'; // Import global CSS which includes Tailwind
 import App from '@app/App';
 import { queryClient } from '@app/queryClient';
-import { AuthProvider } from '@features/auth/components';
+import { AuthInitializer, AuthProvider } from '@features/auth/components';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <AuthInitializer>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </AuthInitializer>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -9,6 +9,51 @@ const DEV_API_DELAY = Number(import.meta.env.VITE_API_DELAY) || 0;
 // Helper function for delay
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+// --- Memory-only access token ---
+let accessToken: string | null = null;
+
+export function setAccessToken(token: string | null) {
+  accessToken = token;
+  // Broadcast to other tabs
+  authChannel.postMessage({ type: 'token_update', token });
+}
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+// --- BroadcastChannel for multi-tab sync ---
+const authChannel = new BroadcastChannel('auth');
+authChannel.addEventListener('message', (event) => {
+  if (event.data?.type === 'token_update') {
+    accessToken = event.data.token;
+  }
+  if (event.data?.type === 'logout') {
+    accessToken = null;
+    queryClient.clear();
+    window.location.href = '/login';
+  }
+});
+
+// --- Separate axios instance for refresh calls (with cookies) ---
+export const refreshClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
+  headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
+});
+
+// --- Refresh queue pattern ---
+let refreshPromise: Promise<string | null> | null = null;
+
+async function refreshAccessToken(): Promise<string | null> {
+  try {
+    const { data } = await refreshClient.post('/auth/refresh');
+    return data.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // Create axios instance with base URL and default headers
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
@@ -21,9 +66,8 @@ const axiosInstance = axios.create({
 // Add request interceptor for authentication
 axiosInstance.interceptors.request.use(
   config => {
-    const token = localStorage.getItem('auth_token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
   },
@@ -41,12 +85,38 @@ axiosInstance.interceptors.response.use(
     }
     return response;
   },
-  (error: AxiosError<ProblemDetails>) => {
-    const { response } = error;
+  async (error: AxiosError<ProblemDetails>) => {
+    const { response, config } = error;
 
-    // Handle authentication errors
-    if (response && response.status === 401) {
-      localStorage.removeItem('auth_token');
+    // Handle 401 — attempt silent refresh
+    if (response && response.status === 401 && config) {
+      // Only attempt refresh once per request
+      if ((config as any)._retried) {
+        accessToken = null;
+        queryClient.clear();
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+
+      (config as any)._retried = true;
+
+      // Queue pattern: reuse in-flight refresh promise
+      if (!refreshPromise) {
+        refreshPromise = refreshAccessToken().finally(() => {
+          refreshPromise = null;
+        });
+      }
+
+      const newToken = await refreshPromise;
+
+      if (newToken) {
+        setAccessToken(newToken);
+        config.headers.Authorization = `Bearer ${newToken}`;
+        return axiosInstance(config);
+      }
+
+      // Refresh failed — force logout
+      accessToken = null;
       queryClient.clear();
       window.location.href = '/login';
       return Promise.reject(error);

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosError } from 'axios';
+import axios, { AxiosHeaders, type AxiosError } from 'axios';
 import { queryClient } from '@app/queryClient';
 import { extractApiError } from '../utils/errorUtils';
 import type { ProblemDetails } from '../types/api';
@@ -12,6 +12,38 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 // --- Memory-only access token ---
 let accessToken: string | null = null;
 
+// --- BroadcastChannel for multi-tab sync (feature-detected) ---
+type AuthChannelMessage =
+  | { type: 'token_update'; token: string | null }
+  | { type: 'logout' };
+
+type AuthChannel = {
+  postMessage: (message: AuthChannelMessage) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (event: { data?: AuthChannelMessage }) => void,
+  ) => void;
+};
+
+const authChannel: AuthChannel =
+  typeof globalThis !== 'undefined' && typeof globalThis.BroadcastChannel === 'function'
+    ? new globalThis.BroadcastChannel('auth')
+    : {
+        postMessage: () => {},
+        addEventListener: () => {},
+      };
+
+authChannel.addEventListener('message', event => {
+  if (event.data?.type === 'token_update') {
+    accessToken = event.data.token;
+  }
+  if (event.data?.type === 'logout') {
+    accessToken = null;
+    queryClient.clear();
+    window.location.href = '/login';
+  }
+});
+
 export function setAccessToken(token: string | null) {
   accessToken = token;
   // Broadcast to other tabs
@@ -22,18 +54,25 @@ export function getAccessToken(): string | null {
   return accessToken;
 }
 
-// --- BroadcastChannel for multi-tab sync ---
-const authChannel = new BroadcastChannel('auth');
-authChannel.addEventListener('message', (event) => {
-  if (event.data?.type === 'token_update') {
-    accessToken = event.data.token;
-  }
-  if (event.data?.type === 'logout') {
-    accessToken = null;
-    queryClient.clear();
-    window.location.href = '/login';
-  }
-});
+/**
+ * Broadcast an explicit logout to other tabs so they clear their auth state
+ * and redirect to /login. Use this (not setAccessToken(null)) when the user
+ * initiates sign-out.
+ */
+export function broadcastLogout() {
+  accessToken = null;
+  authChannel.postMessage({ type: 'logout' });
+}
+
+// Endpoints that must NOT trigger a silent refresh-and-retry on 401.
+// A 401 from /auth/login means bad credentials; a 401 from /auth/refresh
+// means the refresh cookie is invalid — retrying would loop.
+const AUTH_ENDPOINT_PATTERNS = [/\/auth\/login\b/, /\/auth\/refresh\b/, /\/auth\/token\b/];
+
+function isAuthEndpoint(url: string | undefined): boolean {
+  if (!url) return false;
+  return AUTH_ENDPOINT_PATTERNS.some(re => re.test(url));
+}
 
 // --- Separate axios instance for refresh calls (with cookies) ---
 export const refreshClient = axios.create({
@@ -67,6 +106,9 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   config => {
     if (accessToken) {
+      if (!config.headers) {
+        config.headers = new AxiosHeaders();
+      }
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
@@ -88,11 +130,19 @@ axiosInstance.interceptors.response.use(
   async (error: AxiosError<ProblemDetails>) => {
     const { response, config } = error;
 
-    // Handle 401 — attempt silent refresh
-    if (response && response.status === 401 && config) {
+    // Handle 401 — attempt silent refresh.
+    // Skip refresh entirely for auth endpoints: a 401 from /auth/login is a
+    // credential failure (not a stale token) and refresh/token endpoints
+    // would loop or mask the real error.
+    if (
+      response &&
+      response.status === 401 &&
+      config &&
+      !isAuthEndpoint(config.url)
+    ) {
       // Only attempt refresh once per request
       if ((config as any)._retried) {
-        accessToken = null;
+        broadcastLogout();
         queryClient.clear();
         window.location.href = '/login';
         return Promise.reject(error);
@@ -111,12 +161,15 @@ axiosInstance.interceptors.response.use(
 
       if (newToken) {
         setAccessToken(newToken);
+        if (!config.headers) {
+        config.headers = new AxiosHeaders();
+      }
         config.headers.Authorization = `Bearer ${newToken}`;
         return axiosInstance(config);
       }
 
-      // Refresh failed — force logout
-      accessToken = null;
+      // Refresh failed — force logout across tabs
+      broadcastLogout();
       queryClient.clear();
       window.location.href = '/login';
       return Promise.reject(error);

--- a/src/shared/components/Navbar.tsx
+++ b/src/shared/components/Navbar.tsx
@@ -4,7 +4,7 @@ import Icon from '@shared/components/Icon';
 import { useUIStore } from '@shared/store';
 import clsx from 'clsx';
 import { useAuthStore } from '@features/auth/store.ts';
-import { setAccessToken } from '@shared/api/axiosInstance';
+import { broadcastLogout } from '@shared/api/axiosInstance';
 import { queryClient } from '@app/queryClient';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@shared/components/LanguageSwitcher';
@@ -33,7 +33,8 @@ function handleLogout(href: string) {
   // Navigate FIRST — clearing Zustand state would trigger ProtectedRoute
   // to redirect to /login, which cancels the server logout navigation.
   // Clear storage directly without triggering React re-renders.
-  setAccessToken(null);
+  // Use broadcastLogout so other tabs also clear auth + redirect.
+  broadcastLogout();
   queryClient.clear();
   sessionStorage.clear();
   window.location.replace(href);

--- a/src/shared/components/Navbar.tsx
+++ b/src/shared/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Icon from '@shared/components/Icon';
 import { useUIStore } from '@shared/store';
 import clsx from 'clsx';
 import { useAuthStore } from '@features/auth/store.ts';
+import { setAccessToken } from '@shared/api/axiosInstance';
 import { queryClient } from '@app/queryClient';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@shared/components/LanguageSwitcher';
@@ -32,7 +33,7 @@ function handleLogout(href: string) {
   // Navigate FIRST — clearing Zustand state would trigger ProtectedRoute
   // to redirect to /login, which cancels the server logout navigation.
   // Clear storage directly without triggering React re-renders.
-  localStorage.removeItem('auth_token');
+  setAccessToken(null);
   queryClient.clear();
   sessionStorage.clear();
   window.location.replace(href);


### PR DESCRIPTION
## Summary
- Replace localStorage-based access tokens with in-memory state in `axiosInstance`
- Add `AuthInitializer` wrapper that attempts a silent refresh on app load
- Rewire 401 handling with a queued refresh-and-retry pattern + `BroadcastChannel` for cross-tab sync

## Test plan
- [ ] Sign in fresh; verify access token is set in memory and requests include `Authorization`
- [ ] Force a 401 from the API and confirm a single refresh fires, original request retries successfully
- [ ] Open a second tab; signing out in one tab should clear auth and redirect the other
- [ ] Reload the app while logged in; `AuthInitializer` should silently refresh and avoid bouncing to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)