### PR TITLE
feat(workflow): versioning migration UI

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -42,6 +42,7 @@ import Appraisal360Page from '@/features/appraisal/pages/Appraisal360Page';
 import { ReadOnlyPageWrapper, AppraisalReadOnlyWrapper } from '@shared/contexts/PageReadOnlyContext';
 import WorkflowBuilderPage from '@features/workflowBuilder/pages/WorkflowBuilderPage';
 import WorkflowListPage from '@features/workflowBuilder/pages/WorkflowListPage';
+import MigrateInstancesPage from '@features/workflowBuilder/pages/MigrateInstancesPage';
 import PermissionListPage from '@features/userManagement/pages/PermissionListPage';
 import RoleListPage from '@features/userManagement/pages/RoleListPage';
 import GroupListPage from '@features/userManagement/pages/GroupListPage';
@@ -164,6 +165,10 @@ export const router = createBrowserRouter([
           { index: true, element: <WorkflowListPage /> },
           { path: 'new', element: <WorkflowBuilderPage /> },
           { path: ':workflowId', element: <WorkflowBuilderPage /> },
+          {
+            path: ':workflowId/versions/:targetVersionId/migrate',
+            element: <MigrateInstancesPage />,
+          },
         ],
       },
       // Admin Routes

--- a/src/features/workflowBuilder/api/index.ts
+++ b/src/features/workflowBuilder/api/index.ts
@@ -6,6 +6,11 @@ import type {
   WorkflowDefinitionVersion,
   WorkflowSchema,
   ActivityTypeDefinition,
+  PublishImpactReport,
+  PublishVersionResponse,
+  RunningInstanceSummary,
+  MigrateInstancesRequest,
+  MigrateInstancesResult,
 } from '../types';
 
 // === Activity Types ===
