### PR TITLE
Combine lease agreement and rental info into single-step forms

### DIFF
--- a/src/features/appraisal/forms/LeaseAgreementForm.tsx
+++ b/src/features/appraisal/forms/LeaseAgreementForm.tsx
@@ -35,33 +35,33 @@ const SectionRow = ({ title, icon, children, isLast = false }: SectionRowProps) 
   </>
 );
 
-const LeaseAgreementForm = () => {
+const LeaseAgreementForm = ({ namePrefix }: { namePrefix?: string }) => {
   return (
     <div className="w-full max-w-full overflow-hidden">
       <h2 className="text-lg font-semibold text-gray-900 mb-6">Detail of Lease Agreement</h2>
       <div className="grid grid-cols-5 gap-x-6 gap-y-4">
         <SectionRow title="Information" icon="info-circle">
-          <FormFields fields={leaseInfoField} />
+          <FormFields fields={leaseInfoField} namePrefix={namePrefix} />
         </SectionRow>
 
         <SectionRow title="Contract" icon="file-contract">
-          <FormFields fields={leaseContractField} />
+          <FormFields fields={leaseContractField} namePrefix={namePrefix} />
         </SectionRow>
 
         <SectionRow title="Dates & Fees" icon="calendar-days">
-          <FormFields fields={leaseDatesFeesField} />
+          <FormFields fields={leaseDatesFeesField} namePrefix={namePrefix} />
         </SectionRow>
 
         <SectionRow title="Terms" icon="file-lines">
-          <FormFields fields={leaseTermsField} />
+          <FormFields fields={leaseTermsField} namePrefix={namePrefix} />
         </SectionRow>
 
         <SectionRow title="Rental Terms" icon="scroll">
-          <FormFields fields={leaseRentalTermsField} />
+          <FormFields fields={leaseRentalTermsField} namePrefix={namePrefix} />
         </SectionRow>
 
         <SectionRow title="Other" icon="circle-info" isLast>
-          <FormFields fields={leaseOtherField} />
+          <FormFields fields={leaseOtherField} namePrefix={namePrefix} />
         </SectionRow>
       </div>
     </div>

--- a/src/features/appraisal/forms/RentalInfoForm.tsx
+++ b/src/features/appraisal/forms/RentalInfoForm.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormFields } from '@/shared/components/form';
 import Icon from '@/shared/components/Icon';
-import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch, Controller } from 'react-hook-form';
+import { format, formatISO } from 'date-fns';
 import type { RentalInfoFormType } from '../schemas/form';
 import {
   rentalScheduleField,
   rentalGrowthPeriodField,
 } from '../configs/fields';
+import NumberInput from '@/shared/components/inputs/NumberInput';
+import DatePickerInput from '@/shared/components/inputs/DatePickerInput';
+import FormStringToggle from '@/shared/components/inputs/FormStringToggle';
 
 interface SectionRowProps {
   title: string;
@@ -63,31 +67,50 @@ function computeSchedule(data: RentalInfoFormType): ScheduleRow[] {
     contractEnd.setDate(contractEnd.getDate() - 1);
 
     const upFront = upFrontEntries
-      .filter(e => e.atYear === year)
+      .filter(e => {
+        if (typeof e.atYear === 'number') return e.atYear === year;
+        const entryDate = new Date(e.atYear);
+        return entryDate >= contractStart && entryDate <= contractEnd;
+      })
       .reduce((sum, e) => sum + (e.upFrontAmount ?? 0), 0);
 
     let growthRate = 0;
 
-    if (year > 1) {
-      if (data.growthRateType === 'Period') {
-        const interval = data.growthIntervalYears ?? 0;
-        if (interval > 0 && (year - 1) % interval === 0) {
-          growthRate = data.growthRatePercent ?? 0;
-          currentFee += currentFee * growthRate / 100;
-        }
-      } else if (data.growthRateType === 'Property') {
-        const entry = growthPeriodEntries.find(e => year >= e.fromYear && year <= e.toYear);
-        if (entry) {
-          growthRate = entry.growthRate;
-          currentFee = entry.totalAmount;
+    // Frequency growth: apply every N years (skip year 1)
+    if (year > 1 && data.growthRateType === 'Period') {
+      const interval = data.growthIntervalYears ?? 0;
+      if (interval > 0 && (year - 1) % interval === 0) {
+        growthRate = data.growthRatePercent ?? 0;
+        currentFee += currentFee * growthRate / 100;
+      }
+    }
+
+    // Period growth: apply from fromYear (no base year skip)
+    if (data.growthRateType === 'Property') {
+      const entryIdx = growthPeriodEntries.findIndex(e => year >= e.fromYear && year <= e.toYear);
+      const entry = entryIdx >= 0 ? growthPeriodEntries[entryIdx] : undefined;
+      if (entry) {
+        currentFee = entry.totalAmount;
+        // Show growth rate only at the first year of the period
+        if (year === entry.fromYear) {
+          growthRate = entry.growthRate ?? 0;
+          // If rate is 0/null but amount exists, derive from previous period's totalAmount
+          if (!growthRate && (entry.growthAmount ?? 0) > 0) {
+            const prevBase = entryIdx > 0
+              ? growthPeriodEntries[entryIdx - 1].totalAmount
+              : (data.contractRentalFeePerYear ?? 0);
+            if (prevBase > 0) {
+              growthRate = Math.round((entry.growthAmount / prevBase) * 100 * 100) / 100;
+            }
+          }
         }
       }
     }
 
     rows.push({
       year,
-      contractStart: contractStart.toLocaleDateString('en-GB'),
-      contractEnd: contractEnd.toLocaleDateString('en-GB'),
+      contractStart: formatISO(contractStart),
+      contractEnd: formatISO(contractEnd),
       upFront,
       contractRentalFee: currentFee,
       totalAmount: currentFee + upFront,
@@ -98,67 +121,128 @@ function computeSchedule(data: RentalInfoFormType): ScheduleRow[] {
   return rows;
 }
 
-const RentalInfoForm = () => {
-  const { register, control, setValue, getValues } = useFormContext<RentalInfoFormType>();
-  const growthRateType = useWatch({ control, name: 'growthRateType' });
+const fmtNumber = (val: number) =>
+  val.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const RentalInfoForm = ({ namePrefix }: { namePrefix?: string }) => {
+  // Helper to prefix field names
+  const p = (name: string) => (namePrefix ? `${namePrefix}.${name}` : name) as any;
+
+  const { control, setValue, getValues, formState: { errors } } = useFormContext();
+  const growthRateType = useWatch({ control, name: p('growthRateType') });
+  const numberOfYears = useWatch({ control, name: p('numberOfYears') }) ?? 0;
+  const watchedGrowthEntries = useWatch({ control, name: p('growthPeriodEntries') }) as any[] | undefined;
+  const watchedScheduleEntries = useWatch({ control, name: p('scheduleEntries') }) as any[] | undefined;
+  const watchedUpFrontEntries = useWatch({ control, name: p('upFrontEntries') }) as any[] | undefined;
+  const upFrontTotalInput = useWatch({ control, name: p('upFrontTotalAmount') }) ?? 0;
+  const contractRentalFeePerYear = useWatch({ control, name: p('contractRentalFeePerYear') }) ?? 0;
+
+  // Resolve nested errors for prefixed paths
+  const rentalErrors = namePrefix
+    ? (errors as any)?.[namePrefix] ?? {}
+    : errors;
+
+  // Auto-calculate toYear, growthAmount, and totalAmount for growth period entries
+  useEffect(() => {
+    if (!watchedGrowthEntries?.length) return;
+    watchedGrowthEntries.forEach((entry: any, idx: number) => {
+      const nextEntry = watchedGrowthEntries[idx + 1];
+      const expectedToYear = nextEntry?.fromYear ? nextEntry.fromYear - 1 : numberOfYears;
+      if (entry?.toYear !== expectedToYear && expectedToYear > 0) {
+        setValue(p(`growthPeriodEntries.${idx}.toYear`), expectedToYear, { shouldDirty: true });
+      }
+      const prevTotal = idx === 0
+        ? contractRentalFeePerYear
+        : (watchedGrowthEntries[idx - 1]?.totalAmount ?? contractRentalFeePerYear);
+
+      const rate = entry?.growthRate ?? 0;
+      // Only auto-calc growthAmount from rate when rate is non-zero
+      if (rate !== 0) {
+        const expectedAmount = Math.round((rate / 100) * prevTotal * 100) / 100;
+        if (entry?.growthAmount !== expectedAmount) {
+          setValue(p(`growthPeriodEntries.${idx}.growthAmount`), expectedAmount, { shouldDirty: true });
+        }
+      }
+      // Always: totalAmount = prevTotal + growthAmount
+      const currentAmount = entry?.growthAmount ?? 0;
+      const expectedTotal = Math.round((prevTotal + currentAmount) * 100) / 100;
+      if (entry?.totalAmount !== expectedTotal) {
+        setValue(p(`growthPeriodEntries.${idx}.totalAmount`), expectedTotal, { shouldDirty: true });
+      }
+    });
+  }, [watchedGrowthEntries?.map((e: any) => `${e?.fromYear}-${e?.growthRate}-${e?.growthAmount}-${e?.totalAmount}`).join(','), numberOfYears, contractRentalFeePerYear]);
+
+  const handleGrowthAmountChange = (idx: number, amount: number) => {
+    const prevTotal = idx === 0
+      ? contractRentalFeePerYear
+      : (watchedGrowthEntries?.[idx - 1]?.totalAmount ?? contractRentalFeePerYear);
+    const total = Math.round((prevTotal + amount) * 100) / 100;
+    setValue(p(`growthPeriodEntries.${idx}.totalAmount`), total, { shouldDirty: true });
+  };
+
+  const upFrontTotal = (watchedUpFrontEntries ?? []).reduce((sum: number, e: any) => sum + (e?.upFrontAmount ?? 0), 0);
   const [computedRows, setComputedRows] = useState<ScheduleRow[]>([]);
+  const [isScheduleEditing, setIsScheduleEditing] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
 
   const {
     fields: upFrontFields,
     append: appendUpFront,
     remove: removeUpFront,
-  } = useFieldArray({ control, name: 'upFrontEntries' as any });
+  } = useFieldArray({ control, name: p('upFrontEntries') });
 
   const {
     fields: growthFields,
     append: appendGrowth,
     remove: removeGrowth,
-  } = useFieldArray({ control, name: 'growthPeriodEntries' as any });
+  } = useFieldArray({ control, name: p('growthPeriodEntries') });
 
   const {
     fields: scheduleFields,
-  } = useFieldArray({ control, name: 'scheduleEntries' as any });
+    replace: replaceScheduleEntries,
+  } = useFieldArray({ control, name: p('scheduleEntries') });
 
   const handleGenerate = () => {
-    const data = getValues();
-    const rows = computeSchedule(data);
-    setComputedRows(rows);
+    setIsGenerating(true);
+    setTimeout(() => {
+      const allData = getValues();
+      const riData = namePrefix ? allData[namePrefix] : allData;
+      const rows = computeSchedule(riData);
+      setComputedRows(rows);
 
-    // Populate scheduleEntries form field — apply existing overrides
-    const overrides = data.scheduleOverrides ?? [];
-    const entries = rows.map(row => {
-      const override = overrides.find(o => o.year === row.year);
-      return {
+      setValue(p('scheduleOverrides'), [], { shouldDirty: true });
+
+      const entries = rows.map(row => ({
         year: row.year,
         contractStart: row.contractStart,
         contractEnd: row.contractEnd,
-        upFront: override?.upFront ?? row.upFront,
-        contractRentalFee: override?.contractRentalFee ?? row.contractRentalFee,
-        totalAmount: (override?.upFront ?? row.upFront) + (override?.contractRentalFee ?? row.contractRentalFee),
+        upFront: row.upFront,
+        contractRentalFee: row.contractRentalFee,
+        totalAmount: row.totalAmount,
         contractRentalFeeGrowthRatePercent: row.growthRatePercent,
-      };
-    });
-    setValue('scheduleEntries', entries, { shouldDirty: true });
+      }));
+      replaceScheduleEntries(entries);
+      setIsGenerating(false);
+    }, 400);
   };
 
   const handleCellChange = (idx: number, field: 'upFront' | 'contractRentalFee', value: number) => {
-    const entries = getValues('scheduleEntries') ?? [];
+    const entries = getValues(p('scheduleEntries')) ?? [];
     const entry = entries[idx];
     if (!entry) return;
 
     const updatedUpFront = field === 'upFront' ? value : entry.upFront;
     const updatedFee = field === 'contractRentalFee' ? value : entry.contractRentalFee;
 
-    setValue(`scheduleEntries.${idx}.${field}` as any, value, { shouldDirty: true });
-    setValue(`scheduleEntries.${idx}.totalAmount` as any, updatedUpFront + updatedFee, { shouldDirty: true });
+    setValue(p(`scheduleEntries.${idx}.${field}`), value, { shouldDirty: true });
+    setValue(p(`scheduleEntries.${idx}.totalAmount`), updatedUpFront + updatedFee, { shouldDirty: true });
 
-    // Update overrides
-    const overrides = getValues('scheduleOverrides') ?? [];
+    const overrides = getValues(p('scheduleOverrides')) ?? [];
     const computed = computedRows.find(r => r.year === entry.year);
     const isUpFrontOverridden = updatedUpFront !== (computed?.upFront ?? 0);
     const isFeeOverridden = updatedFee !== (computed?.contractRentalFee ?? 0);
 
-    const filtered = overrides.filter(o => o.year !== entry.year);
+    const filtered = overrides.filter((o: any) => o.year !== entry.year);
     if (isUpFrontOverridden || isFeeOverridden) {
       filtered.push({
         year: entry.year,
@@ -166,7 +250,7 @@ const RentalInfoForm = () => {
         contractRentalFee: isFeeOverridden ? updatedFee : null,
       });
     }
-    setValue('scheduleOverrides', filtered, { shouldDirty: true });
+    setValue(p('scheduleOverrides'), filtered, { shouldDirty: true });
   };
 
   return (
@@ -175,77 +259,98 @@ const RentalInfoForm = () => {
       <div className="grid grid-cols-5 gap-x-6 gap-y-4">
         {/* Schedule Header Fields */}
         <SectionRow title="Schedule" icon="calendar-days">
-          <FormFields fields={rentalScheduleField} />
+          <FormFields fields={rentalScheduleField} namePrefix={namePrefix} />
         </SectionRow>
 
         {/* Growth Rate */}
         <SectionRow title="Growth Rate" icon="chart-line">
           <div className="col-span-12 space-y-4">
-            <div className="flex items-center gap-4">
-              <span className="text-sm text-gray-600">Contract Rental Fee Growth Rate</span>
-              <div className="flex rounded-md overflow-hidden border border-gray-300">
-                <button
-                  type="button"
-                  onClick={() => setValue('growthRateType', 'Property', { shouldDirty: true })}
-                  className={`px-4 py-1.5 text-sm font-medium ${growthRateType === 'Property' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600'}`}
-                >
-                  Property
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setValue('growthRateType', 'Period', { shouldDirty: true })}
-                  className={`px-4 py-1.5 text-sm font-medium ${growthRateType === 'Period' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600'}`}
-                >
-                  Period
-                </button>
-              </div>
-            </div>
+            <FormStringToggle
+              name={p('growthRateType')}
+              label="Contract Rental Fee Growth Rate"
+              size="sm"
+              options={[
+                { name: 'Period', label: 'Frequency' },
+                { name: 'Property', label: 'Period' },
+              ]}
+            />
 
             {growthRateType === 'Period' && (
               <div className="grid grid-cols-12 gap-4">
-                <FormFields fields={rentalGrowthPeriodField} />
+                <FormFields fields={rentalGrowthPeriodField} namePrefix={namePrefix} />
               </div>
             )}
 
             {growthRateType === 'Property' && (
               <div>
-                <table className="w-full text-sm">
+                <table className="w-full text-sm border-collapse">
                   <thead>
-                    <tr className="bg-primary-700 text-white">
-                      <th className="px-3 py-2 text-left">#</th>
-                      <th className="px-3 py-2 text-left">From Year</th>
-                      <th className="px-3 py-2 text-left">To Year</th>
-                      <th className="px-3 py-2 text-right">Growth Rate %</th>
-                      <th className="px-3 py-2 text-right">Growth Amount</th>
-                      <th className="px-3 py-2 text-right">Total Amount</th>
+                    <tr className="border-b border-gray-200 bg-gray-50">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">At Year</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">To Year</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Growth Rate</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Growth Amount</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Total Amount (Baht)</th>
                       <th className="px-3 py-2 w-10"></th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100">
+                  <tbody>
                     {growthFields.map((field, idx) => (
-                      <tr key={field.id}>
-                        <td className="px-3 py-2">{idx + 1}</td>
-                        <td className="px-3 py-2">
-                          <input type="number" {...register(`growthPeriodEntries.${idx}.fromYear` as any, { valueAsNumber: true })}
-                            className="w-20 rounded border border-gray-300 px-2 py-1 text-sm" />
+                      <tr key={field.id} className="border-b border-gray-100">
+                        <td className="px-3 py-1.5">
+                          <Controller
+                            control={control}
+                            name={p(`growthPeriodEntries.${idx}.fromYear`)}
+                            render={({ field: f, fieldState: { error } }) => (
+                              <NumberInput {...f} decimalPlaces={0} thousandSeparator={false} error={error?.message} className="!py-1.5" />
+                            )}
+                          />
                         </td>
-                        <td className="px-3 py-2">
-                          <input type="number" {...register(`growthPeriodEntries.${idx}.toYear` as any, { valueAsNumber: true })}
-                            className="w-20 rounded border border-gray-300 px-2 py-1 text-sm" />
+                        <td className="px-3 py-1.5">
+                          <Controller
+                            control={control}
+                            name={p(`growthPeriodEntries.${idx}.toYear`)}
+                            render={({ field: f }) => (
+                              <NumberInput {...f} decimalPlaces={0} thousandSeparator={false} disabled className="!py-1.5" />
+                            )}
+                          />
                         </td>
-                        <td className="px-3 py-2">
-                          <input type="number" step="0.01" {...register(`growthPeriodEntries.${idx}.growthRate` as any, { valueAsNumber: true })}
-                            className="w-24 rounded border border-gray-300 px-2 py-1 text-sm text-right" />
+                        <td className="px-3 py-1.5">
+                          <Controller
+                            control={control}
+                            name={p(`growthPeriodEntries.${idx}.growthRate`)}
+                            render={({ field: f }) => (
+                              <NumberInput {...f} decimalPlaces={2} rightIcon={<span className="text-xs">%</span>} className="!py-1.5" />
+                            )}
+                          />
                         </td>
-                        <td className="px-3 py-2">
-                          <input type="number" step="0.01" {...register(`growthPeriodEntries.${idx}.growthAmount` as any, { valueAsNumber: true })}
-                            className="w-28 rounded border border-gray-300 px-2 py-1 text-sm text-right" />
+                        <td className="px-3 py-1.5">
+                          <Controller
+                            control={control}
+                            name={p(`growthPeriodEntries.${idx}.growthAmount`)}
+                            render={({ field: f }) => (
+                              <NumberInput
+                                {...f}
+                                decimalPlaces={2}
+                                className="!py-1.5"
+                                onChange={(e) => {
+                                  f.onChange(e);
+                                  handleGrowthAmountChange(idx, e.target.value ?? 0);
+                                }}
+                              />
+                            )}
+                          />
                         </td>
-                        <td className="px-3 py-2">
-                          <input type="number" step="0.01" {...register(`growthPeriodEntries.${idx}.totalAmount` as any, { valueAsNumber: true })}
-                            className="w-28 rounded border border-gray-300 px-2 py-1 text-sm text-right" />
+                        <td className="px-3 py-1.5">
+                          <Controller
+                            control={control}
+                            name={p(`growthPeriodEntries.${idx}.totalAmount`)}
+                            render={({ field: f }) => (
+                              <NumberInput {...f} decimalPlaces={2} disabled className="!py-1.5" />
+                            )}
+                          />
                         </td>
-                        <td className="px-3 py-2">
+                        <td className="px-3 py-1.5">
                           <button type="button" onClick={() => removeGrowth(idx)} className="text-red-500 hover:text-red-700">
                             <Icon style="solid" name="xmark" className="size-4" />
                           </button>
@@ -267,26 +372,41 @@ const RentalInfoForm = () => {
         {/* Up Front Entries */}
         <SectionRow title="Up Front" icon="money-bill">
           <div className="col-span-12">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm border-collapse">
               <thead>
-                <tr className="bg-primary-700 text-white">
-                  <th className="px-3 py-2 text-left">At Year</th>
-                  <th className="px-3 py-2 text-right">Up Front Amount</th>
+                <tr className="border-b border-gray-200 bg-gray-50">
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">At Date</th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Up Front Amount</th>
                   <th className="px-3 py-2 w-10"></th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody>
                 {upFrontFields.map((field, idx) => (
-                  <tr key={field.id}>
-                    <td className="px-3 py-2">
-                      <input type="number" {...register(`upFrontEntries.${idx}.atYear` as any, { valueAsNumber: true })}
-                        className="w-24 rounded border border-gray-300 px-2 py-1 text-sm" />
+                  <tr key={field.id} className="border-b border-gray-100">
+                    <td className="px-3 py-1.5">
+                      <Controller
+                        control={control}
+                        name={p(`upFrontEntries.${idx}.atYear`)}
+                        render={({ field: f }) => (
+                          <DatePickerInput
+                            value={typeof f.value === 'string' ? f.value : null}
+                            onChange={(val) => f.onChange(val ?? '')}
+                            onBlur={f.onBlur}
+                            name={f.name}
+                          />
+                        )}
+                      />
                     </td>
-                    <td className="px-3 py-2">
-                      <input type="number" step="0.01" {...register(`upFrontEntries.${idx}.upFrontAmount` as any, { valueAsNumber: true })}
-                        className="w-36 rounded border border-gray-300 px-2 py-1 text-sm text-right" />
+                    <td className="px-3 py-1.5">
+                      <Controller
+                        control={control}
+                        name={p(`upFrontEntries.${idx}.upFrontAmount`)}
+                        render={({ field: f }) => (
+                          <NumberInput {...f} decimalPlaces={2} className="!py-1.5" />
+                        )}
+                      />
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-1.5">
                       <button type="button" onClick={() => removeUpFront(idx)} className="text-red-500 hover:text-red-700">
                         <Icon style="solid" name="xmark" className="size-4" />
                       </button>
@@ -294,9 +414,32 @@ const RentalInfoForm = () => {
                   </tr>
                 ))}
               </tbody>
+              {upFrontFields.length > 0 && (
+                <tfoot>
+                  <tr className="border-t border-gray-200 bg-gray-50">
+                    <td className="px-3 py-2 text-sm font-semibold text-gray-700">Total</td>
+                    <td className="px-3 py-2 text-sm font-semibold text-right text-gray-700">{fmtNumber(upFrontTotal)}</td>
+                    <td className="px-3 py-2 w-10"></td>
+                  </tr>
+                </tfoot>
+              )}
             </table>
+            {upFrontFields.length > 0 && upFrontTotalInput > 0 && Math.abs(upFrontTotal - upFrontTotalInput) > 0.01 && (
+              <div className="mt-2 flex items-center gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-700">
+                <Icon style="solid" name="triangle-exclamation" className="size-4 shrink-0" />
+                <span>
+                  Total up front entries ({fmtNumber(upFrontTotal)}) does not match the Up Front amount ({fmtNumber(upFrontTotalInput)})
+                </span>
+              </div>
+            )}
+            {rentalErrors.upFrontEntries?.message && (
+              <div className="mt-2 flex items-center gap-2 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                <Icon style="solid" name="circle-exclamation" className="size-4 shrink-0" />
+                <span>{rentalErrors.upFrontEntries.message}</span>
+              </div>
+            )}
             <button type="button"
-              onClick={() => appendUpFront({ atYear: 0, upFrontAmount: 0 })}
+              onClick={() => appendUpFront({ atYear: '', upFrontAmount: 0 })}
               className="mt-2 flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700">
               <Icon style="solid" name="plus" className="size-3" /> Add
             </button>
@@ -306,54 +449,116 @@ const RentalInfoForm = () => {
         {/* Rental Schedule */}
         <SectionRow title="Rental Schedule" icon="table" isLast>
           <div className="col-span-12">
-            <div className="flex justify-end mb-3">
-              <button type="button" onClick={handleGenerate}
-                className="px-4 py-1.5 bg-primary-600 text-white text-sm font-medium rounded-md hover:bg-primary-700">
-                GENERATE
+            <div className="flex justify-end gap-2 mb-3">
+              {scheduleFields.length > 0 && (
+                <button type="button" onClick={() => setIsScheduleEditing(!isScheduleEditing)}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-md border ${isScheduleEditing ? 'bg-amber-50 border-amber-300 text-amber-700' : 'border-gray-300 text-gray-600 hover:bg-gray-50'}`}>
+                  <Icon style="solid" name={isScheduleEditing ? 'lock-open' : 'pen'} className="size-3 mr-1.5 inline-block" />
+                  {isScheduleEditing ? 'Editing' : 'Edit'}
+                </button>
+              )}
+              <button type="button" onClick={handleGenerate} disabled={isGenerating}
+                className="px-4 py-1.5 bg-primary-600 text-white text-sm font-medium rounded-md hover:bg-primary-700 disabled:opacity-70 disabled:cursor-not-allowed flex items-center gap-1.5">
+                {isGenerating && <Icon style="solid" name="spinner" className="size-3.5 animate-spin" />}
+                {isGenerating ? 'GENERATING...' : 'GENERATE'}
               </button>
             </div>
-            {scheduleFields.length > 0 ? (
+            {isGenerating ? (
               <div className="overflow-x-auto">
-                <table className="w-full text-sm">
+                <table className="w-full text-sm border-collapse">
                   <thead>
-                    <tr className="bg-primary-700 text-white">
-                      <th className="px-3 py-2 text-left">Year</th>
-                      <th className="px-3 py-2 text-left">Contract Start</th>
-                      <th className="px-3 py-2 text-left">Contract End</th>
-                      <th className="px-3 py-2 text-right">Up Front (Lum)</th>
-                      <th className="px-3 py-2 text-right">Contract Rental Fee</th>
-                      <th className="px-3 py-2 text-right">Total Amount</th>
-                      <th className="px-3 py-2 text-right">Growth Rate %</th>
+                    <tr className="border-b border-gray-200 bg-gray-50">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Year</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Contract Start</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Contract End</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Up Front (Baht/Year)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Contract Rental Fee (Baht/Year)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Total Amount (Baht)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Growth Rate %</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-100">
+                  <tbody>
+                    {Array.from({ length: 5 }).map((_, idx) => (
+                      <tr key={idx} className="border-b border-gray-100">
+                        {Array.from({ length: 7 }).map((_, col) => (
+                          <td key={col} className="px-3 py-2.5">
+                            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : scheduleFields.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="border-b border-gray-200 bg-gray-50">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Year</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Contract Start</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-500">Contract End</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Up Front (Baht/Year)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Contract Rental Fee (Baht/Year)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Total Amount (Baht)</th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-gray-500">Growth Rate %</th>
+                    </tr>
+                  </thead>
+                  <tbody>
                     {scheduleFields.map((field, idx) => {
-                      const entry = getValues(`scheduleEntries.${idx}` as any);
+                      const entry = watchedScheduleEntries?.[idx];
+                      const upFrontVal = entry?.upFront ?? 0;
+                      const feeVal = entry?.contractRentalFee ?? 0;
+                      const totalVal = upFrontVal + feeVal;
                       return (
-                        <tr key={field.id}>
-                          <td className="px-3 py-2">{entry?.year}</td>
-                          <td className="px-3 py-2">{entry?.contractStart}</td>
-                          <td className="px-3 py-2">{entry?.contractEnd}</td>
-                          <td className="px-3 py-2">
-                            <input
-                              type="number"
-                              step="0.01"
-                              {...register(`scheduleEntries.${idx}.upFront` as any, { valueAsNumber: true })}
-                              onChange={(e) => handleCellChange(idx, 'upFront', parseFloat(e.target.value) || 0)}
-                              className="w-28 rounded border border-gray-300 px-2 py-1 text-sm text-right"
-                            />
+                        <tr key={field.id} className="border-b border-gray-100 hover:bg-gray-50">
+                          <td className="px-3 py-1.5 text-gray-700">{entry?.year}</td>
+                          <td className="px-3 py-1.5 text-gray-700">{entry?.contractStart ? format(new Date(entry.contractStart), 'dd/MM/yyyy') : ''}</td>
+                          <td className="px-3 py-1.5 text-gray-700">{entry?.contractEnd ? format(new Date(entry.contractEnd), 'dd/MM/yyyy') : ''}</td>
+                          <td className="px-3 py-1.5">
+                            {isScheduleEditing ? (
+                              <Controller
+                                control={control}
+                                name={p(`scheduleEntries.${idx}.upFront`)}
+                                render={({ field: f }) => (
+                                  <NumberInput
+                                    {...f}
+                                    decimalPlaces={2}
+                                    className="!py-1.5"
+                                    onChange={(e) => {
+                                      f.onChange(e);
+                                      handleCellChange(idx, 'upFront', e.target.value ?? 0);
+                                    }}
+                                  />
+                                )}
+                              />
+                            ) : (
+                              <span className="block text-right text-gray-700">{fmtNumber(upFrontVal)}</span>
+                            )}
                           </td>
-                          <td className="px-3 py-2">
-                            <input
-                              type="number"
-                              step="0.01"
-                              {...register(`scheduleEntries.${idx}.contractRentalFee` as any, { valueAsNumber: true })}
-                              onChange={(e) => handleCellChange(idx, 'contractRentalFee', parseFloat(e.target.value) || 0)}
-                              className="w-28 rounded border border-gray-300 px-2 py-1 text-sm text-right"
-                            />
+                          <td className="px-3 py-1.5">
+                            {isScheduleEditing ? (
+                              <Controller
+                                control={control}
+                                name={p(`scheduleEntries.${idx}.contractRentalFee`)}
+                                render={({ field: f }) => (
+                                  <NumberInput
+                                    {...f}
+                                    decimalPlaces={2}
+                                    className="!py-1.5"
+                                    onChange={(e) => {
+                                      f.onChange(e);
+                                      handleCellChange(idx, 'contractRentalFee', e.target.value ?? 0);
+                                    }}
+                                  />
+                                )}
+                              />
+                            ) : (
+                              <span className="block text-right text-gray-700">{fmtNumber(feeVal)}</span>
+                            )}
                           </td>
-                          <td className="px-3 py-2 text-right">{(entry?.totalAmount ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
-                          <td className="px-3 py-2 text-right">{(entry?.contractRentalFeeGrowthRatePercent ?? 0).toFixed(2)}</td>
+                          <td className="px-3 py-1.5 text-right font-medium text-gray-700">{fmtNumber(totalVal)}</td>
+                          <td className="px-3 py-1.5 text-right text-gray-700">{(entry?.contractRentalFeeGrowthRatePercent ?? 0).toFixed(2)}</td>
                         </tr>
                       );
                     })}

--- a/src/features/appraisal/pages/CreateLeaseAgreementBuildingPage.tsx
+++ b/src/features/appraisal/pages/CreateLeaseAgreementBuildingPage.tsx
@@ -17,20 +17,14 @@ import Button from '@/shared/components/Button';
 import Icon from '@/shared/components/Icon';
 import BuildingDetailForm from '../forms/BuildingDetailForm';
 import {
-  useGetBuildingPropertyById,
-  useGetLeaseAgreement,
-  useGetRentalInfo,
+  useGetLeaseAgreementBuildingPropertyById,
 } from '../api/property';
 import LeaseAgreementForm from '../forms/LeaseAgreementForm';
 import RentalInfoForm from '../forms/RentalInfoForm';
 import {
-  createBuildingForm,
-  createBuildingFormDefault,
-  type createBuildingFormType,
-  createLeaseAgreementForm,
-  type createLeaseAgreementFormType,
-  rentalInfoFormSchema,
-  type RentalInfoFormType,
+  createLeaseAgreementBuildingForm,
+  createLeaseAgreementBuildingFormDefault,
+  type createLeaseAgreementBuildingFormType,
 } from '../schemas/form';
 import {
   mapBuildingPropertyResponseToForm,
@@ -97,22 +91,33 @@ const CreateLeaseAgreementBuildingPage = () => {
   const isEditMode = Boolean(propertyId);
 
   // ─── Building detail form ─────────────────────────────────────
-  const { data: propertyData, isLoading } = useGetBuildingPropertyById(appraisalId, propertyId);
+  const { data: propertyData, isLoading } = useGetLeaseAgreementBuildingPropertyById(appraisalId, propertyId);
 
   const formDefaults = useMemo(() => {
-    if (isEditMode && propertyData) return mapBuildingPropertyResponseToForm(propertyData);
-    return createBuildingFormDefault;
+    if (isEditMode && propertyData) return {
+      ...mapBuildingPropertyResponseToForm(propertyData),
+      leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+      rentalInfo: (propertyData as any).rentalInfo ?? null,
+    };
+    return createLeaseAgreementBuildingFormDefault;
   }, [isEditMode, propertyData]);
 
-  const methods = useForm<createBuildingFormType>({
+  const methods = useForm<createLeaseAgreementBuildingFormType>({
     defaultValues: formDefaults,
-    resolver: zodResolver(createBuildingForm),
+    resolver: zodResolver(createLeaseAgreementBuildingForm),
   });
   const { handleSubmit, getValues, reset } = methods;
 
   useEffect(() => {
-    if (isEditMode && propertyData) reset(mapBuildingPropertyResponseToForm(propertyData));
-  }, [isEditMode, propertyData, reset]);
+    if (!isEditMode || !propertyData) return;
+    const base = mapBuildingPropertyResponseToForm(propertyData);
+    reset({
+      ...createLeaseAgreementBuildingFormDefault,
+      ...base,
+      leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+      rentalInfo: (propertyData as any).rentalInfo ?? null,
+    } as any);
+  }, [isEditMode, propertyData]);
 
   const { mutate: createProperty, isPending: isCreating } = useCreateLeaseAgreementBuildingProperty();
   const { mutate: updateProperty, isPending: isUpdating } = useUpdateLeaseAgreementBuildingProperty();
@@ -131,39 +136,16 @@ const CreateLeaseAgreementBuildingPage = () => {
     }
   }, [isUnderConstruction, activeTab]);
 
-  // ─── Lease Agreement form ─────────────────────────────────────
-  const { data: leaseAgreementData } = useGetLeaseAgreement(appraisalId, propertyId);
-
-  const leaseAgreementMethods = useForm<createLeaseAgreementFormType>({
-    resolver: zodResolver(createLeaseAgreementForm),
-  });
-
-  useEffect(() => {
-    if (leaseAgreementData) leaseAgreementMethods.reset(leaseAgreementData as any);
-  }, [leaseAgreementData, leaseAgreementMethods]);
-
-  // ─── Rental Info form ─────────────────────────────────────────
-  const { data: rentalInfoData } = useGetRentalInfo(appraisalId, propertyId);
-
-  const rentalInfoMethods = useForm<RentalInfoFormType>({
-    resolver: zodResolver(rentalInfoFormSchema),
-  });
-
-  useEffect(() => {
-    if (rentalInfoData) rentalInfoMethods.reset(rentalInfoData as any);
-  }, [rentalInfoData, rentalInfoMethods]);
-
-  const hasDirtyFields = methods.formState.isDirty || leaseAgreementMethods.formState.isDirty || rentalInfoMethods.formState.isDirty;
+  const hasDirtyFields = methods.formState.isDirty;
   const { blocker, skipWarning } = useUnsavedChangesWarning(hasDirtyFields);
 
   // ─── Save handlers ────────────────────────────────────────────
 
-  const onSubmit: SubmitHandler<createBuildingFormType> = data => {
+  const onSubmit: SubmitHandler<createLeaseAgreementBuildingFormType> = async data => {
     setSaveAction('submit');
-    const basePayload = mapBuildingFormDataToApiPayload(data);
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...basePayload, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = data;
+    const basePayload = mapBuildingFormDataToApiPayload(rest as any);
+    const payload = { ...basePayload, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -171,8 +153,6 @@ const CreateLeaseAgreementBuildingPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement building updated successfully');
             setSaveAction(null);
           },
@@ -189,8 +169,6 @@ const CreateLeaseAgreementBuildingPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement building created successfully');
             setSaveAction(null);
             skipWarning();
@@ -208,10 +186,9 @@ const CreateLeaseAgreementBuildingPage = () => {
   const handleSaveDraft = () => {
     setSaveAction('draft');
     const data = getValues();
-    const basePayload = mapBuildingFormDataToApiPayload(data);
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...basePayload, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = data;
+    const basePayload = mapBuildingFormDataToApiPayload(rest as any);
+    const payload = { ...basePayload, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -219,8 +196,6 @@ const CreateLeaseAgreementBuildingPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
           },
@@ -237,8 +212,6 @@ const CreateLeaseAgreementBuildingPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
             if (response.propertyId) {
@@ -295,7 +268,7 @@ const CreateLeaseAgreementBuildingPage = () => {
         />
       </div>
 
-      <FormProvider methods={methods} schema={createBuildingForm}>
+      <FormProvider methods={methods} schema={createLeaseAgreementBuildingForm}>
         <form onSubmit={handleSubmit(onSubmit)} className="flex-1 min-h-0 flex flex-col">
           {/* Scrollable Form Content */}
           <div
@@ -379,9 +352,7 @@ const CreateLeaseAgreementBuildingPage = () => {
                         <h2 className="text-lg font-semibold text-gray-900">Lease Agreement</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={leaseAgreementMethods} schema={createLeaseAgreementForm}>
-                        <LeaseAgreementForm />
-                      </FormProvider>
+                      <LeaseAgreementForm namePrefix="leaseAgreement" />
                     </Section>
                   </div>
 
@@ -398,9 +369,7 @@ const CreateLeaseAgreementBuildingPage = () => {
                         <h2 className="text-lg font-semibold text-gray-900">Rental Info</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={rentalInfoMethods} schema={rentalInfoFormSchema}>
-                        <RentalInfoForm />
-                      </FormProvider>
+                      <RentalInfoForm namePrefix="rentalInfo" />
                     </Section>
                   </div>
                 </div>

--- a/src/features/appraisal/pages/CreateLeaseAgreementLandBuildingPage.tsx
+++ b/src/features/appraisal/pages/CreateLeaseAgreementLandBuildingPage.tsx
@@ -3,7 +3,7 @@ import { type SubmitHandler, useForm } from 'react-hook-form';
 import { FormProvider } from '@shared/components/form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { useBasePath, useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { useAppraisalId, useBasePath } from '@/features/appraisal/context/AppraisalContext';
 
 import ResizableSidebar from '@/shared/components/ResizableSidebar';
 import NavAnchors from '@/shared/components/sections/NavAnchors';
@@ -16,32 +16,19 @@ import ActionBar from '@/shared/components/ActionBar';
 import CancelButton from '@/shared/components/buttons/CancelButton';
 import Button from '@/shared/components/Button';
 import Icon from '@/shared/components/Icon';
-import {
-  useGetLandAndBuildingPropertyById,
-  useGetLeaseAgreement,
-  useGetRentalInfo,
-} from '../api/property';
+import { useGetLeaseAgreementLandAndBuildingPropertyById } from '../api/property';
 import LandDetailForm from '../forms/LandDetailForm';
 import BuildingDetailForm from '../forms/BuildingDetailForm';
 import LeaseAgreementForm from '../forms/LeaseAgreementForm';
 import RentalInfoForm from '../forms/RentalInfoForm';
 import {
-  createLandAndBuildingForm,
-  createLandAndBuildingFormDefault,
-  type createLandAndBuildingFormType,
-  createLeaseAgreementForm,
-  type createLeaseAgreementFormType,
-  rentalInfoFormSchema,
-  type RentalInfoFormType,
+  createLeaseAgreementLandAndBuildingForm,
+  createLeaseAgreementLandAndBuildingFormDefault,
+  type createLeaseAgreementLandAndBuildingFormType,
 } from '../schemas/form';
 import toast from 'react-hot-toast';
-import {
-  mapLandAndBuildingFormDataToApiPayload,
-  mapLandAndBuildingPropertyResponseToForm,
-} from '../utils/mappers';
-import PropertyPhotoSection, {
-  type PropertyPhotoSectionRef,
-} from '../components/PropertyPhotoSection';
+import { mapLandAndBuildingFormDataToApiPayload, mapLandAndBuildingPropertyResponseToForm, } from '../utils/mappers';
+import PropertyPhotoSection, { type PropertyPhotoSectionRef, } from '../components/PropertyPhotoSection';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { ConstructionInspectionTab } from '../components/tabs/ConstructionInspectionTab';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -53,7 +40,11 @@ import { propertyGroupKeys } from '../api/propertyGroup';
 const useCreateLeaseAgreementLandBuildingProperty = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (params: { appraisalId: string; groupId?: string; data: any }): Promise<any> => {
+    mutationFn: async (params: {
+      appraisalId: string;
+      groupId?: string;
+      data: any;
+    }): Promise<any> => {
       const url = `/appraisals/${params.appraisalId}/lease-agreement-land-and-building-properties${params.groupId ? `?groupId=${params.groupId}` : ''}`;
       const { data } = await axios.post(url, params.data);
       return data;
@@ -67,7 +58,11 @@ const useCreateLeaseAgreementLandBuildingProperty = () => {
 const useUpdateLeaseAgreementLandBuildingProperty = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (params: { appraisalId: string; propertyId: string; data: any }): Promise<any> => {
+    mutationFn: async (params: {
+      appraisalId: string;
+      propertyId: string;
+      data: any;
+    }): Promise<any> => {
       const { data } = await axios.put(
         `/appraisals/${params.appraisalId}/properties/${params.propertyId}/lease-agreement-land-building-detail`,
         params.data,
@@ -99,25 +94,37 @@ const CreateLeaseAgreementLandBuildingPage = () => {
   const photoSectionRef = useRef<PropertyPhotoSectionRef>(null);
 
   // ─── Land + Building detail form ─────────────────────────────
-  const { data: propertyData, isLoading } = useGetLandAndBuildingPropertyById(
+  const { data: propertyData, isLoading } = useGetLeaseAgreementLandAndBuildingPropertyById(
     appraisalId,
     propertyId,
   );
 
   const formDefaults = useMemo(() => {
-    if (isEditMode && propertyData) return mapLandAndBuildingPropertyResponseToForm(propertyData);
-    return createLandAndBuildingFormDefault;
+    if (isEditMode && propertyData)
+      return {
+        ...mapLandAndBuildingPropertyResponseToForm(propertyData),
+        leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+        rentalInfo: (propertyData as any).rentalInfo ?? null,
+      };
+    return createLeaseAgreementLandAndBuildingFormDefault;
   }, [isEditMode, propertyData]);
 
-  const methods = useForm<createLandAndBuildingFormType>({
+  const methods = useForm<createLeaseAgreementLandAndBuildingFormType>({
     defaultValues: formDefaults,
-    resolver: zodResolver(createLandAndBuildingForm),
+    resolver: zodResolver(createLeaseAgreementLandAndBuildingForm),
   });
   const { handleSubmit, getValues, reset } = methods;
 
   useEffect(() => {
-    if (isEditMode && propertyData) reset(mapLandAndBuildingPropertyResponseToForm(propertyData));
-  }, [isEditMode, propertyData, reset]);
+    if (!isEditMode || !propertyData) return;
+    const base = mapLandAndBuildingPropertyResponseToForm(propertyData);
+    reset({
+      ...createLeaseAgreementLandAndBuildingFormDefault,
+      ...base,
+      leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+      rentalInfo: (propertyData as any).rentalInfo ?? null,
+    } as any);
+  }, [isEditMode, propertyData]);
 
   const { mutate: createProperty, isPending: isCreating } =
     useCreateLeaseAgreementLandBuildingProperty();
@@ -130,7 +137,9 @@ const CreateLeaseAgreementLandBuildingPage = () => {
   const isUnderConstruction = methods.watch('isUnderConstruction');
   const tabParam = searchParams.get('tab');
   const initialTab = tabParam === 'construction' ? 'construction' : 'land';
-  const [activeTab, setActiveTab] = useState<'land' | 'building' | 'construction' | 'lease-agreement' | 'rental-info'>(initialTab);
+  const [activeTab, setActiveTab] = useState<
+    'land' | 'building' | 'construction' | 'lease-agreement' | 'rental-info'
+  >(initialTab);
 
   useEffect(() => {
     if (activeTab === 'construction' && !isUnderConstruction) {
@@ -138,39 +147,16 @@ const CreateLeaseAgreementLandBuildingPage = () => {
     }
   }, [isUnderConstruction, activeTab]);
 
-  // ─── Lease Agreement form ─────────────────────────────────────
-  const { data: leaseAgreementData } = useGetLeaseAgreement(appraisalId, propertyId);
-
-  const leaseAgreementMethods = useForm<createLeaseAgreementFormType>({
-    resolver: zodResolver(createLeaseAgreementForm),
-  });
-
-  useEffect(() => {
-    if (leaseAgreementData) leaseAgreementMethods.reset(leaseAgreementData as any);
-  }, [leaseAgreementData, leaseAgreementMethods]);
-
-  // ─── Rental Info form ─────────────────────────────────────────
-  const { data: rentalInfoData } = useGetRentalInfo(appraisalId, propertyId);
-
-  const rentalInfoMethods = useForm<RentalInfoFormType>({
-    resolver: zodResolver(rentalInfoFormSchema),
-  });
-
-  useEffect(() => {
-    if (rentalInfoData) rentalInfoMethods.reset(rentalInfoData as any);
-  }, [rentalInfoData, rentalInfoMethods]);
-
-  const hasDirtyFields = methods.formState.isDirty || leaseAgreementMethods.formState.isDirty || rentalInfoMethods.formState.isDirty;
+  const hasDirtyFields = methods.formState.isDirty;
   const { blocker, skipWarning } = useUnsavedChangesWarning(hasDirtyFields);
 
   // ─── Save handlers ────────────────────────────────────────────
 
-  const onSubmit: SubmitHandler<createLandAndBuildingFormType> = data => {
+  const onSubmit: SubmitHandler<createLeaseAgreementLandAndBuildingFormType> = async data => {
     setSaveAction('submit');
-    const basePayload = mapLandAndBuildingFormDataToApiPayload(data);
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...basePayload, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = data;
+    const basePayload = mapLandAndBuildingFormDataToApiPayload(rest as any);
+    const payload = { ...basePayload, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -178,8 +164,6 @@ const CreateLeaseAgreementLandBuildingPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement land and building updated successfully');
             setSaveAction(null);
           },
@@ -196,8 +180,6 @@ const CreateLeaseAgreementLandBuildingPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement land and building created successfully');
             setSaveAction(null);
             skipWarning();
@@ -215,10 +197,9 @@ const CreateLeaseAgreementLandBuildingPage = () => {
   const handleSaveDraft = () => {
     setSaveAction('draft');
     const data = getValues();
-    const basePayload = mapLandAndBuildingFormDataToApiPayload(data);
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...basePayload, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = data;
+    const basePayload = mapLandAndBuildingFormDataToApiPayload(rest as any);
+    const payload = { ...basePayload, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -226,8 +207,6 @@ const CreateLeaseAgreementLandBuildingPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
           },
@@ -244,8 +223,6 @@ const CreateLeaseAgreementLandBuildingPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
             if (response.propertyId) {
@@ -302,13 +279,23 @@ const CreateLeaseAgreementLandBuildingPage = () => {
                   },
                 ]
               : []),
-            { label: 'Lease Agreement', id: 'lease-agreement-section', icon: 'file-contract', onClick: () => setActiveTab('lease-agreement') },
-            { label: 'Rental Info', id: 'rental-info-section', icon: 'calendar-days', onClick: () => setActiveTab('rental-info') },
+            {
+              label: 'Lease Agreement',
+              id: 'lease-agreement-section',
+              icon: 'file-contract',
+              onClick: () => setActiveTab('lease-agreement'),
+            },
+            {
+              label: 'Rental Info',
+              id: 'rental-info-section',
+              icon: 'calendar-days',
+              onClick: () => setActiveTab('rental-info'),
+            },
           ]}
         />
       </div>
 
-      <FormProvider methods={methods} schema={createLandAndBuildingForm}>
+      <FormProvider methods={methods} schema={createLeaseAgreementLandAndBuildingForm}>
         <form onSubmit={handleSubmit(onSubmit)} className="flex-1 min-h-0 flex flex-col">
           {/* Scrollable Form Content */}
           <div
@@ -348,7 +335,11 @@ const CreateLeaseAgreementLandBuildingPage = () => {
                   >
                     <div className="flex items-center gap-3">
                       <div className="w-9 h-9 rounded-lg bg-amber-100 flex items-center justify-center">
-                        <Icon name="mountain-sun" style="solid" className="w-5 h-5 text-amber-600" />
+                        <Icon
+                          name="mountain-sun"
+                          style="solid"
+                          className="w-5 h-5 text-amber-600"
+                        />
                       </div>
                       <h2 className="text-lg font-semibold text-gray-900">Land Information</h2>
                     </div>
@@ -394,9 +385,15 @@ const CreateLeaseAgreementLandBuildingPage = () => {
                     >
                       <div className="flex items-center gap-3">
                         <div className="w-9 h-9 rounded-lg bg-teal-100 flex items-center justify-center">
-                          <Icon name="helmet-safety" style="solid" className="w-5 h-5 text-teal-600" />
+                          <Icon
+                            name="helmet-safety"
+                            style="solid"
+                            className="w-5 h-5 text-teal-600"
+                          />
                         </div>
-                        <h2 className="text-lg font-semibold text-gray-900">Construction Inspection</h2>
+                        <h2 className="text-lg font-semibold text-gray-900">
+                          Construction Inspection
+                        </h2>
                       </div>
                       <div className="h-px bg-gray-200" />
                       <Section id="construction-info" anchor className="flex flex-col gap-6">
@@ -413,14 +410,16 @@ const CreateLeaseAgreementLandBuildingPage = () => {
                     <Section anchor className="min-w-0 overflow-hidden">
                       <div className="flex items-center gap-3 mb-4">
                         <div className="w-9 h-9 rounded-lg bg-purple-100 flex items-center justify-center">
-                          <Icon name="file-contract" style="solid" className="w-5 h-5 text-purple-600" />
+                          <Icon
+                            name="file-contract"
+                            style="solid"
+                            className="w-5 h-5 text-purple-600"
+                          />
                         </div>
                         <h2 className="text-lg font-semibold text-gray-900">Lease Agreement</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={leaseAgreementMethods} schema={createLeaseAgreementForm}>
-                        <LeaseAgreementForm />
-                      </FormProvider>
+                      <LeaseAgreementForm namePrefix="leaseAgreement" />
                     </Section>
                   </div>
 
@@ -432,14 +431,16 @@ const CreateLeaseAgreementLandBuildingPage = () => {
                     <Section anchor className="min-w-0 overflow-hidden">
                       <div className="flex items-center gap-3 mb-4">
                         <div className="w-9 h-9 rounded-lg bg-teal-100 flex items-center justify-center">
-                          <Icon name="calendar-days" style="solid" className="w-5 h-5 text-teal-600" />
+                          <Icon
+                            name="calendar-days"
+                            style="solid"
+                            className="w-5 h-5 text-teal-600"
+                          />
                         </div>
                         <h2 className="text-lg font-semibold text-gray-900">Rental Info</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={rentalInfoMethods} schema={rentalInfoFormSchema}>
-                        <RentalInfoForm />
-                      </FormProvider>
+                      <RentalInfoForm namePrefix="rentalInfo" />
                     </Section>
                   </div>
                 </div>

--- a/src/features/appraisal/pages/CreateLeaseAgreementLandPage.tsx
+++ b/src/features/appraisal/pages/CreateLeaseAgreementLandPage.tsx
@@ -17,21 +17,15 @@ import CancelButton from '@/shared/components/buttons/CancelButton';
 import Button from '@/shared/components/Button';
 import Icon from '@/shared/components/Icon';
 import {
-  useGetLandPropertyById,
-  useGetLeaseAgreement,
-  useGetRentalInfo,
+  useGetLeaseAgreementLandPropertyById,
 } from '../api/property';
 import LandDetailForm from '../forms/LandDetailForm';
 import LeaseAgreementForm from '../forms/LeaseAgreementForm';
 import RentalInfoForm from '../forms/RentalInfoForm';
 import {
-  createLandForm,
-  createLandFormDefault,
-  type createLandFormType,
-  createLeaseAgreementForm,
-  type createLeaseAgreementFormType,
-  rentalInfoFormSchema,
-  type RentalInfoFormType,
+  createLeaseAgreementLandForm,
+  createLeaseAgreementLandFormDefault,
+  type createLeaseAgreementLandFormType,
 } from '../schemas/form';
 import { mapLandPropertyResponseToForm } from '../utils/mappers';
 import toast from 'react-hot-toast';
@@ -94,60 +88,49 @@ const CreateLeaseAgreementLandPage = () => {
   const isEditMode = Boolean(propertyId);
 
   // ─── Land detail form ─────────────────────────────────────────
-  const { data: propertyData, isLoading } = useGetLandPropertyById(appraisalId, propertyId);
+  const { data: propertyData, isLoading } = useGetLeaseAgreementLandPropertyById(appraisalId, propertyId);
 
   const formDefaults = useMemo(() => {
-    if (isEditMode && propertyData) return mapLandPropertyResponseToForm(propertyData);
-    return createLandFormDefault;
+    if (isEditMode && propertyData)
+      return {
+        ...mapLandPropertyResponseToForm(propertyData),
+        leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+        rentalInfo: (propertyData as any).rentalInfo ?? null,
+      };
+    return createLeaseAgreementLandFormDefault;
   }, [isEditMode, propertyData]);
 
-  const methods = useForm<createLandFormType>({
+  const methods = useForm<createLeaseAgreementLandFormType>({
     defaultValues: formDefaults,
-    resolver: zodResolver(createLandForm),
+    resolver: zodResolver(createLeaseAgreementLandForm),
   });
   const { handleSubmit, getValues, reset } = methods;
 
   useEffect(() => {
-    if (isEditMode && propertyData) reset(mapLandPropertyResponseToForm(propertyData));
-  }, [isEditMode, propertyData, reset]);
+    if (!isEditMode || !propertyData) return;
+    const base = mapLandPropertyResponseToForm(propertyData);
+    reset({
+      ...createLeaseAgreementLandFormDefault,
+      ...base,
+      leaseAgreement: (propertyData as any).leaseAgreement ?? null,
+      rentalInfo: (propertyData as any).rentalInfo ?? null,
+    } as any);
+  }, [isEditMode, propertyData]);
 
   const { mutate: createProperty, isPending: isCreating } = useCreateLeaseAgreementLandProperty();
   const { mutate: updateProperty, isPending: isUpdating } = useUpdateLeaseAgreementLandProperty();
   const isPending = isCreating || isUpdating;
   const [saveAction, setSaveAction] = useState<'draft' | 'submit' | null>(null);
 
-  // ─── Lease Agreement form ─────────────────────────────────────
-  const { data: leaseAgreementData } = useGetLeaseAgreement(appraisalId, propertyId);
-
-  const leaseAgreementMethods = useForm<createLeaseAgreementFormType>({
-    resolver: zodResolver(createLeaseAgreementForm),
-  });
-
-  useEffect(() => {
-    if (leaseAgreementData) leaseAgreementMethods.reset(leaseAgreementData as any);
-  }, [leaseAgreementData, leaseAgreementMethods]);
-
-  // ─── Rental Info form ─────────────────────────────────────────
-  const { data: rentalInfoData } = useGetRentalInfo(appraisalId, propertyId);
-
-  const rentalInfoMethods = useForm<RentalInfoFormType>({
-    resolver: zodResolver(rentalInfoFormSchema),
-  });
-
-  useEffect(() => {
-    if (rentalInfoData) rentalInfoMethods.reset(rentalInfoData as any);
-  }, [rentalInfoData, rentalInfoMethods]);
-
-  const hasDirtyFields = methods.formState.isDirty || leaseAgreementMethods.formState.isDirty || rentalInfoMethods.formState.isDirty;
+  const hasDirtyFields = methods.formState.isDirty;
   const { blocker, skipWarning } = useUnsavedChangesWarning(hasDirtyFields);
 
   // ─── Save handlers ────────────────────────────────────────────
 
-  const onSubmit: SubmitHandler<createLandFormType> = data => {
+  const onSubmit: SubmitHandler<createLeaseAgreementLandFormType> = async data => {
     setSaveAction('submit');
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...data, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = data;
+    const payload = { ...rest, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -155,8 +138,6 @@ const CreateLeaseAgreementLandPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement land updated successfully');
             setSaveAction(null);
           },
@@ -173,8 +154,6 @@ const CreateLeaseAgreementLandPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Lease agreement land created successfully');
             setSaveAction(null);
             skipWarning();
@@ -191,10 +170,8 @@ const CreateLeaseAgreementLandPage = () => {
 
   const handleSaveDraft = () => {
     setSaveAction('draft');
-    const data = getValues();
-    const leaseData = leaseAgreementMethods.getValues();
-    const rentalData = rentalInfoMethods.getValues();
-    const payload = { ...data, leaseAgreement: leaseData, rentalInfo: rentalData };
+    const { leaseAgreement, rentalInfo, ...rest } = getValues();
+    const payload = { ...rest, leaseAgreement, rentalInfo };
 
     if (isEditMode && propertyId) {
       updateProperty(
@@ -202,8 +179,6 @@ const CreateLeaseAgreementLandPage = () => {
         {
           onSuccess: () => {
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
           },
@@ -220,8 +195,6 @@ const CreateLeaseAgreementLandPage = () => {
           onSuccess: async (response: any) => {
             await photoSectionRef.current?.linkPhotosToProperty(response.propertyId ?? response.id);
             reset(getValues());
-            leaseAgreementMethods.reset(leaseAgreementMethods.getValues());
-            rentalInfoMethods.reset(rentalInfoMethods.getValues());
             toast.success('Draft saved successfully');
             setSaveAction(null);
             if (response.propertyId) {
@@ -265,7 +238,7 @@ const CreateLeaseAgreementLandPage = () => {
         />
       </div>
 
-      <FormProvider methods={methods} schema={createLandForm}>
+      <FormProvider methods={methods} schema={createLeaseAgreementLandForm}>
         <form onSubmit={handleSubmit(onSubmit)} className="flex-1 min-h-0 flex flex-col">
           {/* Scrollable Form Content */}
           <div
@@ -341,9 +314,7 @@ const CreateLeaseAgreementLandPage = () => {
                         <h2 className="text-lg font-semibold text-gray-900">Lease Agreement</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={leaseAgreementMethods} schema={createLeaseAgreementForm}>
-                        <LeaseAgreementForm />
-                      </FormProvider>
+                      <LeaseAgreementForm namePrefix="leaseAgreement" />
                     </Section>
                   </div>
 
@@ -360,9 +331,7 @@ const CreateLeaseAgreementLandPage = () => {
                         <h2 className="text-lg font-semibold text-gray-900">Rental Info</h2>
                       </div>
                       <div className="h-px bg-gray-200 mb-6" />
-                      <FormProvider methods={rentalInfoMethods} schema={rentalInfoFormSchema}>
-                        <RentalInfoForm />
-                      </FormProvider>
+                      <RentalInfoForm namePrefix="rentalInfo" />
                     </Section>
                   </div>
                 </div>

--- a/src/features/appraisal/schemas/form.ts
+++ b/src/features/appraisal/schemas/form.ts
@@ -735,7 +735,7 @@ export type createLeaseAgreementFormType = z.infer<typeof createLeaseAgreementFo
 // =============================================================================
 
 const upFrontEntryItem = z.object({
-  atYear: z.number(),
+  atYear: z.union([z.number(), z.string()]),
   upFrontAmount: z.number(),
 });
 
@@ -747,7 +747,7 @@ const growthPeriodEntryItem = z.object({
   totalAmount: z.number(),
 });
 
-export const rentalInfoFormSchema = z.object({
+export const rentalInfoBaseSchema = z.object({
   numberOfYears: z.number().nullable().optional(),
   firstYearStartDate: z.string().nullable().optional(),
   contractRentalFeePerYear: z.number().nullable().optional(),
@@ -757,19 +757,114 @@ export const rentalInfoFormSchema = z.object({
   growthIntervalYears: z.number().nullable().optional(),
   upFrontEntries: z.array(upFrontEntryItem).nullable().optional(),
   growthPeriodEntries: z.array(growthPeriodEntryItem).nullable().optional(),
-  scheduleEntries: z.array(z.object({
-    year: z.number(),
-    contractStart: z.string(),
-    contractEnd: z.string(),
-    upFront: z.number(),
-    contractRentalFee: z.number(),
-    totalAmount: z.number(),
-    contractRentalFeeGrowthRatePercent: z.number(),
-  })).nullable().optional(),
-  scheduleOverrides: z.array(z.object({
-    year: z.number(),
-    upFront: z.number().nullable().optional(),
-    contractRentalFee: z.number().nullable().optional(),
-  })).nullable().optional(),
+  scheduleEntries: z
+    .array(
+      z.object({
+        year: z.number(),
+        contractStart: z.string(),
+        contractEnd: z.string(),
+        upFront: z.number(),
+        contractRentalFee: z.number(),
+        totalAmount: z.number(),
+        contractRentalFeeGrowthRatePercent: z.number(),
+      }),
+    )
+    .nullable()
+    .optional(),
+  scheduleOverrides: z
+    .array(
+      z.object({
+        year: z.number(),
+        upFront: z.number().nullable().optional(),
+        contractRentalFee: z.number().nullable().optional(),
+      }),
+    )
+    .nullable()
+    .optional(),
 });
+
+const rentalInfoRefinement = (data: any, ctx: z.RefinementCtx) => {
+  const ri = data.rentalInfo ?? data; // support both nested and flat
+  const numberOfYears = ri.numberOfYears ?? 0;
+
+  const upFrontTotal = ri.upFrontTotalAmount ?? 0;
+  const entriesTotal = (ri.upFrontEntries ?? []).reduce(
+    (sum: number, e: any) => sum + (e.upFrontAmount ?? 0),
+    0,
+  );
+  if (
+    upFrontTotal > 0 &&
+    (ri.upFrontEntries ?? []).length > 0 &&
+    Math.abs(entriesTotal - upFrontTotal) > 0.01
+  ) {
+    const path = data.rentalInfo ? ['rentalInfo', 'upFrontEntries'] : ['upFrontEntries'];
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Up front entries total (${entriesTotal.toLocaleString('en-US', { minimumFractionDigits: 2 })}) does not match Up Front amount (${upFrontTotal.toLocaleString('en-US', { minimumFractionDigits: 2 })})`,
+      path,
+    });
+  }
+
+  if (numberOfYears > 0 && ri.growthPeriodEntries?.length) {
+    ri.growthPeriodEntries.forEach((entry: any, idx: number) => {
+      if (entry.fromYear > numberOfYears) {
+        const path = data.rentalInfo
+          ? ['rentalInfo', 'growthPeriodEntries', idx, 'fromYear']
+          : ['growthPeriodEntries', idx, 'fromYear'];
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `At Year (${entry.fromYear}) exceeds Number of Years (${numberOfYears})`,
+          path,
+        });
+      }
+    });
+  }
+};
+
+export const rentalInfoFormSchema = rentalInfoBaseSchema.superRefine(rentalInfoRefinement);
 export type RentalInfoFormType = z.infer<typeof rentalInfoFormSchema>;
+
+// =============================================================================
+// Combined Lease Agreement Schemas (one form per page)
+// =============================================================================
+
+const leaseAgreementExtension = {
+  leaseAgreement: createLeaseAgreementForm.nullable().optional(),
+  rentalInfo: rentalInfoBaseSchema.nullable().optional(),
+};
+
+export const createLeaseAgreementBuildingForm = buildFormSchema(
+  allBuildingFields,
+  createBuildingFormBase.extend(leaseAgreementExtension),
+).superRefine(constructionProportionRefinement).superRefine(rentalInfoRefinement);
+export type createLeaseAgreementBuildingFormType = z.infer<typeof createLeaseAgreementBuildingForm>;
+
+export const createLeaseAgreementLandForm = buildFormSchema(
+  allLandFields,
+  createLandFormBase.extend(leaseAgreementExtension),
+).superRefine(rentalInfoRefinement);
+export type createLeaseAgreementLandFormType = z.infer<typeof createLeaseAgreementLandForm>;
+
+export const createLeaseAgreementLandAndBuildingForm = buildFormSchema(
+  allLandBuildingFields,
+  createLandAndBuildingFormBase.extend(leaseAgreementExtension),
+).superRefine(constructionProportionRefinement).superRefine(rentalInfoRefinement);
+export type createLeaseAgreementLandAndBuildingFormType = z.infer<typeof createLeaseAgreementLandAndBuildingForm>;
+
+export const createLeaseAgreementBuildingFormDefault: createLeaseAgreementBuildingFormType = {
+  ...createBuildingFormDefault,
+  leaseAgreement: null,
+  rentalInfo: null,
+};
+
+export const createLeaseAgreementLandFormDefault: createLeaseAgreementLandFormType = {
+  ...createLandFormDefault,
+  leaseAgreement: null,
+  rentalInfo: null,
+};
+
+export const createLeaseAgreementLandAndBuildingFormDefault: createLeaseAgreementLandAndBuildingFormType = {
+  ...createLandAndBuildingFormDefault,
+  leaseAgreement: null,
+  rentalInfo: null,
+};


### PR DESCRIPTION
## Summary
- Refactor \`RentalInfoForm\` to support combined entry alongside the lease agreement
- Update the three CreateLeaseAgreement pages (Building, Land, LandBuilding) to render a single combined form
- Extract \`rentalInfoBaseSchema\` and add combined Zod schemas with defaults + entry-total refinements in \`schemas/form.ts\`

## Test plan
- [ ] Create a new lease agreement of each type (building, land, land+building) and verify both lease and rental fields submit together
- [ ] Trigger validation errors on entry totals and confirm refinements fire
- [ ] Edit an existing lease agreement and verify defaults populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)