### PR TITLE
Add leasehold and profit-rent valuation methods to pricing analysis

### DIFF
--- a/src/features/pricingAnalysis/adapters/initializeLeaseholdForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeLeaseholdForm.ts
@@ -1,0 +1,43 @@
+import type { UseFormReset } from 'react-hook-form';
+import { leaseholdFormDefaults, type LeaseholdFormType } from '../schemas/leaseholdForm';
+import type { LeaseholdAnalysis } from '../types/leasehold';
+
+export function initializeLeaseholdForm(
+  analysis: LeaseholdAnalysis | null | undefined,
+  remark: string | null | undefined,
+  reset: UseFormReset<LeaseholdFormType>,
+) {
+  if (!analysis) {
+    reset(leaseholdFormDefaults, { keepDirty: false, keepDirtyValues: false, keepTouched: false });
+    return;
+  }
+
+  reset(
+    {
+      landValuePerSqWa: analysis.landValuePerSqWa,
+      landGrowthRateType: analysis.landGrowthRateType,
+      landGrowthRatePercent: analysis.landGrowthRatePercent,
+      landGrowthIntervalYears: analysis.landGrowthIntervalYears,
+      constructionCostIndex: analysis.constructionCostIndex,
+      initialBuildingValue: analysis.initialBuildingValue,
+      depreciationRate: analysis.depreciationRate,
+      depreciationIntervalYears: analysis.depreciationIntervalYears,
+      buildingCalcStartYear: analysis.buildingCalcStartYear,
+      discountRate: analysis.discountRate,
+      landGrowthPeriods: (analysis.landGrowthPeriods ?? []).map((p) => ({
+        id: p.id,
+        fromYear: p.fromYear,
+        toYear: p.toYear,
+        growthRatePercent: p.growthRatePercent,
+      })),
+      isPartialUsage: analysis.isPartialUsage,
+      partialRai: analysis.partialRai,
+      partialNgan: analysis.partialNgan,
+      partialWa: analysis.partialWa,
+      pricePerSqWa: analysis.pricePerSqWa,
+      estimatePriceRounded: analysis.estimatePriceRounded,
+      remark: remark ?? null,
+    },
+    { keepDirty: false, keepDirtyValues: false, keepTouched: false },
+  );
+}

--- a/src/features/pricingAnalysis/adapters/initializeProfitRentForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeProfitRentForm.ts
@@ -1,0 +1,37 @@
+import type { UseFormReset } from 'react-hook-form';
+import { profitRentFormDefaults, type ProfitRentFormType } from '../schemas/profitRentForm';
+import type { ProfitRentAnalysis } from '../types/profitRent';
+
+export function initializeProfitRentForm(
+  analysis: ProfitRentAnalysis | null | undefined,
+  remark: string | null | undefined,
+  reset: UseFormReset<ProfitRentFormType>,
+) {
+  if (!analysis) {
+    reset(profitRentFormDefaults, { keepDirty: false, keepDirtyValues: false, keepTouched: false });
+    return;
+  }
+
+  reset(
+    {
+      marketRentalFeePerSqWa: analysis.marketRentalFeePerSqWa,
+      growthRateType: analysis.growthRateType,
+      growthRatePercent: analysis.growthRatePercent,
+      growthIntervalYears: analysis.growthIntervalYears,
+      discountRate: analysis.discountRate,
+      includeBuildingCost: analysis.includeBuildingCost,
+      growthPeriods: (analysis.growthPeriods ?? []).map((p) => ({
+        id: p.id,
+        fromYear: p.fromYear,
+        toYear: p.toYear,
+        growthRatePercent: p.growthRatePercent,
+      })),
+      estimatePriceRounded: analysis.estimatePriceRounded,
+      totalBuildingCost: analysis.totalBuildingCost ?? null,
+      appraisalPriceWithBuilding: analysis.appraisalPriceWithBuilding ?? null,
+      appraisalPriceWithBuildingRounded: analysis.appraisalPriceWithBuildingRounded ?? null,
+      remark: remark ?? null,
+    },
+    { keepDirty: false, keepDirtyValues: false, keepTouched: false },
+  );
+}

--- a/src/features/pricingAnalysis/api/index.ts
+++ b/src/features/pricingAnalysis/api/index.ts
@@ -535,6 +535,144 @@ export function useSaveMachineCostItems() {
   });
 }
 
