### PR TITLE
Refine property tabs and construction inspection

### DIFF
--- a/src/features/appraisal/api/property.ts
+++ b/src/features/appraisal/api/property.ts
@@ -202,6 +202,57 @@ export const useGetLandAndBuildingPropertyById = (appraisalId: string, propertyI
   });
 };
 
+export const useGetLeaseAgreementLandPropertyById = (appraisalId: string, propertyId?: string) => {
+  return useQuery({
+    queryKey: ['appraisals', appraisalId, 'lease-agreement-land-properties', propertyId],
+    enabled: !!appraisalId && !!propertyId,
+    queryFn: async (): Promise<GetLandPropertyResponseType> => {
+      const { data } = await axios.get(
+        `/appraisals/${appraisalId}/properties/${propertyId}/lease-agreement-land-detail`,
+      );
+      return data;
+    },
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 404) return false;
+      return failureCount < 3;
+    },
+  });
+};
+
+export const useGetLeaseAgreementBuildingPropertyById = (appraisalId: string, propertyId?: string) => {
+  return useQuery({
+    queryKey: ['appraisals', appraisalId, 'lease-agreement-building-properties', propertyId],
+    enabled: !!appraisalId && !!propertyId,
+    queryFn: async (): Promise<GetBuildingPropertyResponseType> => {
+      const { data } = await axios.get(
+        `/appraisals/${appraisalId}/properties/${propertyId}/lease-agreement-building-detail`,
+      );
+      return data;
+    },
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 404) return false;
+      return failureCount < 3;
+    },
+  });
+};
+
+export const useGetLeaseAgreementLandAndBuildingPropertyById = (appraisalId: string, propertyId?: string) => {
+  return useQuery({
+    queryKey: ['appraisals', appraisalId, 'lease-agreement-land-and-building-properties', propertyId],
+    enabled: !!appraisalId && !!propertyId,
+    queryFn: async (): Promise<GetLandAndBuildingPropertyResponseType> => {
+      const { data } = await axios.get(
+        `/appraisals/${appraisalId}/properties/${propertyId}/lease-agreement-land-building-detail`,
+      );
+      return data;
+    },
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 404) return false;
+      return failureCount < 3;
+    },
+  });
+};
+
 export const useGetMachineryPropertyById = (appraisalId: string, propertyId?: string) => {
   return useQuery({
     queryKey: ['appraisals', appraisalId, 'machinery-properties', propertyId],
@@ -430,7 +481,7 @@ export interface UpdateLeaseAgreementRequest {
 
 export interface UpFrontEntryDto {
   id: string;
-  atYear: number;
+  atYear: string;
   upFrontAmount: number;
 }
 
@@ -455,6 +506,8 @@ export interface RentalInfoResponse {
   growthIntervalYears: number;
   upFrontEntries: UpFrontEntryDto[];
   growthPeriodEntries: GrowthPeriodEntryDto[];
+  scheduleEntries: RentalScheduleRow[];
+  scheduleOverrides: { year: number; upFront?: number; contractRentalFee?: number }[];
 }
 
 export interface UpdateRentalInfoRequest {

--- a/src/features/appraisal/api/propertyGroup.ts
+++ b/src/features/appraisal/api/propertyGroup.ts
@@ -29,18 +29,7 @@ export const propertyGroupKeys = {
 
 // ==================== Type-to-Endpoint Mapping ====================
 
-const typeToDetailEndpoint: Record<string, string> = {
-  'Lands': 'land-detail',
-  'Lease Agreement Lands': 'lease-agreement-land-detail',
-  'Building': 'building-detail',
-  'Lease Agreement Building': 'lease-agreement-building-detail',
-  'Land and building': 'land-and-building-detail',
-  'Lease Agreement Land and building': 'lease-agreement-land-building-detail',
-  'Condominium': 'condo-detail',
-  'Machine': 'machinery-detail',
-  'Vehicle': 'vehicle-detail',
-  'Vessel': 'vessel-detail',
-};
+import { getDetailEndpoint } from '../utils/propertyTypeConfig';
 
 // ==================== Property Group CRUD ====================
 
@@ -337,7 +326,7 @@ export const useGetPropertyDetail = (
   propertyId: string | undefined,
   propertyType: PropertyType | string | undefined,
 ) => {
-  const endpoint = propertyType ? typeToDetailEndpoint[propertyType] : undefined;
+  const endpoint = propertyType ? getDetailEndpoint(propertyType) : undefined;
 
   return useQuery({
     queryKey: propertyGroupKeys.propertyDetail(appraisalId!, propertyId!),

--- a/src/features/appraisal/components/360/PropertyDetailSlideOver.tsx
+++ b/src/features/appraisal/components/360/PropertyDetailSlideOver.tsx
@@ -6,6 +6,7 @@ import Icon from '@/shared/components/Icon';
 import ParameterDisplay from '@/shared/components/ParameterDisplay';
 import type { PropertyType } from '../../types';
 import { getSectionsForType, type FieldDef } from './propertyDetailFieldConfigs';
+import { getDetailEndpoint } from '../../utils/propertyTypeConfig';
 
 interface PropertyDetailSlideOverProps {
   appraisalId: string;
@@ -15,31 +16,11 @@ interface PropertyDetailSlideOverProps {
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
-const LAND_CONFIG = { detailPath: 'land-detail', queryKey: 'land-properties' };
-const BUILDING_CONFIG = { detailPath: 'building-detail', queryKey: 'building-properties' };
-const CONDO_CONFIG = { detailPath: 'condo-detail', queryKey: 'condo-properties' };
-const LAND_BUILDING_CONFIG = { detailPath: 'land-and-building-detail', queryKey: 'land-and-building-properties' };
-const MACHINERY_CONFIG = { detailPath: 'machinery-detail', queryKey: 'machinery-properties' };
-
-const PROPERTY_TYPE_CONFIG: Record<string, { detailPath: string; queryKey: string }> = {
-  Lands: LAND_CONFIG,
-  Building: BUILDING_CONFIG,
-  Condominium: CONDO_CONFIG,
-  'Land and building': LAND_BUILDING_CONFIG,
-  'Lease Agreement Lands': LAND_CONFIG,
-  'Lease Agreement Building': BUILDING_CONFIG,
-  'Lease Agreement Land and building': LAND_BUILDING_CONFIG,
-  Machine: MACHINERY_CONFIG,
-  Vehicle: MACHINERY_CONFIG,
-  Vessel: MACHINERY_CONFIG,
-  L: LAND_CONFIG,
-  B: BUILDING_CONFIG,
-  U: CONDO_CONFIG,
-  LB: LAND_BUILDING_CONFIG,
-  M: MACHINERY_CONFIG,
-};
-
-const DEFAULT_CONFIG = { detailPath: 'land-detail', queryKey: 'land-properties' };
+function getConfig(propertyType: string) {
+  const detailPath = getDetailEndpoint(propertyType) ?? 'land-detail';
+  const queryKey = detailPath.replace('-detail', '-properties');
+  return { detailPath, queryKey };
+}
 
 function formatNumber(value: unknown, decimalPlaces?: number): string {
   const num = Number(value);
@@ -62,7 +43,7 @@ const PropertyDetailSlideOver = ({
   propertyId,
   propertyType,
 }: PropertyDetailSlideOverProps) => {
-  const config = PROPERTY_TYPE_CONFIG[propertyType] || DEFAULT_CONFIG;
+  const config = getConfig(propertyType);
 
   // Use the same query key pattern as existing hooks in api/property.ts
   const { data, isLoading, error } = useQuery({

--- a/src/features/appraisal/components/PropertyCard.tsx
+++ b/src/features/appraisal/components/PropertyCard.tsx
@@ -7,29 +7,9 @@ import type { PropertyItem } from '../types';
 import Icon from '@shared/components/Icon';
 import { PropertyCardContent } from './PropertyCardContent';
 import { usePropertyBasePath } from '../hooks/usePropertyBasePath';
+import { getRouteSegment as getRouteSegmentFromConfig } from '../utils/propertyTypeConfig';
 
-// Map property type to route a segment
-const getRouteSegment = (type: string): string => {
-  const typeMap: Record<string, string> = {
-    Building: 'building',
-    Condominium: 'condo',
-    'Land and building': 'land-building',
-    Lands: 'land',
-    Machinery: 'machinery',
-    'Lease Agreement Building': 'lease-building',
-    'Lease Agreement Land and building': 'lease-land-building',
-    'Lease Agreement Lands': 'lease-land',
-    LSL: 'lease-land',
-    LSB: 'lease-building',
-    LS: 'lease-land-building',
-    L: 'land',
-    B: 'building',
-    LB: 'land-building',
-    U: 'condo',
-    MAC: 'machinery',
-  };
-  return typeMap[type] || 'land';
-};
+const getRouteSegment = (type: string): string => getRouteSegmentFromConfig(type) ?? 'land';
 
 interface PropertyCardProps {
   property: PropertyItem;

--- a/src/features/appraisal/components/PropertyTableRow.tsx
+++ b/src/features/appraisal/components/PropertyTableRow.tsx
@@ -6,24 +6,9 @@ import Icon from '@shared/components/Icon';
 import Badge from '@shared/components/Badge';
 import ParameterDisplay from '@shared/components/ParameterDisplay';
 import { usePropertyBasePath } from '../hooks/usePropertyBasePath';
+import { getRouteSegment as getRouteSegmentFromConfig } from '../utils/propertyTypeConfig';
 
-// Map property type to route segment
-const getRouteSegment = (type: string): string => {
-  const typeMap: Record<string, string> = {
-    Building: 'building',
-    Condominium: 'condo',
-    'Land and building': 'land-building',
-    Lands: 'land',
-    'Lease Agreement Building': 'building',
-    'Lease Agreement Land and building': 'land-building',
-    'Lease Agreement Lands': 'land',
-    L: 'land',
-    B: 'building',
-    LB: 'land-building',
-    U: 'condo',
-  };
-  return typeMap[type] || 'land';
-};
+const getRouteSegment = (type: string): string => getRouteSegmentFromConfig(type) ?? 'land';
 
 interface PropertyTableRowProps {
   property: PropertyItem;

--- a/src/features/appraisal/components/tabs/ConstructionInspectionTab.tsx
+++ b/src/features/appraisal/components/tabs/ConstructionInspectionTab.tsx
@@ -13,38 +13,7 @@ import { mapConstructionInspectionResponseToForm } from '../../utils/mappers';
 import { ConstructionDetailTable } from '../construction/ConstructionDetailTable';
 import { ConstructionSummaryForm } from '../construction/ConstructionSummaryForm';
 import type { PropertyItem } from '../../types';
-
-const BUILDING_TYPES = new Set([
-  'Building',
-  'Land and building',
-  'Lease Agreement Building',
-  'Lease Agreement Land and building',
-  'B',
-  'LB',
-]);
-
-const typeToDetailEndpoint: Record<string, string> = {
-  Building: 'building-detail',
-  'Lease Agreement Building': 'building-detail',
-  'Land and building': 'land-and-building-detail',
-  'Lease Agreement Land and building': 'land-and-building-detail',
-  B: 'building-detail',
-  LB: 'land-and-building-detail',
-};
-
-const getRouteSegment = (type: string): string => {
-  const typeMap: Record<string, string> = {
-    Building: 'building',
-    'Land and building': 'land-building',
-    Lands: 'land',
-    Condominium: 'condo',
-    'Lease Agreement Building': 'building',
-    'Lease Agreement Land and building': 'land-building',
-    B: 'building',
-    LB: 'land-building',
-  };
-  return typeMap[type] || 'building';
-};
+import { isBuildingType, getDetailEndpoint, getRouteSegment } from '../../utils/propertyTypeConfig';
 
 interface ConstructionInspectionTabProps {
   readOnly?: boolean;
@@ -69,7 +38,7 @@ export function ConstructionInspectionTab({ readOnly }: ConstructionInspectionTa
       const found = group.items.find(item => item.id === propertyId);
       if (found) {
         return {
-          buildingProperties: group.items.filter(item => BUILDING_TYPES.has(item.type)),
+          buildingProperties: group.items.filter(item => isBuildingType(item.type)),
           currentProperty: found,
         };
       }
@@ -186,7 +155,7 @@ export function ConstructionInspectionTab({ readOnly }: ConstructionInspectionTa
     setIsCopyOpen(false);
     setIsCopying(true);
     try {
-      const endpoint = typeToDetailEndpoint[source.type] ?? 'building-detail';
+      const endpoint = getDetailEndpoint(source.type) ?? 'building-detail';
       const { data } = await axios.get(
         `/appraisals/${appraisalId}/properties/${source.id}/${endpoint}`,
       );

--- a/src/features/appraisal/components/tabs/PropertiesTab.tsx
+++ b/src/features/appraisal/components/tabs/PropertiesTab.tsx
@@ -34,24 +34,9 @@ import { PropertyContextMenu } from '../PropertyContextMenu';
 import type { PropertyItem } from '../../types';
 import { usePropertyBasePath } from '../../hooks/usePropertyBasePath';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
+import { getRouteSegment as getRouteSegmentFromConfig } from '../../utils/propertyTypeConfig';
 
-// Map property type to route segment
-const getRouteSegment = (type: string): string => {
-  const typeMap: Record<string, string> = {
-    Building: 'building',
-    Condo: 'condo',
-    'Land and building': 'land-building',
-    Lands: 'land',
-    'Lease Agreement Building': 'building',
-    'Lease Agreement Land and building': 'land-building',
-    'Lease Agreement Lands': 'land',
-    L: 'land',
-    B: 'building',
-    LB: 'land-building',
-    U: 'condo',
-  };
-  return typeMap[type] || 'land';
-};
+const getRouteSegment = (type: string): string => getRouteSegmentFromConfig(type) ?? 'land';
 
 // Only measure droppables before a drag starts — prevents ResizeObserver
 // from firing on trivial CSS changes (hover states) and causing re-render loops.


### PR DESCRIPTION
## Summary
- Tweaks to \`PropertyCard\`, \`PropertyTableRow\`, \`PropertyDetailSlideOver\`, and \`PropertiesTab\`
- Updates to \`ConstructionInspectionTab\`
- Adjusts the supporting \`property\` and \`propertyGroup\` API hooks

## Test plan
- [ ] Open the Properties tab; verify cards/rows render and detail slide-over still loads property detail
- [ ] Open the Construction Inspection tab and verify data loads/saves
- [ ] Confirm property group enrichment hook still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)