@@ -208,20 +213,39 @@ export function usePublishVersion() {
       definitionId,
       versionId,
       publishedBy,
+      confirmedBreakingChangeHash,
     }: {
       definitionId: string;
       versionId: string;
       publishedBy: string;
+      confirmedBreakingChangeHash?: string;
     }) => {
-      const { data } = await axiosInstance.post<{
-        isSuccess: boolean;
-        version: number;
-        errorMessage: string | null;
-      }>(
-        `/api/workflows/definitions/${definitionId}/versions/${versionId}/publish`,
-        { publishedBy },
-      );
-      return data;
+      try {
+        const { data } = await axiosInstance.post<PublishVersionResponse>(
+          `/api/workflows/definitions/${definitionId}/versions/${versionId}/publish`,
+          { publishedBy, confirmedBreakingChangeHash },
+        );
+        return data;
+      } catch (err: unknown) {
+        // 409 means breaking changes shifted between preview and confirm — surface the new report
+        if (
+          err &&
+          typeof err === 'object' &&
+          'response' in err &&
+          (err as { response?: { status?: number; data?: unknown } }).response
+            ?.status === 409
+        ) {
+          const resp = (
+            err as { response: { data: { impactReport?: PublishImpactReport } } }
+          ).response.data;
+          const conflict = new Error('Breaking changes updated') as Error & {
+            impactReport?: PublishImpactReport;
+          };
+          conflict.impactReport = resp.impactReport;
+          throw conflict;
+        }
+        throw err;
+      }
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
@@ -232,6 +256,62 @@ export function usePublishVersion() {
       });
       queryClient.invalidateQueries({
         queryKey: workflowKeys.definitions(),
+      });
+    },
+  });
+}
+
+export function usePreviewPublish() {
+  return useMutation({
+    mutationFn: async ({
+      definitionId,
+      versionId,
+    }: {
+      definitionId: string;
+      versionId: string;
+    }) => {
+      const { data } = await axiosInstance.post<PublishImpactReport>(
+        `/api/workflows/definitions/${definitionId}/versions/${versionId}/publish/preview`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useListRunningInstances(
+  definitionId: string,
+  options?: { versionId?: string },
+) {
+  return useQuery({
+    queryKey: workflowKeys.runningInstances(definitionId, options?.versionId),
+    queryFn: async () => {
+      const params = options?.versionId ? `?versionId=${options.versionId}` : '';
+      const { data } = await axiosInstance.get<{
+        instances: RunningInstanceSummary[];
+      }>(`/api/workflows/definitions/${definitionId}/instances${params}`);
+      return data.instances;
+    },
+    enabled: !!definitionId && definitionId !== 'new',
+  });
+}
+
+export function useMigrateInstances(
+  definitionId: string,
+  targetVersionId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: MigrateInstancesRequest) => {
+      const { data } = await axiosInstance.post<MigrateInstancesResult>(
+        `/api/workflows/definitions/${definitionId}/versions/${targetVersionId}/migrate`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: workflowKeys.runningInstances(definitionId),
       });
     },
   });

--- a/src/features/workflowBuilder/api/queryKeys.ts
+++ b/src/features/workflowBuilder/api/queryKeys.ts
@@ -8,4 +8,10 @@ export const workflowKeys = {
   latestVersion: (definitionId: string) =>
     ['workflows', definitionId, 'versions', 'latest'] as const,
   activityTypes: () => ['workflows', 'activity-types'] as const,
+  publishPreview: (definitionId: string, versionId: string) =>
+    ['workflows', definitionId, 'versions', versionId, 'publish-preview'] as const,
+  runningInstances: (definitionId: string, versionId?: string) =>
+    versionId
+      ? (['workflows', definitionId, 'instances', 'running', versionId] as const)
+      : (['workflows', definitionId, 'instances', 'running'] as const),
 };

--- a/src/features/workflowBuilder/components/VersionHistoryPanel.tsx
+++ b/src/features/workflowBuilder/components/VersionHistoryPanel.tsx
@@ -1,4 +1,5 @@
-import { useGetVersions } from '../api';
+import { useNavigate } from 'react-router-dom';
+import { useGetVersions, useListRunningInstances } from '../api';
 import type { WorkflowDefinitionVersion } from '../types';
 
 interface Props {
@@ -8,13 +9,25 @@ interface Props {
   onSelectVersion?: (version: WorkflowDefinitionVersion) => void;
 }
 
+function InstanceCountBadge({ definitionId, versionId }: { definitionId: string; versionId: string }) {
+  const { data: instances } = useListRunningInstances(definitionId, { versionId });
+  const count = instances?.length ?? 0;
+  if (count === 0) return null;
+  return (
+    <span className="badge badge-sm badge-warning">{count} running</span>
+  );
+}
+
 export function VersionHistoryPanel({
   definitionId,
   currentVersionId,
   onClose,
   onSelectVersion,
 }: Props) {
+  const navigate = useNavigate();
   const { data: versions, isLoading } = useGetVersions(definitionId);
+  const { data: publishedVersions } = useGetVersions(definitionId);
+  const currentPublished = publishedVersions?.find((v) => v.status === 'Published');
 
   const statusBadge = (status: string) => {
     switch (status) {
@@ -64,6 +77,7 @@ export function VersionHistoryPanel({
                         current
                       </span>
                     )}
+                    <InstanceCountBadge definitionId={definitionId} versionId={v.id} />
                   </div>
                   <div className="mt-1 text-xs text-base-content/60">
                     {v.publishedAt
@@ -74,14 +88,29 @@ export function VersionHistoryPanel({
                   </div>
                 </div>
 
-                {onSelectVersion && v.id !== currentVersionId && (
-                  <button
-                    onClick={() => onSelectVersion(v)}
-                    className="btn btn-ghost btn-xs"
-                  >
-                    View
-                  </button>
-                )}
+                <div className="flex gap-1">
+                  {onSelectVersion && v.id !== currentVersionId && (
+                    <button
+                      onClick={() => onSelectVersion(v)}
+                      className="btn btn-ghost btn-xs"
+                    >
+                      View
+                    </button>
+                  )}
+                  {v.status === 'Deprecated' && currentPublished && (
+                    <button
+                      onClick={() => {
+                        onClose();
+                        navigate(
+                          `/workflow-builder/${definitionId}/versions/${currentPublished.id}/migrate?fromVersionId=${v.id}`,
+                        );
+                      }}
+                      className="btn btn-warning btn-xs"
+                    >
+                      Migrate
+                    </button>
+                  )}
+                </div>
               </div>
             ))}
           </div>

--- a/src/features/workflowBuilder/components/migrate/InstanceActionPanel.tsx
+++ b/src/features/workflowBuilder/components/migrate/InstanceActionPanel.tsx
@@ -1,0 +1,153 @@
+import type {
+  RunningInstanceSummary,
+  InstanceImpact,
+  MigrationAction,
+  WorkflowSchema,
+  BreakingChange,
+} from '../../types';
+
+interface Props {
+  instance: RunningInstanceSummary | null;
+  classification: InstanceImpact | undefined;
+  targetSchema: WorkflowSchema | null;
+  breakingChanges: BreakingChange[];
+  currentAction: MigrationAction | undefined;
+  onActionChange: (action: MigrationAction) => void;
+}
+
+export function InstanceActionPanel({
+  instance,
+  classification,
+  targetSchema,
+  breakingChanges,
+  currentAction,
+  onActionChange,
+}: Props) {
+  if (!instance) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-base-content/50">
+        Select an instance to configure its migration action.
+      </div>
+    );
+  }
+
+  // Non-terminal activities in target schema (exclude EndActivity types)
+  const targetActivities =
+    targetSchema?.activities.filter((a) => !a.isEndActivity) ?? [];
+
+  const remapValue =
+    currentAction?.kind === 'remap' ? currentAction.newActivityId : '';
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div>
+        <p className="text-sm font-semibold">{instance.name}</p>
+        <p className="font-mono text-xs text-base-content/60">
+          {instance.id.slice(0, 8)}…
+        </p>
+        <p className="mt-1 text-xs text-base-content/60">
+          Currently at:{' '}
+          <span className="font-medium text-base-content">
+            {instance.currentActivityId}
+          </span>
+        </p>
+      </div>
+
+      {/* Warning banner for unsafe instances */}
+      {classification === 'Unsafe' && breakingChanges.length > 0 && (
+        <div className="rounded-lg border border-error/30 bg-error/5 p-3">
+          <p className="mb-1 text-xs font-semibold text-error">Breaking changes</p>
+          {/* TODO: Ideally filter to only changes affecting THIS instance's reachable path */}
+          {breakingChanges.map((bc, i) => (
+            <p key={i} className="text-xs text-base-content/70">
+              • {bc.description} ({bc.affectedComponent})
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {classification === 'Safe' ? (
+          <>
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="radio"
+                className="radio radio-sm radio-primary"
+                checked={currentAction?.kind === 'bump' || currentAction === undefined}
+                onChange={() => onActionChange({ kind: 'bump' })}
+              />
+              <span className="text-sm">Migrate to new version</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="radio"
+                className="radio radio-sm"
+                checked={currentAction?.kind === 'skip'}
+                onChange={() => onActionChange({ kind: 'skip' })}
+              />
+              <span className="text-sm">Leave pinned on old version</span>
+            </label>
+          </>
+        ) : (
+          <>
+            <label className="flex cursor-pointer items-start gap-2">
+              <input
+                type="radio"
+                className="radio radio-sm mt-0.5"
+                checked={currentAction?.kind === 'skip' || currentAction === undefined}
+                onChange={() => onActionChange({ kind: 'skip' })}
+              />
+              <span className="text-sm">
+                Leave pinned on old version{' '}
+                <span className="badge badge-xs badge-ghost ml-1">recommended</span>
+              </span>
+            </label>
+
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="radio"
+                className="radio radio-sm radio-warning"
+                checked={currentAction?.kind === 'remap'}
+                onChange={() =>
+                  onActionChange({ kind: 'remap', newActivityId: remapValue })
+                }
+              />
+              <span className="text-sm">Manual remap</span>
+            </label>
+
+            {currentAction?.kind === 'remap' && (
+              <div className="ml-6">
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={remapValue}
+                  onChange={(e) =>
+                    onActionChange({ kind: 'remap', newActivityId: e.target.value })
+                  }
+                >
+                  <option value="" disabled>
+                    Select target activity…
+                  </option>
+                  {targetActivities.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.name} ({a.id})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <label className="flex cursor-pointer items-center gap-2 opacity-50">
+              <input type="radio" className="radio radio-sm" disabled />
+              <span className="text-sm">
+                Cancel instance{' '}
+                <span className="text-xs text-base-content/50">
+                  — use the cancel endpoint separately
+                </span>
+              </span>
+            </label>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/workflowBuilder/components/migrate/InstanceTable.tsx
+++ b/src/features/workflowBuilder/components/migrate/InstanceTable.tsx
@@ -1,0 +1,81 @@
+import { useMigrationStore } from '../../hooks/useMigrationStore';
+import type { RunningInstanceSummary, InstanceImpact, MigrationAction } from '../../types';
+
+interface Props {
+  instances: RunningInstanceSummary[];
+  classifications: Record<string, InstanceImpact>;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function actionLabel(action: MigrationAction | undefined): string {
+  if (!action) return '—';
+  if (action.kind === 'bump') return 'Migrate';
+  if (action.kind === 'skip') return 'Pinned';
+  return `Remap: ${action.newActivityId}`;
+}
+
+export function InstanceTable({ instances, classifications, selectedId, onSelect }: Props) {
+  const actions = useMigrationStore((s) => s.actions);
+
+  if (instances.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-base-content/60">
+        No running instances on the previous version — nothing to migrate.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table table-sm w-full">
+        <thead>
+          <tr>
+            <th>Instance</th>
+            <th>Name</th>
+            <th>Current Activity</th>
+            <th>Started</th>
+            <th>Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {instances.map((inst) => {
+            const classification = classifications[inst.id];
+            const action = actions[inst.id];
+            const isSelected = inst.id === selectedId;
+
+            return (
+              <tr
+                key={inst.id}
+                className={`cursor-pointer hover ${isSelected ? 'bg-primary/10' : ''}`}
+                onClick={() => onSelect(inst.id)}
+              >
+                <td className="font-mono text-xs">{inst.id.slice(0, 8)}…</td>
+                <td className="max-w-[10rem] truncate text-sm">{inst.name}</td>
+                <td className="text-sm">{inst.currentActivityId}</td>
+                <td className="text-xs text-base-content/60">
+                  {new Date(inst.startedOn).toLocaleDateString()}
+                </td>
+                <td>
+                  {classification ? (
+                    <span
+                      className={`badge badge-xs ${
+                        classification === 'Safe' ? 'badge-success' : 'badge-error'
+                      }`}
+                    >
+                      {classification}
+                    </span>
+                  ) : (
+                    <span className="badge badge-xs badge-ghost">Unknown</span>
+                  )}
+                </td>
+                <td className="text-xs text-base-content/60">{actionLabel(action)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/workflowBuilder/components/publish/PublishPreviewModal.tsx
+++ b/src/features/workflowBuilder/components/publish/PublishPreviewModal.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { usePreviewPublish, usePublishVersion } from '../../api';
+import type { PublishImpactReport, PublishVersionResponse } from '../../types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  definitionId: string;
+  versionId: string;
+  publishedBy: string;
+  onPublished: (result: PublishVersionResponse) => void;
+}
+
+const impactColor: Record<string, string> = {
+  Low: 'badge-info',
+  Medium: 'badge-warning',
+  High: 'badge-error',
+  Critical: 'badge-error',
+};
+
+export function PublishPreviewModal({
+  open,
+  onClose,
+  definitionId,
+  versionId,
+  publishedBy,
+  onPublished,
+}: Props) {
+  const [report, setReport] = useState<PublishImpactReport | null>(null);
+
+  const previewMutation = usePreviewPublish();
+  const publishMutation = usePublishVersion();
+
+  // Fetch preview whenever modal opens
+  useEffect(() => {
+    if (!open) return;
+    setReport(null);
+    previewMutation.mutate(
+      { definitionId, versionId },
+      { onSuccess: setReport },
+    );
+  }, [open, definitionId, versionId]);
+
+  if (!open) return null;
+
+  const handlePublish = () => {
+    if (!report) return;
+    publishMutation.mutate(
+      {
+        definitionId,
+        versionId,
+        publishedBy,
+        confirmedBreakingChangeHash: report.breakingChangeHash || null,
+      },
+      {
+        onSuccess: (result) => {
+          if (!result.isSuccess) {
+            toast.error(result.errorMessage || 'Publish failed');
+            return;
+          }
+          toast.success(`Workflow published (v${result.version})`);
+          onPublished(result);
+        },
+        onError: (err: unknown) => {
+          // 409 — breaking changes changed since preview; refresh report
+          const conflict = err as { impactReport?: PublishImpactReport };
+          if (conflict?.impactReport) {
+            setReport(conflict.impactReport);
+            toast.error('Breaking changes updated — please review again');
+            return;
+          }
+          toast.error('Failed to publish workflow');
+        },
+      },
+    );
+  };
+
+  const isLoading = previewMutation.isPending;
+  const isPublishing = publishMutation.isPending;
+  const hasInstances = report && (report.safeCount > 0 || report.unsafeCount > 0);
+
+  return (
+    <dialog open className="modal modal-open">
+      <div className="modal-box max-w-2xl">
+        <h3 className="text-lg font-bold">Publish Workflow</h3>
+
+        {isLoading ? (
+          <div className="flex justify-center p-8">
+            <span className="loading loading-spinner" />
+          </div>
+        ) : report ? (
+          <div className="mt-4 flex flex-col gap-4">
+            {/* Breaking changes */}
+            <div>
+              <h4 className="mb-2 text-sm font-semibold">Breaking Changes</h4>
+              {report.breakingChanges.length === 0 ? (
+                <p className="text-sm text-success">No breaking changes detected ✓</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {report.breakingChanges.map((bc, i) => (
+                    <div
+                      key={i}
+                      className="flex items-start gap-2 rounded-lg border border-base-300 p-2"
+                    >
+                      <span className={`badge badge-sm shrink-0 ${impactColor[bc.impact] ?? 'badge-ghost'}`}>
+                        {bc.impact}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm">{bc.description}</p>
+                        <p className="text-xs text-base-content/60">
+                          {bc.affectedComponent}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Running instance impact */}
+            {hasInstances && (
+              <div>
+                <h4 className="mb-2 text-sm font-semibold">Running Instances</h4>
+                <p className="text-sm">
+                  {report.safeCount + report.unsafeCount} running instance
+                  {report.safeCount + report.unsafeCount !== 1 ? 's' : ''} affected —{' '}
+                  <span className="text-success">{report.safeCount} safe</span>,{' '}
+                  <span className="text-error">{report.unsafeCount} need manual action</span>
+                </p>
+                {report.sample.length > 0 && (
+                  <div className="mt-2 overflow-x-auto">
+                    <table className="table table-xs w-full">
+                      <thead>
+                        <tr>
+                          <th>Instance</th>
+                          <th>Current Activity</th>
+                          <th>Started</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {report.sample.map((inst) => (
+                          <tr key={inst.instanceId}>
+                            <td className="font-mono text-xs">
+                              {inst.instanceId.slice(0, 8)}…
+                            </td>
+                            <td>{inst.currentActivityId}</td>
+                            <td>{new Date(inst.startedOn).toLocaleDateString()}</td>
+                            <td>
+                              <span
+                                className={`badge badge-xs ${
+                                  inst.classification === 'Safe'
+                                    ? 'badge-success'
+                                    : 'badge-error'
+                                }`}
+                              >
+                                {inst.classification}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                {report.unsafeCount > 0 && (
+                  <p className="mt-2 text-xs text-base-content/60">
+                    Unsafe instances will stay pinned on the current (now deprecated) version.
+                    You can migrate them manually after publishing.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        ) : previewMutation.isError ? (
+          <p className="mt-4 text-sm text-error">
+            Failed to load preview. You can still publish without impact analysis.
+          </p>
+        ) : null}
+
+        <div className="modal-action">
+          <button onClick={onClose} className="btn btn-ghost btn-sm" disabled={isPublishing}>
+            Cancel
+          </button>
+          <button
+            onClick={handlePublish}
+            disabled={isLoading || isPublishing}
+            className="btn btn-primary btn-sm"
+          >
+            {isPublishing ? (
+              <span className="loading loading-spinner loading-xs" />
+            ) : null}
+            {hasInstances && report!.unsafeCount > 0
+              ? 'Publish & Migrate'
+              : 'Publish'}
+          </button>
+        </div>
+      </div>
+      <div className="modal-backdrop" onClick={onClose} />
+    </dialog>
+  );
+}

--- a/src/features/workflowBuilder/hooks/useMigrationStore.ts
+++ b/src/features/workflowBuilder/hooks/useMigrationStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import type { MigrationAction } from '../types';
+
+interface MigrationStoreState {
+  actions: Record<string, MigrationAction>;
+  setAction: (instanceId: string, action: MigrationAction) => void;
+  bulkSet: (ids: string[], action: MigrationAction) => void;
+  reset: () => void;
+}
+
+export const useMigrationStore = create<MigrationStoreState>((set) => ({
+  actions: {},
+
+  setAction: (instanceId, action) =>
+    set((state) => ({
+      actions: { ...state.actions, [instanceId]: action },
+    })),
+
+  bulkSet: (ids, action) =>
+    set((state) => {
+      const next = { ...state.actions };
+      for (const id of ids) {
+        next[id] = action;
+      }
+      return { actions: next };
+    }),
+
+  reset: () => set({ actions: {} }),
+}));

--- a/src/features/workflowBuilder/pages/MigrateInstancesPage.tsx
+++ b/src/features/workflowBuilder/pages/MigrateInstancesPage.tsx
@@ -1,0 +1,246 @@
+import { useState, useEffect } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { useListRunningInstances, useMigrateInstances, useGetVersion } from '../api';
+import { useMigrationStore } from '../hooks/useMigrationStore';
+import { InstanceTable } from '../components/migrate/InstanceTable';
+import { InstanceActionPanel } from '../components/migrate/InstanceActionPanel';
+import type {
+  InstanceImpact,
+  PublishImpactReport,
+  WorkflowSchema,
+  MigrateInstancesResult,
+} from '../types';
+
+export default function MigrateInstancesPage() {
+  const { workflowId = '', targetVersionId = '' } = useParams<{
+    workflowId: string;
+    targetVersionId: string;
+  }>();
+  const [searchParams] = useSearchParams();
+  const fromVersionId = searchParams.get('fromVersionId') ?? undefined;
+  const navigate = useNavigate();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [impactReport, setImpactReport] = useState<PublishImpactReport | null>(null);
+  const [resultModal, setResultModal] = useState<MigrateInstancesResult | null>(null);
+
+  const { actions, setAction, bulkSet, reset } = useMigrationStore();
+
+  // Fetch running instances on the prior version
+  const { data: instances = [], isLoading: loadingInstances } = useListRunningInstances(
+    workflowId,
+    fromVersionId ? { onVersionId: fromVersionId } : undefined,
+  );
+
+  // Fetch target schema for remap dropdown
+  const { data: targetVersion } = useGetVersion(workflowId, targetVersionId);
+  const targetSchema: WorkflowSchema | null = targetVersion?.jsonSchema
+    ? (() => {
+        try {
+          return JSON.parse(targetVersion.jsonSchema) as WorkflowSchema;
+        } catch {
+          return null;
+        }
+      })()
+    : null;
+
+  const migrateMutation = useMigrateInstances(workflowId, targetVersionId);
+
+  // Try to recover impact report from navigation state (set by WorkflowBuilderPage on publish success)
+  useEffect(() => {
+    const state = window.history.state as { impactReport?: PublishImpactReport } | null;
+    if (state?.impactReport) {
+      setImpactReport(state.impactReport);
+    }
+  }, []);
+
+  // Build classifications from impact report sample + default
+  const classifications: Record<string, InstanceImpact> = {};
+  if (impactReport) {
+    for (const c of impactReport.sample) {
+      classifications[c.instanceId] = c.classification;
+    }
+  }
+  // Instances not in the sample default to Safe
+  for (const inst of instances) {
+    if (!(inst.id in classifications)) {
+      classifications[inst.id] = 'Safe';
+    }
+  }
+
+  const selectedInstance = instances.find((i) => i.id === selectedId) ?? null;
+
+  const safeIds = instances.filter((i) => classifications[i.id] === 'Safe').map((i) => i.id);
+  const unsafeIds = instances.filter((i) => classifications[i.id] === 'Unsafe').map((i) => i.id);
+
+  const bumpCount = Object.values(actions).filter((a) => a.kind === 'bump').length;
+  const remapCount = Object.values(actions).filter((a) => a.kind === 'remap').length;
+  const skipCount = Object.values(actions).filter((a) => a.kind === 'skip').length;
+
+  const handleApply = () => {
+    const safeInstanceIds: string[] = [];
+    const manualRemaps: Record<string, string> = {};
+
+    for (const [id, action] of Object.entries(actions)) {
+      if (action.kind === 'bump') safeInstanceIds.push(id);
+      else if (action.kind === 'remap' && action.newActivityId)
+        manualRemaps[id] = action.newActivityId;
+    }
+
+    if (safeInstanceIds.length === 0 && Object.keys(manualRemaps).length === 0) {
+      toast('No instances selected for migration.');
+      return;
+    }
+
+    migrateMutation.mutate(
+      {
+        targetVersionId,
+        safeInstanceIds,
+        manualRemaps,
+        migratedBy: 'current-user',
+      },
+      {
+        onSuccess: (result) => {
+          setResultModal(result);
+          reset();
+        },
+        onError: () => {
+          toast.error('Migration failed');
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="flex h-[calc(100vh-64px)] flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-base-300 bg-base-100 px-4 py-2">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate(`/workflow-builder/${workflowId}`)}
+            className="btn btn-ghost btn-sm"
+          >
+            ←
+          </button>
+          <h1 className="text-base font-semibold">Migrate Running Instances</h1>
+        </div>
+
+        {/* Bulk actions */}
+        <div className="flex items-center gap-2">
+          <button
+            className="btn btn-ghost btn-xs"
+            onClick={() => bulkSet(safeIds, { kind: 'bump' })}
+            disabled={safeIds.length === 0}
+          >
+            All Safe → Migrate
+          </button>
+          <button
+            className="btn btn-ghost btn-xs"
+            onClick={() => bulkSet(unsafeIds, { kind: 'skip' })}
+            disabled={unsafeIds.length === 0}
+          >
+            All Unsafe → Pin
+          </button>
+          <button className="btn btn-ghost btn-xs" onClick={reset}>
+            Clear all
+          </button>
+        </div>
+      </div>
+
+      {/* Split pane */}
+      <div className="grid flex-1 grid-cols-[1fr_24rem] overflow-hidden">
+        {/* Left — instance table */}
+        <div className="overflow-y-auto border-r border-base-300 p-4">
+          {loadingInstances ? (
+            <div className="flex justify-center p-8">
+              <span className="loading loading-spinner" />
+            </div>
+          ) : (
+            <InstanceTable
+              instances={instances}
+              classifications={classifications}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          )}
+        </div>
+
+        {/* Right — action panel */}
+        <div className="overflow-y-auto">
+          <InstanceActionPanel
+            instance={selectedInstance}
+            classification={selectedId ? classifications[selectedId] : undefined}
+            targetSchema={targetSchema}
+            breakingChanges={impactReport?.breakingChanges ?? []}
+            currentAction={selectedId ? actions[selectedId] : undefined}
+            onActionChange={(action) => {
+              if (selectedId) setAction(selectedId, action);
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-base-300 bg-base-100 px-4 py-2">
+        <p className="text-sm text-base-content/60">
+          {bumpCount} migrating · {remapCount} remapping · {skipCount} pinned
+        </p>
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={migrateMutation.isPending || (bumpCount === 0 && remapCount === 0)}
+          onClick={handleApply}
+        >
+          {migrateMutation.isPending ? (
+            <span className="loading loading-spinner loading-xs" />
+          ) : null}
+          Apply migration
+        </button>
+      </div>
+
+      {/* Result modal */}
+      {resultModal && (
+        <dialog open className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="text-lg font-bold">Migration Complete</h3>
+            <div className="mt-4 flex flex-col gap-1 text-sm">
+              <p>
+                <span className="text-success">{resultModal.migratedCount}</span> migrated
+              </p>
+              {resultModal.failedCount > 0 && (
+                <p>
+                  <span className="text-error">{resultModal.failedCount}</span> failed
+                </p>
+              )}
+              {resultModal.skippedCount > 0 && (
+                <p>{resultModal.skippedCount} skipped</p>
+              )}
+              {resultModal.errors.length > 0 && (
+                <div className="mt-2">
+                  <p className="text-xs font-semibold text-error">Errors</p>
+                  {resultModal.errors.map((e, i) => (
+                    <p key={i} className="text-xs text-error">
+                      {e.instanceId.slice(0, 8)}… — {e.message}
+                    </p>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="modal-action">
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => {
+                  setResultModal(null);
+                  navigate(`/workflow-builder/${workflowId}`);
+                }}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+          <div className="modal-backdrop" onClick={() => setResultModal(null)} />
+        </dialog>
+      )}
+    </div>
+  );
+}

--- a/src/features/workflowBuilder/pages/WorkflowBuilderPage.tsx
+++ b/src/features/workflowBuilder/pages/WorkflowBuilderPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useParams, useBlocker, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { useWorkflowStore } from '../hooks/useWorkflowStore';
@@ -6,19 +6,21 @@ import {
   useGetLatestVersion,
   useCreateDefinition,
   useSaveDraftSchema,
-  usePublishVersion,
 } from '../api';
 import { WorkflowCanvas } from '../components/canvas/WorkflowCanvas';
 import { ActivityPalette } from '../components/palette/ActivityPalette';
 import { PropertyPanel } from '../components/panels/PropertyPanel';
 import { WorkflowToolbar } from '../components/toolbar/WorkflowToolbar';
+import { PublishPreviewModal } from '../components/publish/PublishPreviewModal';
 import { ActivityType } from '../types';
+import type { PublishImpactReport } from '../types';
 import { normalizeSchema } from '../utils/normalizeSchema';
 
 export default function WorkflowBuilderPage() {
   const { workflowId = 'new' } = useParams<{ workflowId: string }>();
   const isNew = workflowId === 'new';
   const navigate = useNavigate();
+  const [showPublishModal, setShowPublishModal] = useState(false);
 
   const loadFromSchema = useWorkflowStore((s) => s.loadFromSchema);
   const addActivity = useWorkflowStore((s) => s.addActivity);
@@ -32,7 +34,6 @@ export default function WorkflowBuilderPage() {
 
   const createDefinitionMutation = useCreateDefinition();
   const saveDraftMutation = useSaveDraftSchema();
-  const publishMutation = usePublishVersion();
 
   // Load data into store
   useEffect(() => {
@@ -170,35 +171,7 @@ export default function WorkflowBuilderPage() {
       return;
     }
 
-    const confirmed = window.confirm(
-      'Are you sure you want to publish this workflow? This will make it the live version.',
-    );
-    if (!confirmed) return;
-
-    // Save draft first if dirty, then publish
-    const doPublish = () => {
-      publishMutation.mutate(
-        {
-          definitionId: workflowId,
-          versionId: latestVersion.id,
-          publishedBy: 'current-user',
-        },
-        {
-          onSuccess: (result) => {
-            if (!result.isSuccess) {
-              toast.error(result.errorMessage || 'Publish failed');
-              return;
-            }
-            markClean();
-            toast.success(`Workflow published (v${result.version})`);
-          },
-          onError: () => {
-            toast.error('Failed to publish workflow');
-          },
-        },
-      );
-    };
-
+    // Save draft first if dirty, then open preview modal
     if (isDirty) {
       const schema = toSchema();
       saveDraftMutation.mutate(
@@ -210,7 +183,8 @@ export default function WorkflowBuilderPage() {
         },
         {
           onSuccess: () => {
-            doPublish();
+            markClean();
+            setShowPublishModal(true);
           },
           onError: () => {
             toast.error('Failed to save before publishing');
@@ -218,17 +192,24 @@ export default function WorkflowBuilderPage() {
         },
       );
     } else {
-      doPublish();
+      setShowPublishModal(true);
     }
-  }, [
-    workflowId,
-    latestVersion,
-    isDirty,
-    toSchema,
-    markClean,
-    saveDraftMutation,
-    publishMutation,
-  ]);
+  }, [workflowId, latestVersion, isDirty, toSchema, markClean, saveDraftMutation]);
+
+  const handlePublished = useCallback(
+    (report: PublishImpactReport, newVersionId: string) => {
+      setShowPublishModal(false);
+      const hasInstances = report.safeCount + report.unsafeCount > 0;
+      if (hasInstances) {
+        navigate(
+          `/workflow-builder/${workflowId}/versions/${newVersionId}/migrate?fromVersionId=${latestVersion?.id ?? ''}`,
+        );
+      } else {
+        toast.success('Workflow published');
+      }
+    },
+    [workflowId, latestVersion, navigate],
+  );
 
   return (
     <div className="flex h-[calc(100vh-64px)] flex-col">
@@ -238,7 +219,7 @@ export default function WorkflowBuilderPage() {
         isSaving={
           saveDraftMutation.isPending || createDefinitionMutation.isPending
         }
-        isPublishing={publishMutation.isPending}
+        isPublishing={false}
         versionNumber={latestVersion?.version}
         versionStatus={latestVersion?.status}
       />
@@ -252,6 +233,17 @@ export default function WorkflowBuilderPage() {
 
         <PropertyPanel />
       </div>
+
+      {showPublishModal && latestVersion && (
+        <PublishPreviewModal
+          open={showPublishModal}
+          onClose={() => setShowPublishModal(false)}
+          definitionId={workflowId}
+          versionId={latestVersion.id}
+          publishedBy="current-user"
+          onPublished={handlePublished}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/workflowBuilder/types/index.ts
+++ b/src/features/workflowBuilder/types/index.ts
@@ -159,6 +159,73 @@ export interface WorkflowSchema {
   metadata: WorkflowMetadata;
 }
 
+// Versioning / breaking-change types
+
+export type BreakingChangeType = 'ActivityRemoved' | 'PropertyChanged' | 'TransitionRemoved';
+export type ChangeImpact = 'Low' | 'Medium' | 'High' | 'Critical';
+
+export interface BreakingChange {
+  type: BreakingChangeType;
+  description: string;
+  affectedComponent: string;
+  impact: ChangeImpact;
+  migrationData?: Record<string, unknown>;
+}
+
+export type InstanceImpact = 'Safe' | 'Unsafe';
+
+export interface InstanceClassification {
+  instanceId: string;
+  currentActivityId: string;
+  startedOn: string;
+  classification: InstanceImpact;
+}
+
+export interface PublishImpactReport {
+  breakingChanges: BreakingChange[];
+  breakingChangeHash: string;
+  safeCount: number;
+  unsafeCount: number;
+  sample: InstanceClassification[];
+}
+
+export interface PublishVersionResponse {
+  isSuccess: boolean;
+  version: number;
+  errorMessage: string | null;
+  impactReport?: PublishImpactReport;
+}
+
+export interface RunningInstanceSummary {
+  instanceId: string;
+  definitionId: string;
+  versionId: string;
+  currentActivityId: string;
+  startedOn: string;
+  startedBy: string;
+  classification: InstanceImpact;
+}
+
+export interface MigrateInstancesRequest {
+  targetVersionId: string;
+  safeInstanceIds: string[];
+  manualRemaps: Record<string, string>;
+  migratedBy: string;
+}
+
+export interface MigrationInstanceResult {
+  instanceId: string;
+  success: boolean;
+  errorMessage: string | null;
+}
+
+export interface MigrateInstancesResult {
+  migratedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  results: MigrationInstanceResult[];
+}
+
 // Backend API response types
 
 export interface WorkflowDefinitionSummary {


### PR DESCRIPTION
## Summary

- **PublishPreviewModal** — replaces `window.confirm`; fires preview endpoint, shows breaking changes with impact badges and running instance summary, confirms publish with `BreakingChangeHash`; on 409 refreshes the report automatically
- **MigrateInstancesPage** — split-pane migration screen: instance table with Safe/Unsafe badges, per-instance action panel (bump / skip / manual remap with activity dropdown), bulk-select toolbar, Apply migration button + result modal
- **useMigrationStore** — Zustand store holding per-instance action state (skip / bump / remap)
- **VersionHistoryPanel** — running instance count badge per version row; Migrate button on Deprecated rows navigates to migration screen
- **New API hooks** — `usePreviewPublish`, `useListRunningInstances`, `useMigrateInstances`; `usePublishVersion` extended with `confirmedBreakingChangeHash` and 409 handling
- **New types** — `BreakingChange`, `PublishImpactReport`, `RunningInstanceSummary`, `MigrateInstancesRequest`, `MigrateInstancesResult`
- **Router** — added `/:workflowId/versions/:targetVersionId/migrate` route

## Test plan

- [ ] Open workflow builder, edit a draft, click Publish → preview modal opens with no breaking changes (first publish)
- [ ] Create v2 draft removing an activity an existing instance sits on → preview modal shows 1 breaking change + 1 unsafe instance
- [ ] Publish → success navigates to migration screen
- [ ] Migration screen: select unsafe instance → action panel shows remap dropdown populated from target schema activities
- [ ] Apply migration → instance version pointer flips; confirm via backend resume
- [ ] Version history panel: deprecated v1 row shows running count badge and Migrate link

🤖 Generated with [Claude Code](https://claude.com/claude-code)