+// ==================== Leasehold Analysis Hooks ====================
+
+import type {
+  GetLeaseholdAnalysisResponse,
+  SaveLeaseholdAnalysisRequest,
+  SaveLeaseholdAnalysisResponse,
+} from '../types/leasehold';
+
+/**
+ * Fetch leasehold analysis for a method
+ * GET /pricing-analysis/{id}/methods/{methodId}/leasehold-analysis
+ */
+export function useGetLeaseholdAnalysis(
+  pricingAnalysisId: string | undefined,
+  methodId: string | undefined,
+) {
+  return useQuery({
+    queryKey: pricingAnalysisKeys.leaseholdAnalysis(pricingAnalysisId ?? '', methodId ?? ''),
+    queryFn: async (): Promise<GetLeaseholdAnalysisResponse> => {
+      const { data } = await axios.get(
+        `/pricing-analysis/${pricingAnalysisId}/methods/${methodId}/leasehold-analysis`,
+      );
+      return data as GetLeaseholdAnalysisResponse;
+    },
+    enabled: !!pricingAnalysisId && !!methodId,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+  });
+}
+
+/**
+ * Save leasehold analysis (create or update)
+ * PUT /pricing-analysis/{id}/methods/{methodId}/leasehold-analysis
+ */
+export function useSaveLeaseholdAnalysis() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      methodId,
+      request,
+    }: {
+      pricingAnalysisId: string;
+      methodId: string;
+      request: SaveLeaseholdAnalysisRequest;
+    }): Promise<SaveLeaseholdAnalysisResponse> => {
+      const { data: response } = await axios.put(
+        `/pricing-analysis/${pricingAnalysisId}/methods/${methodId}/leasehold-analysis`,
+        request,
+      );
+      return response;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.leaseholdAnalysis(
+          variables.pricingAnalysisId,
+          variables.methodId,
+        ),
+      });
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.detail(variables.pricingAnalysisId),
+        refetchType: 'none',
+      });
+    },
+  });
+}
+
+// ==================== Profit Rent Analysis Hooks ====================
+
+import type {
+  GetProfitRentAnalysisResponse,
+  SaveProfitRentAnalysisRequest,
+  SaveProfitRentAnalysisResponse,
+} from '../types/profitRent';
+
+/**
+ * Fetch profit rent analysis for a method
+ * GET /pricing-analysis/{id}/methods/{methodId}/profit-rent-analysis
+ */
+export function useGetProfitRentAnalysis(
+  pricingAnalysisId: string | undefined,
+  methodId: string | undefined,
+) {
+  return useQuery({
+    queryKey: pricingAnalysisKeys.profitRentAnalysis(pricingAnalysisId ?? '', methodId ?? ''),
+    queryFn: async (): Promise<GetProfitRentAnalysisResponse> => {
+      const { data } = await axios.get(
+        `/pricing-analysis/${pricingAnalysisId}/methods/${methodId}/profit-rent-analysis`,
+      );
+      return data as GetProfitRentAnalysisResponse;
+    },
+    enabled: !!pricingAnalysisId && !!methodId,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+  });
+}
+
+/**
+ * Save profit rent analysis (create or update)
+ * PUT /pricing-analysis/{id}/methods/{methodId}/profit-rent-analysis
+ */
+export function useSaveProfitRentAnalysis() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      methodId,
+      request,
+    }: {
+      pricingAnalysisId: string;
+      methodId: string;
+      request: SaveProfitRentAnalysisRequest;
+    }): Promise<SaveProfitRentAnalysisResponse> => {
+      const { data: response } = await axios.put(
+        `/pricing-analysis/${pricingAnalysisId}/methods/${methodId}/profit-rent-analysis`,
+        request,
+      );
+      return response;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.profitRentAnalysis(
+          variables.pricingAnalysisId,
+          variables.methodId,
+        ),
+      });
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.detail(variables.pricingAnalysisId),
+        refetchType: 'none',
+      });
+    },
+  });
+}
+
 // ==================== Template & Factor Hooks ====================
 
 /**

--- a/src/features/pricingAnalysis/api/queryKeys.ts
+++ b/src/features/pricingAnalysis/api/queryKeys.ts
@@ -11,4 +11,8 @@ export const pricingAnalysisKeys = {
     ['price-analysis', id, 'final-value', methodId] as const,
   machineCostItems: (pricingAnalysisId: string, methodId: string) =>
     ['price-analysis', pricingAnalysisId, 'machine-cost-items', methodId] as const,
+  leaseholdAnalysis: (pricingAnalysisId: string, methodId: string) =>
+    ['price-analysis', pricingAnalysisId, 'leasehold-analysis', methodId] as const,
+  profitRentAnalysis: (pricingAnalysisId: string, methodId: string) =>
+    ['price-analysis', pricingAnalysisId, 'profit-rent-analysis', methodId] as const,
 };

--- a/src/features/pricingAnalysis/components/BuildingCostTable.tsx
+++ b/src/features/pricingAnalysis/components/BuildingCostTable.tsx
@@ -614,25 +614,41 @@ export function BuildingCostTable({ buildingCost, onChange }: BuildingCostTableP
 
             <tbody className="divide-y divide-neutral-3">
               {!isEmpty &&
-                buildings.map(({ bIdx, computedRows }) => {
+                buildings.map(({ building, bIdx, computedRows }) => {
                   if (computedRows.length === 0 && !canEdit) return null;
 
-                  const firstGroupWithRows = ROW_GROUPING.groups.find(g =>
-                    computedRows.some(r => r[ROW_GROUPING.field] === g.value),
-                  );
                   const totalDataRows = computedRows.length;
-                  let bldgCellRendered = false;
 
                   const groupsWithData = ROW_GROUPING.groups.filter(g =>
                     computedRows.some(r => r[ROW_GROUPING.field] === g.value),
                   );
                   const bldgCellRowSpan =
+                    1 + // property name header row
                     groupsWithData.length * 2 + // group-label row + subtotal row per group
                     totalDataRows +
                     (canEdit ? 1 : 0); // "Add row" row
 
                   return (
                     <Fragment key={bIdx}>
+                      {/* Property name header row */}
+                      <tr className="bg-white">
+                        <td
+                          rowSpan={bldgCellRowSpan}
+                          className="border-b border-r border-neutral-3 text-center align-middle px-1 bg-white"
+                        >
+                          <div className="flex flex-col items-center gap-1 py-1">
+                            <div className="items-center justify-center text-xs font-bold text-primary shrink-0">
+                              {bIdx + 1}
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          colSpan={visibleColCount - 1}
+                          className="py-1.5 px-3 text-xs font-bold border-b border-neutral-3"
+                        >
+                          {building.propertyName || `Property ${bIdx + 1}`}
+                        </td>
+                      </tr>
                       {ROW_GROUPING.groups.map(group => {
                         const groupIndices: number[] = [];
                         computedRows.forEach((row, i) => {
@@ -641,29 +657,12 @@ export function BuildingCostTable({ buildingCost, onChange }: BuildingCostTableP
                         if (groupIndices.length === 0) return null;
 
                         const groupRows = groupIndices.map(i => computedRows[i]);
-                        const isFirstGroup = group === firstGroupWithRows;
-                        const shouldRenderBldgCell = isFirstGroup && !bldgCellRendered;
-                        if (shouldRenderBldgCell) bldgCellRendered = true;
 
                         return (
                           <Fragment key={`${bIdx}-${String(group.value)}`}>
                             <tr className={clsx(group.className)}>
-                              {shouldRenderBldgCell && (
-                                <td
-                                  rowSpan={bldgCellRowSpan}
-                                  className="border-b border-r border-neutral-3 text-center align-middle px-1 bg-white"
-                                >
-                                  <div className="flex flex-col items-center gap-1 py-1">
-                                    <div className="items-center justify-center text-xs font-bold text-primary shrink-0">
-                                      {bIdx + 1}
-                                    </div>
-                                  </div>
-                                </td>
-                              )}
                               <td
-                                colSpan={
-                                  shouldRenderBldgCell ? visibleColCount - 1 : visibleColCount
-                                }
+                                colSpan={visibleColCount}
                                 className="py-1.5 px-3 text-xs font-semibold border-b border-neutral-3"
                               >
                                 {group.label} ({groupIndices.length})

--- a/src/features/pricingAnalysis/components/KpiSummaryStrip.tsx
+++ b/src/features/pricingAnalysis/components/KpiSummaryStrip.tsx
@@ -1,0 +1,79 @@
+import { Icon } from '@/shared/components';
+
+export interface KpiCard {
+  label: string;
+  value: number | null;
+  icon: string;
+  color: 'green' | 'blue' | 'gray' | 'amber';
+  primary?: boolean;
+  suffix?: string;
+}
+
+const colorMap = {
+  green: {
+    bg: 'bg-green-50',
+    border: 'border-green-200',
+    icon: 'text-green-600',
+    value: 'text-green-700',
+    label: 'text-green-600/70',
+  },
+  blue: {
+    bg: 'bg-blue-50',
+    border: 'border-blue-200',
+    icon: 'text-blue-600',
+    value: 'text-blue-700',
+    label: 'text-blue-600/70',
+  },
+  gray: {
+    bg: 'bg-gray-50',
+    border: 'border-gray-200',
+    icon: 'text-gray-500',
+    value: 'text-gray-700',
+    label: 'text-gray-500',
+  },
+  amber: {
+    bg: 'bg-amber-50',
+    border: 'border-amber-200',
+    icon: 'text-amber-600',
+    value: 'text-amber-700',
+    label: 'text-amber-600/70',
+  },
+};
+
+const fmt = (n: number | null | undefined): string => {
+  if (n == null || !Number.isFinite(n)) return '-';
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+};
+
+interface KpiSummaryStripProps {
+  cards: KpiCard[];
+}
+
+export function KpiSummaryStrip({ cards }: KpiSummaryStripProps) {
+  if (cards.every((c) => c.value == null || c.value === 0)) return null;
+
+  return (
+    <div className={`grid gap-3`} style={{ gridTemplateColumns: `repeat(${cards.length}, minmax(0, 1fr))` }}>
+      {cards.map((card) => {
+        const c = colorMap[card.color];
+        return (
+          <div
+            key={card.label}
+            className={`rounded-lg border px-3 py-2.5 ${c.bg} ${c.border} ${card.primary ? 'ring-1 ring-green-300' : ''}`}
+          >
+            <div className="flex items-center gap-1.5 mb-1">
+              <Icon name={card.icon} className={`size-3 ${c.icon}`} />
+              <span className={`text-[10px] uppercase tracking-wide font-medium ${c.label}`}>
+                {card.label}
+              </span>
+            </div>
+            <div className={`text-sm font-bold ${c.value} tabular-nums`}>
+              {fmt(card.value)}
+              {card.suffix && <span className="text-[10px] font-normal ml-1 opacity-70">{card.suffix}</span>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseTimelineBar.tsx
+++ b/src/features/pricingAnalysis/components/LeaseTimelineBar.tsx
@@ -1,0 +1,64 @@
+interface LeaseTimelineBarProps {
+  leaseStartDate?: string;
+  leaseEndDate?: string;
+  appraisalDate?: string;
+}
+
+function toDate(s?: string): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function formatShort(d: Date): string {
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+export function LeaseTimelineBar({ leaseStartDate, leaseEndDate, appraisalDate }: LeaseTimelineBarProps) {
+  const start = toDate(leaseStartDate);
+  const end = toDate(leaseEndDate);
+  const appraisal = toDate(appraisalDate);
+
+  if (!start || !end) return null;
+
+  const totalMs = end.getTime() - start.getTime();
+  if (totalMs <= 0) return null;
+
+  const elapsedMs = appraisal ? appraisal.getTime() - start.getTime() : 0;
+  const pct = Math.max(0, Math.min(100, (elapsedMs / totalMs) * 100));
+
+  const remainingDays = appraisal ? Math.max(0, Math.round((end.getTime() - appraisal.getTime()) / (1000 * 60 * 60 * 24))) : Math.round(totalMs / (1000 * 60 * 60 * 24));
+  const remainingYears = (remainingDays / 365.25).toFixed(1);
+
+  return (
+    <div className="space-y-1.5">
+      {/* Bar */}
+      <div className="relative h-2 rounded-full bg-gray-200 overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-gray-400 to-gray-500"
+          style={{ width: `${pct}%` }}
+        />
+        {appraisal && (
+          <div
+            className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-primary border-2 border-white shadow-sm"
+            style={{ left: `${pct}%`, marginLeft: '-6px' }}
+          />
+        )}
+      </div>
+
+      {/* Labels */}
+      <div className="flex items-center justify-between text-[10px] text-gray-400">
+        <span>Start {formatShort(start)}</span>
+        {appraisal && (
+          <span className="text-primary font-medium">
+            {pct.toFixed(0)}% elapsed · {remainingYears} yr remaining
+          </span>
+        )}
+        <span>End {formatShort(end)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdChart.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdChart.tsx
@@ -1,0 +1,146 @@
+import {
+  ComposedChart,
+  AreaChart,
+  Area,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import type { LeaseholdTableResult } from '../domain/calculateLeasehold';
+
+interface LeaseholdChartProps {
+  result: LeaseholdTableResult;
+}
+
+const fmtCompact = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toFixed(0);
+};
+
+const fmtTooltip = (n: number): string =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tooltipFormatter = ((value: number, name: string) => [fmtTooltip(value), name]) as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const labelFormatter = ((label: any) => `Year ${Number(label).toFixed(1)}`) as any;
+const tooltipStyle = { fontSize: 11, borderRadius: 8, border: '1px solid #e5e7eb' };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function PropertyTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  const land = payload.find((p: any) => p.dataKey === 'landValue')?.value ?? 0;
+  const building = payload.find((p: any) => p.dataKey === 'buildingAfterDepre')?.value ?? 0;
+  const total = land + building;
+  return (
+    <div style={tooltipStyle} className="bg-white px-3 py-2 shadow-md">
+      <div className="text-gray-500 mb-1">Year {Number(label).toFixed(1)}</div>
+      <div style={{ color: '#22c55e' }}>Land Value: {fmtTooltip(land)}</div>
+      <div style={{ color: '#3b82f6' }}>Building (After Depre.): {fmtTooltip(building)}</div>
+      <div className="border-t border-gray-100 mt-1 pt-1 font-medium text-gray-700">Total L&B: {fmtTooltip(total)}</div>
+    </div>
+  );
+}
+
+export function LeaseholdChart({ result }: LeaseholdChartProps) {
+  const data = result.rows.map((r) => ({
+    year: r.year,
+    landValue: r.landValue,
+    buildingAfterDepre: r.buildingAfterDepreciation,
+    totalLandAndBuilding: r.totalLandAndBuilding,
+    rentalIncome: r.rentalIncome,
+    netPvRental: r.netCurrentRentalIncome,
+  }));
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {/* Left: Property Value */}
+      <div className="rounded-lg border border-gray-200 p-3">
+        <div className="text-[11px] font-medium text-gray-500 mb-1.5">Property Value Over Lease Term</div>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: 0 }} stackOffset="none">
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis
+              dataKey="year"
+              tick={{ fontSize: 9, fill: '#9ca3af' }}
+              tickFormatter={(v) => v.toFixed(1)}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fill: '#9ca3af' }}
+              tickFormatter={fmtCompact}
+              width={45}
+            />
+            <Tooltip content={<PropertyTooltip />} />
+            <Legend wrapperStyle={{ fontSize: 9, paddingTop: 2 }} />
+            <Area
+              type="monotone"
+              dataKey="buildingAfterDepre"
+              name="Building (After Depre.)"
+              stackId="property"
+              stroke="#3b82f6"
+              fill="#3b82f6"
+              fillOpacity={0.3}
+              strokeWidth={1.5}
+            />
+            <Area
+              type="monotone"
+              dataKey="landValue"
+              name="Land Value"
+              stackId="property"
+              stroke="#22c55e"
+              fill="#22c55e"
+              fillOpacity={0.3}
+              strokeWidth={1.5}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Right: Income Analysis */}
+      <div className="rounded-lg border border-gray-200 p-3">
+        <div className="text-[11px] font-medium text-gray-500 mb-1.5">Income Analysis</div>
+        <ResponsiveContainer width="100%" height={200}>
+          <ComposedChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis
+              dataKey="year"
+              tick={{ fontSize: 9, fill: '#9ca3af' }}
+              tickFormatter={(v) => v.toFixed(1)}
+            />
+            <YAxis
+              tick={{ fontSize: 9, fill: '#9ca3af' }}
+              tickFormatter={fmtCompact}
+              width={45}
+            />
+            <Tooltip
+              contentStyle={tooltipStyle}
+              formatter={tooltipFormatter}
+              labelFormatter={labelFormatter}
+            />
+            <Legend wrapperStyle={{ fontSize: 9, paddingTop: 2 }} />
+            <Bar
+              dataKey="rentalIncome"
+              name="Rental Income"
+              fill="#f97316"
+              fillOpacity={0.6}
+              radius={[2, 2, 0, 0]}
+            />
+            <Bar
+              dataKey="netPvRental"
+              name="Net PV Rental"
+              fill="#22c55e"
+              fillOpacity={0.6}
+              radius={[2, 2, 0, 0]}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdLandValueModal.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdLandValueModal.tsx
@@ -1,0 +1,222 @@
+import { useState, useEffect } from 'react';
+import { Button, Icon } from '@/shared/components';
+import { NumberInput } from '@/shared/components/inputs';
+import type { LandGrowthRateType, LandGrowthPeriod } from '../types/leasehold';
+
+interface LeaseholdLandValueModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  landValuePerSqWa: number;
+  landGrowthRateType: LandGrowthRateType;
+  landGrowthRatePercent: number;
+  landGrowthIntervalYears: number;
+  landGrowthPeriods: Omit<LandGrowthPeriod, 'id'>[];
+  onSave: (data: {
+    landValuePerSqWa: number;
+    landGrowthRateType: LandGrowthRateType;
+    landGrowthRatePercent: number;
+    landGrowthIntervalYears: number;
+    landGrowthPeriods: Omit<LandGrowthPeriod, 'id'>[];
+  }) => void;
+}
+
+export function LeaseholdLandValueModal({
+  isOpen,
+  onClose,
+  landValuePerSqWa,
+  landGrowthRateType,
+  landGrowthRatePercent,
+  landGrowthIntervalYears,
+  landGrowthPeriods,
+  onSave,
+}: LeaseholdLandValueModalProps) {
+  const [value, setValue] = useState(landValuePerSqWa);
+  const [growthType, setGrowthType] = useState<LandGrowthRateType>(landGrowthRateType);
+  const [ratePercent, setRatePercent] = useState(landGrowthRatePercent);
+  const [intervalYears, setIntervalYears] = useState(landGrowthIntervalYears);
+  const [periods, setPeriods] = useState<Omit<LandGrowthPeriod, 'id'>[]>(landGrowthPeriods);
+
+  useEffect(() => {
+    if (isOpen) {
+      setValue(landValuePerSqWa);
+      setGrowthType(landGrowthRateType);
+      setRatePercent(landGrowthRatePercent);
+      setIntervalYears(landGrowthIntervalYears);
+      setPeriods([...landGrowthPeriods]);
+    }
+  }, [isOpen, landValuePerSqWa, landGrowthRateType, landGrowthRatePercent, landGrowthIntervalYears, landGrowthPeriods]);
+
+  if (!isOpen) return null;
+
+  const handleAddPeriod = () => {
+    const lastTo = periods.length > 0 ? periods[periods.length - 1].toYear : 0;
+    setPeriods([...periods, { fromYear: lastTo + 1, toYear: lastTo + 5, growthRatePercent: 0 }]);
+  };
+
+  const handleRemovePeriod = (idx: number) => {
+    setPeriods(periods.filter((_, i) => i !== idx));
+  };
+
+  const handlePeriodChange = (idx: number, field: keyof Omit<LandGrowthPeriod, 'id'>, val: number | null) => {
+    const updated = [...periods];
+    updated[idx] = { ...updated[idx], [field]: val ?? 0 };
+    setPeriods(updated);
+  };
+
+  const handleClear = () => {
+    setValue(0);
+    setRatePercent(0);
+    setIntervalYears(1);
+    setPeriods([]);
+  };
+
+  const handleSave = () => {
+    onSave({
+      landValuePerSqWa: value,
+      landGrowthRateType: growthType,
+      landGrowthRatePercent: ratePercent,
+      landGrowthIntervalYears: intervalYears,
+      landGrowthPeriods: periods,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg p-6 space-y-4" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Land Value</h3>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <Icon name="xmark" className="size-5" />
+          </button>
+        </div>
+
+        {/* Land Value */}
+        <NumberInput
+          label="Land Value *"
+          value={value}
+          onChange={(e) => setValue(e.target.value ?? 0)}
+          decimalPlaces={2}
+          rightIcon={<span className="text-xs text-gray-400">Baht/Sq.Wa</span>}
+          className="!pr-[5.5rem]"
+        />
+
+        {/* Growth Type Toggle */}
+        <div>
+          <label className="text-sm text-gray-600">Land Value Growth Rate</label>
+          <div className="flex gap-2 mt-1">
+            <button
+              type="button"
+              onClick={() => setGrowthType('Frequency')}
+              className={`px-3 py-1.5 text-xs rounded-full border ${
+                growthType === 'Frequency'
+                  ? 'bg-primary text-white border-primary'
+                  : 'bg-white text-gray-600 border-gray-300'
+              }`}
+            >
+              Frequency
+            </button>
+            <button
+              type="button"
+              onClick={() => setGrowthType('Period')}
+              className={`px-3 py-1.5 text-xs rounded-full border ${
+                growthType === 'Period'
+                  ? 'bg-primary text-white border-primary'
+                  : 'bg-white text-gray-600 border-gray-300'
+              }`}
+            >
+              Period
+            </button>
+          </div>
+        </div>
+
+        {/* Frequency Mode */}
+        {growthType === 'Frequency' && (
+          <div className="flex gap-3 items-end">
+            <div className="flex-1">
+              <NumberInput
+                label="Rate (%)"
+                value={ratePercent}
+                onChange={(e) => setRatePercent(e.target.value ?? 0)}
+                decimalPlaces={2}
+                rightIcon={<span className="text-xs text-gray-400">%</span>}
+              />
+            </div>
+            <span className="text-sm text-gray-500 pb-2">Every</span>
+            <div className="flex-1">
+              <NumberInput
+                label="Year(s)"
+                value={intervalYears}
+                onChange={(e) => setIntervalYears(e.target.value ?? 1)}
+                decimalPlaces={0}
+                rightIcon={<span className="text-xs text-gray-400">Year</span>}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Period Mode */}
+        {growthType === 'Period' && (
+          <div className="space-y-2">
+            <div className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 text-xs text-gray-500 font-medium">
+              <span>From Year</span>
+              <span>To Year</span>
+              <span>Growth Rate (%)</span>
+              <span />
+            </div>
+            {periods.map((p, idx) => (
+              <div key={idx} className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 items-end">
+                <NumberInput
+                  value={p.fromYear}
+                  onChange={(e) => handlePeriodChange(idx, 'fromYear', e.target.value)}
+                  decimalPlaces={0}
+                />
+                <NumberInput
+                  value={p.toYear}
+                  onChange={(e) => handlePeriodChange(idx, 'toYear', e.target.value)}
+                  decimalPlaces={0}
+                />
+                <NumberInput
+                  value={p.growthRatePercent}
+                  onChange={(e) => handlePeriodChange(idx, 'growthRatePercent', e.target.value)}
+                  decimalPlaces={2}
+                  rightIcon={<span className="text-xs text-gray-400">%</span>}
+                />
+                <button
+                  type="button"
+                  onClick={() => handleRemovePeriod(idx)}
+                  className="flex items-center justify-center text-red-400 hover:text-red-600 pb-1"
+                >
+                  <Icon name="xmark" className="size-4" />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={handleAddPeriod}
+              className="text-xs text-primary hover:underline flex items-center gap-1"
+            >
+              <Icon name="plus" className="size-3" />
+              Add Periods
+            </button>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-between pt-2 border-t border-gray-100">
+          <div className="flex gap-2">
+            <Button variant="ghost" type="button" onClick={onClose}>
+              Close
+            </Button>
+            <Button variant="ghost" type="button" onClick={handleClear} className="text-red-500">
+              Clear
+            </Button>
+          </div>
+          <Button type="button" onClick={handleSave}>
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdPanel.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdPanel.tsx
@@ -1,0 +1,897 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, useWatch, useController, useFieldArray } from 'react-hook-form';
+import { FormProvider } from '@/shared/components/form/FormProvider';
+import { MethodFooterActions } from './MethodFooterActions';
+import { LeaseholdFormSchema, leaseholdFormDefaults, type LeaseholdFormType } from '../schemas/leaseholdForm';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from '@/shared/components';
+import { NumberInput, Toggle } from '@/shared/components/inputs';
+import { initializeLeaseholdForm } from '../adapters/initializeLeaseholdForm';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useGetLeaseholdAnalysis, useSaveLeaseholdAnalysis } from '../api';
+import { useResetMethod } from '../api';
+import { pricingAnalysisKeys } from '../api/queryKeys';
+import { LeaseholdTable } from './LeaseholdTable';
+import { LeaseholdRentalInfoModal } from './LeaseholdRentalInfoModal';
+import { LeaseTimelineBar } from './LeaseTimelineBar';
+import { LeaseholdChart } from './LeaseholdChart';
+import { SensitivityStrip } from './SensitivityStrip';
+import { RemarkSection } from './RemarkSection';
+import { LeaseholdPartialUsageSection } from './LeaseholdPartialUsageSection';
+import { KpiSummaryStrip, type KpiCard } from './KpiSummaryStrip';
+import { RHFInputCell } from './table/RHFInputCell';
+import { generateLeaseholdTable, computeAppraisalSchedule, calculatePartialUsage, type LeaseholdTableResult } from '../domain/calculateLeasehold';
+import type { SaveLeaseholdAnalysisRequest } from '../types/leasehold';
+import { roundToThousand } from '../domain/calculation';
+import { useGetRentalSchedule, useGetLeaseAgreement } from '@/features/appraisal/api/property';
+import { typeToDetailEndpoint } from '@/features/appraisal/utils/propertyTypeConfig';
+import axios from '@shared/api/axiosInstance';
+import { useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { useGetAppointment } from '@/features/appraisal/api/appointment';
+import toast from 'react-hot-toast';
+import { formatDateOnly } from '../domain/formatters';
+
+interface LeaseholdPanelProps {
+  activeMethod?: {
+    pricingAnalysisId?: string;
+    approachId?: string;
+    approachType?: string;
+    methodId?: string;
+    methodType?: string;
+  };
+  firstPropertyId?: string;
+  firstPropertyType?: string;
+  onCalculationSave: (payload: {
+    approachType: string;
+    methodType: string;
+    appraisalValue: number;
+  }) => void;
+  onCalculationMethodDirty: (check: boolean) => void;
+  onCancelCalculationMethod: () => void;
+}
+
+export function LeaseholdPanel({
+  activeMethod,
+  firstPropertyId,
+  firstPropertyType,
+  onCalculationSave,
+  onCalculationMethodDirty,
+  onCancelCalculationMethod,
+}: LeaseholdPanelProps) {
+  const appraisalId = useAppraisalId();
+  const { data: appointment } = useGetAppointment(appraisalId ?? '');
+  const { pricingAnalysisId, methodId } = activeMethod ?? {};
+  const queryClient = useQueryClient();
+  const [isShowResetDialog, setIsShowResetDialog] = useState(false);
+  const [isRentalInfoModalOpen, setIsRentalInfoModalOpen] = useState(false);
+  const [tableResult, setTableResult] = useState<LeaseholdTableResult | null>(null);
+  const tableResultRef = useRef<LeaseholdTableResult | null>(null);
+  const [estimateNetPrice, setEstimateNetPrice] = useState<number | null>(null);
+
+  const resetMutation = useResetMethod();
+  const saveMutation = useSaveLeaseholdAnalysis();
+
+  const { data: savedData, isPending: isLoading } = useGetLeaseholdAnalysis(
+    pricingAnalysisId,
+    methodId,
+  );
+
+  // Fetch property detail directly to get totalLandAreaInSqWa and building depreciation
+  const detailEndpoint = firstPropertyType ? typeToDetailEndpoint[firstPropertyType] : undefined;
+
+  const { data: propertyDetail } = useQuery({
+    queryKey: ['appraisal', appraisalId, 'property', firstPropertyId, 'detail-lh'],
+    queryFn: async () => {
+      const { data } = await axios.get(
+        `/appraisals/${appraisalId}/properties/${firstPropertyId}/${detailEndpoint}`,
+      );
+      return data as Record<string, any>;
+    },
+    enabled: !!appraisalId && !!firstPropertyId && !!detailEndpoint,
+    staleTime: Infinity,
+  });
+
+  const propertyData = useMemo(() => {
+    if (!propertyDetail) return null;
+    const d = propertyDetail;
+    const depDetails = (d.depreciationDetails ?? []) as any[];
+    const totalBuildingPriceBeforeDepreciation = depDetails.reduce(
+      (sum: number, item: any) => sum + (Number(item?.priceBeforeDepreciation) || 0),
+      0,
+    );
+    return {
+      totalLandAreaInSqWa: Number(d.totalLandAreaInSqWa) || 0,
+      totalBuildingPriceBeforeDepreciation,
+    };
+  }, [propertyDetail]);
+
+  // Fetch rental schedule and lease agreement for rental income data and lease dates
+  const { data: rentalScheduleData } = useGetRentalSchedule(appraisalId ?? '', firstPropertyId);
+  const { data: leaseAgreement } = useGetLeaseAgreement(appraisalId ?? '', firstPropertyId);
+
+  const methods = useForm<LeaseholdFormType>({
+    mode: 'onSubmit',
+    resolver: zodResolver(LeaseholdFormSchema),
+    defaultValues: leaseholdFormDefaults,
+  });
+
+  const {
+    handleSubmit,
+    formState: { isDirty },
+    getValues,
+    setValue,
+    reset,
+    control,
+    watch,
+  } = methods;
+
+  // Initialize form once when data loads
+  const isInitialized = useRef(false);
+  useEffect(() => {
+    if (savedData !== undefined && !isInitialized.current) {
+      isInitialized.current = true;
+      initializeLeaseholdForm(savedData?.analysis, savedData?.remark, reset);
+
+      // Load stored table from backend if available (no Generate click needed)
+      if (savedData?.analysis?.calculationDetails?.length) {
+        const details = savedData.analysis.calculationDetails;
+        const result: LeaseholdTableResult = {
+          rows: details.map((d) => ({
+            year: d.year,
+            landValue: d.landValue,
+            landGrowthPercent: d.landGrowthPercent,
+            buildingValue: d.buildingValue,
+            depreciationAmount: d.depreciationAmount,
+            depreciationPercent: d.depreciationPercent,
+            buildingAfterDepreciation: d.buildingAfterDepreciation,
+            totalLandAndBuilding: d.totalLandAndBuilding,
+            rentalIncome: d.rentalIncome,
+            pvFactor: d.pvFactor,
+            netCurrentRentalIncome: d.netCurrentRentalIncome,
+          })),
+          totalIncomeOverLeaseTerm: savedData.analysis.totalIncomeOverLeaseTerm,
+          valueAtLeaseExpiry: savedData.analysis.valueAtLeaseExpiry,
+          finalValue: savedData.analysis.finalValue,
+          finalValueRounded: savedData.analysis.finalValueRounded,
+        };
+        tableResultRef.current = result;
+        setTableResult(result);
+      }
+
+      // Restore estimate net price from saved data
+      if (savedData?.analysis?.isPartialUsage) {
+        setEstimateNetPrice(savedData.analysis.estimateNetPrice ?? null);
+      }
+
+    }
+  }, [savedData]);
+
+  // Auto-generate on first visit when no saved data but all dependencies are ready
+  const hasAutoGenerated = useRef(false);
+  useEffect(() => {
+    if (
+      !hasAutoGenerated.current &&
+      isInitialized.current &&
+      !tableResultRef.current &&
+      rentalScheduleData?.rows?.length &&
+      appointment?.appointmentDateTime &&
+      propertyData
+    ) {
+      hasAutoGenerated.current = true;
+      handleGenerate();
+    }
+  }, [rentalScheduleData, appointment, propertyData, tableResult]);
+
+  useEffect(() => {
+    onCalculationMethodDirty(isDirty);
+  }, [isDirty, onCalculationMethodDirty]);
+
+  // Stable ref for getValues — avoids re-creating callbacks on every render (C3 fix)
+  const getValuesRef = useRef(getValues);
+  getValuesRef.current = getValues;
+
+  const handleGenerate = useCallback((overrideValues?: LeaseholdFormType) => {
+    const data = overrideValues ?? getValuesRef.current();
+
+    // Compute appraisal schedule to get years and rental income per period
+    const appraisalDateStr = appointment?.appointmentDateTime;
+    const contractRows = rentalScheduleData?.rows ?? [];
+    const { rows: appraisalRows } = appraisalDateStr
+      ? computeAppraisalSchedule(contractRows, appraisalDateStr)
+      : { rows: [] };
+
+    // Don't overwrite existing table if data isn't ready yet
+    if (appraisalRows.length === 0) return;
+
+    // Use appraisal schedule years and rental amounts
+    const years = appraisalRows.map((r) => r.year);
+    const rentalIncomePerPeriod = appraisalRows.map((r) => r.totalAmount);
+
+    // Land base value = pricePerSqWa × totalLandArea
+    const baseLandValue = (data.landValuePerSqWa ?? 0) * (propertyData?.totalLandAreaInSqWa ?? 0);
+
+    const result = generateLeaseholdTable({
+      years,
+      landValueConfig: {
+        baseValue: baseLandValue,
+        growthType: data.landGrowthRateType ?? 'Frequency',
+        growthRatePercent: data.landGrowthRatePercent ?? 0,
+        intervalYears: data.landGrowthIntervalYears ?? 1,
+        periods: data.landGrowthPeriods ?? [],
+      },
+      initialBuildingValue: propertyData?.totalBuildingPriceBeforeDepreciation ?? (data.initialBuildingValue ?? 0),
+      constructionCostIndex: data.constructionCostIndex ?? 0,
+      depreciationRate: data.depreciationRate ?? 0,
+      depreciationIntervalYears: data.depreciationIntervalYears ?? 1,
+      buildingCalcStartYear: data.buildingCalcStartYear ?? 0,
+      discountRate: data.discountRate ?? 0,
+      rentalIncomePerPeriod,
+    });
+
+    tableResultRef.current = result;
+    setTableResult(result);
+
+    // Auto-update estimate price with new computed value
+    const gv = getValuesRef.current;
+    const currentPartial = gv('isPartialUsage')
+      ? calculatePartialUsage({
+          finalValue: result.finalValueRounded,
+          rai: (gv('partialRai') as number) ?? 0,
+          ngan: (gv('partialNgan') as number) ?? 0,
+          wa: (gv('partialWa') as number) ?? 0,
+          pricePerSqWa: (gv('pricePerSqWa') as number) ?? 0,
+        })
+      : null;
+    const newEstimate = currentPartial?.estimatePriceRounded ?? result.finalValueRounded;
+
+    setValue('estimatePriceRounded', newEstimate);
+  }, [appointment, rentalScheduleData, propertyData, setValue]);
+
+  // Sensitivity: recalculate final value with a different discount rate (C3 fix: no getValues in deps)
+  const calcSensitivity = useCallback((rate: number): number | null => {
+    const data = getValuesRef.current();
+    const appraisalDateStr = appointment?.appointmentDateTime;
+    const contractRows = rentalScheduleData?.rows ?? [];
+    const { rows: appraisalRows } = appraisalDateStr
+      ? computeAppraisalSchedule(contractRows, appraisalDateStr)
+      : { rows: [] };
+    if (appraisalRows.length === 0) return null;
+
+    const years = appraisalRows.map((r) => r.year);
+    const rentalIncomePerPeriod = appraisalRows.map((r) => r.totalAmount);
+    const baseLandValue = (data.landValuePerSqWa ?? 0) * (propertyData?.totalLandAreaInSqWa ?? 0);
+
+    const result = generateLeaseholdTable({
+      years,
+      landValueConfig: {
+        baseValue: baseLandValue,
+        growthType: data.landGrowthRateType ?? 'Frequency',
+        growthRatePercent: data.landGrowthRatePercent ?? 0,
+        intervalYears: data.landGrowthIntervalYears ?? 1,
+        periods: data.landGrowthPeriods ?? [],
+      },
+      initialBuildingValue: propertyData?.totalBuildingPriceBeforeDepreciation ?? (data.initialBuildingValue ?? 0),
+      constructionCostIndex: data.constructionCostIndex ?? 0,
+      depreciationRate: data.depreciationRate ?? 0,
+      depreciationIntervalYears: data.depreciationIntervalYears ?? 1,
+      buildingCalcStartYear: data.buildingCalcStartYear ?? 0,
+      discountRate: rate,
+      rentalIncomePerPeriod,
+    });
+    return result.finalValueRounded;
+  }, [appointment, rentalScheduleData, propertyData]);
+
+  const handleOnSubmit = async () => {
+    if (!pricingAnalysisId || !methodId) return;
+
+    const data = getValues();
+    const request: SaveLeaseholdAnalysisRequest = {
+      landValuePerSqWa: data.landValuePerSqWa,
+      landGrowthRateType: data.landGrowthRateType,
+      landGrowthRatePercent: data.landGrowthRatePercent,
+      landGrowthIntervalYears: data.landGrowthIntervalYears,
+      constructionCostIndex: data.constructionCostIndex,
+      initialBuildingValue: propertyData?.totalBuildingPriceBeforeDepreciation ?? data.initialBuildingValue,
+      depreciationRate: data.depreciationRate,
+      depreciationIntervalYears: data.depreciationIntervalYears,
+      buildingCalcStartYear: data.buildingCalcStartYear,
+      discountRate: data.discountRate,
+      landGrowthPeriods: (data.landGrowthPeriods ?? []).map((p) => ({
+        fromYear: p.fromYear,
+        toYear: p.toYear,
+        growthRatePercent: p.growthRatePercent,
+      })),
+      isPartialUsage: data.isPartialUsage,
+      partialRai: data.partialRai,
+      partialNgan: data.partialNgan,
+      partialWa: data.partialWa,
+      pricePerSqWa: data.pricePerSqWa,
+      estimatePriceRounded: data.estimatePriceRounded,
+      remark: data.remark,
+    };
+
+    try {
+      const result = await saveMutation.mutateAsync({
+        pricingAnalysisId,
+        methodId,
+        request,
+      });
+
+      if (activeMethod?.approachType && activeMethod?.methodType) {
+        onCalculationSave({
+          approachType: activeMethod.approachType,
+          methodType: activeMethod.methodType,
+          appraisalValue: data.estimatePriceRounded ?? result.finalValueRounded,
+        });
+      }
+      toast.success('Saved!');
+    } catch {
+      toast.error('Failed to save');
+    }
+  };
+
+  const handleOnReset = () => setIsShowResetDialog(true);
+  const handleOnConfirmReset = async () => {
+    setIsShowResetDialog(false);
+    if (!pricingAnalysisId || !methodId) return;
+    try {
+      await resetMutation.mutateAsync({ pricingAnalysisId, methodId });
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.leaseholdAnalysis(pricingAnalysisId, methodId),
+      });
+      isInitialized.current = false;
+      hasAutoGenerated.current = false;
+      tableResultRef.current = null;
+      initializeLeaseholdForm(null, null, reset);
+      setTableResult(null);
+      toast.success('Method reset successfully');
+    } catch {
+      toast.error('Failed to reset method');
+    }
+  };
+
+  // Inline land value controls
+  const landGrowthRateType = useWatch({ control, name: 'landGrowthRateType' });
+  const { field: landValueField } = useController({ control, name: 'landValuePerSqWa' });
+  const { field: landGrowthPercentField } = useController({ control, name: 'landGrowthRatePercent' });
+  const { field: landIntervalField } = useController({ control, name: 'landGrowthIntervalYears' });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { fields: landPeriodFields, append: appendLandPeriod, remove: removeLandPeriod } = useFieldArray({
+    control: control as any,
+    name: 'landGrowthPeriods',
+  });
+
+  // Auto-recalculate when inline table inputs change (C2 fix: stable deps via ref comparison)
+  const watchedLandInputs = useWatch({
+    control,
+    name: ['landValuePerSqWa', 'landGrowthRateType', 'landGrowthRatePercent', 'landGrowthIntervalYears'],
+  });
+  const watchedLandPeriods = useWatch({ control, name: 'landGrowthPeriods' });
+  const watchedTableInputs = useWatch({
+    control,
+    name: ['constructionCostIndex', 'depreciationRate', 'depreciationIntervalYears', 'discountRate', 'buildingCalcStartYear'],
+  });
+  const prevWatchKey = useRef<string | null>(null);
+  useEffect(() => {
+    const key = watchedTableInputs.join(',') + '|' + watchedLandInputs.join(',') + '|' + JSON.stringify(watchedLandPeriods);
+    // Seed the key on first run so we don't fire on mount/cache reload
+    if (prevWatchKey.current === null) {
+      prevWatchKey.current = key;
+      return;
+    }
+    if (!isDirty) return;
+    if (key === prevWatchKey.current) return;
+    prevWatchKey.current = key;
+    if (tableResult) handleGenerate();
+  }, [isDirty, watchedTableInputs, watchedLandInputs, watchedLandPeriods, tableResult, handleGenerate]);
+
+  const finalValueRounded = tableResult?.finalValueRounded ?? 0;
+
+  // Estimate Price (Rounded) — auto-fills from computed, user can override
+  const { field: estimateField } = useController({ control, name: 'estimatePriceRounded' });
+
+  if (isLoading) {
+    return <PanelSkeleton />;
+  }
+
+  return (
+    <FormProvider methods={methods} schema={LeaseholdFormSchema}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit(handleOnSubmit)(e);
+        }}
+        className="flex flex-col h-full gap-4"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+            <Icon name="file-contract" className="size-4" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900">Leasehold Analysis</h2>
+        </div>
+
+        {/* Lease Info */}
+        <div className="rounded-lg border border-gray-200 p-5 space-y-4">
+          <div className="grid grid-cols-4 gap-4">
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-gray-400 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Appraisal Date</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {appointment?.appointmentDateTime ? formatDateOnly(appointment.appointmentDateTime) : '-'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-green-500 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease Start</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {leaseAgreement?.leaseStartDate ? formatDateOnly(leaseAgreement.leaseStartDate) : '-'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-red-400 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease End</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {leaseAgreement?.leaseEndDate ? formatDateOnly(leaseAgreement.leaseEndDate) : '-'}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsRentalInfoModalOpen(true)}
+              className="flex items-center gap-3 rounded-md bg-primary/5 border border-primary/20 px-3 py-2.5 hover:bg-primary/10 transition-colors"
+            >
+              <Icon name="receipt" className="size-4 text-primary shrink-0" />
+              <div className="text-left">
+                <div className="text-[11px] text-primary/60 uppercase tracking-wide">View</div>
+                <div className="text-sm font-medium text-primary">Rental Information</div>
+              </div>
+            </button>
+          </div>
+          <LeaseTimelineBar
+            leaseStartDate={leaseAgreement?.leaseStartDate}
+            leaseEndDate={leaseAgreement?.leaseEndDate}
+            appraisalDate={appointment?.appointmentDateTime}
+          />
+        </div>
+
+        {/* Land Value & Growth Config — inline (replaces modal) */}
+        <div className="rounded-lg border border-gray-200 p-5 space-y-5">
+          <div className="grid grid-cols-3 gap-4">
+            <div className="rounded-md bg-gray-50 px-4 py-3">
+              <div className="text-[11px] text-gray-400 uppercase tracking-wide mb-1">Land Area</div>
+              <div className="flex items-baseline gap-1.5">
+                <Icon name="ruler-combined" className="size-3.5 text-gray-400 shrink-0 relative top-0.5" />
+                <span className="text-lg font-semibold text-gray-900">
+                  {(propertyData?.totalLandAreaInSqWa ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+                <span className="text-xs text-gray-500">Sq. Wa</span>
+              </div>
+            </div>
+            <div className="rounded-md bg-gray-50 px-4 py-3">
+              <label className="text-[11px] text-gray-400 uppercase tracking-wide mb-1 block">
+                Land Value <span className="text-red-400">*</span>
+              </label>
+              <div className="flex items-baseline gap-1.5">
+                <div className="w-28">
+                  <NumberInput
+                    name={landValueField.name}
+                    ref={landValueField.ref}
+                    value={landValueField.value}
+                    onChange={(e) => landValueField.onChange(e.target.value)}
+                    onBlur={landValueField.onBlur}
+                    decimalPlaces={2}
+                  />
+                </div>
+                <span className="text-xs text-gray-500">Baht/Sq.Wa</span>
+              </div>
+            </div>
+            <div className="rounded-md bg-primary/5 border border-primary/10 px-4 py-3">
+              <div className="text-[11px] text-primary/60 uppercase tracking-wide mb-1">Total Land Value</div>
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-lg font-semibold text-primary">
+                  {((landValueField.value ?? 0) * (propertyData?.totalLandAreaInSqWa ?? 0)).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+                <span className="text-xs text-primary/60">Baht</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-200" />
+
+          {/* Growth Rate Config */}
+          <div className="space-y-3">
+            <Toggle
+              label="Land Value Growth Rate"
+              options={['Frequency', 'Period']}
+              checked={landGrowthRateType === 'Period'}
+              onChange={(checked) => setValue('landGrowthRateType', checked ? 'Period' : 'Frequency', { shouldDirty: true })}
+              size="sm"
+            />
+
+            {landGrowthRateType === 'Frequency' ? (
+              <div className="flex gap-3 items-end">
+                <div className="flex-1">
+                  <NumberInput
+                    label="Rate"
+                    name={landGrowthPercentField.name}
+                    ref={landGrowthPercentField.ref}
+                    value={landGrowthPercentField.value}
+                    onChange={(e) => landGrowthPercentField.onChange(e.target.value)}
+                    onBlur={landGrowthPercentField.onBlur}
+                    decimalPlaces={2}
+                    rightIcon={<span className="text-xs text-gray-400">%</span>}
+                  />
+                </div>
+                <span className="text-sm text-gray-500 pb-2">Every</span>
+                <div className="flex-1">
+                  <NumberInput
+                    label="Interval"
+                    name={landIntervalField.name}
+                    ref={landIntervalField.ref}
+                    value={landIntervalField.value}
+                    onChange={(e) => landIntervalField.onChange(e.target.value)}
+                    onBlur={landIntervalField.onBlur}
+                    decimalPlaces={0}
+                    rightIcon={<span className="text-xs text-gray-400">Year</span>}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 text-xs text-gray-500 font-medium">
+                  <span>From Year</span>
+                  <span>To Year</span>
+                  <span>Growth Rate (%)</span>
+                  <span />
+                </div>
+                {landPeriodFields.map((field, index) => (
+                  <div key={field.id} className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 items-end">
+                    <NumberInput
+                      value={watch(`landGrowthPeriods.${index}.fromYear` as any) as number}
+                      onChange={(e) => setValue(`landGrowthPeriods.${index}.fromYear` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={0}
+                    />
+                    <NumberInput
+                      value={watch(`landGrowthPeriods.${index}.toYear` as any) as number}
+                      onChange={(e) => setValue(`landGrowthPeriods.${index}.toYear` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={0}
+                    />
+                    <NumberInput
+                      value={watch(`landGrowthPeriods.${index}.growthRatePercent` as any) as number}
+                      onChange={(e) => setValue(`landGrowthPeriods.${index}.growthRatePercent` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={2}
+                      rightIcon={<span className="text-xs text-gray-400">%</span>}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeLandPeriod(index)}
+                      className="flex items-center justify-center text-red-400 hover:text-red-600 pb-1"
+                    >
+                      <Icon name="xmark" className="size-4" />
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => appendLandPeriod({ fromYear: 0, toYear: 0, growthRatePercent: 0 })}
+                  className="text-xs text-primary hover:underline flex items-center gap-1"
+                >
+                  <Icon name="plus" className="size-3" />
+                  Add Periods
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-gray-200" />
+
+          {/* Building & Depreciation & Discount Rate */}
+          <div className="grid grid-cols-4 gap-3">
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Construction Cost Index
+              </label>
+              <div className="flex items-center gap-1">
+                <div className="w-20">
+                  <RHFInputCell fieldName="constructionCostIndex" inputType="number" number={{ decimalPlaces: 2 }} />
+                </div>
+                <span className="text-[10px] text-gray-400">%</span>
+              </div>
+            </div>
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Building Calc Start
+              </label>
+              <div className="flex items-center gap-1">
+                <div className="w-14">
+                  <RHFInputCell fieldName="buildingCalcStartYear" inputType="number" number={{ decimalPlaces: 0 }} />
+                </div>
+                <span className="text-[10px] text-gray-400">year(s)</span>
+              </div>
+            </div>
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Depreciation Rate
+              </label>
+              <div className="flex items-center gap-1">
+                <div className="w-16">
+                  <RHFInputCell fieldName="depreciationRate" inputType="number" number={{ decimalPlaces: 2 }} />
+                </div>
+                <span className="text-[10px] text-gray-400">% every</span>
+                <div className="w-10">
+                  <RHFInputCell fieldName="depreciationIntervalYears" inputType="number" number={{ decimalPlaces: 0 }} />
+                </div>
+                <span className="text-[10px] text-gray-400">yr</span>
+              </div>
+            </div>
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Discounted Rate
+              </label>
+              <div className="flex items-center gap-1">
+                <div className="w-20">
+                  <RHFInputCell fieldName="discountRate" inputType="number" number={{ decimalPlaces: 2 }} />
+                </div>
+                <span className="text-[10px] text-gray-400">%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* KPI Summary */}
+        {tableResult && (
+          <KpiSummaryStrip
+            cards={[
+              { label: 'Total Income', value: tableResult.totalIncomeOverLeaseTerm, icon: 'coins', color: 'blue' },
+              { label: 'Value at Expiry', value: tableResult.valueAtLeaseExpiry, icon: 'building', color: 'gray' },
+              { label: 'Final Value', value: tableResult.finalValueRounded, icon: 'circle-check', color: 'green', primary: true },
+              {
+                label: 'Effective Yield',
+                value: tableResult.finalValueRounded
+                  ? (tableResult.totalIncomeOverLeaseTerm / tableResult.finalValueRounded) * 100
+                  : null,
+                icon: 'chart-line',
+                color: 'amber',
+                suffix: '%',
+              },
+            ] satisfies KpiCard[]}
+          />
+        )}
+
+        {/* Chart */}
+        {tableResult && <LeaseholdChart result={tableResult} />}
+
+        {/* Sensitivity */}
+        {tableResult && (
+          <SensitivityStrip
+            currentRate={getValues('discountRate') ?? 0}
+            calculateFinalValue={calcSensitivity}
+          />
+        )}
+
+        {/* Table */}
+        {tableResult ? (
+          <LeaseholdTable result={tableResult} />
+        ) : isLoading ? (
+          <TableSkeleton />
+        ) : null}
+
+        {/* Partial Usage */}
+        <LeaseholdPartialUsageSection
+          finalValueRounded={finalValueRounded}
+          landValuePerSqWa={getValues('landValuePerSqWa') ?? 0}
+          onEstimateChange={(estimateRounded, estimateNet) => {
+            setValue('estimatePriceRounded', estimateRounded);
+            setEstimateNetPrice(estimateNet);
+          }}
+        />
+
+        {/* Estimate Price */}
+        <div className="text-sm divide-y divide-gray-100 border-t border-gray-200 pt-3">
+          <div className="flex items-center justify-between py-1.5">
+            <span className="text-xs text-gray-600">Estimate Price (from PV)</span>
+            <span className="text-xs font-medium text-gray-800 tabular-nums">
+              {finalValueRounded.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </span>
+          </div>
+          {watch('isPartialUsage') && estimateNetPrice != null && (
+            <>
+              <div className="flex items-center justify-between py-1.5">
+                <span className="text-xs text-gray-600">
+                  <span className="font-bold mr-1">+</span>
+                  Partial Land Price
+                </span>
+                <span className="text-xs font-medium text-gray-800 tabular-nums">
+                  {((estimateNetPrice ?? finalValueRounded) - finalValueRounded).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+              </div>
+              <div className="flex items-center justify-between py-1.5">
+                <span className="text-xs text-gray-700 font-medium">
+                  <span className="font-bold mr-1">=</span>
+                  Appraisal Price w/ Partial Land
+                </span>
+                <span className="text-xs font-semibold text-gray-900 tabular-nums">
+                  {(estimateNetPrice ?? finalValueRounded).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+              </div>
+            </>
+          )}
+          <div className="flex items-center justify-between py-2">
+            <span className="text-xs font-semibold text-gray-900 shrink-0">Appraisal Price</span>
+            <div className="flex items-center gap-2">
+              {(() => {
+                const rounded = Number(estimateField.value) || 0;
+                const computed = roundToThousand(estimateNetPrice ?? finalValueRounded);
+                const diff = rounded - computed;
+                if (diff === 0 || computed === 0) return null;
+                const pct = ((diff / computed) * 100).toFixed(1);
+                const color = diff > 0 ? 'text-green-600' : 'text-red-600';
+                const bgColor = diff > 0 ? 'bg-green-100' : 'bg-red-100';
+                const icon = diff > 0 ? 'arrow-up' : 'arrow-down';
+                return (
+                  <span
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium ${color} ${bgColor} shrink-0`}
+                  >
+                    <Icon name={icon} style="solid" className="size-2.5" />
+                    {Math.abs(diff).toLocaleString()} ({diff > 0 ? '+' : ''}{pct}%)
+                  </span>
+                );
+              })()}
+              <div className="w-40">
+                <NumberInput
+                  name={estimateField.name}
+                  ref={estimateField.ref}
+                  value={estimateField.value}
+                  onChange={(e) => {
+                    estimateField.onChange(e.target.value);
+                  }}
+                  onBlur={estimateField.onBlur}
+                  decimalPlaces={2}
+                  className="!font-bold !text-right !text-sm !text-green-700"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Notes & Assumptions */}
+        <RemarkSection setValue={setValue} watch={watch} />
+
+        {/* Footer */}
+        <MethodFooterActions
+          showReset={true}
+          isSubmitting={saveMutation.isPending}
+          onReset={handleOnReset}
+          onCancel={onCancelCalculationMethod}
+        />
+
+        {/* Dialogs */}
+        <ConfirmDialog
+          isOpen={isShowResetDialog}
+          onClose={() => setIsShowResetDialog(false)}
+          onConfirm={handleOnConfirmReset}
+          message="Are you sure you want to reset this method? All calculation data will be cleared."
+        />
+
+        <LeaseholdRentalInfoModal
+          isOpen={isRentalInfoModalOpen}
+          onClose={() => setIsRentalInfoModalOpen(false)}
+          contractSchedule={rentalScheduleData?.rows ?? []}
+          appraisalDate={appointment?.appointmentDateTime ?? undefined}
+        />
+      </form>
+    </FormProvider>
+  );
+}
+
+
+
+/** Full panel skeleton — shown while initial data loads */
+function PanelSkeleton() {
+  return (
+    <div className="flex flex-col h-full gap-4 animate-pulse">
+      {/* Header */}
+      <div className="flex items-center gap-2.5">
+        <div className="size-8 rounded-lg bg-gray-200" />
+        <div className="bg-gray-200 rounded h-5 w-32" />
+      </div>
+
+      {/* Info cards */}
+      <div className="rounded-lg border border-gray-200 p-5 space-y-4">
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-md bg-gray-100 px-3 py-2.5 h-14">
+              <div className="bg-gray-200 rounded h-2.5 w-16 mb-2" />
+              <div className="bg-gray-200 rounded h-3.5 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Land Value & Growth Config */}
+      <div className="rounded-lg border border-gray-200 p-5 space-y-5">
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-md bg-gray-100 px-4 py-3 h-16">
+              <div className="bg-gray-200 rounded h-2.5 w-20 mb-2" />
+              <div className="bg-gray-200 rounded h-5 w-28" />
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-gray-200" />
+        <div className="space-y-3">
+          <div className="bg-gray-200 rounded h-3.5 w-40" />
+          <div className="flex gap-2">
+            <div className="bg-gray-200 rounded-full h-7 w-20" />
+            <div className="bg-gray-200 rounded-full h-7 w-16" />
+          </div>
+        </div>
+        <div className="border-t border-gray-200" />
+        <div className="grid grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-md bg-gray-100 px-3 py-2 h-14">
+              <div className="bg-gray-200 rounded h-2.5 w-20 mb-2" />
+              <div className="bg-gray-200 rounded h-4 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Table skeleton */}
+      <TableSkeleton />
+
+      {/* Estimate Price */}
+      <div className="border-t border-gray-200 pt-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="bg-gray-200 rounded h-3 w-32" />
+          <div className="bg-gray-200 rounded h-3 w-24" />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="bg-gray-200 rounded h-4 w-28" />
+          <div className="bg-gray-100 rounded h-9 w-40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton loader for the leasehold table */
+function TableSkeleton() {
+  return (
+    <div className="animate-pulse space-y-0 border border-gray-200 rounded-lg overflow-hidden">
+      {/* Header */}
+      <div className="bg-gray-100 h-9 flex items-center px-3">
+        <div className="bg-gray-300 rounded h-3 w-16" />
+        <div className="flex gap-6 ml-auto">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="bg-gray-300 rounded h-3 w-12" />
+          ))}
+        </div>
+      </div>
+      {/* Rows */}
+      {Array.from({ length: 8 }).map((_, row) => (
+        <div key={row} className="h-8 flex items-center px-3 border-t border-gray-100">
+          <div className="bg-gray-200 rounded h-3 w-32" />
+          <div className="flex gap-6 ml-auto">
+            {Array.from({ length: 5 }).map((_, col) => (
+              <div key={col} className="bg-gray-200 rounded h-3 w-16" />
+            ))}
+          </div>
+        </div>
+      ))}
+      {/* Footer */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className={`h-9 flex items-center px-3 border-t border-gray-200 ${i >= 2 ? 'bg-green-50' : 'bg-gray-50'}`}>
+          <div className="bg-gray-300 rounded h-3 w-40" />
+          <div className="ml-auto bg-gray-300 rounded h-3 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdPartialUsageSection.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdPartialUsageSection.tsx
@@ -1,0 +1,228 @@
+import { useFormContext, useWatch, useController } from 'react-hook-form';
+import type { LeaseholdFormType } from '../schemas/leaseholdForm';
+import { calculatePartialUsage } from '../domain/calculateLeasehold';
+import { useEffect, useMemo, useState } from 'react';
+import { NumberInput } from '@/shared/components/inputs';
+import Toggle from '@/shared/components/inputs/Toggle';
+
+interface LeaseholdPartialUsageSectionProps {
+  finalValueRounded: number;
+  landValuePerSqWa: number;
+  onEstimateChange?: (estimateRounded: number, estimateNet: number | null) => void;
+}
+
+const fmt = (n: number) =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+export function LeaseholdPartialUsageSection({
+  finalValueRounded,
+  landValuePerSqWa,
+  onEstimateChange,
+}: LeaseholdPartialUsageSectionProps) {
+  const { control, setValue } = useFormContext<LeaseholdFormType>();
+  const isPartialUsage = useWatch({ control, name: 'isPartialUsage' });
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const partialRaiCtrl = useController({ control, name: 'partialRai' });
+  const partialNganCtrl = useController({ control, name: 'partialNgan' });
+  const partialWaCtrl = useController({ control, name: 'partialWa' });
+  const pricePerSqWaCtrl = useController({ control, name: 'pricePerSqWa' });
+
+  useEffect(() => {
+    if (isPartialUsage && landValuePerSqWa > 0 && !pricePerSqWaCtrl.field.value) {
+      setValue('pricePerSqWa', landValuePerSqWa, { shouldDirty: true });
+    }
+  }, [isPartialUsage, landValuePerSqWa]);
+
+  const partial = useMemo(() => {
+    if (!isPartialUsage) return null;
+    return calculatePartialUsage({
+      finalValue: finalValueRounded,
+      rai: partialRaiCtrl.field.value ?? 0,
+      ngan: partialNganCtrl.field.value ?? 0,
+      wa: partialWaCtrl.field.value ?? 0,
+      pricePerSqWa: pricePerSqWaCtrl.field.value ?? 0,
+    });
+  }, [
+    isPartialUsage,
+    finalValueRounded,
+    partialRaiCtrl.field.value,
+    partialNganCtrl.field.value,
+    partialWaCtrl.field.value,
+    pricePerSqWaCtrl.field.value,
+  ]);
+
+  const recalcEstimate = (overrides: Partial<{ rai: number | null; ngan: number | null; wa: number | null; pricePerSqWa: number | null }> = {}) => {
+    const p = calculatePartialUsage({
+      finalValue: finalValueRounded,
+      rai: (overrides.rai !== undefined ? overrides.rai : partialRaiCtrl.field.value) ?? 0,
+      ngan: (overrides.ngan !== undefined ? overrides.ngan : partialNganCtrl.field.value) ?? 0,
+      wa: (overrides.wa !== undefined ? overrides.wa : partialWaCtrl.field.value) ?? 0,
+      pricePerSqWa: (overrides.pricePerSqWa !== undefined ? overrides.pricePerSqWa : pricePerSqWaCtrl.field.value) ?? 0,
+    });
+    onEstimateChange?.(p.estimatePriceRounded, p.estimateNetPrice);
+  };
+
+  const rai = partialRaiCtrl.field.value ?? 0;
+  const ngan = partialNganCtrl.field.value ?? 0;
+  const wa = partialWaCtrl.field.value ?? 0;
+  const hasArea = rai > 0 || ngan > 0 || wa > 0;
+
+  const formatArea = () => `${rai}-${ngan}-${wa}`;
+
+  return (
+    <div className="border-t border-gray-200 pt-4">
+      <div className="flex items-center justify-between">
+        <Toggle
+          label="Partial Usage"
+          options={['No', 'Yes']}
+          size="sm"
+          checked={isPartialUsage}
+          onChange={(checked) => {
+            setValue('isPartialUsage', checked, { shouldDirty: true });
+            if (checked) {
+              recalcEstimate({});
+              setIsModalOpen(true);
+            } else {
+              onEstimateChange?.(finalValueRounded, null);
+            }
+          }}
+        />
+        <div className="flex items-center gap-6">
+          <div className="text-right">
+            <div className="text-[10px] text-gray-400">Partial Land Area</div>
+            {isPartialUsage ? (
+              <div className="flex items-center gap-1 justify-end">
+                <div className="text-xs font-medium text-gray-700">
+                  {hasArea ? (
+                    <>
+                      <span className="text-gray-400">{formatArea()}</span>
+                      {' '}
+                      {fmt(partial?.partialLandArea ?? 0)}
+                    </>
+                  ) : '-'}
+                  <span className="text-[10px] text-gray-400 ml-0.5">Sq.Wa</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(true)}
+                  className="text-primary hover:text-primary/80 p-0.5 rounded hover:bg-primary/5 transition-colors"
+                  title="Edit partial land area"
+                >
+                  <svg className="size-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <div className="text-xs text-gray-400">-</div>
+            )}
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] text-gray-400">Price per Sq.Wa</div>
+            <div className="text-xs font-medium text-gray-700">
+              {isPartialUsage ? fmt(pricePerSqWaCtrl.field.value ?? landValuePerSqWa) : '-'}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] text-gray-400">Partial Land Price</div>
+            <div className="text-sm font-bold text-gray-900">
+              {isPartialUsage && partial ? fmt(partial.partialLandPrice) : '-'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal for editing Rai / Ngan / Sq.Wa */}
+      {isModalOpen && (
+        <PartialAreaModal
+          rai={rai}
+          ngan={ngan}
+          wa={wa}
+          onSave={(r, n, w) => {
+            setValue('partialRai', r, { shouldDirty: true });
+            setValue('partialNgan', n, { shouldDirty: true });
+            setValue('partialWa', w, { shouldDirty: true });
+            recalcEstimate({ rai: r, ngan: n, wa: w });
+            setIsModalOpen(false);
+          }}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function PartialAreaModal({
+  rai,
+  ngan,
+  wa,
+  onSave,
+  onClose,
+}: {
+  rai: number;
+  ngan: number;
+  wa: number;
+  onSave: (rai: number, ngan: number, wa: number) => void;
+  onClose: () => void;
+}) {
+  const [localRai, setLocalRai] = useState(rai);
+  const [localNgan, setLocalNgan] = useState(ngan);
+  const [localWa, setLocalWa] = useState(wa);
+
+  const totalSqWa = (localRai || 0) * 400 + (localNgan || 0) * 100 + (localWa || 0);
+  const fmt = (n: number) =>
+    n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative bg-white rounded-lg shadow-xl p-5 w-80 space-y-4">
+        <h3 className="text-sm font-semibold text-gray-900">Partial Land Area</h3>
+        <div className="space-y-3">
+          <NumberInput
+            label="Rai"
+            name="modalRai"
+            value={localRai}
+            onChange={(e) => setLocalRai(e.target.value ?? 0)}
+            decimalPlaces={0}
+          />
+          <NumberInput
+            label="Ngan"
+            name="modalNgan"
+            value={localNgan}
+            onChange={(e) => setLocalNgan(e.target.value ?? 0)}
+            decimalPlaces={0}
+          />
+          <NumberInput
+            label="Sq.Wa"
+            name="modalWa"
+            value={localWa}
+            onChange={(e) => setLocalWa(e.target.value ?? 0)}
+            decimalPlaces={2}
+          />
+        </div>
+        <div className="flex items-center justify-between border-t border-gray-100 pt-3">
+          <span className="text-xs text-gray-500">Total</span>
+          <span className="text-sm font-semibold text-gray-900">{fmt(totalSqWa)} Sq.Wa</span>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onSave(localRai, localNgan, localWa)}
+            className="px-3 py-1.5 text-xs font-medium text-white bg-primary rounded-md hover:bg-primary/90"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdRentalInfoModal.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdRentalInfoModal.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo } from 'react';
+import { Button, Icon } from '@/shared/components';
+import type { RentalScheduleRow } from '@/features/appraisal/api/property';
+import { computeAppraisalSchedule, type AppraisalScheduleRow } from '../domain/calculateLeasehold';
+
+interface LeaseholdRentalInfoModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  contractSchedule: RentalScheduleRow[];
+  appraisalDate?: string;
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '-';
+  const d = new Date(dateStr);
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+const fmt = (n: number) =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+
+export function LeaseholdRentalInfoModal({
+  isOpen,
+  onClose,
+  contractSchedule,
+  appraisalDate,
+}: LeaseholdRentalInfoModalProps) {
+  const { rows: appraisalRows, startIdx } = useMemo(
+    () => (appraisalDate ? computeAppraisalSchedule(contractSchedule, appraisalDate) : { rows: [], startIdx: -1 }),
+    [contractSchedule, appraisalDate],
+  );
+
+  const contractTotal = contractSchedule.reduce((sum, r) => sum + r.totalAmount, 0);
+  const appraisalTotal = appraisalRows.reduce((sum, r) => sum + r.totalAmount, 0);
+
+  // Build aligned rows: each row index maps to one visual row across both tables
+  const totalVisualRows = Math.max(contractSchedule.length, (startIdx >= 0 ? startIdx : 0) + appraisalRows.length);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-[95vw] p-6 space-y-4 max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Rental Information</h3>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <Icon name="xmark" className="size-5" />
+          </button>
+        </div>
+
+        <div className="overflow-auto flex-1">
+          <div className="grid grid-cols-[auto_auto] gap-0">
+            {/* Headers */}
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 mb-2">Rental schedule as per contract</h4>
+            </div>
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 mb-2 pl-6">Rental schedule starting from the appraisal date</h4>
+            </div>
+
+            {/* Tables side-by-side with aligned rows */}
+            <table className="text-xs border border-gray-200 rounded-lg">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Year</th>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Contract Start Date</th>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Contract End Date</th>
+                  <th className="px-3 py-2 text-right text-gray-500 font-medium whitespace-nowrap">Up Front (Baht/year)</th>
+                  <th className="px-3 py-2 text-right text-gray-500 font-medium whitespace-nowrap">Contract rental fee (Baht/year)</th>
+                  <th className="px-3 py-2 text-right text-gray-500 font-medium whitespace-nowrap">Total Amount (Baht)</th>
+                  <th className="px-3 py-2 text-right text-gray-500 font-medium whitespace-nowrap">Contract rental fee growth rate (%)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: totalVisualRows }).map((_, idx) => {
+                  const row = contractSchedule[idx];
+                  if (!row) {
+                    return (
+                      <tr key={idx} className="border-t border-gray-100 h-8">
+                        <td colSpan={7} />
+                      </tr>
+                    );
+                  }
+                  return (
+                    <tr key={idx} className="border-t border-gray-100 h-8">
+                      <td className="px-3 py-1.5 text-gray-700">{row.year}</td>
+                      <td className="px-3 py-1.5 text-gray-700">{formatDate(row.contractStart)}</td>
+                      <td className="px-3 py-1.5 text-gray-700">{formatDate(row.contractEnd)}</td>
+                      <td className="px-3 py-1.5 text-right text-gray-700">{fmt(row.upFront)}</td>
+                      <td className="px-3 py-1.5 text-right text-gray-700">{fmt(row.contractRentalFee)}</td>
+                      <td className="px-3 py-1.5 text-right text-gray-700">{fmt(row.totalAmount)}</td>
+                      <td className="px-3 py-1.5 text-right text-gray-700">{fmt(row.contractRentalFeeGrowthRatePercent)}</td>
+                    </tr>
+                  );
+                })}
+                <tr className="border-t-2 border-gray-300 bg-gray-50 font-medium h-8">
+                  <td className="px-3 py-1.5 text-gray-700">Total</td>
+                  <td colSpan={4} />
+                  <td className="px-3 py-1.5 text-right text-gray-900">{fmt(contractTotal)}</td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+
+            <table className="text-xs border border-gray-200 rounded-lg ml-6">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Year</th>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Contract Start Date</th>
+                  <th className="px-3 py-2 text-left text-gray-500 font-medium whitespace-nowrap">Contract End Date</th>
+                  <th className="px-3 py-2 text-right text-gray-500 font-medium whitespace-nowrap">Total Amount (Baht)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: totalVisualRows }).map((_, idx) => {
+                  // Appraisal rows start at startIdx in the visual grid
+                  const appraisalIdx = idx - (startIdx >= 0 ? startIdx : 0);
+                  const row = appraisalIdx >= 0 ? appraisalRows[appraisalIdx] : undefined;
+                  if (!row) {
+                    return (
+                      <tr key={idx} className="border-t border-gray-100 h-8">
+                        <td colSpan={4} />
+                      </tr>
+                    );
+                  }
+                  return (
+                    <tr key={idx} className="border-t border-gray-100 h-8">
+                      <td className="px-3 py-1.5 text-gray-700">{row.year}</td>
+                      <td className="px-3 py-1.5 text-gray-700">{formatDate(row.contractStart)}</td>
+                      <td className="px-3 py-1.5 text-gray-700">{formatDate(row.contractEnd)}</td>
+                      <td className="px-3 py-1.5 text-right text-gray-700">{fmt(row.totalAmount)}</td>
+                    </tr>
+                  );
+                })}
+                <tr className="border-t-2 border-gray-300 bg-gray-50 font-medium h-8">
+                  <td className="px-3 py-1.5 text-gray-700">Total</td>
+                  <td colSpan={2} />
+                  <td className="px-3 py-1.5 text-right text-gray-900">{fmt(appraisalTotal)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-2 border-t border-gray-100">
+          <Button variant="ghost" type="button" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/LeaseholdTable.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdTable.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react';
+import { Icon } from '@/shared/components';
+import { ScrollableTableContainer } from './ScrollableTableContainer';
+import type { LeaseholdTableResult } from '../domain/calculateLeasehold';
+
+interface LeaseholdTableProps {
+  result: LeaseholdTableResult;
+}
+
+const fmt = (n: number) =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const fmtPv = (n: number) => n.toFixed(2);
+
+export function LeaseholdTable({ result }: LeaseholdTableProps) {
+  const { rows, totalIncomeOverLeaseTerm, valueAtLeaseExpiry, finalValue, finalValueRounded } =
+    result;
+
+  const [hoveredCol, setHoveredCol] = useState<number | null>(null);
+  const [propertyExpanded, setPropertyExpanded] = useState(true);
+  const [incomeExpanded, setIncomeExpanded] = useState(true);
+
+  const colHl = 'bg-blue-50/60';
+
+  const stickyCell = 'sticky left-0 z-10 bg-white px-3 py-1.5 border-b border-gray-100';
+  const stickyCellBold = 'sticky left-0 z-10 bg-gray-50 px-3 py-1.5 border-b border-gray-200';
+
+  const dataCls = (col: number) =>
+    `px-3 py-1.5 text-right text-gray-700 border-b border-gray-100 ${hoveredCol === col ? colHl : ''}`;
+  const dataBoldCls = (col: number) =>
+    `px-3 py-1.5 text-right text-gray-800 font-medium border-b border-gray-200 ${hoveredCol === col ? colHl : ''}`;
+  const headCls = (col: number) =>
+    `px-3 py-2 text-right text-gray-600 font-medium min-w-[130px] border-b border-gray-200 ${hoveredCol === col ? colHl : ''}`;
+
+  const cp = (col: number) => ({
+    onMouseEnter: () => setHoveredCol(col),
+    onMouseLeave: () => setHoveredCol(null),
+  });
+
+  const groupHeaderCls = 'sticky left-0 z-10 bg-gray-100 px-3 py-1.5 border-b border-gray-200';
+
+  return (
+    <>
+    <ScrollableTableContainer>
+      <table className="w-full text-xs border-collapse" onMouseLeave={() => setHoveredCol(null)}>
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="sticky left-0 z-10 bg-gray-50 px-3 py-2 text-left text-gray-600 font-medium min-w-[360px] border-b border-gray-200">
+              Year
+            </th>
+            {rows.map((r, i) => (
+              <th key={r.year} className={headCls(i)} {...cp(i)}>
+                {r.year}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {/* Group: Property Values */}
+          <tr
+            role="button"
+            tabIndex={0}
+            aria-expanded={propertyExpanded}
+            className="bg-gray-100 cursor-pointer hover:bg-gray-200/60 transition-colors"
+            onClick={() => setPropertyExpanded(!propertyExpanded)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setPropertyExpanded(!propertyExpanded); } }}
+          >
+            <td className={groupHeaderCls} colSpan={1}>
+              <span className="flex items-center gap-1.5 text-gray-700 font-semibold text-[11px] uppercase tracking-wide">
+                <Icon
+                  name="chevron-down"
+                  className={`size-3 transition-transform ${propertyExpanded ? '' : '-rotate-90'}`}
+                />
+                Property Values
+              </span>
+            </td>
+            {rows.map((r, i) => (
+              <td key={r.year} className={`border-b border-gray-200 bg-gray-100 ${hoveredCol === i ? colHl : ''}`} {...cp(i)} />
+            ))}
+          </tr>
+
+          {propertyExpanded && (
+            <>
+              {/* Land Value */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="font-medium text-gray-700 pl-4">Land Value</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>
+                    <div>{fmt(r.landValue)}</div>
+                    {i > 0 && r.landGrowthPercent !== 0 && (
+                      <div className="text-[10px] text-gray-400 mt-0.5">{r.landGrowthPercent.toFixed(2)} %</div>
+                    )}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Building Value */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="text-gray-700 pl-4">Building Value</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>{r.buildingValue ? fmt(r.buildingValue) : ''}</td>
+                ))}
+              </tr>
+
+              {/* Depreciation */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="text-gray-700 pl-4">Depreciation</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>
+                    {r.depreciationAmount ? (
+                      <>
+                        <div>{fmt(r.depreciationAmount)}</div>
+                        {r.depreciationPercent !== 0 && (
+                          <div className="text-[10px] text-gray-400 mt-0.5">{r.depreciationPercent.toFixed(2)} %</div>
+                        )}
+                      </>
+                    ) : ''}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Building value after depreciation */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="text-gray-700 pl-4">Building after depreciation</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>{r.buildingAfterDepreciation ? fmt(r.buildingAfterDepreciation) : ''}</td>
+                ))}
+              </tr>
+            </>
+          )}
+
+          {/* Total value of land and buildings — always visible */}
+          <tr className="bg-gray-50 font-medium">
+            <td className={stickyCellBold}>
+              <span className="text-gray-800 font-semibold">Total value of land and buildings</span>
+            </td>
+            {rows.map((r, i) => (
+              <td key={r.year} className={dataBoldCls(i)} {...cp(i)}>{fmt(r.totalLandAndBuilding)}</td>
+            ))}
+          </tr>
+
+          {/* Group: Income Analysis */}
+          <tr
+            role="button"
+            tabIndex={0}
+            aria-expanded={incomeExpanded}
+            className="bg-gray-100 cursor-pointer hover:bg-gray-200/60 transition-colors"
+            onClick={() => setIncomeExpanded(!incomeExpanded)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setIncomeExpanded(!incomeExpanded); } }}
+          >
+            <td className={groupHeaderCls} colSpan={1}>
+              <span className="flex items-center gap-1.5 text-gray-700 font-semibold text-[11px] uppercase tracking-wide">
+                <Icon
+                  name="chevron-down"
+                  className={`size-3 transition-transform ${incomeExpanded ? '' : '-rotate-90'}`}
+                />
+                Income Analysis
+              </span>
+            </td>
+            {rows.map((r, i) => (
+              <td key={r.year} className={`border-b border-gray-200 bg-gray-100 ${hoveredCol === i ? colHl : ''}`} {...cp(i)} />
+            ))}
+          </tr>
+
+          {incomeExpanded && (
+            <>
+              {/* Rental Income */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="text-gray-700 pl-4">Rental income</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>{fmt(r.rentalIncome)}</td>
+                ))}
+              </tr>
+
+              {/* PV Factor */}
+              <tr className="hover:bg-gray-50/50">
+                <td className={stickyCell}>
+                  <span className="text-gray-700 pl-4">PV Factor</span>
+                </td>
+                {rows.map((r, i) => (
+                  <td key={r.year} className={dataCls(i)} {...cp(i)}>{fmtPv(r.pvFactor)}</td>
+                ))}
+              </tr>
+            </>
+          )}
+
+          {/* Net Current Rental Income — always visible */}
+          <tr className="bg-gray-50 font-medium">
+            <td className={stickyCellBold}>
+              <span className="text-gray-800 font-semibold">Net Current Rental Income</span>
+            </td>
+            {rows.map((r, i) => (
+              <td key={r.year} className={dataBoldCls(i)} {...cp(i)}>{fmt(r.netCurrentRentalIncome)}</td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </ScrollableTableContainer>
+
+    {/* Summary — outside scroll container */}
+    <div className="text-xs border-t border-gray-300">
+      <div className="flex bg-gray-50 border-b border-gray-200">
+        <div className="px-3 py-2 text-gray-800 font-medium min-w-[360px]">Total income over the lease term</div>
+        <div className="px-3 py-2 text-right text-gray-800 font-medium flex-1">{fmt(totalIncomeOverLeaseTerm)}</div>
+      </div>
+      <div className="flex bg-gray-50 border-b border-gray-200">
+        <div className="px-3 py-2 text-gray-800 font-medium min-w-[360px]">Total value of land and buildings when the lease expires</div>
+        <div className="px-3 py-2 text-right text-gray-800 font-medium flex-1">{fmt(valueAtLeaseExpiry)}</div>
+      </div>
+      <div className="flex bg-gray-100 border-b border-gray-200">
+        <div className="px-3 py-2 text-gray-900 font-semibold min-w-[360px]">Final Value</div>
+        <div className="px-3 py-2 text-right text-gray-900 font-semibold flex-1">{fmt(finalValue)}</div>
+      </div>
+      <div className="flex bg-gray-200">
+        <div className="px-3 py-2 text-gray-900 font-bold min-w-[360px]">Final Value (Rounded)</div>
+        <div className="px-3 py-2 text-right text-gray-900 font-bold text-sm flex-1">{fmt(finalValueRounded)}</div>
+      </div>
+    </div>
+    </>
+  );
+}

--- a/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
@@ -8,10 +8,13 @@ import type { TemplateDtoType } from '@/shared/schemas/v1';
 import { DiscountedCashFlowPanel } from './DiscountedCashFlowPanel';
 import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
 import { CostMachinePanel } from './CostMachinePanel';
+import { LeaseholdPanel } from './LeaseholdPanel';
+import { ProfitRentPanel } from './ProfitRentPanel';
 
 interface MethodSectionRendererProps {
   state: SelectionState;
   serverData: PricingServerData;
+  appraisalId?: string;
   calculationMethodData: {
     comparativeFactors: GetComparativeFactorsResponseType | undefined;
     templateList: TemplateDtoType[] | undefined;
@@ -28,6 +31,7 @@ interface MethodSectionRendererProps {
 export function MethodSectionRenderer({
   state,
   serverData,
+  appraisalId,
   calculationMethodData,
   onCalculationSave,
   onCalculationMethodDirty,
@@ -74,6 +78,24 @@ export function MethodSectionRenderer({
       return <SaleAdjustmentGridPanel {...panelProps} />;
     case 'DC_COST':
       return <DirectComparisonPanel {...panelProps} />;
+    case 'LH':
+      return (
+        <LeaseholdPanel
+          {...panelProps}
+          propertiesMap={serverData.propertiesMap}
+          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId}
+          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType}
+        />
+      );
+    case 'PR':
+      return (
+        <ProfitRentPanel
+          {...panelProps}
+          propertiesMap={serverData.propertiesMap}
+          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId}
+          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType}
+        />
+      );
     default:
       return <></>;
   }

--- a/src/features/pricingAnalysis/components/ProfitRentChart.tsx
+++ b/src/features/pricingAnalysis/components/ProfitRentChart.tsx
@@ -1,0 +1,98 @@
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import type { ProfitRentTableResult } from '../domain/calculateProfitRent';
+
+interface ProfitRentChartProps {
+  result: ProfitRentTableResult;
+}
+
+const fmtCompact = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toFixed(0);
+};
+
+const fmtTooltip = (n: number): string =>
+  n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+export function ProfitRentChart({ result }: ProfitRentChartProps) {
+  const data = result.rows.map((r) => ({
+    year: r.year,
+    marketRental: r.marketRentalFeePerYear,
+    contractRental: r.contractRentalFeePerYear,
+    returns: r.returnsFromLease,
+    presentValue: r.presentValue,
+  }));
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-4">
+      <div className="text-xs font-medium text-gray-500 mb-2">Market vs Contract Rental & Present Value</div>
+      <ResponsiveContainer width="100%" height={240}>
+        <ComposedChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis
+            dataKey="year"
+            tick={{ fontSize: 10, fill: '#9ca3af' }}
+            tickFormatter={(v) => v.toFixed(1)}
+          />
+          <YAxis
+            yAxisId="left"
+            tick={{ fontSize: 10, fill: '#9ca3af' }}
+            tickFormatter={fmtCompact}
+            width={50}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            tick={{ fontSize: 10, fill: '#9ca3af' }}
+            tickFormatter={fmtCompact}
+            width={50}
+          />
+          <Tooltip
+            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid #e5e7eb' }}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            formatter={((value: number, name: string) => [fmtTooltip(value), name]) as any}
+            labelFormatter={(label) => `Year ${Number(label).toFixed(1)}`}
+          />
+          <Legend
+            wrapperStyle={{ fontSize: 10, paddingTop: 4 }}
+          />
+          <Bar
+            yAxisId="left"
+            dataKey="marketRental"
+            name="Market Rental (Year)"
+            fill="#93c5fd"
+            fillOpacity={0.7}
+            radius={[2, 2, 0, 0]}
+          />
+          <Bar
+            yAxisId="left"
+            dataKey="contractRental"
+            name="Contract Rental (Year)"
+            fill="#d1d5db"
+            fillOpacity={0.7}
+            radius={[2, 2, 0, 0]}
+          />
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="presentValue"
+            name="Present Value"
+            stroke="#22c55e"
+            strokeWidth={2}
+            dot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/ProfitRentPanel.tsx
+++ b/src/features/pricingAnalysis/components/ProfitRentPanel.tsx
@@ -1,0 +1,1176 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, useFieldArray, useController, useWatch } from 'react-hook-form';
+import { FormProvider } from '@/shared/components/form/FormProvider';
+import { MethodFooterActions } from './MethodFooterActions';
+import { ProfitRentFormSchema, profitRentFormDefaults, type ProfitRentFormType } from '../schemas/profitRentForm';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from '@/shared/components';
+import { NumberInput, Toggle } from '@/shared/components/inputs';
+import { initializeProfitRentForm } from '../adapters/initializeProfitRentForm';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useGetProfitRentAnalysis, useSaveProfitRentAnalysis } from '../api';
+import { useResetMethod } from '../api';
+import { pricingAnalysisKeys } from '../api/queryKeys';
+import type { SaveProfitRentAnalysisRequest } from '../types/profitRent';
+import { useGetRentalSchedule, useGetLeaseAgreement } from '@/features/appraisal/api/property';
+import { typeToDetailEndpoint } from '@/features/appraisal/utils/propertyTypeConfig';
+import axios from '@shared/api/axiosInstance';
+import { useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { useGetAppointment } from '@/features/appraisal/api/appointment';
+import toast from 'react-hot-toast';
+import { LeaseholdRentalInfoModal } from './LeaseholdRentalInfoModal';
+import { BuildingCostTable } from './BuildingCostTable';
+import { KpiSummaryStrip, type KpiCard } from './KpiSummaryStrip';
+import { ProfitRentChart } from './ProfitRentChart';
+import { SensitivityStrip } from './SensitivityStrip';
+import { RemarkSection } from './RemarkSection';
+import { ScrollableTableContainer } from './ScrollableTableContainer';
+import { LeaseTimelineBar } from './LeaseTimelineBar';
+import {
+  generateProfitRentTable,
+  computeProfitRentSchedule,
+  type ProfitRentTableResult,
+} from '../domain/calculateProfitRent';
+import { formatDateOnly, fmt, toNum } from '../domain/formatters';
+import { roundToThousand } from '../domain/calculation';
+
+interface ProfitRentPanelProps {
+  activeMethod?: {
+    pricingAnalysisId?: string;
+    approachId?: string;
+    approachType?: string;
+    methodId?: string;
+    methodType?: string;
+  };
+  propertiesMap?: Record<string, Record<string, unknown>>;
+  firstPropertyId?: string;
+  firstPropertyType?: string;
+  onCalculationSave: (payload: {
+    approachType: string;
+    methodType: string;
+    appraisalValue: number;
+  }) => void;
+  onCalculationMethodDirty: (check: boolean) => void;
+  onCancelCalculationMethod: () => void;
+}
+
+export function ProfitRentPanel({
+  activeMethod,
+  propertiesMap,
+  firstPropertyId,
+  firstPropertyType,
+  onCalculationSave,
+  onCalculationMethodDirty,
+  onCancelCalculationMethod,
+}: ProfitRentPanelProps) {
+  const appraisalId = useAppraisalId();
+  const { data: appointment } = useGetAppointment(appraisalId ?? '');
+  const { pricingAnalysisId, methodId } = activeMethod ?? {};
+  const queryClient = useQueryClient();
+  const [isShowResetDialog, setIsShowResetDialog] = useState(false);
+  const [isRentalInfoModalOpen, setIsRentalInfoModalOpen] = useState(false);
+  const [tableResult, setTableResult] = useState<ProfitRentTableResult | null>(null);
+  const [hoveredCol, setHoveredCol] = useState<number | null>(null);
+
+  const resetMutation = useResetMethod();
+  const saveMutation = useSaveProfitRentAnalysis();
+
+  const { data: savedData, isPending: isLoading } = useGetProfitRentAnalysis(
+    pricingAnalysisId,
+    methodId,
+  );
+
+  // Fetch property detail for land area
+  const detailEndpoint = firstPropertyType ? typeToDetailEndpoint[firstPropertyType] : undefined;
+  const { data: propertyDetail } = useQuery({
+    queryKey: ['appraisal', appraisalId, 'property', firstPropertyId, 'detail-pr'],
+    queryFn: async () => {
+      const { data } = await axios.get(
+        `/appraisals/${appraisalId}/properties/${firstPropertyId}/${detailEndpoint}`,
+      );
+      return data as Record<string, any>;
+    },
+    enabled: !!appraisalId && !!firstPropertyId && !!detailEndpoint,
+    staleTime: Infinity,
+  });
+
+  const landAreaSqWa = useMemo(() => {
+    return Number(propertyDetail?.totalLandAreaInSqWa) || 0;
+  }, [propertyDetail]);
+
+  // Fetch rental schedule and lease agreement
+  const { data: rentalScheduleData } = useGetRentalSchedule(appraisalId ?? '', firstPropertyId);
+  const { data: leaseAgreement } = useGetLeaseAgreement(appraisalId ?? '', firstPropertyId);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const methods = useForm<ProfitRentFormType>({
+    mode: 'onSubmit',
+    resolver: zodResolver(ProfitRentFormSchema) as any,
+    defaultValues: profitRentFormDefaults,
+  });
+
+  const {
+    handleSubmit,
+    formState: { isDirty },
+    getValues,
+    setValue,
+    reset,
+    control,
+    watch,
+  } = methods;
+
+  const growthRateType = watch('growthRateType');
+
+  const { fields: growthPeriodFields, append: appendPeriod, remove: removePeriod } = useFieldArray({
+    control,
+    name: 'growthPeriods' as any,
+  });
+
+  // useController for NumberInput fields
+  const { field: marketFeeField } = useController({ control, name: 'marketRentalFeePerSqWa' });
+  const { field: growthPercentField } = useController({ control, name: 'growthRatePercent' });
+  const { field: intervalField } = useController({ control, name: 'growthIntervalYears' });
+  const { field: estimateField } = useController({ control, name: 'estimatePriceRounded' });
+
+  // Initialize form on data load
+  const isInitialized = useRef(false);
+  const tableResultRef = useRef<ProfitRentTableResult | null>(null);
+  useEffect(() => {
+    if (savedData !== undefined && !isInitialized.current) {
+      isInitialized.current = true;
+      initializeProfitRentForm(savedData?.analysis, savedData?.remark, reset);
+
+      if (savedData?.analysis?.calculationDetails?.length) {
+        const details = savedData.analysis.calculationDetails;
+        const result: ProfitRentTableResult = {
+          rows: details.map((d) => ({
+            year: d.year,
+            numberOfMonths: d.numberOfMonths,
+            contractStart: '',
+            contractEnd: '',
+            marketRentalFeePerSqWa: d.marketRentalFeePerSqWa,
+            marketRentalFeeGrowthPercent: d.marketRentalFeeGrowthPercent,
+            marketRentalFeePerMonth: d.marketRentalFeePerMonth,
+            marketRentalFeePerYear: d.marketRentalFeePerYear,
+            contractRentalFeePerYear: d.contractRentalFeePerYear,
+            returnsFromLease: d.returnsFromLease,
+            pvFactor: d.pvFactor,
+            presentValue: d.presentValue,
+          })),
+          totalMarketRentalFee: savedData.analysis.totalMarketRentalFee,
+          totalContractRentalFee: savedData.analysis.totalContractRentalFee,
+          totalReturnsFromLease: savedData.analysis.totalReturnsFromLease,
+          totalPresentValue: savedData.analysis.totalPresentValue,
+          finalValueRounded: savedData.analysis.finalValueRounded,
+        };
+        tableResultRef.current = result;
+        setTableResult(result);
+      }
+    }
+  }, [savedData, reset]);
+
+  useEffect(() => {
+    onCalculationMethodDirty(isDirty);
+  }, [isDirty, onCalculationMethodDirty]);
+
+  // Stable ref for getValues — avoids re-creating callbacks on every render
+  const getValuesRef = useRef(getValues);
+  getValuesRef.current = getValues;
+
+  const handleGenerate = useCallback((preserveEstimate = false) => {
+    const data = getValuesRef.current();
+    const appraisalDateStr = appointment?.appointmentDateTime;
+    const contractRows = rentalScheduleData?.rows ?? [];
+
+    const appraisalSchedule = appraisalDateStr
+      ? computeProfitRentSchedule(contractRows, appraisalDateStr)
+      : [];
+
+    if (appraisalSchedule.length === 0) return;
+
+    // Save current values before regeneration
+    const savedEstimate = preserveEstimate ? data.estimatePriceRounded : undefined;
+    const savedBuildingRounded = preserveEstimate ? data.appraisalPriceWithBuildingRounded : undefined;
+
+    const result = generateProfitRentTable({
+      appraisalSchedule,
+      landAreaSqWa,
+      marketRentalFeePerSqWa: data.marketRentalFeePerSqWa ?? 0,
+      growthRateType: data.growthRateType ?? 'Frequency',
+      growthRatePercent: data.growthRatePercent ?? 0,
+      growthIntervalYears: data.growthIntervalYears ?? 1,
+      growthPeriods: (data.growthPeriods ?? []) as any,
+      discountRate: data.discountRate ?? 0,
+    });
+
+    setTableResult(result);
+    tableResultRef.current = result;
+
+    if (preserveEstimate) {
+      // Restore saved values after regeneration
+      if (savedEstimate != null && savedEstimate !== 0) {
+        setValue('estimatePriceRounded', savedEstimate, { shouldDirty: false });
+      }
+      if (savedBuildingRounded != null && savedBuildingRounded !== 0) {
+        setValue('appraisalPriceWithBuildingRounded', savedBuildingRounded, { shouldDirty: false });
+      }
+    } else {
+      setValue('estimatePriceRounded', result.finalValueRounded);
+    }
+  }, [appointment, rentalScheduleData, landAreaSqWa, setValue]);
+
+  // Recalculate table once rental schedule is available (fixes dates, numberOfMonths, etc.)
+  const hasRecalculated = useRef(false);
+  useEffect(() => {
+    if (hasRecalculated.current) return;
+    if (!tableResult || !rentalScheduleData?.rows?.length || !appointment?.appointmentDateTime) return;
+    if (tableResult.rows[0]?.contractStart) return;
+    hasRecalculated.current = true;
+    handleGenerate(true);
+  }, [tableResult, rentalScheduleData, appointment, handleGenerate]);
+
+
+  // Auto-generate on first visit when no saved data but all dependencies are ready
+  const hasAutoGenerated = useRef(false);
+  useEffect(() => {
+    if (
+      !hasAutoGenerated.current &&
+      isInitialized.current &&
+      !tableResultRef.current &&
+      rentalScheduleData?.rows?.length &&
+      appointment?.appointmentDateTime &&
+      landAreaSqWa > 0
+    ) {
+      hasAutoGenerated.current = true;
+      handleGenerate();
+    }
+  }, [rentalScheduleData, appointment, landAreaSqWa, tableResult, handleGenerate, setValue]);
+
+  // Auto-recalculate when inline inputs change
+  const watchedInputs = useWatch({
+    control,
+    name: ['marketRentalFeePerSqWa', 'growthRateType', 'growthRatePercent', 'growthIntervalYears', 'discountRate'],
+  });
+  const watchedGrowthPeriods = useWatch({ control, name: 'growthPeriods' });
+  const prevWatchKey = useRef<string | null>(null);
+  useEffect(() => {
+    const key = watchedInputs.join(',') + '|' + JSON.stringify(watchedGrowthPeriods);
+    if (prevWatchKey.current === null) {
+      prevWatchKey.current = key;
+      return;
+    }
+    if (!isDirty) return;
+    if (key === prevWatchKey.current) return;
+    prevWatchKey.current = key;
+    if (tableResult) handleGenerate();
+  }, [isDirty, watchedInputs, watchedGrowthPeriods, tableResult, handleGenerate]);
+
+  // Sensitivity: recalculate final value with a different discount rate (C3 fix: no getValues in deps)
+  const calcSensitivity = useCallback((rate: number): number | null => {
+    const data = getValuesRef.current();
+    const appraisalDateStr = appointment?.appointmentDateTime;
+    const contractRows = rentalScheduleData?.rows ?? [];
+    const appraisalSchedule = appraisalDateStr
+      ? computeProfitRentSchedule(contractRows, appraisalDateStr)
+      : [];
+    if (appraisalSchedule.length === 0) return null;
+
+    const result = generateProfitRentTable({
+      appraisalSchedule,
+      landAreaSqWa,
+      marketRentalFeePerSqWa: data.marketRentalFeePerSqWa ?? 0,
+      growthRateType: data.growthRateType ?? 'Frequency',
+      growthRatePercent: data.growthRatePercent ?? 0,
+      growthIntervalYears: data.growthIntervalYears ?? 1,
+      growthPeriods: (data.growthPeriods ?? []) as any,
+      discountRate: rate,
+    });
+    return result.finalValueRounded;
+  }, [appointment, rentalScheduleData, landAreaSqWa]);
+
+  const handleOnSubmit = async () => {
+    if (!pricingAnalysisId || !methodId) return;
+
+    const data = getValues();
+    const request: SaveProfitRentAnalysisRequest = {
+      marketRentalFeePerSqWa: data.marketRentalFeePerSqWa,
+      growthRateType: data.growthRateType as 'Frequency' | 'Period',
+      growthRatePercent: data.growthRatePercent,
+      growthIntervalYears: data.growthIntervalYears,
+      discountRate: data.discountRate,
+      includeBuildingCost: data.includeBuildingCost,
+      growthPeriods: ((data.growthPeriods ?? []) as any[]).map((p: any) => ({
+        fromYear: p.fromYear,
+        toYear: p.toYear,
+        growthRatePercent: p.growthRatePercent,
+      })),
+      estimatePriceRounded: data.estimatePriceRounded,
+      remark: data.remark,
+      appraisalPriceWithBuildingRounded: data.includeBuildingCost
+        ? data.appraisalPriceWithBuildingRounded
+        : null,
+    };
+
+    try {
+      const result = await saveMutation.mutateAsync({
+        pricingAnalysisId,
+        methodId,
+        request,
+      });
+
+      // Hydrate form with backend-computed building cost values
+      if (result.totalBuildingCost != null) {
+        setValue('totalBuildingCost', result.totalBuildingCost, { shouldDirty: false });
+        setValue('appraisalPriceWithBuilding', result.appraisalPriceWithBuilding, { shouldDirty: false });
+        setValue('appraisalPriceWithBuildingRounded', result.appraisalPriceWithBuildingRounded, { shouldDirty: false });
+      }
+
+      // Propagate building-inclusive price when building cost is included
+      const appraisalValue =
+        data.includeBuildingCost && result.appraisalPriceWithBuildingRounded
+          ? result.appraisalPriceWithBuildingRounded
+          : data.estimatePriceRounded ?? result.finalValueRounded;
+
+      if (activeMethod?.approachType && activeMethod?.methodType) {
+        onCalculationSave({
+          approachType: activeMethod.approachType,
+          methodType: activeMethod.methodType,
+          appraisalValue,
+        });
+      }
+      toast.success('Saved!');
+    } catch {
+      toast.error('Failed to save');
+    }
+  };
+
+  const handleOnReset = () => setIsShowResetDialog(true);
+  const handleOnConfirmReset = async () => {
+    setIsShowResetDialog(false);
+    if (!pricingAnalysisId || !methodId) return;
+    try {
+      await resetMutation.mutateAsync({ pricingAnalysisId, methodId });
+      setTableResult(null);
+      tableResultRef.current = null;
+      isInitialized.current = false;
+      hasAutoGenerated.current = false;
+      prevWatchKey.current = null;
+      reset(profitRentFormDefaults);
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.profitRentAnalysis(pricingAnalysisId, methodId),
+      });
+      toast.success('Reset successful');
+    } catch {
+      toast.error('Failed to reset');
+    }
+  };
+
+  const discountRateValue = watch('discountRate') ?? 0;
+  const isBuildingCostIncluded = watch('includeBuildingCost');
+  const estimatePrice = watch('estimatePriceRounded');
+
+  // Collect building properties for BuildingCostTable:
+  // 1. The primary property (LS/LB) if it has depreciationDetails (already fetched)
+  // 2. Any separate building properties (B/LSB) from the group's propertiesMap
+  const allGroupProperties = useMemo(() => {
+    const items: Record<string, unknown>[] = [];
+
+    // Primary property (already fetched for land area)
+    if (propertyDetail?.depreciationDetails) {
+      items.push(propertyDetail);
+    }
+
+    // Additional properties from the group (separate B/LSB)
+    if (propertiesMap) {
+      for (const prop of Object.values(propertiesMap)) {
+        if (prop.propertyId !== firstPropertyId && prop.depreciationDetails) {
+          items.push(prop);
+        }
+      }
+    }
+
+    return items;
+  }, [propertyDetail, propertiesMap, firstPropertyId]);
+
+  // Compute totalBuildingCost preview from depreciation details (same as WQS pattern)
+  useEffect(() => {
+    if (!isBuildingCostIncluded || !allGroupProperties.length) {
+      return;
+    }
+
+    let grandTotal = 0;
+    for (const building of allGroupProperties) {
+      const rawRows: unknown[] = (building.depreciationDetails as unknown[]) ?? [];
+      for (const rawRow of rawRows) {
+        const row = rawRow as Record<string, unknown>;
+        const priceBeforeDepreciation =
+          toNum(row['area']) * toNum(row['pricePerSqMBeforeDepreciation']);
+        const periods: unknown[] = (row['depreciationPeriods'] as unknown[]) ?? [];
+        const priceDepreciation = periods.reduce(
+          (acc: number, b: unknown) => acc + toNum((b as Record<string, unknown>).priceDepreciation),
+          0,
+        );
+        grandTotal += priceBeforeDepreciation - priceDepreciation;
+      }
+    }
+
+    setValue('totalBuildingCost', grandTotal, { shouldDirty: false });
+  }, [allGroupProperties, isBuildingCostIncluded, setValue]);
+
+  // Compute derived building cost fields for preview
+  const totalBuildingCost = watch('totalBuildingCost') ?? 0;
+  const prevBuildingPriceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!isBuildingCostIncluded || !isInitialized.current) return;
+    const est = Number(estimatePrice) || 0;
+    const buildingCost = Number(totalBuildingCost) || 0;
+    const sum = est + buildingCost;
+    setValue('appraisalPriceWithBuilding', sum, { shouldDirty: false });
+
+    // Auto-update rounded only when the user actively changes inputs (isDirty),
+    // not during initial hydration from saved data
+    if (!isDirty) {
+      // On init: only set if no saved value
+      const currentRounded = getValues('appraisalPriceWithBuildingRounded');
+      if (currentRounded == null || currentRounded === 0) {
+        setValue('appraisalPriceWithBuildingRounded', roundToThousand(sum), { shouldDirty: false });
+      }
+      prevBuildingPriceRef.current = sum;
+      return;
+    }
+
+    if (prevBuildingPriceRef.current !== sum) {
+      prevBuildingPriceRef.current = sum;
+      setValue('appraisalPriceWithBuildingRounded', roundToThousand(sum), { shouldDirty: false });
+    }
+  }, [isBuildingCostIncluded, estimatePrice, totalBuildingCost, isDirty, getValues, setValue]);
+
+  if (isLoading) {
+    return <PanelSkeleton />;
+  }
+
+  return (
+    <FormProvider methods={methods as any} schema={ProfitRentFormSchema as any}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit(handleOnSubmit)(e);
+        }}
+        className="flex flex-col h-full gap-4"
+      >
+        {/* Header — matches Leasehold */}
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
+            <Icon name="file-signature" className="size-4" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900">Profit Rent</h2>
+        </div>
+
+        {/* Lease Info Cards — matches Leasehold layout */}
+        <div className="rounded-lg border border-gray-200 p-5 space-y-4">
+          <div className="grid grid-cols-4 gap-4">
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-gray-400 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Appraisal Date</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {appointment?.appointmentDateTime ? formatDateOnly(appointment.appointmentDateTime) : '-'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-green-500 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease Start</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {leaseAgreement?.leaseStartDate ? formatDateOnly(leaseAgreement.leaseStartDate) : '-'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
+              <Icon name="calendar" className="size-4 text-red-400 shrink-0" />
+              <div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease End</div>
+                <div className="text-sm font-medium text-gray-900">
+                  {leaseAgreement?.leaseEndDate ? formatDateOnly(leaseAgreement.leaseEndDate) : '-'}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsRentalInfoModalOpen(true)}
+              className="flex items-center gap-3 rounded-md bg-primary/5 border border-primary/20 px-3 py-2.5 hover:bg-primary/10 transition-colors"
+            >
+              <Icon name="receipt" className="size-4 text-primary shrink-0" />
+              <div className="text-left">
+                <div className="text-[11px] text-primary/60 uppercase tracking-wide">View</div>
+                <div className="text-sm font-medium text-primary">Rental Information</div>
+              </div>
+            </button>
+          </div>
+          <LeaseTimelineBar
+            leaseStartDate={leaseAgreement?.leaseStartDate}
+            leaseEndDate={leaseAgreement?.leaseEndDate}
+            appraisalDate={appointment?.appointmentDateTime}
+          />
+        </div>
+
+        {/* Market Rental Fee & Land Area & Rates */}
+        <div className="rounded-lg border border-gray-200 p-4 space-y-3">
+          {/* Top row: Land Area + Market Fee + Monthly Total + Discount Rate */}
+          <div className="grid grid-cols-4 gap-3">
+            {/* Land Area — read-only */}
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Land Area</div>
+              <div className="flex items-baseline gap-1">
+                <Icon name="ruler-combined" className="size-3 text-gray-400 shrink-0 relative top-0.5" />
+                <span className="text-sm font-semibold text-gray-900">{fmt(landAreaSqWa)}</span>
+                <span className="text-[10px] text-gray-500">Sq. Wa</span>
+              </div>
+            </div>
+
+            {/* Market Rental Fee — input */}
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Market Rental Fee <span className="text-red-400">*</span>
+              </label>
+              <div className="flex items-baseline gap-1">
+                <div className="w-24">
+                  <NumberInput
+                    name={marketFeeField.name}
+                    ref={marketFeeField.ref}
+                    value={marketFeeField.value}
+                    onChange={(e) => marketFeeField.onChange(e.target.value)}
+                    onBlur={marketFeeField.onBlur}
+                    decimalPlaces={2}
+                  />
+                </div>
+                <span className="text-[10px] text-gray-500">Baht/Sq.Wa/Mo</span>
+              </div>
+            </div>
+
+            {/* Monthly Total — computed */}
+            <div className="rounded-md bg-primary/5 border border-primary/10 px-3 py-2">
+              <div className="text-[10px] text-primary/60 uppercase tracking-wide mb-0.5">Monthly Total</div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-sm font-semibold text-primary">
+                  {fmt((marketFeeField.value ?? 0) * landAreaSqWa)}
+                </span>
+                <span className="text-[10px] text-primary/60">Baht/Mo</span>
+              </div>
+            </div>
+
+            {/* Discounted Rate — input */}
+            <div className="rounded-md bg-gray-50 px-3 py-2">
+              <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
+                Discounted Rate
+              </label>
+              <div className="w-24">
+                <NumberInput
+                  name="discountRate"
+                  value={watch('discountRate')}
+                  onChange={(e) => setValue('discountRate', e.target.value ?? 0, { shouldDirty: true })}
+                  decimalPlaces={2}
+                  rightIcon={<span className="text-xs text-gray-400">%</span>}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="border-t border-gray-200" />
+
+          {/* Market Rental Fee Increase */}
+          <div className="space-y-2">
+            <Toggle
+              label="Market Rental Fee Increase"
+              options={['Frequency', 'Period']}
+              checked={growthRateType === 'Period'}
+              onChange={(checked) => setValue('growthRateType', checked ? 'Period' : 'Frequency', { shouldDirty: true })}
+              size="sm"
+            />
+
+            {growthRateType === 'Frequency' ? (
+              <div className="flex gap-3 items-end">
+                <div className="flex-1">
+                  <NumberInput
+                    label="Rate"
+                    name={growthPercentField.name}
+                    ref={growthPercentField.ref}
+                    value={growthPercentField.value}
+                    onChange={(e) => growthPercentField.onChange(e.target.value)}
+                    onBlur={growthPercentField.onBlur}
+                    decimalPlaces={2}
+                    rightIcon={<span className="text-xs text-gray-400">%</span>}
+                  />
+                </div>
+                <span className="text-sm text-gray-500 pb-2">Every</span>
+                <div className="flex-1">
+                  <NumberInput
+                    label="Interval"
+                    name={intervalField.name}
+                    ref={intervalField.ref}
+                    value={intervalField.value}
+                    onChange={(e) => intervalField.onChange(e.target.value)}
+                    onBlur={intervalField.onBlur}
+                    decimalPlaces={0}
+                    rightIcon={<span className="text-xs text-gray-400">Year</span>}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 text-xs text-gray-500 font-medium">
+                  <span>From Year</span>
+                  <span>To Year</span>
+                  <span>Growth Rate (%)</span>
+                  <span />
+                </div>
+                {growthPeriodFields.map((field, index) => (
+                  <div key={field.id} className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 items-end">
+                    <NumberInput
+                      value={watch(`growthPeriods.${index}.fromYear` as any)}
+                      onChange={(e) => setValue(`growthPeriods.${index}.fromYear` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={0}
+                    />
+                    <NumberInput
+                      value={watch(`growthPeriods.${index}.toYear` as any)}
+                      onChange={(e) => setValue(`growthPeriods.${index}.toYear` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={0}
+                    />
+                    <NumberInput
+                      value={watch(`growthPeriods.${index}.growthRatePercent` as any)}
+                      onChange={(e) => setValue(`growthPeriods.${index}.growthRatePercent` as any, e.target.value ?? 0, { shouldDirty: true })}
+                      decimalPlaces={2}
+                      rightIcon={<span className="text-xs text-gray-400">%</span>}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removePeriod(index)}
+                      className="flex items-center justify-center text-red-400 hover:text-red-600 pb-1"
+                    >
+                      <Icon name="xmark" className="size-4" />
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => appendPeriod({ fromYear: 0, toYear: 0, growthRatePercent: 0 })}
+                  className="text-xs text-primary hover:underline flex items-center gap-1"
+                >
+                  <Icon name="plus" className="size-3" />
+                  Add Periods
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* KPI Summary */}
+        {tableResult && tableResult.rows.length > 0 && (
+          <KpiSummaryStrip
+            cards={[
+              { label: 'Total Market Rental', value: tableResult.totalMarketRentalFee, icon: 'chart-bar', color: 'blue' },
+              { label: 'Total Contract Rental', value: tableResult.totalContractRentalFee, icon: 'file-contract', color: 'gray' },
+              { label: 'Total Returns', value: tableResult.totalReturnsFromLease, icon: 'arrow-trend-up', color: 'amber' },
+              { label: 'Present Value', value: tableResult.totalPresentValue, icon: 'circle-check', color: 'green', primary: true },
+            ] satisfies KpiCard[]}
+          />
+        )}
+
+        {/* Chart */}
+        {tableResult && tableResult.rows.length > 0 && (
+          <ProfitRentChart result={tableResult} />
+        )}
+
+        {/* Sensitivity */}
+        {tableResult && tableResult.rows.length > 0 && (
+          <SensitivityStrip
+            currentRate={discountRateValue}
+            calculateFinalValue={calcSensitivity}
+          />
+        )}
+
+        {/* Calculation Table */}
+        {tableResult && tableResult.rows.length > 0 ? (
+          <ScrollableTableContainer maxHeight="500px">
+            <table className="w-full text-xs border-collapse">
+              <ProfitRentTable
+                tableResult={tableResult}
+                discountRateValue={discountRateValue}
+                hoveredCol={hoveredCol}
+                onColHover={setHoveredCol}
+              />
+            </table>
+          </ScrollableTableContainer>
+        ) : isLoading ? (
+          <TableSkeleton />
+        ) : null}
+
+        {/* Include building cost section */}
+        <div className="border-t border-gray-200 pt-2 space-y-3">
+          <Toggle
+            label="Include building cost"
+            options={['No', 'Yes']}
+            size="sm"
+            checked={isBuildingCostIncluded}
+            onChange={(checked) =>
+              setValue('includeBuildingCost', checked, { shouldDirty: true })
+            }
+          />
+
+          {isBuildingCostIncluded && (
+            <>
+              <BuildingCostCollapsible buildingCost={allGroupProperties} />
+              <div className="border-t border-gray-200" />
+
+              {/* Formula rows */}
+              <div className="text-sm divide-y divide-gray-100">
+                <div className="flex items-center justify-between py-1.5">
+                  <span className="text-xs text-gray-600">Estimate Price (from PV)</span>
+                  <span className="text-xs font-medium text-gray-800 tabular-nums">{fmt(Number(estimatePrice) || 0)}</span>
+                </div>
+                <div className="flex items-center justify-between py-1.5">
+                  <span className="text-xs text-gray-600">
+                    <span className="font-bold mr-1">+</span>
+                    Building Cost (after depre.)
+                  </span>
+                  <span className="text-xs font-medium text-gray-800 tabular-nums">{fmt(Number(watch('totalBuildingCost')) || 0)}</span>
+                </div>
+                <div className="flex items-center justify-between py-1.5">
+                  <span className="text-xs text-gray-700 font-medium">
+                    <span className="font-bold mr-1">=</span>
+                    Appraisal Price w/ Building
+                  </span>
+                  <span className="text-xs font-semibold text-gray-900 tabular-nums">{fmt(Number(watch('appraisalPriceWithBuilding')) || 0)}</span>
+                </div>
+                {/* Appraisal Price */}
+                <div className="flex items-center justify-between py-2">
+                  <span className="text-xs font-semibold text-gray-900">
+                    Appraisal Price
+                  </span>
+                  <div className="flex items-center gap-2">
+                    {(() => {
+                      const rounded = Number(watch('appraisalPriceWithBuildingRounded')) || 0;
+                      const computed = roundToThousand(Number(watch('appraisalPriceWithBuilding')) || 0);
+                      const diff = rounded - computed;
+                      if (diff === 0) return null;
+                      const pct = computed !== 0 ? ((diff / computed) * 100).toFixed(1) : '0.0';
+                      const color = diff > 0 ? 'text-green-600' : 'text-red-600';
+                      const bgColor = diff > 0 ? 'bg-green-100' : 'bg-red-100';
+                      const icon = diff > 0 ? 'arrow-up' : 'arrow-down';
+                      return (
+                        <span
+                          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium ${color} ${bgColor} shrink-0`}
+                        >
+                          <Icon name={icon} style="solid" className="size-2.5" />
+                          {Math.abs(diff).toLocaleString()} ({diff > 0 ? '+' : ''}{pct}%)
+                        </span>
+                      );
+                    })()}
+                    <div className="w-40">
+                      <NumberInput
+                        name="appraisalPriceWithBuildingRounded"
+                        value={watch('appraisalPriceWithBuildingRounded') ?? 0}
+                        onChange={(e) =>
+                          setValue('appraisalPriceWithBuildingRounded', Number(e.target.value) || 0, {
+                            shouldDirty: true,
+                          })
+                        }
+                        decimalPlaces={2}
+                        className="!font-bold !text-right !text-sm !text-green-700"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Estimate Price + Appraisal Price — when no building cost */}
+        {!isBuildingCostIncluded && (
+          <div className="text-sm divide-y divide-gray-100 border-t border-gray-200">
+            <div className="flex items-center justify-between py-1.5">
+              <span className="text-xs text-gray-600">Estimate Price (from PV)</span>
+              <span className="text-xs font-medium text-gray-800 tabular-nums">{fmt(tableResult?.finalValueRounded ?? 0)}</span>
+            </div>
+            <div className="flex items-center justify-between py-2">
+              <span className="text-xs font-semibold text-gray-900 shrink-0">
+                Appraisal Price
+              </span>
+              <div className="flex items-center gap-2">
+                {(() => {
+                  const rounded = Number(estimateField.value) || 0;
+                  const computed = tableResult?.finalValueRounded ?? 0;
+                  const diff = rounded - computed;
+                  if (diff === 0 || computed === 0) return null;
+                  const pct = ((diff / computed) * 100).toFixed(1);
+                  const color = diff > 0 ? 'text-green-600' : 'text-red-600';
+                  const bgColor = diff > 0 ? 'bg-green-100' : 'bg-red-100';
+                  const icon = diff > 0 ? 'arrow-up' : 'arrow-down';
+                  return (
+                    <span
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium ${color} ${bgColor} shrink-0`}
+                    >
+                      <Icon name={icon} style="solid" className="size-2.5" />
+                      {Math.abs(diff).toLocaleString()} ({diff > 0 ? '+' : ''}{pct}%)
+                    </span>
+                  );
+                })()}
+                <div className="w-40">
+                  <NumberInput
+                    name={estimateField.name}
+                    ref={estimateField.ref}
+                    value={estimateField.value}
+                    onChange={(e) => estimateField.onChange(e.target.value)}
+                    onBlur={estimateField.onBlur}
+                    decimalPlaces={2}
+                    className="!font-bold !text-right !text-sm !text-green-700"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Notes & Assumptions */}
+        <RemarkSection setValue={setValue} watch={watch} />
+
+        {/* Footer — matches Leasehold */}
+        <MethodFooterActions
+          showReset={true}
+          isSubmitting={saveMutation.isPending}
+          onReset={handleOnReset}
+          onCancel={onCancelCalculationMethod}
+        />
+
+        {/* Dialogs */}
+        <ConfirmDialog
+          isOpen={isShowResetDialog}
+          onClose={() => setIsShowResetDialog(false)}
+          onConfirm={handleOnConfirmReset}
+          message="Are you sure you want to reset this method? All calculation data will be cleared."
+        />
+
+        <LeaseholdRentalInfoModal
+          isOpen={isRentalInfoModalOpen}
+          onClose={() => setIsRentalInfoModalOpen(false)}
+          contractSchedule={rentalScheduleData?.rows ?? []}
+          appraisalDate={appointment?.appointmentDateTime ?? undefined}
+        />
+      </form>
+    </FormProvider>
+  );
+}
+
+/** Extracted table with column hover highlight */
+function ProfitRentTable({
+  tableResult,
+  discountRateValue,
+  hoveredCol,
+  onColHover,
+}: {
+  tableResult: ProfitRentTableResult;
+  discountRateValue: number;
+  hoveredCol: number | null;
+  onColHover: (col: number | null) => void;
+}) {
+  const colHl = 'bg-blue-50/60';
+
+  // Sticky columns: 0=Year, 1=Start, 2=End (pinned left)
+  const stickyBase = [
+    'sticky left-0 z-10 min-w-[60px]',
+    'sticky left-[60px] z-10 min-w-[100px]',
+    'sticky left-[160px] z-10 min-w-[100px] shadow-[2px_0_4px_-2px_rgba(0,0,0,0.1)]',
+  ];
+
+  const headBg = 'bg-gray-50';
+  const bodyBg = 'bg-white';
+  const totalBg = 'bg-gray-100';
+
+  const thCls = (col: number, extra?: string) => {
+    const isSticky = col < 3;
+    // Sticky-left + sticky-top headers need z-30 (above both axes)
+    const base = isSticky
+      ? `${stickyBase[col]} sticky top-0 z-30 ${headBg} px-3 py-2 text-gray-600 font-medium border-b border-gray-200`
+      : `sticky top-0 z-20 ${headBg} px-3 py-2 text-right text-gray-600 font-medium border-b border-gray-200 ${extra ?? ''}`;
+    return `${base} ${hoveredCol === col ? colHl : ''}`;
+  };
+
+  const tdCls = (col: number, extra?: string) => {
+    const isSticky = col < 3;
+    const base = isSticky
+      ? `${stickyBase[col]} ${bodyBg} px-3 py-1.5 text-gray-700 border-b border-gray-100`
+      : `px-3 py-1.5 text-right text-gray-700 border-b border-gray-100 ${extra ?? ''}`;
+    return `${base} ${hoveredCol === col ? colHl : ''}`;
+  };
+
+  const totalTdCls = (col: number, extra?: string) => {
+    const base = `px-3 py-2 text-right text-gray-800 ${extra ?? ''}`;
+    return `${base} ${hoveredCol === col ? colHl : ''}`;
+  };
+
+  const cellProps = (col: number) => ({
+    onMouseEnter: () => onColHover(col),
+    onMouseLeave: () => onColHover(null),
+  });
+
+  const headers = [
+    { label: 'Year', align: 'text-left' },
+    { label: 'Period Start Date', align: 'text-left' },
+    { label: 'Period End Date', align: 'text-left' },
+    { label: 'Number of Month', minW: 'min-w-[80px]' },
+    { label: 'Market Rental Fee (Baht/Sq.Wa/Month)', minW: 'min-w-[130px]' },
+    { label: 'Market Rental Fee (Baht/month)', minW: 'min-w-[120px]' },
+    { label: 'Market Rental Fee (Baht/year)', minW: 'min-w-[120px]' },
+    { label: 'Contract Rental Fee (Baht/year)', minW: 'min-w-[120px]' },
+    { label: 'Returns from Lease (Baht)', minW: 'min-w-[120px]' },
+    { label: 'Discounted Rate', minW: 'min-w-[100px]' },
+    { label: 'Present Value (Baht)', minW: 'min-w-[120px]' },
+  ];
+
+  return (
+    <>
+      <thead>
+        <tr className="bg-gray-50">
+          {headers.map((h, col) => (
+            <th key={col} className={thCls(col, h.minW)} {...cellProps(col)}>
+              {h.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody onMouseLeave={() => onColHover(null)}>
+        {tableResult.rows.map((row) => (
+          <tr key={row.year} className="hover:bg-gray-50/50">
+            <td className={tdCls(0)} {...cellProps(0)}>{row.year.toFixed(1)}</td>
+            <td className={tdCls(1)} {...cellProps(1)}>{row.contractStart ? formatDateOnly(row.contractStart) : '-'}</td>
+            <td className={tdCls(2)} {...cellProps(2)}>{row.contractEnd ? formatDateOnly(row.contractEnd) : '-'}</td>
+            <td className={tdCls(3)} {...cellProps(3)}>{row.numberOfMonths.toFixed(1)}</td>
+            <td className={tdCls(4)} {...cellProps(4)}>
+              <div>{fmt(row.marketRentalFeePerSqWa)}</div>
+              {row.marketRentalFeeGrowthPercent > 0 && (
+                <div className="text-[9px] text-gray-400">+{row.marketRentalFeeGrowthPercent}%</div>
+              )}
+            </td>
+            <td className={tdCls(5)} {...cellProps(5)}>{fmt(row.marketRentalFeePerMonth)}</td>
+            <td className={tdCls(6)} {...cellProps(6)}>{fmt(row.marketRentalFeePerYear)}</td>
+            <td className={tdCls(7)} {...cellProps(7)}>{fmt(row.contractRentalFeePerYear)}</td>
+            <td className={tdCls(8)} {...cellProps(8)}>{fmt(row.returnsFromLease)}</td>
+            <td className={tdCls(9)} {...cellProps(9)}>{discountRateValue.toFixed(2)} %</td>
+            <td className={tdCls(10)} {...cellProps(10)}>{fmt(row.presentValue)}</td>
+          </tr>
+        ))}
+      </tbody>
+      <tfoot className="sticky bottom-0 z-20">
+        <tr className="bg-gray-100 font-semibold border-t-2 border-gray-300">
+          <td className={`sticky left-0 z-30 ${totalBg} px-3 py-2 text-gray-800`} colSpan={3}>Total</td>
+          <td className={`${totalBg} ${totalTdCls(3)}`} {...cellProps(3)}></td>
+          <td className={`${totalBg} ${totalTdCls(4)}`} {...cellProps(4)}></td>
+          <td className={`${totalBg} ${totalTdCls(5)}`} {...cellProps(5)}></td>
+          <td className={`${totalBg} ${totalTdCls(6)}`} {...cellProps(6)}>{fmt(tableResult.totalMarketRentalFee)}</td>
+          <td className={`${totalBg} ${totalTdCls(7)}`} {...cellProps(7)}>{fmt(tableResult.totalContractRentalFee)}</td>
+          <td className={`${totalBg} ${totalTdCls(8)}`} {...cellProps(8)}>{fmt(tableResult.totalReturnsFromLease)}</td>
+          <td className={`${totalBg} ${totalTdCls(9)}`} {...cellProps(9)}></td>
+          <td className={`${totalBg} ${totalTdCls(10)}`} {...cellProps(10)}>{fmt(tableResult.totalPresentValue)}</td>
+        </tr>
+      </tfoot>
+    </>
+  );
+}
+
+/** 11b: Compact building cost summary with expand/collapse */
+function BuildingCostCollapsible({ buildingCost }: { buildingCost: Record<string, unknown>[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Compute summary per building
+  const summaries = buildingCost.map((building) => {
+    const rows: unknown[] = (building.depreciationDetails as unknown[]) ?? [];
+    let totalArea = 0;
+    let totalBefore = 0;
+    let totalAfter = 0;
+    for (const rawRow of rows) {
+      const row = rawRow as Record<string, unknown>;
+      const area = toNum(row['area']);
+      const before = area * toNum(row['pricePerSqMBeforeDepreciation']);
+      const periods: unknown[] = (row['depreciationPeriods'] as unknown[]) ?? [];
+      const depre = periods.reduce(
+        (acc: number, b: unknown) => acc + toNum((b as Record<string, unknown>).priceDepreciation),
+        0,
+      );
+      totalArea += area;
+      totalBefore += before;
+      totalAfter += before - depre;
+    }
+    return {
+      name: (building.propertyName as string) || 'Building',
+      itemCount: rows.length,
+      totalArea,
+      totalBefore,
+      totalAfter,
+    };
+  });
+
+  const grandAfter = summaries.reduce((s, b) => s + b.totalAfter, 0);
+
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden">
+      {/* Compact summary */}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-50 hover:bg-gray-100 transition-colors text-left"
+      >
+        <div className="flex items-center gap-2">
+          <Icon name="building" className="size-3.5 text-gray-500" />
+          <span className="text-xs font-semibold text-gray-700">
+            Building Cost Summary
+          </span>
+          <span className="text-[10px] text-gray-400">
+            ({summaries.reduce((s, b) => s + b.itemCount, 0)} items)
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-medium text-gray-600 tabular-nums">
+            After Depre. {grandAfter.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+          </span>
+          <Icon
+            name="chevron-down"
+            className={`size-3 text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          />
+        </div>
+      </button>
+
+      {/* Summary table - always visible */}
+      {!expanded && (
+        <div className="border-t border-gray-100">
+          {/* Column headers */}
+          <div className="flex items-center justify-between px-4 py-1 text-[10px] text-gray-400 uppercase tracking-wide border-b border-gray-100">
+            <span>Property</span>
+            <div className="flex gap-6">
+              <span className="w-20 text-right">Area</span>
+              <span className="w-28 text-right">Before Depre.</span>
+              <span className="w-28 text-right">After Depre.</span>
+            </div>
+          </div>
+          {summaries.map((s, i) => (
+            <div key={i} className="flex items-center justify-between px-4 py-1.5 text-xs border-b border-gray-50 last:border-b-0">
+              <span className="text-gray-600">{s.name}</span>
+              <div className="flex gap-6 tabular-nums">
+                <span className="text-gray-400 w-20 text-right">{s.totalArea.toLocaleString()} m²</span>
+                <span className="text-gray-500 w-28 text-right">{s.totalBefore.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                <span className="text-gray-700 font-medium w-28 text-right">{s.totalAfter.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Expanded: full BuildingCostTable */}
+      {expanded && (
+        <div className="border-t border-gray-200">
+          <BuildingCostTable buildingCost={buildingCost as any} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Full panel skeleton — shown while initial data loads */
+function PanelSkeleton() {
+  return (
+    <div className="flex flex-col h-full gap-4 animate-pulse">
+      {/* Header */}
+      <div className="flex items-center gap-2.5">
+        <div className="size-8 rounded-lg bg-gray-200" />
+        <div className="bg-gray-200 rounded h-5 w-32" />
+      </div>
+
+      {/* Info cards */}
+      <div className="rounded-lg border border-gray-200 p-5 space-y-4">
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-md bg-gray-100 px-3 py-2.5 h-14">
+              <div className="bg-gray-200 rounded h-2.5 w-16 mb-2" />
+              <div className="bg-gray-200 rounded h-3.5 w-24" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Market Rental Fee section */}
+      <div className="rounded-lg border border-gray-200 p-5 space-y-5">
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-md bg-gray-100 px-4 py-3 h-16">
+              <div className="bg-gray-200 rounded h-2.5 w-20 mb-2" />
+              <div className="bg-gray-200 rounded h-5 w-28" />
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-gray-200" />
+        <div className="space-y-3">
+          <div className="bg-gray-200 rounded h-3.5 w-40" />
+          <div className="flex gap-2">
+            <div className="bg-gray-200 rounded-full h-7 w-20" />
+            <div className="bg-gray-200 rounded-full h-7 w-16" />
+          </div>
+          <div className="flex gap-3 items-end">
+            <div className="bg-gray-100 rounded h-9 w-24" />
+            <div className="bg-gray-200 rounded h-3 w-10" />
+            <div className="bg-gray-100 rounded h-9 w-24" />
+          </div>
+        </div>
+      </div>
+
+      {/* Discount Rate + Generate */}
+      <div className="flex items-end justify-between">
+        <div className="bg-gray-100 rounded h-14 w-40" />
+        <div className="bg-gray-200 rounded h-8 w-24" />
+      </div>
+
+      {/* Table skeleton */}
+      <TableSkeleton />
+
+      {/* Estimate Price */}
+      <div className="rounded-lg border border-gray-200 p-4 flex items-center justify-between">
+        <div className="bg-gray-200 rounded h-4 w-36" />
+        <div className="bg-gray-100 rounded h-9 w-64" />
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton loader for the table */
+function TableSkeleton() {
+  return (
+    <div className="animate-pulse space-y-0 border border-gray-200 rounded-lg overflow-hidden">
+      <div className="bg-gray-100 h-9 flex items-center px-3">
+        <div className="bg-gray-300 rounded h-3 w-16" />
+        <div className="flex gap-6 ml-auto">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="bg-gray-300 rounded h-3 w-12" />
+          ))}
+        </div>
+      </div>
+      {Array.from({ length: 8 }).map((_, row) => (
+        <div key={row} className="h-8 flex items-center px-3 border-t border-gray-100">
+          <div className="bg-gray-200 rounded h-3 w-32" />
+          <div className="flex gap-6 ml-auto">
+            {Array.from({ length: 6 }).map((_, col) => (
+              <div key={col} className="bg-gray-200 rounded h-3 w-16" />
+            ))}
+          </div>
+        </div>
+      ))}
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className={`h-9 flex items-center px-3 border-t border-gray-200 ${i >= 1 ? 'bg-green-50' : 'bg-gray-50'}`}>
+          <div className="bg-gray-300 rounded h-3 w-40" />
+          <div className="ml-auto bg-gray-300 rounded h-3 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/RemarkSection.tsx
+++ b/src/features/pricingAnalysis/components/RemarkSection.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Icon } from '@/shared/components';
+import type { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+
+interface RemarkSectionProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setValue: UseFormSetValue<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  watch: UseFormWatch<any>;
+}
+
+export function RemarkSection({ setValue, watch }: RemarkSectionProps) {
+  const remark = watch('remark') ?? '';
+  const hasContent = remark.trim().length > 0;
+  const [expanded, setExpanded] = useState(hasContent);
+
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-50 hover:bg-gray-100 transition-colors text-left"
+      >
+        <div className="flex items-center gap-2">
+          <Icon name="note-sticky" className="size-3.5 text-gray-500" />
+          <span className="text-xs font-semibold text-gray-700">Notes & Assumptions</span>
+          {hasContent && !expanded && (
+            <span className="text-[10px] text-gray-400 truncate max-w-[200px]">
+              — {remark.slice(0, 50)}{remark.length > 50 ? '...' : ''}
+            </span>
+          )}
+        </div>
+        <Icon
+          name="chevron-down"
+          className={`size-3 text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {expanded && (
+        <div className="px-4 py-3 border-t border-gray-100">
+          <textarea
+            value={remark}
+            onChange={(e) => setValue('remark', e.target.value || null, { shouldDirty: true })}
+            placeholder="Document your assumptions, rationale for growth rates, discount rate justification, or any adjustments made..."
+            className="w-full text-xs text-gray-700 bg-transparent border border-gray-200 rounded-md px-3 py-2 resize-y min-h-[80px] focus:outline-none focus:ring-1 focus:ring-primary/30 focus:border-primary/40 placeholder:text-gray-400"
+            rows={3}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/components/ScrollableTableContainer.tsx
+++ b/src/features/pricingAnalysis/components/ScrollableTableContainer.tsx
@@ -6,22 +6,20 @@ import clsx from 'clsx';
 interface ScrollableTableContainerProps {
   children: ReactNode;
   className?: string;
+  maxHeight?: string;
 }
 
-export function ScrollableTableContainer({ children, className }: ScrollableTableContainerProps) {
+export function ScrollableTableContainer({ children, className, maxHeight }: ScrollableTableContainerProps) {
   const { t } = useTranslation('common');
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
-  const [buttonTop, setButtonTop] = useState(0);
-
   const updateScrollState = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
     const hasOverflow = el.scrollWidth > el.clientWidth;
     setCanScrollLeft(hasOverflow && el.scrollLeft > 1);
     setCanScrollRight(hasOverflow && el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-    setButtonTop(el.scrollTop + el.clientHeight / 2);
   }, []);
 
   useEffect(() => {
@@ -67,7 +65,7 @@ export function ScrollableTableContainer({ children, className }: ScrollableTabl
   const hasOverflow = canScrollLeft || canScrollRight;
 
   return (
-    <div className={clsx('relative', className)}>
+    <div className={clsx('relative overflow-hidden', className)}>
       {hasOverflow && (
         <div className="flex justify-end px-2 py-1">
           <span className="text-xs text-gray-400 flex items-center gap-1">
@@ -81,6 +79,7 @@ export function ScrollableTableContainer({ children, className }: ScrollableTabl
       <div
         ref={scrollRef}
         tabIndex={0}
+        style={maxHeight ? { maxHeight } : undefined}
         className="h-full overflow-auto outline-none focus-visible:outline-none"
         onScroll={updateScrollState}
         onKeyDown={handleKeyDown}
@@ -92,8 +91,7 @@ export function ScrollableTableContainer({ children, className }: ScrollableTabl
         <button
           type="button"
           onClick={() => scroll('left')}
-          style={{ top: buttonTop }}
-          className="absolute left-2 -translate-y-1/2 z-40 size-8 rounded-full bg-white/80 shadow-md border border-gray-200 flex items-center justify-center cursor-pointer hover:bg-white hover:shadow-lg transition-all"
+          className="absolute left-2 top-1/2 -translate-y-1/2 z-40 size-8 rounded-full bg-white/80 shadow-md border border-gray-200 flex items-center justify-center cursor-pointer hover:bg-white hover:shadow-lg transition-all"
           aria-label="Scroll left"
         >
           <Icon name="chevron-left" className="size-4 text-gray-600" />
@@ -104,8 +102,7 @@ export function ScrollableTableContainer({ children, className }: ScrollableTabl
         <button
           type="button"
           onClick={() => scroll('right')}
-          style={{ top: buttonTop }}
-          className="absolute right-2 -translate-y-1/2 z-40 size-8 rounded-full bg-white/80 shadow-md border border-gray-200 flex items-center justify-center cursor-pointer hover:bg-white hover:shadow-lg transition-all"
+          className="absolute right-2 top-1/2 -translate-y-1/2 z-40 size-8 rounded-full bg-white/80 shadow-md border border-gray-200 flex items-center justify-center cursor-pointer hover:bg-white hover:shadow-lg transition-all"
           aria-label="Scroll right"
         >
           <Icon name="chevron-right" className="size-4 text-gray-600" />

--- a/src/features/pricingAnalysis/components/SensitivityStrip.tsx
+++ b/src/features/pricingAnalysis/components/SensitivityStrip.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+
+interface SensitivityStripProps {
+  currentRate: number;
+  calculateFinalValue: (rate: number) => number | null;
+}
+
+const fmt = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+};
+
+export function SensitivityStrip({ currentRate, calculateFinalValue }: SensitivityStripProps) {
+  const scenarios = useMemo(() => {
+    const offsets = [-2, -1, 0, 1, 2];
+    const seen = new Set<number>();
+    return offsets
+      .map((offset) => {
+        const rate = Math.round(Math.max(0, currentRate + offset) * 10) / 10;
+        if (seen.has(rate)) return null;
+        seen.add(rate);
+        const value = calculateFinalValue(rate);
+        return { rate, value, offset, isCurrent: offset === 0 };
+      })
+      .filter(Boolean) as { rate: number; value: number | null; offset: number; isCurrent: boolean }[];
+  }, [currentRate, calculateFinalValue]);
+
+  // Don't render if no valid calculations
+  if (scenarios.every((s) => s.value == null)) return null;
+
+  const currentValue = scenarios.find((s) => s.isCurrent)?.value ?? 0;
+
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden">
+      <div className="flex items-center gap-3">
+        <div className="px-3 py-1.5 text-[10px] font-medium text-gray-500 uppercase tracking-wide whitespace-nowrap shrink-0">
+          Discount Rate Sensitivity
+        </div>
+        <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(${scenarios.length}, minmax(0, 1fr))` }}>
+          {scenarios.map((s) => {
+            const diff = currentValue && s.value ? s.value - currentValue : 0;
+            const diffPct = currentValue ? (diff / currentValue) * 100 : 0;
+            return (
+              <div
+                key={s.rate}
+                className={`px-2 py-1.5 text-center border-l border-gray-100 ${
+                  s.isCurrent ? 'bg-primary/5 ring-1 ring-inset ring-primary/20' : ''
+                }`}
+              >
+                <div className={`text-[10px] font-medium mb-0.5 ${s.isCurrent ? 'text-primary' : 'text-gray-500'}`}>
+                  {s.rate.toFixed(1)}%
+                </div>
+                <div className={`text-xs font-bold tabular-nums ${s.isCurrent ? 'text-primary' : 'text-gray-800'}`}>
+                  {s.value != null ? fmt(s.value) : '-'}
+                </div>
+                {!s.isCurrent && diff !== 0 && (
+                  <div className={`text-[9px] mt-0.5 tabular-nums ${diff > 0 ? 'text-green-600' : 'text-red-500'}`}>
+                    {diff > 0 ? '+' : ''}{diffPct.toFixed(1)}%
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pricingAnalysis/domain/calculateLeasehold.ts
+++ b/src/features/pricingAnalysis/domain/calculateLeasehold.ts
@@ -1,0 +1,398 @@
+import type { LandGrowthRateType } from '../types/leasehold';
+import type { RentalScheduleRow } from '@/features/appraisal/api/property';
+
+/**
+ * Round to 2 decimal places.
+ */
+function round2(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * ROUND(value, -3) — round to nearest 1,000.
+ */
+function roundToThousands(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n / 1000) * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Land Value Growth
+// ---------------------------------------------------------------------------
+
+interface LandGrowthPeriodInput {
+  fromYear: number;
+  toYear: number;
+  growthRatePercent: number;
+}
+
+interface LandValueGrowthConfig {
+  baseValue: number;
+  growthType: LandGrowthRateType;
+  /** Used when growthType === 'Frequency' */
+  growthRatePercent: number;
+  /** Used when growthType === 'Frequency' */
+  intervalYears: number;
+  /** Used when growthType === 'Period' */
+  periods: LandGrowthPeriodInput[];
+}
+
+/**
+ * Calculate land value for a given year based on growth configuration.
+ *
+ * - Frequency mode: value grows by `growthRatePercent` every `intervalYears`.
+ * - Period mode: value grows by the rate defined for the period containing `year`.
+ */
+export function calculateLandValueGrowth(
+  config: LandValueGrowthConfig,
+  year: number,
+): number {
+  const { baseValue, growthType, growthRatePercent, intervalYears, periods } = config;
+  if (year <= 0) return round2(baseValue);
+
+  if (growthType === 'Frequency') {
+    const interval = intervalYears > 0 ? intervalYears : 1;
+    const growthSteps = Math.floor(year / interval);
+    return round2(baseValue * Math.pow(1 + growthRatePercent / 100, growthSteps));
+  }
+
+  // Period mode: compound year by year using the rate for each year's period
+  let value = baseValue;
+  for (let y = 1; y <= year; y++) {
+    const period = periods.find((p) => y >= p.fromYear && y <= p.toYear);
+    const rate = period ? period.growthRatePercent / 100 : 0;
+    value = value * (1 + rate);
+  }
+  return round2(value);
+}
+
+// ---------------------------------------------------------------------------
+// Building Depreciation
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate building value after depreciation for a given year.
+ *
+ * @param buildingValue   - Initial building value
+ * @param costIndex       - Construction cost index (%) applied yearly
+ * @param depRate         - Depreciation rate (%) per interval
+ * @param depInterval     - Depreciation interval in years
+ * @param startYear       - Year offset at which building calculation starts
+ * @param year            - The target year to calculate
+ */
+export function calculateBuildingDepreciation(
+  buildingValue: number,
+  costIndex: number,
+  depRate: number,
+  depInterval: number,
+  startYear: number,
+  year: number,
+): number {
+  if (buildingValue <= 0) return 0;
+
+  const effectiveYear = year + startYear;
+  // Adjust building value by cost index
+  const adjustedValue = buildingValue * Math.pow(1 + costIndex / 100, effectiveYear);
+  // Apply compound depreciation (matches backend: Math.Pow(1 - depRate/100, depPeriods))
+  const interval = depInterval > 0 ? depInterval : 1;
+  const depSteps = Math.floor(effectiveYear / interval);
+  const depreciation = Math.pow(1 - depRate / 100, depSteps);
+  const result = adjustedValue * Math.max(depreciation, 0);
+  return round2(result);
+}
+
+// ---------------------------------------------------------------------------
+// Present Value Factor
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate present value factor: 1 / (1 + r)^t
+ *
+ * @param discountRate  - Annual discount rate in percent
+ * @param year          - Number of years
+ */
+export function calculatePVFactor(discountRate: number, year: number): number {
+  if (discountRate <= 0 || year <= 0) return 1;
+  return 1 / Math.pow(1 + discountRate / 100, year);
+}
+
+// ---------------------------------------------------------------------------
+// Partial Usage
+// ---------------------------------------------------------------------------
+
+interface PartialUsageInput {
+  finalValue: number;
+  rai: number;
+  ngan: number;
+  wa: number;
+  pricePerSqWa: number;
+}
+
+/**
+ * Calculate partial land usage deduction.
+ *
+ * Partial land area (Sq.Wa) = rai * 400 + ngan * 100 + wa
+ * Partial land price = partialLandArea * pricePerSqWa
+ * Estimate net price = finalValue - partialLandPrice
+ */
+export function calculatePartialUsage(input: PartialUsageInput) {
+  const { finalValue, rai, ngan, wa, pricePerSqWa } = input;
+  const partialLandArea = round2((rai || 0) * 400 + (ngan || 0) * 100 + (wa || 0));
+  const partialLandPrice = round2(partialLandArea * (pricePerSqWa || 0));
+  const estimateNetPrice = round2(finalValue + partialLandPrice);
+  const estimatePriceRounded = roundToThousands(estimateNetPrice);
+  return { partialLandArea, partialLandPrice, estimateNetPrice, estimatePriceRounded };
+}
+
+// ---------------------------------------------------------------------------
+// Full Table Generation
+// ---------------------------------------------------------------------------
+
+interface LeaseholdTableInput {
+  /** Half-year intervals: [0.5, 1.5, 2.5, ...] */
+  years: number[];
+  landValueConfig: LandValueGrowthConfig;
+  initialBuildingValue: number;
+  constructionCostIndex: number;
+  depreciationRate: number;
+  depreciationIntervalYears: number;
+  buildingCalcStartYear: number;
+  discountRate: number;
+  /** Rental income per period (aligned with years array) */
+  rentalIncomePerPeriod: number[];
+}
+
+export interface LeaseholdTableRow {
+  year: number;
+  landValue: number;
+  landGrowthPercent: number;
+  buildingValue: number;
+  depreciationAmount: number;
+  depreciationPercent: number;
+  buildingAfterDepreciation: number;
+  totalLandAndBuilding: number;
+  rentalIncome: number;
+  pvFactor: number;
+  netCurrentRentalIncome: number;
+}
+
+export interface LeaseholdTableResult {
+  rows: LeaseholdTableRow[];
+  totalIncomeOverLeaseTerm: number;
+  valueAtLeaseExpiry: number;
+  finalValue: number;
+  finalValueRounded: number;
+}
+
+/**
+ * Generate the full leasehold analysis table.
+ *
+ * Each column represents a half-year period. The function calculates:
+ * - Land value growth per period
+ * - Building depreciation per period
+ * - Total property value (land + building after depreciation)
+ * - PV factor and net current rental income
+ * - Summary values (total income, value at expiry, final value)
+ */
+export function generateLeaseholdTable(input: LeaseholdTableInput): LeaseholdTableResult {
+  const {
+    years,
+    landValueConfig,
+    initialBuildingValue,
+    constructionCostIndex,
+    depreciationRate,
+    depreciationIntervalYears,
+    buildingCalcStartYear,
+    discountRate,
+    rentalIncomePerPeriod,
+  } = input;
+
+  // Running building: track prev building value and prev depreciation amount
+  let prevBuildingValue = 0;
+  let prevDepAmount = 0;
+  const depInterval = depreciationIntervalYears > 0 ? depreciationIntervalYears : 1;
+
+  const rows: LeaseholdTableRow[] = years.map((year, i) => {
+    const landValue = calculateLandValueGrowth(landValueConfig, year);
+
+    // Determine land growth % for this period
+    let landGrowthPercent = 0;
+    if (i > 0) {
+      const prevLandValue = calculateLandValueGrowth(landValueConfig, years[i - 1]);
+      if (prevLandValue > 0) {
+        landGrowthPercent = round2(((landValue - prevLandValue) / prevLandValue) * 100);
+      }
+    }
+
+    // buildingCalcStartYear is 1-based column index. e.g. 2 = start from 2nd column (i=1)
+    const showBuilding = initialBuildingValue > 0 && (i + 1) >= buildingCalcStartYear;
+    const isFirstBuildingYear = showBuilding && (i + 1) === buildingCalcStartYear;
+
+    // Building value:
+    // 1st building year: raw initialBuildingValue
+    // subsequent: (prevBuildingValue × (1 + costIndex%)) - prevDepreciationAmount
+    const buildingValue = !showBuilding
+      ? 0
+      : isFirstBuildingYear
+        ? round2(initialBuildingValue)
+        : round2(prevBuildingValue * (1 + constructionCostIndex / 100) - prevDepAmount);
+
+    // Depreciation: flat depreciationRate% of building value, applied every depInterval years
+    const isDepreciationYear = showBuilding && Math.floor(year / depInterval) > Math.floor((year - 1) / depInterval);
+    const depreciationPercent = isDepreciationYear ? depreciationRate : 0;
+    const depreciationAmount = isDepreciationYear ? round2(buildingValue * depreciationRate / 100) : 0;
+    const buildingAfterDepreciation = showBuilding ? round2(buildingValue - depreciationAmount) : 0;
+
+    // Update running values for next iteration
+    if (showBuilding) {
+      prevBuildingValue = buildingValue;
+      prevDepAmount = depreciationAmount;
+    }
+
+    const totalLandAndBuilding = round2(landValue + buildingAfterDepreciation);
+    const rentalIncome = rentalIncomePerPeriod[i] ?? 0;
+    const pvFactor = calculatePVFactor(discountRate, year);
+    const netCurrentRentalIncome = round2(rentalIncome * pvFactor);
+
+    return {
+      year,
+      landValue,
+      landGrowthPercent,
+      buildingValue,
+      depreciationAmount,
+      depreciationPercent,
+      buildingAfterDepreciation,
+      totalLandAndBuilding,
+      rentalIncome,
+      pvFactor,
+      netCurrentRentalIncome,
+    };
+  });
+
+  const totalIncomeOverLeaseTerm = round2(
+    rows.reduce((sum, r) => sum + r.netCurrentRentalIncome, 0),
+  );
+
+  const lastRow = rows[rows.length - 1];
+  const valueAtLeaseExpiry = lastRow
+    ? round2(lastRow.totalLandAndBuilding * lastRow.pvFactor)
+    : 0;
+
+  const finalValue = round2(totalIncomeOverLeaseTerm + valueAtLeaseExpiry);
+  const finalValueRounded = roundToThousands(finalValue);
+
+  return {
+    rows,
+    totalIncomeOverLeaseTerm,
+    valueAtLeaseExpiry,
+    finalValue,
+    finalValueRounded,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Appraisal Schedule (re-indexed from appraisal date)
+// ---------------------------------------------------------------------------
+
+export interface AppraisalScheduleRow {
+  year: number;
+  contractStart: string;
+  contractEnd: string;
+  totalAmount: number;
+}
+
+/**
+ * DAYS360 calculation (US/NASD method) — same as Excel's DAYS360.
+ * Treats each month as 30 days, each year as 360 days.
+ */
+export function days360Between(start: Date, end: Date): number {
+  const d1 = Math.min(start.getDate(), 30);
+  let d2 = end.getDate();
+  if (d1 === 30) d2 = Math.min(d2, 30);
+
+  const m1 = start.getMonth() + 1;
+  const m2 = end.getMonth() + 1;
+  const y1 = start.getFullYear();
+  const y2 = end.getFullYear();
+
+  return (y2 - y1) * 360 + (m2 - m1) * 30 + (d2 - d1);
+}
+
+/**
+ * Compute appraisal schedule from contract schedule + appraisal date.
+ *
+ * 1. Find which contract row the appraisal date falls into
+ * 2. Calculate remaining fraction using DAYS360: ROUND((DAYS360(appraisalDate, contractEnd) + 1) / 360, 1)
+ * 3. First row: year=fraction, start=appraisalDate, end=contractEnd, amount=fraction×totalAmount
+ * 4. Subsequent rows: year increments by 1, full amounts, original contract dates
+ *
+ * Returns the schedule rows and the index in contractSchedule where it starts (for row alignment).
+ */
+export function computeAppraisalSchedule(
+  contractRows: RentalScheduleRow[],
+  appraisalDate: string,
+): { rows: AppraisalScheduleRow[]; startIdx: number } {
+  if (!contractRows.length || !appraisalDate) return { rows: [], startIdx: -1 };
+
+  const appraisal = new Date(appraisalDate);
+
+  // Find the contract row that contains the appraisal date
+  let startIdx = -1;
+  for (let i = 0; i < contractRows.length; i++) {
+    const start = new Date(contractRows[i].contractStart);
+    const end = new Date(contractRows[i].contractEnd);
+    if (appraisal >= start && appraisal <= end) {
+      startIdx = i;
+      break;
+    }
+  }
+
+  // Appraisal date is before contract starts
+  if (startIdx === -1) {
+    const firstStart = new Date(contractRows[0].contractStart);
+    if (appraisal < firstStart) {
+      const result: AppraisalScheduleRow[] = [];
+      for (let i = 0; i < contractRows.length; i++) {
+        const row = contractRows[i];
+        result.push({
+          year: i + 1,
+          contractStart: i === 0 ? appraisalDate : row.contractStart,
+          contractEnd: row.contractEnd,
+          totalAmount: row.totalAmount,
+        });
+      }
+      return { rows: result, startIdx: 0 };
+    }
+    return { rows: [], startIdx: -1 };
+  }
+
+  // Appraisal date falls within a contract period
+  const result: AppraisalScheduleRow[] = [];
+  const firstRow = contractRows[startIdx];
+  const periodEnd = new Date(firstRow.contractEnd);
+
+  const days360 = days360Between(appraisal, periodEnd);
+  const fraction = Math.round(((days360 + 1) / 360) * 10) / 10;
+
+  if (fraction > 0) {
+    result.push({
+      year: fraction,
+      contractStart: appraisalDate,
+      contractEnd: firstRow.contractEnd,
+      totalAmount: firstRow.totalAmount * fraction,
+    });
+  }
+
+  for (let i = startIdx + 1; i < contractRows.length; i++) {
+    const row = contractRows[i];
+    result.push({
+      year: fraction + (i - startIdx),
+      contractStart: row.contractStart,
+      contractEnd: row.contractEnd,
+      totalAmount: row.totalAmount,
+    });
+  }
+
+  return { rows: result, startIdx };
+}

--- a/src/features/pricingAnalysis/domain/calculateProfitRent.ts
+++ b/src/features/pricingAnalysis/domain/calculateProfitRent.ts
@@ -1,0 +1,177 @@
+import type { GrowthRateType, ProfitRentGrowthPeriod } from '../types/profitRent';
+import { calculatePVFactor, computeAppraisalSchedule, type AppraisalScheduleRow } from './calculateLeasehold';
+import type { RentalScheduleRow } from '@/features/appraisal/api/property';
+
+function round2(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function roundToThousands(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n / 1000) * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Market Fee Growth
+// ---------------------------------------------------------------------------
+
+interface MarketFeeGrowthConfig {
+  baseFee: number;
+  growthType: GrowthRateType;
+  growthRatePercent: number;
+  intervalYears: number;
+  periods: ProfitRentGrowthPeriod[];
+}
+
+function calculateMarketFeeGrowth(config: MarketFeeGrowthConfig, year: number): number {
+  const { baseFee, growthType, growthRatePercent, intervalYears, periods } = config;
+  if (baseFee <= 0) return 0;
+
+  if (growthType === 'Frequency') {
+    const interval = intervalYears > 0 ? intervalYears : 1;
+    const steps = Math.floor(year / interval);
+    return round2(baseFee * Math.pow(1 + growthRatePercent / 100, steps));
+  }
+
+  // Period mode
+  let value = baseFee;
+  for (let y = 1; y <= Math.floor(year); y++) {
+    const period = periods.find((p) => y >= p.fromYear && y <= p.toYear);
+    const rate = period ? period.growthRatePercent / 100 : 0;
+    value = value * (1 + rate);
+  }
+  return round2(value);
+}
+
+// ---------------------------------------------------------------------------
+// Table Generation
+// ---------------------------------------------------------------------------
+
+export interface ProfitRentTableRow {
+  year: number;
+  numberOfMonths: number;
+  contractStart: string;
+  contractEnd: string;
+  marketRentalFeePerSqWa: number;
+  marketRentalFeeGrowthPercent: number;
+  marketRentalFeePerMonth: number;
+  marketRentalFeePerYear: number;
+  contractRentalFeePerYear: number;
+  returnsFromLease: number;
+  pvFactor: number;
+  presentValue: number;
+}
+
+export interface ProfitRentTableResult {
+  rows: ProfitRentTableRow[];
+  totalMarketRentalFee: number;
+  totalContractRentalFee: number;
+  totalReturnsFromLease: number;
+  totalPresentValue: number;
+  finalValueRounded: number;
+}
+
+interface ProfitRentTableInput {
+  appraisalSchedule: AppraisalScheduleRow[];
+  landAreaSqWa: number;
+  marketRentalFeePerSqWa: number;
+  growthRateType: GrowthRateType;
+  growthRatePercent: number;
+  growthIntervalYears: number;
+  growthPeriods: ProfitRentGrowthPeriod[];
+  discountRate: number;
+}
+
+export function generateProfitRentTable(input: ProfitRentTableInput): ProfitRentTableResult {
+  const {
+    appraisalSchedule,
+    landAreaSqWa,
+    marketRentalFeePerSqWa,
+    growthRateType,
+    growthRatePercent,
+    growthIntervalYears,
+    growthPeriods,
+    discountRate,
+  } = input;
+
+  if (appraisalSchedule.length === 0) {
+    return { rows: [], totalMarketRentalFee: 0, totalContractRentalFee: 0, totalReturnsFromLease: 0, totalPresentValue: 0, finalValueRounded: 0 };
+  }
+
+  const config: MarketFeeGrowthConfig = {
+    baseFee: marketRentalFeePerSqWa,
+    growthType: growthRateType,
+    growthRatePercent,
+    intervalYears: growthIntervalYears,
+    periods: growthPeriods,
+  };
+
+  let prevFeePerSqWa = 0;
+  let totalMarket = 0;
+  let totalContract = 0;
+  let totalReturns = 0;
+  let totalPV = 0;
+
+  const rows: ProfitRentTableRow[] = appraisalSchedule.map((schedRow, i) => {
+    const year = schedRow.year;
+    const isFirstRow = i === 0 && year < 1;
+    const numberOfMonths = isFirstRow ? round2(year * 12) : 12;
+
+    const feePerSqWa = calculateMarketFeeGrowth(config, year);
+
+    let growthPercent = 0;
+    if (i > 0 && prevFeePerSqWa > 0) {
+      growthPercent = round2(((feePerSqWa - prevFeePerSqWa) / prevFeePerSqWa) * 100);
+    }
+    prevFeePerSqWa = feePerSqWa;
+
+    const marketFeePerMonth = round2(feePerSqWa * landAreaSqWa);
+    const marketFeePerYear = round2(marketFeePerMonth * numberOfMonths);
+    const contractFeePerYear = round2(schedRow.totalAmount);
+    const returnsFromLease = round2(marketFeePerYear - contractFeePerYear);
+    const pvFactor = calculatePVFactor(discountRate, year);
+    const presentValue = round2(returnsFromLease * pvFactor);
+
+    totalMarket += marketFeePerYear;
+    totalContract += contractFeePerYear;
+    totalReturns += returnsFromLease;
+    totalPV += presentValue;
+
+    return {
+      year,
+      numberOfMonths,
+      contractStart: schedRow.contractStart,
+      contractEnd: schedRow.contractEnd,
+      marketRentalFeePerSqWa: feePerSqWa,
+      marketRentalFeeGrowthPercent: growthPercent,
+      marketRentalFeePerMonth: marketFeePerMonth,
+      marketRentalFeePerYear: marketFeePerYear,
+      contractRentalFeePerYear: contractFeePerYear,
+      returnsFromLease,
+      pvFactor,
+      presentValue,
+    };
+  });
+
+  return {
+    rows,
+    totalMarketRentalFee: round2(totalMarket),
+    totalContractRentalFee: round2(totalContract),
+    totalReturnsFromLease: round2(totalReturns),
+    totalPresentValue: round2(totalPV),
+    finalValueRounded: roundToThousands(totalPV),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Schedule builder for ProfitRent (reuses computeAppraisalSchedule from leasehold)
+// ---------------------------------------------------------------------------
+
+export function computeProfitRentSchedule(
+  contractRows: RentalScheduleRow[],
+  appraisalDate: string,
+): AppraisalScheduleRow[] {
+  const { rows } = computeAppraisalSchedule(contractRows, appraisalDate);
+  return rows;
+}

--- a/src/features/pricingAnalysis/domain/formatters.ts
+++ b/src/features/pricingAnalysis/domain/formatters.ts
@@ -1,0 +1,27 @@
+/** Format number with 2 decimal places and thousands separator */
+export const fmt = (n: number | null | undefined): string => {
+  if (n == null || !Number.isFinite(n)) return '-';
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+};
+
+/** Format number in compact form: 11.2M, 500K, etc. */
+export const fmtCompact = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+};
+
+/** Format date string as DD/MM/YYYY */
+export function formatDateOnly(dateStr: string): string {
+  const d = new Date(dateStr);
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
+}
+
+/** Safe number conversion — returns 0 for non-finite values */
+export const toNum = (v: unknown): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};

--- a/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
+++ b/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
@@ -350,6 +350,7 @@ function PricingAnalysisContent({
                         <MethodSectionRenderer
                           state={state}
                           serverData={serverData}
+                          appraisalId={appraisalId}
                           calculationMethodData={calculationMethodData}
                           onCalculationSave={calcFlow.onCalculationSave}
                           onCalculationMethodDirty={handleOnCalculationMethodDirty}

--- a/src/features/pricingAnalysis/schemas/index.ts
+++ b/src/features/pricingAnalysis/schemas/index.ts
@@ -144,3 +144,6 @@ export type TemplateDetailType = z.infer<typeof TemplateDetailDto>;
 export type GetPricingTemplatesByMethodResponseType = z.infer<
   typeof GetPricingTemplateByMethodResponse
 >;
+
+// -- Leasehold Analysis --
+export { LeaseholdFormSchema, type LeaseholdFormType, type LandGrowthPeriodFormType } from './leaseholdForm';

--- a/src/features/pricingAnalysis/schemas/leaseholdForm.ts
+++ b/src/features/pricingAnalysis/schemas/leaseholdForm.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+const requireMsg = (fieldName: string, msg: string = 'is required.') => ({
+  required_error: `${fieldName} ${msg}`,
+  invalid_type_error: `${fieldName} ${msg}`,
+});
+
+const LandGrowthPeriodSchema = z.object({
+  id: z.string().optional(),
+  fromYear: z.number(requireMsg('From year')).min(0),
+  toYear: z.number(requireMsg('To year')).min(0),
+  growthRatePercent: z.number(requireMsg('Growth rate')),
+});
+
+/** Coerce null/undefined to 0 for number fields set by RHFInputCell */
+const num = z.coerce.number().default(0);
+
+export const LeaseholdFormSchema = z
+  .object({
+    landValuePerSqWa: num,
+    landGrowthRateType: z.enum(['Frequency', 'Period']).default('Frequency'),
+    landGrowthRatePercent: num,
+    landGrowthIntervalYears: z.coerce.number().default(1),
+    constructionCostIndex: num,
+    initialBuildingValue: num,
+    depreciationRate: num,
+    depreciationIntervalYears: z.coerce.number().default(1),
+    buildingCalcStartYear: num,
+    discountRate: num,
+    landGrowthPeriods: z.array(LandGrowthPeriodSchema).default([]),
+    isPartialUsage: z.boolean().default(false),
+    partialRai: z.number().nullable().default(null),
+    partialNgan: z.number().nullable().default(null),
+    partialWa: z.number().nullable().default(null),
+    pricePerSqWa: z.number().nullable().default(null),
+    estimatePriceRounded: z.number().nullable().default(null),
+    remark: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export type LeaseholdFormType = z.infer<typeof LeaseholdFormSchema>;
+export type LandGrowthPeriodFormType = z.infer<typeof LandGrowthPeriodSchema>;
+
+export const leaseholdFormDefaults: LeaseholdFormType = {
+  landValuePerSqWa: 0,
+  landGrowthRateType: 'Frequency',
+  landGrowthRatePercent: 0,
+  landGrowthIntervalYears: 1,
+  constructionCostIndex: 0,
+  initialBuildingValue: 0,
+  depreciationRate: 0,
+  depreciationIntervalYears: 1,
+  buildingCalcStartYear: 0,
+  discountRate: 0,
+  landGrowthPeriods: [],
+  isPartialUsage: false,
+  partialRai: null,
+  partialNgan: null,
+  partialWa: null,
+  pricePerSqWa: null,
+  estimatePriceRounded: null,
+  remark: null,
+};

--- a/src/features/pricingAnalysis/schemas/profitRentForm.ts
+++ b/src/features/pricingAnalysis/schemas/profitRentForm.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const GrowthPeriodSchema = z.object({
+  id: z.string().optional(),
+  fromYear: z.number().min(0),
+  toYear: z.number().min(0),
+  growthRatePercent: z.number(),
+});
+
+const num = z.coerce.number().default(0);
+
+export const ProfitRentFormSchema = z.object({
+  marketRentalFeePerSqWa: num,
+  growthRateType: z.enum(['Frequency', 'Period']).default('Frequency'),
+  growthRatePercent: num,
+  growthIntervalYears: z.coerce.number().default(1),
+  discountRate: num,
+  includeBuildingCost: z.boolean().default(false),
+  growthPeriods: z.array(GrowthPeriodSchema).default([]),
+  estimatePriceRounded: z.number().nullable().default(null),
+  totalBuildingCost: z.number().nullable().default(null),
+  appraisalPriceWithBuilding: z.number().nullable().default(null),
+  appraisalPriceWithBuildingRounded: z.number().nullable().default(null),
+  remark: z.string().nullable().optional(),
+});
+
+export type ProfitRentFormType = z.infer<typeof ProfitRentFormSchema>;
+export type GrowthPeriodFormType = z.infer<typeof GrowthPeriodSchema>;
+
+export const profitRentFormDefaults: ProfitRentFormType = {
+  marketRentalFeePerSqWa: 0,
+  growthRateType: 'Frequency',
+  growthRatePercent: 0,
+  growthIntervalYears: 1,
+  discountRate: 0,
+  includeBuildingCost: false,
+  growthPeriods: [],
+  estimatePriceRounded: null,
+  totalBuildingCost: null,
+  appraisalPriceWithBuilding: null,
+  appraisalPriceWithBuildingRounded: null,
+  remark: null,
+};

--- a/src/features/pricingAnalysis/types/leasehold.ts
+++ b/src/features/pricingAnalysis/types/leasehold.ts
@@ -1,0 +1,87 @@
+export type LandGrowthRateType = 'Frequency' | 'Period';
+
+export interface LandGrowthPeriod {
+  id?: string;
+  fromYear: number;
+  toYear: number;
+  growthRatePercent: number;
+}
+
+export interface LeaseholdAnalysis {
+  id: string;
+  pricingMethodId: string;
+  landValuePerSqWa: number;
+  landGrowthRateType: LandGrowthRateType;
+  landGrowthRatePercent: number;
+  landGrowthIntervalYears: number;
+  constructionCostIndex: number;
+  initialBuildingValue: number;
+  depreciationRate: number;
+  depreciationIntervalYears: number;
+  buildingCalcStartYear: number;
+  discountRate: number;
+  totalIncomeOverLeaseTerm: number;
+  valueAtLeaseExpiry: number;
+  finalValue: number;
+  finalValueRounded: number;
+  isPartialUsage: boolean;
+  partialRai: number | null;
+  partialNgan: number | null;
+  partialWa: number | null;
+  partialLandArea: number | null;
+  pricePerSqWa: number | null;
+  partialLandPrice: number | null;
+  estimateNetPrice: number | null;
+  estimatePriceRounded: number | null;
+  landGrowthPeriods: LandGrowthPeriod[];
+  calculationDetails: LeaseholdCalculationDetail[];
+}
+
+export interface LeaseholdCalculationDetail {
+  year: number;
+  landValue: number;
+  landGrowthPercent: number;
+  buildingValue: number;
+  depreciationAmount: number;
+  depreciationPercent: number;
+  buildingAfterDepreciation: number;
+  totalLandAndBuilding: number;
+  rentalIncome: number;
+  pvFactor: number;
+  netCurrentRentalIncome: number;
+}
+
+export interface GetLeaseholdAnalysisResponse {
+  analysis: LeaseholdAnalysis | null;
+  remark: string | null;
+}
+
+export interface SaveLeaseholdAnalysisRequest {
+  landValuePerSqWa: number;
+  landGrowthRateType: LandGrowthRateType;
+  landGrowthRatePercent: number;
+  landGrowthIntervalYears: number;
+  constructionCostIndex: number;
+  initialBuildingValue: number;
+  depreciationRate: number;
+  depreciationIntervalYears: number;
+  buildingCalcStartYear: number;
+  discountRate: number;
+  landGrowthPeriods: Omit<LandGrowthPeriod, 'id'>[];
+  isPartialUsage: boolean;
+  partialRai: number | null;
+  partialNgan: number | null;
+  partialWa: number | null;
+  pricePerSqWa: number | null;
+  estimatePriceRounded?: number | null;
+  remark?: string | null;
+}
+
+export interface SaveLeaseholdAnalysisResponse {
+  pricingAnalysisId: string;
+  methodId: string;
+  totalIncomeOverLeaseTerm: number;
+  valueAtLeaseExpiry: number;
+  finalValue: number;
+  finalValueRounded: number;
+}

--- a/src/features/pricingAnalysis/types/profitRent.ts
+++ b/src/features/pricingAnalysis/types/profitRent.ts
@@ -1,0 +1,74 @@
+export type GrowthRateType = 'Frequency' | 'Period';
+
+export interface ProfitRentGrowthPeriod {
+  id?: string;
+  fromYear: number;
+  toYear: number;
+  growthRatePercent: number;
+}
+
+export interface ProfitRentCalculationDetail {
+  year: number;
+  numberOfMonths: number;
+  marketRentalFeePerSqWa: number;
+  marketRentalFeeGrowthPercent: number;
+  marketRentalFeePerMonth: number;
+  marketRentalFeePerYear: number;
+  contractRentalFeePerYear: number;
+  returnsFromLease: number;
+  pvFactor: number;
+  presentValue: number;
+}
+
+export interface ProfitRentAnalysis {
+  id: string;
+  pricingMethodId: string;
+  marketRentalFeePerSqWa: number;
+  growthRateType: GrowthRateType;
+  growthRatePercent: number;
+  growthIntervalYears: number;
+  discountRate: number;
+  includeBuildingCost: boolean;
+  totalMarketRentalFee: number;
+  totalContractRentalFee: number;
+  totalReturnsFromLease: number;
+  totalPresentValue: number;
+  finalValueRounded: number;
+  estimatePriceRounded: number | null;
+  totalBuildingCost: number | null;
+  appraisalPriceWithBuilding: number | null;
+  appraisalPriceWithBuildingRounded: number | null;
+  growthPeriods: ProfitRentGrowthPeriod[];
+  calculationDetails: ProfitRentCalculationDetail[];
+}
+
+export interface GetProfitRentAnalysisResponse {
+  analysis: ProfitRentAnalysis | null;
+  remark: string | null;
+}
+
+export interface SaveProfitRentAnalysisRequest {
+  marketRentalFeePerSqWa: number;
+  growthRateType: GrowthRateType;
+  growthRatePercent: number;
+  growthIntervalYears: number;
+  discountRate: number;
+  includeBuildingCost: boolean;
+  growthPeriods?: Omit<ProfitRentGrowthPeriod, 'id'>[];
+  remark?: string | null;
+  estimatePriceRounded?: number | null;
+  appraisalPriceWithBuildingRounded?: number | null;
+}
+
+export interface SaveProfitRentAnalysisResponse {
+  pricingAnalysisId: string;
+  methodId: string;
+  totalMarketRentalFee: number;
+  totalContractRentalFee: number;
+  totalReturnsFromLease: number;
+  totalPresentValue: number;
+  finalValueRounded: number;
+  totalBuildingCost: number | null;
+  appraisalPriceWithBuilding: number | null;
+  appraisalPriceWithBuildingRounded: number | null;
+}


### PR DESCRIPTION
## Summary
- New \`LeaseholdPanel\` and \`ProfitRentPanel\` with supporting tables, charts, modals, and KPI/sensitivity strips
- Domain calculations: \`calculateLeasehold\`, \`calculateProfitRent\`, shared \`formatters\`
- Form schemas, adapters, and types for both methods
- New \`useGet/useSave\` hooks for leasehold and profit-rent analyses, query key entries, and \`MethodSectionRenderer\` wiring

## Test plan
- [ ] Open a pricing analysis and switch to the leasehold method; verify data loads, edits persist, and recalculation reflects in chart/KPIs
- [ ] Same for profit rent
- [ ] Validate land-value and rental-info modals on leasehold panel
- [ ] Confirm sensitivity strip + lease timeline render with realistic inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)