### PR TITLE
feat: appraisal list page, DCF read-only, decision summary section config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ dist-ssr
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Claude Code local tooling state
+.claude/agents/
+.claude/plans/
+.claude/tasks/
+.claude/worktrees/
+.claude/settings.local.json

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -45,6 +45,7 @@ import CreateLeaseAgreementLandPage from '@/features/appraisal/pages/CreateLease
 import CreateLeaseAgreementBuildingPage from '@/features/appraisal/pages/CreateLeaseAgreementBuildingPage';
 import CreateLeaseAgreementLandBuildingPage from '@/features/appraisal/pages/CreateLeaseAgreementLandBuildingPage';
 import AppraisalSearchPage from '@/features/appraisal/pages/AppraisalSearchPage';
+import AppraisalListPage from '@/features/appraisal/pages/AppraisalListPage';
 import Appraisal360Page from '@/features/appraisal/pages/Appraisal360Page';
 import {
   ReadOnlyPageWrapper,
@@ -106,7 +107,12 @@ export const router = createBrowserRouter([
         index: true,
         element: <HomePage />,
       },
-      // Appraisal Search
+      // Appraisal List (enhanced search with filters, smart views, export)
+      {
+        path: 'appraisals/list',
+        element: <AppraisalListPage />,
+      },
+      // Appraisal Search (global cross-entity search)
       {
         path: 'appraisals/search',
         element: <AppraisalSearchPage />,

--- a/src/features/appraisal/api/appraisalSearch.ts
+++ b/src/features/appraisal/api/appraisalSearch.ts
@@ -1,0 +1,210 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+
+// ── Types ──────────────────────────────────────────────────
+
+export interface AppraisalSearchParams {
+  search?: string;
+  status?: string;
+  priority?: string;
+  appraisalType?: string;
+  slaStatus?: string;
+  assignmentType?: string;
+  assigneeUserId?: string;
+  assigneeCompanyId?: string;
+  channel?: string;
+  bankingSegment?: string;
+  isPma?: boolean;
+  province?: string;
+  district?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  slaDueDateFrom?: string;
+  slaDueDateTo?: string;
+  assignedDateFrom?: string;
+  assignedDateTo?: string;
+  appointmentDateFrom?: string;
+  appointmentDateTo?: string;
+  sortBy?: string;
+  sortDir?: string;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface AppraisalDto {
+  id: string;
+  appraisalNumber: string | null;
+  requestId: string;
+  requestNumber: string | null;
+  status: string;
+  appraisalType: string;
+  priority: string;
+  isPma: boolean;
+  purpose: string | null;
+  channel: string | null;
+  bankingSegment: string | null;
+  facilityLimit: number | null;
+  requestedBy: string | null;
+  requestedAt: string | null;
+  slaDays: number | null;
+  slaDueDate: string | null;
+  slaStatus: string | null;
+  propertyCount: number;
+  createdAt: string | null;
+  assigneeUserId: string | null; // username like "P5229", not GUID
+  assigneeCompanyId: string | null;
+  assignmentType: string | null;
+  assignmentStatus: string | null;
+  assignedDate: string | null;
+  companyName: string | null;
+  customerName: string | null;
+  province: string | null;
+  district: string | null;
+  appointmentDateTime: string | null;
+  elapsedHours: number | null;
+  remainingHours: number | null;
+}
+
+export interface FacetItem {
+  value: string;
+  count: number;
+}
+
+export interface AppraisalFacets {
+  status: FacetItem[];
+  slaStatus: FacetItem[];
+  priority: FacetItem[];
+  appraisalType: FacetItem[];
+  assignmentType: FacetItem[];
+}
+
+export interface AppraisalSearchResponse {
+  result: {
+    items: AppraisalDto[];
+    count: number;
+    pageNumber: number;
+    pageSize: number;
+  };
+  facets: AppraisalFacets | null;
+}
+
+export interface SmartViewDto {
+  key: string;
+  name: string;
+  description: string;
+  filters: Record<string, string>;
+}
+
+export interface SavedSearchDto {
+  id: string;
+  name: string;
+  entityType: string;
+  filtersJson: string;
+  sortBy: string | null;
+  sortDir: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Query Keys ─────────────────────────────────────────────
+
+export const appraisalSearchKeys = {
+  all: ['appraisal-search'] as const,
+  list: (params: AppraisalSearchParams) => ['appraisal-search', 'list', params] as const,
+  views: ['appraisal-search', 'views'] as const,
+  savedSearches: (entityType?: string) => ['saved-searches', entityType] as const,
+};
+
+// ── Hooks ──────────────────────────────────────────────────
+
+export function useAppraisalSearch(params: AppraisalSearchParams) {
+  return useQuery({
+    queryKey: appraisalSearchKeys.list(params),
+    queryFn: async () => {
+      const cleanParams = Object.fromEntries(
+        Object.entries(params).filter(([, v]) => v !== undefined && v !== '' && v !== null),
+      );
+      const { data } = await axios.get<AppraisalSearchResponse>('/appraisals', {
+        params: cleanParams,
+      });
+      return data;
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}
+
+export function useSmartViews() {
+  return useQuery({
+    queryKey: appraisalSearchKeys.views,
+    queryFn: async () => {
+      const { data } = await axios.get<{ views: SmartViewDto[] }>('/appraisals/views');
+      return data.views;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useSavedSearches(entityType?: string) {
+  return useQuery({
+    queryKey: appraisalSearchKeys.savedSearches(entityType),
+    queryFn: async () => {
+      const { data } = await axios.get<{ items: SavedSearchDto[] }>('/saved-searches', {
+        params: entityType ? { entityType } : undefined,
+      });
+      return data.items;
+    },
+  });
+}
+
+export function useCreateSavedSearch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: {
+      name: string;
+      entityType: string;
+      filtersJson: string;
+      sortBy?: string;
+      sortDir?: string;
+    }) => {
+      const { data } = await axios.post('/saved-searches', payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
+    },
+  });
+}
+
+export function useDeleteSavedSearch() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.delete(`/saved-searches/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
+    },
+  });
+}
+
+export async function exportAppraisals(
+  params: Omit<AppraisalSearchParams, 'pageNumber' | 'pageSize'>,
+  format: 'xlsx' | 'csv' = 'xlsx',
+) {
+  const cleanParams = Object.fromEntries(
+    Object.entries({ ...params, format })
+      .filter(([, v]) => v !== undefined && v !== '' && v !== null)
+      .map(([k, v]) => [k, String(v)]),
+  );
+  const { data } = await axios.get('/appraisals/export', {
+    params: cleanParams,
+    responseType: 'blob',
+  });
+  const url = URL.createObjectURL(data);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `appraisals-${new Date().toISOString().slice(0, 10)}.${format}`;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/features/appraisal/components/search/ActiveFilterChips.tsx
+++ b/src/features/appraisal/components/search/ActiveFilterChips.tsx
@@ -1,0 +1,44 @@
+import Icon from '@/shared/components/Icon';
+
+interface ActiveFilterChipsProps {
+  filters: Record<string, string>;
+  onRemove: (key: string) => void;
+  onClearAll: () => void;
+}
+
+const formatLabel = (key: string): string =>
+  key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, s => s.toUpperCase())
+    .trim();
+
+function ActiveFilterChips({ filters, onRemove, onClearAll }: ActiveFilterChipsProps) {
+  const active = Object.entries(filters).filter(([, v]) => v !== '' && v !== undefined);
+  if (active.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-gray-500">Filters:</span>
+      {active.map(([key, value]) => (
+        <span
+          key={key}
+          className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-full"
+        >
+          <span className="font-medium">{formatLabel(key)}:</span> {value}
+          <button
+            onClick={() => onRemove(key)}
+            aria-label={`Remove ${formatLabel(key)} filter`}
+            className="hover:text-primary/70 ml-0.5"
+          >
+            <Icon style="solid" name="xmark" className="size-3" />
+          </button>
+        </span>
+      ))}
+      <button onClick={onClearAll} className="text-xs text-gray-500 hover:text-gray-700 underline">
+        Clear all
+      </button>
+    </div>
+  );
+}
+
+export default ActiveFilterChips;

--- a/src/features/appraisal/components/search/AppraisalResultsTable.tsx
+++ b/src/features/appraisal/components/search/AppraisalResultsTable.tsx
@@ -1,0 +1,142 @@
+import type { AppraisalDto } from '../../api/appraisalSearch';
+import type { AppraisalColumnDef } from './tabConfigs';
+import Badge from '@/shared/components/Badge';
+import Icon from '@/shared/components/Icon';
+import { TableRowSkeleton } from '@/shared/components/Skeleton';
+
+interface AppraisalResultsTableProps {
+  columns: AppraisalColumnDef[];
+  items: AppraisalDto[];
+  isLoading: boolean;
+  sortBy: string;
+  sortDir: string;
+  onSort: (field: string) => void;
+  onRowClick: (item: AppraisalDto) => void;
+}
+
+function AppraisalResultsTable({
+  columns,
+  items,
+  isLoading,
+  sortBy,
+  sortDir,
+  onSort,
+  onRowClick,
+}: AppraisalResultsTableProps) {
+  const getCellValue = (item: AppraisalDto, key: string): string => {
+    const val = item[key as keyof AppraisalDto];
+    if (val === null || val === undefined) return '-';
+    if (key === 'createdAt' || key === 'assignedDate' || key === 'appointmentDateTime') {
+      return new Date(val as string).toLocaleDateString();
+    }
+    return String(val);
+  };
+
+  const formatSlaStatus = (item: AppraisalDto): string => {
+    if (!item.slaStatus) return '-';
+    if (item.remainingHours !== null && item.remainingHours !== undefined) {
+      const days = Math.floor(Math.abs(item.remainingHours) / 24);
+      const hours = Math.abs(item.remainingHours) % 24;
+      const timeStr = days > 0 ? `${days}d ${hours}h` : `${hours}h`;
+      return item.remainingHours < 0 ? `Overdue ${timeStr}` : `${timeStr} left`;
+    }
+    return item.slaStatus;
+  };
+
+  return (
+    <div className="flex-1 min-h-0 overflow-auto">
+      <table className="table table-sm min-w-max w-full">
+        <thead className="sticky top-0 z-20 bg-gray-50">
+          <tr className="border-b border-gray-200">
+            <th className="text-left font-medium text-gray-600 px-3 py-2.5 whitespace-nowrap w-12">
+              #
+            </th>
+            {columns.map(col => (
+              <th
+                key={col.key}
+                onClick={() => col.sortable && onSort(col.key)}
+                className={`text-left font-medium text-gray-600 px-3 py-2.5 whitespace-nowrap ${
+                  col.sortable ? 'cursor-pointer hover:text-primary select-none' : ''
+                }`}
+              >
+                <span className="inline-flex items-center gap-1">
+                  {col.label}
+                  {col.sortable && sortBy === col.key && (
+                    <Icon
+                      style="solid"
+                      name={sortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
+                      className="size-3 text-primary"
+                    />
+                  )}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
+            <TableRowSkeleton
+              columns={[{ width: 'w-8' }, ...columns.map(() => ({ width: 'w-32' }))]}
+              rows={8}
+            />
+          ) : items.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length + 1} className="text-center py-16">
+                <div className="flex flex-col items-center gap-2">
+                  <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
+                  <p className="text-gray-500 font-medium">No appraisals found</p>
+                  <p className="text-xs text-gray-400">Try adjusting your search or filters</p>
+                </div>
+              </td>
+            </tr>
+          ) : (
+            items.map((item, index) => (
+              <tr
+                key={item.id}
+                onClick={() => onRowClick(item)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') onRowClick(item);
+                }}
+                tabIndex={0}
+                className="hover:bg-gray-50 cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+              >
+                <td className="px-3 py-2.5 text-gray-400 text-sm">{index + 1}</td>
+                {columns.map(col => (
+                  <td key={col.key} className="px-3 py-2.5 text-gray-600 text-sm">
+                    {col.key === 'status' ? (
+                      <Badge type="status" value={item.status} size="sm" />
+                    ) : col.key === 'priority' ? (
+                      <Badge type="priority" value={item.priority} size="sm" />
+                    ) : col.key === 'slaStatus' ? (
+                      <span
+                        className={`text-xs font-medium ${
+                          item.slaStatus === 'Breached'
+                            ? 'text-red-600'
+                            : item.slaStatus === 'AtRisk'
+                              ? 'text-amber-600'
+                              : item.slaStatus === 'OnTrack'
+                                ? 'text-green-600'
+                                : 'text-gray-400'
+                        }`}
+                      >
+                        {formatSlaStatus(item)}
+                      </span>
+                    ) : col.key === 'appraisalNumber' ? (
+                      <span className="font-medium text-primary">
+                        {item.appraisalNumber || '-'}
+                      </span>
+                    ) : (
+                      getCellValue(item, col.key)
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default AppraisalResultsTable;

--- a/src/features/appraisal/components/search/SavedSearchesDropdown.tsx
+++ b/src/features/appraisal/components/search/SavedSearchesDropdown.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import Icon from '@/shared/components/Icon';
+import type { SavedSearchDto } from '../../api/appraisalSearch';
+
+interface SavedSearchesDropdownProps {
+  savedSearches: SavedSearchDto[];
+  onLoad: (search: SavedSearchDto) => void;
+  onSave: (name: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function SavedSearchesDropdown({
+  savedSearches,
+  onLoad,
+  onSave,
+  onDelete,
+}: SavedSearchesDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [newName, setNewName] = useState('');
+
+  const handleSave = () => {
+    if (newName.trim()) {
+      onSave(newName.trim());
+      setNewName('');
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
+      >
+        <Icon style="solid" name="bookmark" className="size-3" />
+        Saved
+        {savedSearches.length > 0 && (
+          <span className="bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded-full text-[10px]">
+            {savedSearches.length}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-30"
+            onClick={() => {
+              setIsOpen(false);
+              setIsSaving(false);
+            }}
+          />
+          <div
+            className="absolute right-0 top-full mt-1 w-72 bg-white border border-gray-200 rounded-lg shadow-lg z-40"
+            onKeyDown={e => {
+              if (e.key === 'Escape') {
+                setIsOpen(false);
+                setIsSaving(false);
+              }
+            }}
+          >
+            <div className="p-2 border-b border-gray-100">
+              {isSaving ? (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={newName}
+                    onChange={e => setNewName(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && handleSave()}
+                    placeholder="Search name..."
+                    className="flex-1 px-2 py-1 text-xs border border-gray-200 rounded focus:ring-1 focus:ring-primary outline-none"
+                    autoFocus
+                  />
+                  <button
+                    onClick={handleSave}
+                    className="text-xs text-primary font-medium hover:underline"
+                  >
+                    Save
+                  </button>
+                  <button
+                    onClick={() => setIsSaving(false)}
+                    className="text-xs text-gray-400 hover:text-gray-600"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setIsSaving(true)}
+                  className="w-full text-left text-xs text-primary font-medium hover:underline flex items-center gap-1"
+                >
+                  <Icon style="solid" name="plus" className="size-3" />
+                  Save current search
+                </button>
+              )}
+            </div>
+            <div className="max-h-48 overflow-y-auto">
+              {savedSearches.length === 0 ? (
+                <p className="p-3 text-xs text-gray-400 text-center">No saved searches yet</p>
+              ) : (
+                savedSearches.map(s => (
+                  <div
+                    key={s.id}
+                    className="flex items-center justify-between px-3 py-2 hover:bg-gray-50 group cursor-pointer"
+                    onClick={() => {
+                      onLoad(s);
+                      setIsOpen(false);
+                    }}
+                  >
+                    <div className="min-w-0">
+                      <p className="text-xs font-medium text-gray-700 truncate">{s.name}</p>
+                      <p className="text-[10px] text-gray-400">
+                        {new Date(s.updatedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        onDelete(s.id);
+                      }}
+                      className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity"
+                    >
+                      <Icon style="solid" name="trash" className="size-3" />
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default SavedSearchesDropdown;

--- a/src/features/appraisal/components/search/SmartViewBar.tsx
+++ b/src/features/appraisal/components/search/SmartViewBar.tsx
@@ -1,0 +1,46 @@
+import Icon from '@/shared/components/Icon';
+import type { SmartViewDto } from '../../api/appraisalSearch';
+
+interface SmartViewBarProps {
+  views: SmartViewDto[];
+  activeViewKey: string | null;
+  onSelect: (view: SmartViewDto) => void;
+}
+
+const viewIcons: Record<string, string> = {
+  'my-assignments': 'user',
+  'sla-at-risk': 'triangle-exclamation',
+  'todays-appointments': 'calendar-day',
+  unassigned: 'inbox',
+  'high-priority-active': 'bolt',
+  'nearing-deadline': 'clock',
+  'external-assignments': 'building',
+  'my-company-queue': 'briefcase',
+};
+
+function SmartViewBar({ views, activeViewKey, onSelect }: SmartViewBarProps) {
+  if (!views.length) return null;
+
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto pb-1">
+      <span className="text-xs text-gray-500 shrink-0">Quick views:</span>
+      {views.map(view => (
+        <button
+          key={view.key}
+          onClick={() => onSelect(view)}
+          title={view.description}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border transition-colors whitespace-nowrap ${
+            activeViewKey === view.key
+              ? 'bg-primary text-white border-primary'
+              : 'bg-white text-gray-600 border-gray-200 hover:border-primary hover:text-primary'
+          }`}
+        >
+          <Icon style="solid" name={viewIcons[view.key] || 'filter'} className="size-3" />
+          {view.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default SmartViewBar;

--- a/src/features/appraisal/components/search/tabConfigs.ts
+++ b/src/features/appraisal/components/search/tabConfigs.ts
@@ -146,3 +146,85 @@ const propertiesTab: TabConfig = {
 };
 
 export const tabConfigs: TabConfig[] = [requestsTab, customersTab, propertiesTab];
+
+// ── Enhanced Appraisal Search Config (for AppraisalListPage) ──
+
+export interface AppraisalColumnDef {
+  key: string;
+  label: string;
+  sortable?: boolean;
+}
+
+export const appraisalFilters: FilterField[] = [
+  {
+    key: 'status',
+    label: 'Status',
+    type: 'select',
+    placeholder: 'All statuses',
+    options: [
+      { value: 'Pending', label: 'Pending' },
+      { value: 'Assigned', label: 'Assigned' },
+      { value: 'InProgress', label: 'In Progress' },
+      { value: 'UnderReview', label: 'Under Review' },
+      { value: 'Completed', label: 'Completed' },
+      { value: 'Cancelled', label: 'Cancelled' },
+    ],
+  },
+  {
+    key: 'priority',
+    label: 'Priority',
+    type: 'select',
+    placeholder: 'All priorities',
+    options: [
+      { value: 'Normal', label: 'Normal' },
+      { value: 'High', label: 'High' },
+    ],
+  },
+  {
+    key: 'slaStatus',
+    label: 'SLA Status',
+    type: 'select',
+    placeholder: 'All SLA',
+    options: [
+      { value: 'OnTrack', label: 'On Track' },
+      { value: 'AtRisk', label: 'At Risk' },
+      { value: 'Breached', label: 'Breached' },
+    ],
+  },
+  {
+    key: 'appraisalType',
+    label: 'Type',
+    type: 'select',
+    placeholder: 'All types',
+    options: [
+      { value: 'New', label: 'New' },
+      { value: 'Revaluation', label: 'Revaluation' },
+    ],
+  },
+  {
+    key: 'assignmentType',
+    label: 'Assignment',
+    type: 'select',
+    placeholder: 'All assignments',
+    options: [
+      { value: 'Internal', label: 'Internal' },
+      { value: 'External', label: 'External' },
+    ],
+  },
+  { key: 'province', label: 'Province', type: 'text', placeholder: 'Province...' },
+  { key: 'createdFrom', label: 'Created From', type: 'date' },
+  { key: 'createdTo', label: 'Created To', type: 'date' },
+  { key: 'slaDueDateFrom', label: 'SLA Due From', type: 'date' },
+  { key: 'slaDueDateTo', label: 'SLA Due To', type: 'date' },
+];
+
+export const appraisalColumns: AppraisalColumnDef[] = [
+  { key: 'appraisalNumber', label: 'Appraisal No.', sortable: true },
+  { key: 'customerName', label: 'Customer', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'priority', label: 'Priority', sortable: true },
+  { key: 'slaStatus', label: 'SLA', sortable: true },
+  { key: 'province', label: 'Province', sortable: true },
+  { key: 'assignmentType', label: 'Assignment', sortable: true },
+  { key: 'createdAt', label: 'Created', sortable: true },
+];

--- a/src/features/appraisal/components/summary/ApprovalListSection.tsx
+++ b/src/features/appraisal/components/summary/ApprovalListSection.tsx
@@ -1,8 +1,6 @@
 import Icon from '@/shared/components/Icon';
 import Badge from '@/shared/components/Badge';
-import Button from '@/shared/components/Button';
 import FormCard from '@/shared/components/sections/FormCard';
-import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import MeetingChip from '@/features/meeting/components/MeetingChip';
 
 import {
@@ -11,7 +9,6 @@ import {
   type ApprovalMember,
   type GetApprovalListResponse,
 } from '../../api/decisionSummary';
-import VoteDialog from './VoteDialog';
 
 interface ApprovalListSectionProps {
   workflowInstanceId: string | undefined;
@@ -60,7 +57,6 @@ const conditionLabel = (condition: ApprovalCondition): string => {
 
 const ApprovalListSection = ({ workflowInstanceId, activityId }: ApprovalListSectionProps) => {
   const { data, isLoading } = useGetApprovalList(workflowInstanceId, activityId);
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   if (!workflowInstanceId || !activityId) {
     // No active approval activity for this appraisal — committee-review step hasn't been reached.
@@ -90,9 +86,6 @@ const ApprovalListSection = ({ workflowInstanceId, activityId }: ApprovalListSec
 
   const status = deriveStatus(data);
   const members: ApprovalMember[] = data.members;
-  const currentUser = members.find(m => m.isCurrentUser);
-  const canVote = status === 'Pending' && currentUser != null && currentUser.status !== 'Voted';
-
   return (
     <FormCard title="Committee Approval" icon="users-gear" iconColor="blue">
       <div className="space-y-4">
@@ -117,12 +110,6 @@ const ApprovalListSection = ({ workflowInstanceId, activityId }: ApprovalListSec
               />
             )}
           </div>
-          {canVote && (
-            <Button type="button" size="sm" onClick={onOpen}>
-              <Icon name="check-to-slot" style="solid" className="size-4 mr-2" />
-              Submit Vote
-            </Button>
-          )}
         </div>
 
         {/* Status banner */}
@@ -245,13 +232,6 @@ const ApprovalListSection = ({ workflowInstanceId, activityId }: ApprovalListSec
         )}
       </div>
 
-      {/* Vote Dialog */}
-      <VoteDialog
-        isOpen={isOpen}
-        onClose={onClose}
-        workflowInstanceId={workflowInstanceId}
-        activityId={activityId}
-      />
     </FormCard>
   );
 };

--- a/src/features/appraisal/components/summary/DecisionSection.tsx
+++ b/src/features/appraisal/components/summary/DecisionSection.tsx
@@ -6,16 +6,8 @@ import FormCard from '@/shared/components/sections/FormCard';
 import Dropdown from '@/shared/components/inputs/Dropdown';
 import Textarea from '@/shared/components/inputs/Textarea';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
-import {
-  useWorkflowInstanceId,
-  useActivityId,
-  useIsTaskOwner,
-} from '@/features/appraisal/context/AppraisalContext';
-import {
-  useGetActivityActions,
-  useGetTaskHistory,
-  type TaskHistoryItem,
-} from '@/features/appraisal/api/workflow';
+import { useActivityId, useIsTaskOwner, useWorkflowInstanceId, } from '@/features/appraisal/context/AppraisalContext';
+import { type TaskHistoryItem, useGetActivityActions, useGetTaskHistory, } from '@/features/appraisal/api/workflow';
 import { useGetEligibleStaff } from '@/features/appraisal/api/administration';
 import { RaiseFollowupDialog } from '@/features/document-followup/components/RaiseFollowupDialog';
 import { OpenFollowupBanner } from '@/features/document-followup/components/OpenFollowupBanner';
@@ -88,7 +80,7 @@ const DecisionSection = ({
   );
 
   const isManualAssignment =
-    selectedAction?.assignmentMode === 'manual' && !!selectedAction.targetActivityId;
+    selectedAction?.assignmentMode === 'user' && !!selectedAction.targetActivityId;
 
   const { data: eligibleStaff, isLoading: isStaffLoading } = useGetEligibleStaff(
     workflowInstanceId,
@@ -125,7 +117,11 @@ const DecisionSection = ({
           <div className="min-w-0">
             <div className="flex items-center gap-2.5 mb-5 px-3 py-2.5 rounded-lg bg-gradient-to-r from-cyan-50 to-transparent border border-cyan-100">
               <div className="w-7 h-7 rounded-md bg-cyan-100 flex items-center justify-center shrink-0">
-                <Icon name="clock-rotate-left" style="solid" className="w-3.5 h-3.5 text-cyan-600" />
+                <Icon
+                  name="clock-rotate-left"
+                  style="solid"
+                  className="w-3.5 h-3.5 text-cyan-600"
+                />
               </div>
               <h3 className="text-sm font-semibold text-gray-800">Activity Tracking</h3>
             </div>
@@ -160,7 +156,11 @@ const DecisionSection = ({
                 <div>
                   <label className="block text-xs font-medium text-gray-700 mb-1">Decision</label>
                   {selectedDecision ? (
-                    <Badge type="vote" value={badgeMap[selectedDecision] ?? selectedDecision} size="md" />
+                    <Badge
+                      type="vote"
+                      value={badgeMap[selectedDecision] ?? selectedDecision}
+                      size="md"
+                    />
                   ) : (
                     <span className="text-sm text-gray-400">No decision made</span>
                   )}
@@ -188,7 +188,7 @@ const DecisionSection = ({
                         required
                         options={decisionOptions}
                         value={selectedDecision ?? undefined}
-                        onChange={(value) => {
+                        onChange={value => {
                           // Clear stale assignee when decision changes — target activity may differ
                           onAssigneeChange(null);
                           onDecisionChange(value);
@@ -197,13 +197,17 @@ const DecisionSection = ({
                       />
                       {selectedDecision && (
                         <div className="mt-2">
-                          <Badge type="vote" value={badgeMap[selectedDecision] ?? selectedDecision} size="sm" />
+                          <Badge
+                            type="vote"
+                            value={badgeMap[selectedDecision] ?? selectedDecision}
+                            size="sm"
+                          />
                         </div>
                       )}
                     </div>
 
-                    {isManualAssignment && (
-                      isStaffLoading ? (
+                    {isManualAssignment &&
+                      (isStaffLoading ? (
                         <div className="flex items-center gap-2 text-sm text-gray-500">
                           <Icon name="spinner" style="solid" className="w-4 h-4 animate-spin" />
                           Loading assignees...
@@ -217,13 +221,12 @@ const DecisionSection = ({
                           onChange={onAssigneeChange}
                           placeholder="Select an assignee..."
                         />
-                      )
-                    )}
+                      ))}
 
                     <Textarea
                       label="Comments"
                       value={comments}
-                      onChange={(e) => onCommentsChange(e.target.value)}
+                      onChange={e => onCommentsChange(e.target.value)}
                       placeholder="Enter your comments or reason for this decision..."
                     />
 

--- a/src/features/appraisal/pages/AppraisalListPage.tsx
+++ b/src/features/appraisal/pages/AppraisalListPage.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Icon from '@/shared/components/Icon';
+import Pagination from '@/shared/components/Pagination';
+import {
+  useAppraisalSearch,
+  useSmartViews,
+  useSavedSearches,
+  useCreateSavedSearch,
+  useDeleteSavedSearch,
+  exportAppraisals,
+  type AppraisalDto,
+  type SmartViewDto,
+  type SavedSearchDto,
+} from '../api/appraisalSearch';
+import { appraisalFilters, appraisalColumns } from '../components/search/tabConfigs';
+import SearchFilterBar from '../components/search/SearchFilterBar';
+import ActiveFilterChips from '../components/search/ActiveFilterChips';
+import SmartViewBar from '../components/search/SmartViewBar';
+import SavedSearchesDropdown from '../components/search/SavedSearchesDropdown';
+import AppraisalResultsTable from '../components/search/AppraisalResultsTable';
+import ActivityTrackingSlideOver from '../components/search/ActivityTrackingSlideOver';
+
+const NON_FILTER_KEYS = new Set(['search', 'page', 'pageSize', 'sortBy', 'sortDir', 'view']);
+const VALID_FILTER_KEYS = new Set(appraisalFilters.map(f => f.key));
+
+function AppraisalListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Read initial state from URL (once on mount)
+  const initRef = useRef({
+    search: searchParams.get('search') || '',
+    page: Number(searchParams.get('page')) || 0,
+    pageSize: Number(searchParams.get('pageSize')) || 25,
+    sortBy: searchParams.get('sortBy') || 'CreatedAt',
+    sortDir: searchParams.get('sortDir') || 'desc',
+    view: searchParams.get('view') || null,
+    filters: (() => {
+      const f: Record<string, string> = {};
+      searchParams.forEach((value, key) => {
+        if (!NON_FILTER_KEYS.has(key) && value && VALID_FILTER_KEYS.has(key)) f[key] = value;
+      });
+      return f;
+    })(),
+  });
+  const init = initRef.current;
+
+  const [searchTerm, setSearchTerm] = useState(init.search);
+  const [debouncedSearch, setDebouncedSearch] = useState(init.search);
+  const [pageNumber, setPageNumber] = useState(init.page);
+  const [pageSize, setPageSize] = useState(init.pageSize);
+  const [sortBy, setSortBy] = useState(init.sortBy);
+  const [sortDir, setSortDir] = useState(init.sortDir);
+  const [filters, setFilters] = useState<Record<string, string>>(init.filters);
+  const [activeViewKey, setActiveViewKey] = useState<string | null>(init.view);
+  const [selectedAppraisalId, setSelectedAppraisalId] = useState<string | null>(null);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
+  // Reset page on search/filter/sort change
+  useEffect(() => {
+    setPageNumber(0);
+  }, [debouncedSearch, filters, sortBy, sortDir]);
+
+  // Sync all state to URL
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedSearch) params.search = debouncedSearch;
+    if (pageNumber > 0) params.page = String(pageNumber);
+    if (pageSize !== 25) params.pageSize = String(pageSize);
+    if (sortBy !== 'CreatedAt') params.sortBy = sortBy;
+    if (sortDir !== 'desc') params.sortDir = sortDir;
+    if (activeViewKey) params.view = activeViewKey;
+    Object.entries(filters).forEach(([k, v]) => {
+      if (v) params[k] = v;
+    });
+    setSearchParams(params, { replace: true });
+  }, [debouncedSearch, pageNumber, pageSize, sortBy, sortDir, filters, activeViewKey, setSearchParams]);
+
+  // Data hooks
+  const { data, isLoading } = useAppraisalSearch({
+    search: debouncedSearch || undefined,
+    pageNumber,
+    pageSize,
+    sortBy,
+    sortDir,
+    ...filters,
+  });
+
+  const { data: smartViews = [] } = useSmartViews();
+  const { data: savedSearches = [] } = useSavedSearches('appraisal');
+  const createSavedSearch = useCreateSavedSearch();
+  const deleteSavedSearch = useDeleteSavedSearch();
+
+  const items = data?.result.items ?? [];
+  const totalCount = data?.result.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+  const facets = data?.facets;
+
+  // Handlers
+  const handleSort = (field: string) => {
+    if (sortBy === field) {
+      setSortDir(prev => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(field);
+      setSortDir('asc');
+    }
+  };
+
+  const handleFilterChange = (key: string, value: string) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+    setActiveViewKey(null);
+  };
+
+  const handleRemoveFilter = (key: string) => {
+    setFilters(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setActiveViewKey(null);
+  };
+
+  const handleClearFilters = () => {
+    setFilters({});
+    setActiveViewKey(null);
+  };
+
+  const handleSmartView = (view: SmartViewDto) => {
+    setFilters(view.filters);
+    setActiveViewKey(view.key);
+    setSearchTerm('');
+    setDebouncedSearch('');
+  };
+
+  const handleLoadSavedSearch = (search: SavedSearchDto) => {
+    try {
+      const parsed = JSON.parse(search.filtersJson);
+      setFilters(parsed);
+      if (search.sortBy) setSortBy(search.sortBy);
+      if (search.sortDir) setSortDir(search.sortDir);
+      setActiveViewKey(null);
+    } catch {
+      /* ignore invalid JSON */
+    }
+  };
+
+  const handleSaveSearch = (name: string) => {
+    createSavedSearch.mutate({
+      name,
+      entityType: 'appraisal',
+      filtersJson: JSON.stringify(filters),
+      sortBy: sortBy !== 'CreatedAt' ? sortBy : undefined,
+      sortDir: sortDir !== 'desc' ? sortDir : undefined,
+    });
+  };
+
+  const handleRowClick = (item: AppraisalDto) => {
+    setSelectedAppraisalId(item.id);
+  };
+
+  const handleExport = (format: 'xlsx' | 'csv') => {
+    exportAppraisals({ search: debouncedSearch || undefined, sortBy, sortDir, ...filters }, format);
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 min-w-0 gap-3">
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">Appraisals</h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            {totalCount > 0
+              ? `${totalCount.toLocaleString()} appraisals found`
+              : 'Browse and search appraisals'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Export */}
+          <div className="relative group">
+            <button className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:border-gray-300">
+              <Icon style="solid" name="arrow-down-tray" className="size-3" />
+              Export
+            </button>
+            <div className="hidden group-hover:block absolute right-0 top-full pt-1 w-36 z-40">
+              <div className="bg-white border border-gray-200 rounded-lg shadow-lg">
+              <button
+                onClick={() => handleExport('xlsx')}
+                className="w-full text-left px-3 py-2 text-xs hover:bg-gray-50"
+              >
+                Excel (.xlsx)
+              </button>
+              <button
+                onClick={() => handleExport('csv')}
+                className="w-full text-left px-3 py-2 text-xs hover:bg-gray-50"
+              >
+                CSV (.csv)
+              </button>
+              </div>
+            </div>
+          </div>
+          {/* Saved Searches */}
+          <SavedSearchesDropdown
+            savedSearches={savedSearches}
+            onLoad={handleLoadSavedSearch}
+            onSave={handleSaveSearch}
+            onDelete={id => deleteSavedSearch.mutate(id)}
+          />
+        </div>
+      </div>
+
+      {/* Smart Views */}
+      <div className="shrink-0">
+        <SmartViewBar views={smartViews} activeViewKey={activeViewKey} onSelect={handleSmartView} />
+      </div>
+
+      {/* Search + Filters */}
+      <div className="shrink-0 flex flex-col gap-2">
+        <div className="relative">
+          <Icon
+            style="solid"
+            name="magnifying-glass"
+            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-gray-400"
+          />
+          <input
+            type="text"
+            placeholder="Search by appraisal number, customer name, or request number..."
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:ring-1 focus:ring-primary focus:border-primary outline-none"
+          />
+          {searchTerm && (
+            <button
+              onClick={() => {
+                setSearchTerm('');
+                setDebouncedSearch('');
+              }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            >
+              <Icon style="solid" name="xmark" className="size-4" />
+            </button>
+          )}
+        </div>
+        <SearchFilterBar
+          filters={appraisalFilters}
+          values={filters}
+          onChange={handleFilterChange}
+          onClear={handleClearFilters}
+        />
+      </div>
+
+      {/* Active Filter Chips */}
+      <div className="shrink-0">
+        <ActiveFilterChips
+          filters={filters}
+          onRemove={handleRemoveFilter}
+          onClearAll={handleClearFilters}
+        />
+      </div>
+
+      {/* Facet Summary */}
+      {facets && facets.status.length > 0 && (
+        <div className="shrink-0 flex items-center gap-2 flex-wrap text-xs">
+          {facets.status.map(f => (
+            <button
+              key={f.value}
+              onClick={() => handleFilterChange('status', f.value)}
+              className={`px-2 py-0.5 rounded-full border transition-colors ${
+                filters.status === f.value
+                  ? 'bg-primary/10 border-primary/30 text-primary'
+                  : 'border-gray-200 text-gray-500 hover:border-gray-300'
+              }`}
+            >
+              {f.value} ({f.count})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Results Table */}
+      <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
+        <AppraisalResultsTable
+          columns={appraisalColumns}
+          items={items}
+          isLoading={isLoading}
+          sortBy={sortBy}
+          sortDir={sortDir}
+          onSort={handleSort}
+          onRowClick={handleRowClick}
+        />
+        <Pagination
+          currentPage={pageNumber}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={setPageNumber}
+          onPageSizeChange={size => {
+            setPageSize(size);
+            setPageNumber(0);
+          }}
+        />
+      </div>
+
+      <ActivityTrackingSlideOver
+        appraisalId={selectedAppraisalId}
+        onClose={() => setSelectedAppraisalId(null)}
+      />
+    </div>
+  );
+}
+
+export default AppraisalListPage;

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppraisalId, useWorkflowInstanceId, useActivityId, useIsTaskOwner, useAppraisalIsPma, useAppraisalFacilityLimit, useAppraisalHasAppraisalBook, useAppraisalContext } from '@/features/appraisal/context/AppraisalContext';
 import { useForm } from 'react-hook-form';
@@ -13,6 +13,7 @@ import UnsavedChangesDialog from '@/shared/components/UnsavedChangesDialog';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { formatNumber } from '@/shared/utils/formatUtils';
 import { FormProvider, FormFields, type FormField } from '@/shared/components/form';
+import { FormReadOnlyContext } from '@/shared/components/form/context';
 
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useGetDecisionSummary, useSaveDecisionSummary } from '../api/decisionSummary';
@@ -141,6 +142,56 @@ const additionalAssumptionsFields: FormField[] = [
   },
 ];
 
+// ==================== Section Visibility Config ====================
+
+type SectionKey =
+  | 'decisionApproach'
+  | 'priceSummary'
+  | 'priceVerification'
+  | 'governmentPrice'
+  | 'condition'
+  | 'remark'
+  | 'appraiserOpinion'
+  | 'committeeOpinion'
+  | 'reviewPrices'
+  | 'additionalAssumptions'
+  | 'committeeApproval';
+
+interface ActivitySectionConfig {
+  sections: SectionKey[];
+  readOnly?: boolean;
+  editableSections?: SectionKey[];
+}
+
+const ACTIVITY_SECTION_CONFIG: Record<string, ActivitySectionConfig> = {
+  'appraisal-initiation-check': { sections: [] },
+  'appraisal-initiation':       { sections: [] },
+  'appraisal-assignment':        { sections: [] },
+  'ext-appraisal-assignment':    { sections: [] },
+  'ext-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'] },
+  'ext-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
+  'ext-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
+  'appraisal-book-verification': { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true, editableSections: ['reviewPrices'] },
+  'int-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'additionalAssumptions'] },
+  'int-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'additionalAssumptions'], readOnly: true },
+  'int-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'additionalAssumptions'], readOnly: true },
+  'pending-approval':            { sections: ['committeeApproval'] },
+};
+
+/** Wraps children with FormReadOnlyContext override when forceReadOnly is true */
+const SectionReadOnlyWrap = ({
+  forceReadOnly,
+  children,
+}: {
+  forceReadOnly: boolean;
+  children: ReactNode;
+}) =>
+  forceReadOnly ? (
+    <FormReadOnlyContext.Provider value={true}>{children}</FormReadOnlyContext.Provider>
+  ) : (
+    <>{children}</>
+  );
+
 // ==================== Page Component ====================
 
 const DecisionSummaryPage = () => {
@@ -150,6 +201,18 @@ const DecisionSummaryPage = () => {
   const workflowInstanceId = useWorkflowInstanceId();
   const activityId = useActivityId();
   const isTaskOwner = useIsTaskOwner();
+
+  // Section visibility by activity
+  const sectionConfig = activityId
+    ? ACTIVITY_SECTION_CONFIG[activityId] ?? { sections: [] }
+    : null; // null = no activityId = show all sections
+  const showSection = (key: SectionKey) =>
+    sectionConfig === null || sectionConfig.sections.includes(key);
+  const isActivityReadOnly = sectionConfig?.readOnly ?? false;
+  const shouldForceReadOnly = (key: SectionKey) =>
+    !isReadOnly && isActivityReadOnly && !sectionConfig?.editableSections?.includes(key);
+  const hasEditableSections =
+    sectionConfig === null ? false : !sectionConfig.readOnly || (sectionConfig.editableSections?.length ?? 0) > 0;
 
   // Decision state (lifted from DecisionSection)
   const [selectedDecision, setSelectedDecision] = useState<string | null>(null);
@@ -175,7 +238,7 @@ const DecisionSummaryPage = () => {
   );
 
   const isManualAssignment =
-    selectedAction?.assignmentMode === 'manual' && !!selectedAction.targetActivityId;
+    selectedAction?.assignmentMode === 'user' && !!selectedAction.targetActivityId;
 
   // Form setup
   const mapDataToForm = useMemo(() => {
@@ -339,102 +402,138 @@ const DecisionSummaryPage = () => {
           <div className="flex-1 min-h-0 overflow-y-auto">
             <div className="flex flex-col gap-6 pb-6 pr-4">
               {/* 1. Decision Approach */}
-              <FormCard title="Decision Approach" icon="table-cells" iconColor="teal">
-                {data?.approachMatrix && data.approachMatrix.length > 0 ? (
-                  <ApproachMatrixTable groups={data.approachMatrix} />
-                ) : (
-                  <p className="text-sm text-gray-500">No approach data available.</p>
-                )}
-              </FormCard>
+              {showSection('decisionApproach') && (
+                <FormCard title="Decision Approach" icon="table-cells" iconColor="teal">
+                  {data?.approachMatrix && data.approachMatrix.length > 0 ? (
+                    <ApproachMatrixTable groups={data.approachMatrix} />
+                  ) : (
+                    <p className="text-sm text-gray-500">No approach data available.</p>
+                  )}
+                </FormCard>
+              )}
 
-              {/* 3. Total Appraisal Price / Force Selling Price / Building Insurance */}
-              <FormCard title="Appraisal Price Summary" icon="coins" iconColor="amber">
-                <div className="grid grid-cols-3 gap-6">
-                  <ReadOnlyField label="Total Appraisal Price" value={data?.totalAppraisalPrice} />
-                  <ReadOnlyField label="Force Selling Price" value={data?.forceSellingPrice} />
-                  <ReadOnlyField label="Building Insurance" value={data?.buildingInsurance} />
-                </div>
-              </FormCard>
+              {/* 2. Appraisal Price Summary */}
+              {showSection('priceSummary') && (
+                <FormCard title="Appraisal Price Summary" icon="coins" iconColor="amber">
+                  <div className="grid grid-cols-3 gap-6">
+                    <ReadOnlyField label="Total Appraisal Price" value={data?.totalAppraisalPrice} />
+                    <ReadOnlyField label="Force Selling Price" value={data?.forceSellingPrice} />
+                    <ReadOnlyField label="Building Insurance" value={data?.buildingInsurance} />
+                  </div>
+                </FormCard>
+              )}
 
-              {/* 4. Price Verification */}
-              <FormCard title="Price Verification" icon="badge-check" iconColor="emerald">
-                <FormFields fields={priceVerificationFields} />
-              </FormCard>
+              {/* 3. Price Verification */}
+              {showSection('priceVerification') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('priceVerification')}>
+                  <FormCard title="Price Verification" icon="badge-check" iconColor="emerald">
+                    <FormFields fields={priceVerificationFields} />
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 5. Government Appraisal Price */}
-              <FormCard
-                title={`Government Appraisal Price${data?.governmentPrices ? ` (${data.governmentPrices.length})` : ''}`}
-                icon="landmark"
-                iconColor="teal"
-              >
-                {data?.governmentPrices && data.governmentPrices.length > 0 ? (
-                  <GovernmentPriceTable
-                    rows={data.governmentPrices}
-                    totalArea={data.governmentPriceTotalArea ?? 0}
-                    avgPerSqWa={data.governmentPriceAvgPerSqWa ?? 0}
-                  />
-                ) : (
-                  <p className="text-sm text-gray-500">No government price data available.</p>
-                )}
-              </FormCard>
+              {/* 4. Government Appraisal Price */}
+              {showSection('governmentPrice') && (
+                <FormCard
+                  title={`Government Appraisal Price${data?.governmentPrices ? ` (${data.governmentPrices.length})` : ''}`}
+                  icon="landmark"
+                  iconColor="teal"
+                >
+                  {data?.governmentPrices && data.governmentPrices.length > 0 ? (
+                    <GovernmentPriceTable
+                      rows={data.governmentPrices}
+                      totalArea={data.governmentPriceTotalArea ?? 0}
+                      avgPerSqWa={data.governmentPriceAvgPerSqWa ?? 0}
+                    />
+                  ) : (
+                    <p className="text-sm text-gray-500">No government price data available.</p>
+                  )}
+                </FormCard>
+              )}
 
-              {/* 6. Condition */}
-              <FormCard title="Condition" icon="clipboard-list" iconColor="blue">
-                <div className="space-y-4">
-                  <FormFields fields={conditionFields} />
-                </div>
-              </FormCard>
+              {/* 5. Condition */}
+              {showSection('condition') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('condition')}>
+                  <FormCard title="Condition" icon="clipboard-list" iconColor="blue">
+                    <div className="space-y-4">
+                      <FormFields fields={conditionFields} />
+                    </div>
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 7. Remark */}
-              <FormCard title="Remark" icon="message-lines" iconColor="purple">
-                <div className="space-y-4">
-                  <FormFields fields={remarkFields} />
-                </div>
-              </FormCard>
+              {/* 6. Remark */}
+              {showSection('remark') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('remark')}>
+                  <FormCard title="Remark" icon="message-lines" iconColor="purple">
+                    <div className="space-y-4">
+                      <FormFields fields={remarkFields} />
+                    </div>
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 8. Summary of Appraiser Opinions */}
-              <FormCard title="Summary of Appraiser Opinions" icon="user-pen" iconColor="cyan">
-                <div className="space-y-4">
-                  <FormFields fields={appraiserOpinionFields} />
-                </div>
-              </FormCard>
+              {/* 7. Summary of Appraiser Opinions */}
+              {showSection('appraiserOpinion') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('appraiserOpinion')}>
+                  <FormCard title="Summary of Appraiser Opinions" icon="user-pen" iconColor="cyan">
+                    <div className="space-y-4">
+                      <FormFields fields={appraiserOpinionFields} />
+                    </div>
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 9. Summary of Appraisal Price Committee Opinions */}
-              <FormCard
-                title="Summary of Appraisal Price Committee Opinions"
-                icon="users"
-                iconColor="orange"
-              >
-                <div className="space-y-4">
-                  <FormFields fields={committeeOpinionFields} />
-                </div>
-              </FormCard>
+              {/* 8. Summary of Appraisal Price Committee Opinions */}
+              {showSection('committeeOpinion') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('committeeOpinion')}>
+                  <FormCard
+                    title="Summary of Appraisal Price Committee Opinions"
+                    icon="users"
+                    iconColor="orange"
+                  >
+                    <div className="space-y-4">
+                      <FormFields fields={committeeOpinionFields} />
+                    </div>
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 10. Review Prices */}
-              <FormCard title="Review Prices" icon="magnifying-glass-dollar" iconColor="amber">
-                <div className="grid grid-cols-3 gap-6">
-                  <FormFields fields={reviewPriceFields} />
-                  <ReadOnlyField
-                    label="Force Selling Price (Review)"
-                    value={data?.forceSellingPriceReview}
-                  />
-                  <ReadOnlyField
-                    label="Building Insurance (Review)"
-                    value={data?.buildingInsuranceReview}
-                  />
-                </div>
-              </FormCard>
+              {/* 9. Review Prices */}
+              {showSection('reviewPrices') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('reviewPrices')}>
+                  <FormCard title="Review Prices" icon="magnifying-glass-dollar" iconColor="amber">
+                    <div className="grid grid-cols-3 gap-6">
+                      <FormFields fields={reviewPriceFields} />
+                      <ReadOnlyField
+                        label="Force Selling Price (Review)"
+                        value={data?.forceSellingPriceReview}
+                      />
+                      <ReadOnlyField
+                        label="Building Insurance (Review)"
+                        value={data?.buildingInsuranceReview}
+                      />
+                    </div>
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 11. Additional / Special Assumptions */}
-              <FormCard title="Additional / Special Assumptions" icon="lightbulb" iconColor="amber">
-                <FormFields fields={additionalAssumptionsFields} />
-              </FormCard>
+              {/* 10. Additional / Special Assumptions */}
+              {showSection('additionalAssumptions') && (
+                <SectionReadOnlyWrap forceReadOnly={shouldForceReadOnly('additionalAssumptions')}>
+                  <FormCard title="Additional / Special Assumptions" icon="lightbulb" iconColor="amber">
+                    <FormFields fields={additionalAssumptionsFields} />
+                  </FormCard>
+                </SectionReadOnlyWrap>
+              )}
 
-              {/* 12. Committee Approval */}
-              <ApprovalListSection
-                workflowInstanceId={workflowInstanceId}
-                activityId={activityId}
-              />
+              {/* 11. Committee Approval */}
+              {showSection('committeeApproval') && (
+                <ApprovalListSection
+                  workflowInstanceId={workflowInstanceId}
+                  activityId={activityId}
+                />
+              )}
 
               {/* 13. Decision */}
               <DecisionSection
@@ -465,10 +564,12 @@ const DecisionSummaryPage = () => {
                   )}
                 </div>
                 <div className="flex gap-3">
-                  <Button variant="outline" type="submit" disabled={!appraisalId || !isDirty || isSaving}>
-                    <Icon style="regular" name="floppy-disk" className="size-4 mr-2" />
-                    Save
-                  </Button>
+                  {hasEditableSections && (
+                    <Button variant="outline" type="submit" disabled={!appraisalId || !isDirty || isSaving}>
+                      <Icon style="regular" name="floppy-disk" className="size-4 mr-2" />
+                      Save
+                    </Button>
+                  )}
                   <Button
                     type="button"
                     disabled={

--- a/src/features/dashboard/components/ReminderWidget.tsx
+++ b/src/features/dashboard/components/ReminderWidget.tsx
@@ -90,19 +90,17 @@ function ReminderWidget() {
                   </div>
 
                   <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+                    {item.appraisalNumber && (
+                      <span className="text-xs font-semibold text-blue-600">
+                        {item.appraisalNumber}
+                      </span>
+                    )}
                     <span className="text-sm font-medium text-gray-800 truncate">
                       {item.title}
                     </span>
-                    <div className="flex items-center gap-2">
-                      {item.appraisalNumber && (
-                        <span className="text-xs font-medium text-blue-600">
-                          {item.appraisalNumber}
-                        </span>
-                      )}
-                      {dueLabel && (
-                        <span className="text-xs text-gray-400">{dueLabel}</span>
-                      )}
-                    </div>
+                    {dueLabel && (
+                      <span className="text-xs text-gray-400">{dueLabel}</span>
+                    )}
                   </div>
 
                   {item.overdue && (

--- a/src/features/dashboard/components/TotalAppraisalsWidget.tsx
+++ b/src/features/dashboard/components/TotalAppraisalsWidget.tsx
@@ -135,48 +135,68 @@ function TotalAppraisalsWidget() {
           </div>
 
           {/* Chart */}
-          <div className="relative">
-            <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} className="w-full h-32">
-              <defs>
-                <linearGradient id="thisYearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                  <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.2" />
-                  <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
-                </linearGradient>
-              </defs>
+          <div>
+            {/* Chart area: SVG stretches to fill container; dots are HTML overlays so they stay circular */}
+            <div className="relative h-32">
+              <svg
+                viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+                preserveAspectRatio="none"
+                className="absolute inset-0 h-full w-full"
+              >
+                <defs>
+                  <linearGradient id="thisYearGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                    <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.2" />
+                    <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
+                  </linearGradient>
+                </defs>
 
-              {/* Area fill */}
-              <path d={thisYearAreaPath} fill="url(#thisYearGradient)" />
+                {/* Area fill */}
+                <path d={thisYearAreaPath} fill="url(#thisYearGradient)" />
 
-              {/* Last year line */}
-              <path
-                d={lastYearPath}
-                fill="none"
-                stroke="#f59e0b"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
+                {/* Last year line */}
+                <path
+                  d={lastYearPath}
+                  fill="none"
+                  stroke="#f59e0b"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  vectorEffect="non-scaling-stroke"
+                />
 
-              {/* This year line */}
-              <path
-                d={thisYearPath}
-                fill="none"
-                stroke="#3b82f6"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
+                {/* This year line */}
+                <path
+                  d={thisYearPath}
+                  fill="none"
+                  stroke="#3b82f6"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  vectorEffect="non-scaling-stroke"
+                />
+              </svg>
 
-              {/* Data points for this year */}
+              {/* Data points for this year — HTML overlay so dots stay circular under non-uniform SVG scaling */}
               {data.map((d, i) => (
-                <circle key={i} cx={getX(i)} cy={getY(d.thisYear)} r="4" fill="#3b82f6" />
+                <div
+                  key={i}
+                  className="pointer-events-none absolute size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-500"
+                  style={{
+                    left: `${(i / (data.length - 1)) * 100}%`,
+                    top: `${(getY(d.thisYear) / chartHeight) * 100}%`,
+                  }}
+                />
               ))}
-            </svg>
+            </div>
 
-            {/* X-axis labels */}
-            <div className="flex justify-between mt-2 px-1">
-              {data.map((d) => (
-                <span key={d.month} className="text-xs text-gray-400">
+            {/* X-axis labels — absolute positioning keeps each label center aligned with its dot */}
+            <div className="relative mt-2 h-4">
+              {data.map((d, i) => (
+                <span
+                  key={d.month}
+                  className="absolute -translate-x-1/2 text-xs text-gray-400"
+                  style={{ left: `${(i / (data.length - 1)) * 100}%` }}
+                >
                   {d.month}
                 </span>
               ))}

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowAssumption.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowAssumption.tsx
@@ -13,6 +13,7 @@ interface DiscountedCashFlowAssumptionProps {
   editing: string | null;
   onOpenEditMode: (assumptionType: string) => void;
   onRemoveAssumption: () => void;
+  isReadOnly?: boolean;
 }
 
 export function DiscountedCashFlowAssumption({
@@ -22,6 +23,7 @@ export function DiscountedCashFlowAssumption({
   editing,
   onOpenEditMode,
   onRemoveAssumption,
+  isReadOnly,
 }: DiscountedCashFlowAssumptionProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -74,22 +76,26 @@ export function DiscountedCashFlowAssumption({
                     </span>
                   )}
                 />
-                <button
-                  type="button"
-                  className="flex justify-center items-center gap-2 p-1.5 border border-dashed border-primary text-primary rounded-lg hover:bg-primary/10 duration-200 transition-all cursor-pointer font-medium"
-                  onClick={() => {
-                    onOpenEditMode(assumption.clientId);
-                  }}
-                >
-                  <Icon name="pencil" style="regular" className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  className="flex justify-center items-center gap-2 p-1.5 border border-dashed border-danger text-danger rounded-lg hover:bg-danger/10 duration-200 transition-all cursor-pointer font-medium"
-                  onClick={onRemoveAssumption}
-                >
-                  <Icon name="trash" style="regular" className="size-4" />
-                </button>
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    className="flex justify-center items-center gap-2 p-1.5 border border-dashed border-primary text-primary rounded-lg hover:bg-primary/10 duration-200 transition-all cursor-pointer font-medium"
+                    onClick={() => {
+                      onOpenEditMode(assumption.clientId);
+                    }}
+                  >
+                    <Icon name="pencil" style="regular" className="size-4" />
+                  </button>
+                )}
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    className="flex justify-center items-center gap-2 p-1.5 border border-dashed border-danger text-danger rounded-lg hover:bg-danger/10 duration-200 transition-all cursor-pointer font-medium"
+                    onClick={onRemoveAssumption}
+                  >
+                    <Icon name="trash" style="regular" className="size-4" />
+                  </button>
+                )}
               </div>
             </div>
           </div>
@@ -123,6 +129,7 @@ export function DiscountedCashFlowAssumption({
         assumption={assumption}
         method={assumption.method}
         totalNumberOfYear={totalNumberOfYears}
+        isReadOnly={isReadOnly}
       />
     </>
   );

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategory.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategory.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Icon } from '@/shared/components';
 import clsx from 'clsx';
 import { DiscountedCashFlowAssumption } from './DiscountedCashFlowAssumption';
@@ -7,6 +7,7 @@ import { useFormContext } from 'react-hook-form';
 import { type DCFAssumption, type DCFCategory, type DCFSection } from '../../types/dcf';
 import { DiscountedCashFlowMethodModal } from './DiscountedCashFlowMethodModal';
 import { useAssumptionManagement } from '../../domain/dcf/useAssumptionManagement';
+import { useAssumptionEditor } from '../../domain/dcf/useAssumptionEditor';
 
 interface DiscountedCashFlowCategoryProps {
   name: string;
@@ -16,6 +17,7 @@ interface DiscountedCashFlowCategoryProps {
   totalNumberOfYears: number;
   color: SectionColor;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 
 export function DiscountedCashFlowCategory({
@@ -26,43 +28,22 @@ export function DiscountedCashFlowCategory({
   totalNumberOfYears,
   color,
   baseStyles,
+  isReadOnly,
 }: DiscountedCashFlowCategoryProps) {
   const { getValues, setValue, control } = useFormContext();
 
   const {
     fields,
     editing,
+    activeAssumption,
     handleOnAddAssumption,
     handleOnRemoveAssumption,
     handleOnOpenEditMode,
     handleOnCancelEditMode,
     handleOnSaveEditMode,
-  } = useAssumptionManagement(name, getValues, setValue, control);
+  } = useAssumptionManagement({ name, getValues, setValue, control });
 
-  const activeAssumption = fields
-    .map((_, idx) => getValues(`${name}.assumptions.${idx}`) as DCFAssumption)
-    .find(a => a?.clientId === editing);
-
-  const modalInitialData = useMemo(() => {
-    if (!activeAssumption) return null;
-
-    return {
-      targetSectionClientId: section.clientId,
-      targetCategoryClientId: category.clientId,
-      targetAssumptionClientId: activeAssumption.clientId,
-      assumptionType: activeAssumption.assumptionType ?? null,
-      assumptionName: activeAssumption.assumptionName ?? null,
-      displayName: activeAssumption.assumptionName ?? null,
-      method: activeAssumption.method ?? null,
-    };
-  }, [
-    section.clientId,
-    category.clientId,
-    activeAssumption?.clientId,
-    activeAssumption?.assumptionType,
-    activeAssumption?.assumptionName,
-    activeAssumption?.method,
-  ]);
+  const { modalInitialData } = useAssumptionEditor({ section, category, activeAssumption });
 
   const [isExpanded, setExpanded] = useState(true);
 
@@ -130,6 +111,7 @@ export function DiscountedCashFlowCategory({
                   totalNumberOfYears={totalNumberOfYears}
                   onOpenEditMode={handleOnOpenEditMode}
                   onRemoveAssumption={() => handleOnRemoveAssumption(idx)}
+                  isReadOnly={isReadOnly}
                 />
               </Fragment>
             );
@@ -144,25 +126,28 @@ export function DiscountedCashFlowCategory({
               onCancelEditMode={handleOnCancelEditMode}
               onSaveEditMode={handleOnSaveEditMode}
               size="2xl"
+              isReadOnly={isReadOnly}
             />
           )}
 
-          <tr>
-            <td className={clsx(baseStyles.rowHeader)}>
-              <div className="flex flex-row items-center gap-1.5">
-                <button
-                  type="button"
-                  onClick={handleOnAddAssumption}
-                  className="px-1.5 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                >
-                  + Add Assumption
-                </button>
-              </div>
-            </td>
-            {Array.from({ length: totalNumberOfYears }, (_, index) => (
-              <td key={index} className={clsx(baseStyles.rowBody)} />
-            ))}
-          </tr>
+          {!isReadOnly && (
+            <tr>
+              <td className={clsx(baseStyles.rowHeader)}>
+                <div className="flex flex-row items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={handleOnAddAssumption}
+                    className="px-1.5 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                  >
+                    + Add Assumption
+                  </button>
+                </div>
+              </td>
+              {Array.from({ length: totalNumberOfYears }, (_, index) => (
+                <td key={index} className={clsx(baseStyles.rowBody)} />
+              ))}
+            </tr>
+          )}
         </>
       )}
     </>

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategoryRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategoryRenderer.tsx
@@ -10,6 +10,7 @@ interface DiscountedCashFlowCategoryRendererProps {
   category: DCFCategory;
   totalNumberOfYears: number;
   color: SectionColor;
+  isReadOnly?: boolean;
 }
 export function DiscountedCashFlowCategoryRenderer({
   name,
@@ -18,6 +19,7 @@ export function DiscountedCashFlowCategoryRenderer({
   category,
   totalNumberOfYears,
   color,
+  isReadOnly,
 }: DiscountedCashFlowCategoryRendererProps) {
   const props = {
     name: name,
@@ -26,6 +28,7 @@ export function DiscountedCashFlowCategoryRenderer({
     category: category,
     totalNumberOfYears: totalNumberOfYears,
     color: color,
+    isReadOnly: isReadOnly,
     baseStyles: {
       rowHeader: 'pl-8 px-1 py-1.5 h-12 text-sm border-b border-gray-300',
       rowBody: 'pl-8 px-1.5 py-1.5 h-12 text-sm text-right border-b border-gray-300',

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowHighestBestUsed.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowHighestBestUsed.tsx
@@ -7,7 +7,11 @@ import { floorToThousands } from '../../domain/calculation';
 import { useEffect, useRef } from 'react';
 import { shouldAutoDefault } from '../../domain/shouldAutoDefault';
 
-export function DiscountedCashFlowHighestBestUsed() {
+interface DiscountedCashFlowHighestBestUsedProps {
+  isReadOnly?: boolean;
+}
+
+export function DiscountedCashFlowHighestBestUsed({ isReadOnly }: DiscountedCashFlowHighestBestUsedProps) {
   const { control, getValues, setValue } = useFormContext();
   const isHighestBestUsed = useWatch({ control, name: 'isHighestBestUsed' });
 
@@ -67,6 +71,7 @@ export function DiscountedCashFlowHighestBestUsed() {
         <RHFInputCell
           fieldName={'isHighestBestUsed'}
           inputType="toggle"
+          disabled={isReadOnly}
           toggle={{ checked: isHighestBestUsed, options: ['No', 'Yes'] }}
           onUserChange={e => {
             if (!e) {
@@ -91,6 +96,7 @@ export function DiscountedCashFlowHighestBestUsed() {
                 <RHFInputCell
                   fieldName={'highestBestUsed.areaRai'}
                   inputType="number"
+                  disabled={isReadOnly}
                   number={{
                     label: 'Rai',
                     decimalPlaces: 0,
@@ -103,6 +109,7 @@ export function DiscountedCashFlowHighestBestUsed() {
                 <RHFInputCell
                   fieldName={'highestBestUsed.areaNgan'}
                   inputType="number"
+                  disabled={isReadOnly}
                   number={{
                     label: 'Ngan',
                     decimalPlaces: 0,
@@ -116,6 +123,7 @@ export function DiscountedCashFlowHighestBestUsed() {
                 <RHFInputCell
                   fieldName={'highestBestUsed.areaWa'}
                   inputType="number"
+                  disabled={isReadOnly}
                   number={{
                     label: 'Wa',
                     decimalPlaces: 2,
@@ -138,6 +146,7 @@ export function DiscountedCashFlowHighestBestUsed() {
                 <RHFInputCell
                   fieldName={'highestBestUsed.pricePerSqWa'}
                   inputType="number"
+                  disabled={isReadOnly}
                   number={{
                     label: 'Price/ Sq.Wa',
                     decimalPlaces: 2,
@@ -179,6 +188,7 @@ export function DiscountedCashFlowHighestBestUsed() {
           <RHFInputCell
             fieldName={'appraisalPriceRounded'}
             inputType="number"
+            disabled={isReadOnly}
             number={{
               decimalPlaces: 2,
               maxIntegerDigits: 15,

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
@@ -10,6 +10,7 @@ import {
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { DiscountedCashFlowModalRenderer } from './DiscountedCashFlowMethodModalRenderer';
 import type { DCFMethod, DCFSection } from '../../types/dcf';
+import { createDefaultMethod } from '../../domain/dcf/createEmptyMethodDetail';
 import { buildDiscountedCashFlowCategoryOptions } from '../../adapters/buildDiscountedCashFlowCategoryOptions';
 import { mapDCFMethodCodeToSystemType } from '../../domain/mapDCFMethodCodeToSystemType';
 import { getDCFFilteredAssumptions } from '../../domain/getDCFFilteredAssumptions';
@@ -32,6 +33,7 @@ interface DiscountedCashFlowMethodModalProps {
   onCancelEditMode: () => void;
   onSaveEditMode: (data: AssumptionEditDraft) => void;
   size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+  isReadOnly?: boolean;
 }
 export function DiscountedCashFlowMethodModal({
   editing,
@@ -41,6 +43,7 @@ export function DiscountedCashFlowMethodModal({
   onCancelEditMode,
   onSaveEditMode,
   size,
+  isReadOnly,
 }: DiscountedCashFlowMethodModalProps) {
   const methods = useForm<AssumptionEditDraft>({
     defaultValues: initialData,
@@ -68,13 +71,12 @@ export function DiscountedCashFlowMethodModal({
     (nextMethodType: string) => {
       const currentValues = getValues();
 
+      const newMethod = createDefaultMethod(
+        nextMethodType as AssumptionEditDraft['method']['methodType'],
+      );
       reset({
         ...currentValues,
-        method: {
-          ...currentValues.method,
-          methodType: nextMethodType as AssumptionEditDraft['method']['methodType'],
-          detail: undefined,
-        },
+        method: newMethod,
       });
     },
     [getValues, reset],
@@ -227,6 +229,7 @@ export function DiscountedCashFlowMethodModal({
               methodType={systemMethodType}
               properties={properties}
               getOuterFormValues={getOuterFormValues}
+              isReadOnly={isReadOnly}
             />
           )}
 
@@ -240,7 +243,7 @@ export function DiscountedCashFlowMethodModal({
             >
               Cancel
             </Button>
-            <Button type="submit" variant="primary" size="sm">
+            <Button type="submit" variant="primary" size="sm" disabled={isReadOnly}>
               Save
             </Button>
           </div>

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
@@ -20,14 +20,16 @@ interface DiscountedCashFlowModalRendererProps {
   methodType: string;
   properties: Record<string, unknown>[];
   getOuterFormValues: UseFormGetValues<FormValues>;
+  isReadOnly?: boolean;
 }
 export function DiscountedCashFlowModalRenderer({
   name,
   methodType,
   properties,
   getOuterFormValues,
+  isReadOnly,
 }: DiscountedCashFlowModalRendererProps) {
-  const props = { name, properties, getOuterFormValues };
+  const props = { name, properties, getOuterFormValues, isReadOnly };
 
   switch (methodType) {
     case 'specifiedRoomIncomePerDay': {

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodRenderer.tsx
@@ -22,6 +22,7 @@ interface DiscountedCashFlowMethodRendererProps {
   assumption: DCFAssumption;
   method: DCFMethod;
   totalNumberOfYear: number;
+  isReadOnly?: boolean;
 }
 export function DiscountedCashFlowMethodRenderer({
   name,
@@ -30,6 +31,7 @@ export function DiscountedCashFlowMethodRenderer({
   assumption,
   method,
   totalNumberOfYear,
+  isReadOnly,
 }: DiscountedCashFlowMethodRendererProps) {
   const props = {
     name: name,
@@ -40,6 +42,7 @@ export function DiscountedCashFlowMethodRenderer({
     assumptionId: assumption.clientId,
     assumptionName: assumption.assumptionName,
     assumptionType: assumption.assumptionType,
+    isReadOnly: isReadOnly,
     baseStyles: {
       rowHeader: 'pl-24 px-1.5 h-12 text-sm text-gray-500 border-b border-gray-300',
       rowBody: 'px-1.5 h-12 text-sm text-right text-gray-500 border-b border-gray-300',

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
@@ -9,12 +9,14 @@ import { COLLATERAL_TYPE } from '@features/pricingAnalysis/data/constants.ts';
 import { MethodFooterActions } from '@features/pricingAnalysis/components/MethodFooterActions.tsx';
 import ConfirmDialog from '@shared/components/ConfirmDialog.tsx';
 import { DiscountedCashFlowHighestBestUsed } from './DiscountedCashFlowHighestBestUsed';
+import { usePageReadOnly } from '@shared/contexts/PageReadOnlyContext.tsx';
 import { initializeDiscountedCashFlowForm } from '../../adapters/initializeDiscountedCashFlowForm';
 import { pricingTemplateDtoToDcfTemplate } from '../../adapters/pricingTemplateDtoToDcfTemplate';
 import { useGetPricingTemplates, useGetPricingTemplateByCode, useSaveIncomeAnalysis, useGetIncomeAnalysis, usePreviewIncomeAnalysis } from '../../api';
 import { mapDCFFormToSaveRequest } from '../../mappers/formToSaveRequest';
 import { mapIncomeAnalysisToDCFForm } from '../../mappers/analysisToForm';
 import { useDebounce } from '@/shared/hooks/useDebounce';
+import { DiscountedCashFlowSummaryAssumption } from './DiscountedCashFlowSummaryAssumption';
 
 interface DiscountedCashFlowPanelProps {
   activeMethod?: {
@@ -41,6 +43,7 @@ export function DiscountedCashFlowPanel({
   onCalculationMethodDirty: _onCalculationMethodDirty,
   onCancelCalculationMethod,
 }: DiscountedCashFlowPanelProps) {
+  const isReadOnly = usePageReadOnly();
   const methods = useForm<DCFFormType>({
     mode: 'onSubmit',
     resolver: zodResolver(DCFForm),
@@ -52,6 +55,7 @@ export function DiscountedCashFlowPanel({
   const [selectedTemplateCode, setSelectedTemplateCode] = useState<string>('');
   const [isGenerated, setIsGenerated] = useState<boolean>(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [showAssumptionSummary, setShowAssumptionSummary] = useState(false);
 
   const { data: pricingTemplates = [] } = useGetPricingTemplates(true);
   const { data: templateDto } = useGetPricingTemplateByCode(selectedTemplateCode || undefined);
@@ -271,9 +275,17 @@ export function DiscountedCashFlowPanel({
             <DiscountedCashFlowTable
               totalNumberOfYears={getValues('totalNumberOfYears')}
               properties={properties ?? []}
+              isReadOnly={isReadOnly}
             />
 
-            <DiscountedCashFlowHighestBestUsed />
+            <DiscountedCashFlowSummaryAssumption
+              properties={properties ?? []}
+              getValues={getValues}
+              showAssumptionSummary={showAssumptionSummary}
+              onShowAssumptionSummary={() => setShowAssumptionSummary(!showAssumptionSummary)}
+            />
+
+            <DiscountedCashFlowHighestBestUsed isReadOnly={isReadOnly} />
 
             {saveError && (
               <p className="text-sm text-red-600 px-1">{saveError}</p>

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSectionRenderer.tsx
@@ -12,6 +12,7 @@ interface DiscountedCashFlowSectionRendererProps {
   totalNumberOfYears: number;
   icon: string;
   color: SectionColor;
+  isReadOnly?: boolean;
 }
 export function DiscountedCashFlowSectionRenderer({
   name,
@@ -20,6 +21,7 @@ export function DiscountedCashFlowSectionRenderer({
   totalNumberOfYears,
   icon,
   color,
+  isReadOnly,
 }: DiscountedCashFlowSectionRendererProps) {
   switch (section.sectionType) {
     case 'income': {
@@ -31,6 +33,7 @@ export function DiscountedCashFlowSectionRenderer({
           color={color}
           icon={icon}
           properties={properties}
+          isReadOnly={isReadOnly}
         />
       );
     }
@@ -43,14 +46,15 @@ export function DiscountedCashFlowSectionRenderer({
           color={color}
           icon={icon}
           properties={properties}
+          isReadOnly={isReadOnly}
         />
       );
     }
     case 'summaryDCF': {
-      return <SectionSummaryDCF name={name} totalNumberOfYears={totalNumberOfYears} />;
+      return <SectionSummaryDCF name={name} totalNumberOfYears={totalNumberOfYears} isReadOnly={isReadOnly} />;
     }
     case 'summaryDirect': {
-      return <SectionSummaryDirectCashFlow name={name} totalNumberOfYears={totalNumberOfYears} />;
+      return <SectionSummaryDirectCashFlow name={name} totalNumberOfYears={totalNumberOfYears} isReadOnly={isReadOnly} />;
     }
   }
 }

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSummaryAssumption.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSummaryAssumption.tsx
@@ -1,0 +1,109 @@
+import type {
+  DCFAssumption,
+  DCFCategory,
+  DCFSection,
+} from '../../types/dcf';
+import { useFormContext, type UseFormGetValues, useWatch } from 'react-hook-form';
+import Modal from '@/shared/components/Modal';
+import { DiscountedCashFlowModalRenderer } from './DiscountedCashFlowMethodModalRenderer';
+import { Button } from '@shared/components';
+import { assumptionParams } from '../../data/dcfParameters';
+import { mapDCFMethodCodeToSystemType } from '../../domain/mapDCFMethodCodeToSystemType';
+
+interface DiscountedCashFlowSummaryAssumptionProps {
+  properties: Record<string, unknown>[];
+  getValues: UseFormGetValues<any>;
+  showAssumptionSummary: boolean;
+  onShowAssumptionSummary: () => void;
+}
+export function DiscountedCashFlowSummaryAssumption({
+  properties,
+  getValues,
+  showAssumptionSummary,
+  onShowAssumptionSummary,
+}: DiscountedCashFlowSummaryAssumptionProps) {
+  const { control } = useFormContext();
+  const sections = useWatch({ name: 'sections', control });
+  const props = { properties, getOuterFormValues: getValues, isReadOnly: true };
+
+  return (
+    <>
+      <div className={'flex justify-end items-center'}>
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={onShowAssumptionSummary}
+          className={'border border-gray-300 border-dashed cursor-pointer'}
+        >
+          View Assumption Summary
+        </Button>
+      </div>
+      <Modal
+        isOpen={showAssumptionSummary}
+        onClose={onShowAssumptionSummary}
+        title={`Assumption Summary`}
+        size="3xl"
+      >
+        <div className={'overflow-auto max-h-[600px] flex flex-col gap-2'}>
+          {(sections ?? []).map((section: DCFSection, sectionIdx: number) => {
+            if (section.sectionType === 'income' || section.sectionType === 'expenses') {
+              return (
+                <div className={'flex flex-col gap-2'} key={section.clientId ?? sectionIdx}>
+                  <span className={'p-1.5 text-2xl'}>Section: {section.sectionName}</span>
+                  {(section.categories ?? []).map((category: DCFCategory, categoryIdx: number) => {
+                    if (
+                      category.categoryType === 'income' ||
+                      category.categoryType === 'expenses' ||
+                      category.categoryType === 'fixedExps'
+                    ) {
+                      return (
+                        <div className={'p-1.5 gap-2 ml-8'} key={category.clientId ?? categoryIdx}>
+                          <span className={'p-1.5 text-xl'}>Category: {category.categoryName}</span>
+                          <div className={'flex flex-col gap-2'}>
+                            {(category.assumptions ?? []).map(
+                              (assumption: DCFAssumption, assumptionIdx: number) => {
+                                const methodCode = assumption.method?.methodType ?? null;
+
+                                const systemMethodType = methodCode
+                                  ? mapDCFMethodCodeToSystemType(methodCode)
+                                  : null;
+                                if (!systemMethodType) return null;
+
+                                const methodProps = {
+                                  ...props,
+                                  methodType: systemMethodType,
+                                  name: `sections.${sectionIdx}.categories.${categoryIdx}.assumptions.${assumptionIdx}.method.detail`,
+                                };
+                                return (
+                                  <div
+                                    className={'flex flex-col gap-2 ml-8'}
+                                    key={assumption.clientId ?? assumptionIdx}
+                                  >
+                                    <span className={'p-1.5 border-b border-gray-300'}>
+                                      {assumption.assumptionName
+                                        ? assumption.assumptionName
+                                        : assumptionParams.find(
+                                            (p: any) => p.code === assumption.assumptionType,
+                                          )?.description}
+                                    </span>
+                                    <div className={'ml-4 p-2'}>
+                                      <DiscountedCashFlowModalRenderer {...methodProps} />
+                                    </div>
+                                  </div>
+                                );
+                              },
+                            )}
+                          </div>
+                        </div>
+                      );
+                    }
+                  })}
+                </div>
+              );
+            }
+          })}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
@@ -80,11 +80,13 @@ const getIconSection = (identifier: string) => {
 interface DiscountedCashFlowTableProps {
   totalNumberOfYears: number;
   properties: Record<string, unknown>[];
+  isReadOnly?: boolean;
 }
 
 export function DiscountedCashFlowTable({
   totalNumberOfYears,
   properties,
+  isReadOnly,
 }: DiscountedCashFlowTableProps) {
   const { control } = useFormContext();
   const watchSections = useWatch({ control, name: 'sections' });
@@ -147,6 +149,7 @@ export function DiscountedCashFlowTable({
                     <RHFInputCell
                       fieldName="totalNumberOfDayInYear"
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 0,
                         maxIntegerDigits: 3,
@@ -180,6 +183,7 @@ export function DiscountedCashFlowTable({
                   color={getSectionColor(section.sectionType)}
                   totalNumberOfYears={totalNumberOfYears}
                   icon={getIconSection(section.identifier)}
+                  isReadOnly={isReadOnly}
                 />
               );
             })}

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValue.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValue.tsx
@@ -7,6 +7,7 @@ interface MethodParameterBasedOnTierOfPrpertyValueProps {
   totalNumberOfYears: number;
   method: MethodParameterBasedOnTierOfPropertyValueWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodParameterBasedOnTierOfPropertyValue({
   expanded,
@@ -18,7 +19,7 @@ export function MethodParameterBasedOnTierOfPropertyValue({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
@@ -16,10 +16,12 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
   name,
   properties,
   getOuterFormValues,
+  isReadOnly,
 }: {
   name: string;
   properties: Record<string, unknown>[];
   getOuterFormValues: UseFormGetValues<FormValues>;
+  isReadOnly?: boolean;
 }) {
   const landGovPrice = (properties ?? [])
     .filter(p => p.propertyType === 'L')
@@ -115,6 +117,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
@@ -123,6 +126,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
@@ -134,6 +138,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
           <RHFInputCell
             fieldName={`${name}.startIn`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{
               decimalPlaces: 0,
               maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculation.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculation.tsx
@@ -5,6 +5,7 @@ interface MethodPositionBasedSalaryCalculationProps {
   expanded: boolean;
   method: MethodPositionBasedSalaryCalculationWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodPositionBasedSalaryCalculation({
   expanded,
@@ -14,7 +15,7 @@ export function MethodPositionBasedSalaryCalculation({
   return (
     expanded && (
       <>
-        <tr>
+        <tr className="group transition-colors">
           <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
           {(method.detail?.increaseRate ?? []).map((val, idx) => {
             return (
@@ -24,7 +25,7 @@ export function MethodPositionBasedSalaryCalculation({
             );
           })}
         </tr>
-        <tr>
+        <tr className="group transition-colors">
           <td className={clsx(baseStyles.rowHeader)}>
             <span>Total</span>
           </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculationModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculationModal.tsx
@@ -10,10 +10,12 @@ import { jobPositionParameters } from '@/features/pricingAnalysis/data/dcfParame
 interface MethodPositionBasedSalaryCalculationModalProps {
   name: string;
   getOuterFormValues: (name: string) => object;
+  isReadOnly?: boolean;
 }
 export function MethodPositionBasedSalaryCalculationModal({
   name,
   getOuterFormValues,
+  isReadOnly,
 }: MethodPositionBasedSalaryCalculationModalProps) {
   const { getValues } = useFormContext();
   const { fields, append, remove } = useFieldArray({ name: `${name}.jobPositionDetails` });
@@ -130,6 +132,7 @@ export function MethodPositionBasedSalaryCalculationModal({
                           <RHFInputCell
                             fieldName={`${name}.jobPositionDetails.${index}.jobPosition`}
                             inputType="select"
+                            disabled={isReadOnly}
                             options={jobPositionParameters.map(p => ({
                               value: p.code,
                               label: p.description,
@@ -139,23 +142,27 @@ export function MethodPositionBasedSalaryCalculationModal({
                             <RHFInputCell
                               fieldName={`${name}.jobPositionDetails.${index}.jobPositionOther`}
                               inputType="text"
+                              disabled={isReadOnly}
                               text={{ maxLength: 50 }}
                             />
                           )}
-                          <button
-                            type="button"
-                            onClick={() => handleOnRemove(index)}
-                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
-                          >
-                            <Icon style="solid" name="trash" className="size-1" />
-                          </button>
+                          {!isReadOnly && (
+                            <button
+                              type="button"
+                              onClick={() => handleOnRemove(index)}
+                              className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                              title="Delete"
+                            >
+                              <Icon style="solid" name="trash" className="size-1" />
+                            </button>
+                          )}
                         </div>
                       </td>
                       <td className="px-1.5 py-1.5 border-b border-gray-300">
                         <RHFInputCell
                           fieldName={`${name}.jobPositionDetails.${index}.salaryBahtPerPersonPerMonth`}
                           inputType="number"
+                          disabled={isReadOnly}
                           number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
                         />
                       </td>
@@ -163,6 +170,7 @@ export function MethodPositionBasedSalaryCalculationModal({
                         <RHFInputCell
                           fieldName={`${name}.jobPositionDetails.${index}.numberOfEmployees`}
                           inputType="number"
+                          disabled={isReadOnly}
                           number={{ decimalPlaces: 0, maxIntegerDigits: 4, allowNegative: false }}
                         />
                       </td>
@@ -182,20 +190,22 @@ export function MethodPositionBasedSalaryCalculationModal({
                     </tr>
                   );
                 })}
-                <tr>
-                  <td>
-                    <button
-                      type="button"
-                      onClick={() => handleOnAdd()}
-                      className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                    >
-                      + Add Job Position
-                    </button>
-                  </td>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                </tr>
+                {!isReadOnly && (
+                  <tr>
+                    <td>
+                      <button
+                        type="button"
+                        onClick={() => handleOnAdd()}
+                        className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                      >
+                        + Add Job Position
+                      </button>
+                    </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                )}
                 <tr>
                   <td className="sticky bottom-0 px-1.5 bg-white">Total</td>
                   <td className="sticky bottom-0 px-1.5 bg-white">
@@ -257,6 +267,7 @@ export function MethodPositionBasedSalaryCalculationModal({
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -269,6 +280,7 @@ export function MethodPositionBasedSalaryCalculationModal({
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportion.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportion.tsx
@@ -11,6 +11,7 @@ interface MethodProportionProps {
   method: MethodProportionWrapper;
   assumptionType: string;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodProportion({
   name,
@@ -18,6 +19,7 @@ export function MethodProportion({
   method,
   assumptionType,
   baseStyles,
+  isReadOnly,
 }: MethodProportionProps) {
   const { getValues } = useFormContext();
   const sections = (getValues('sections') ?? []).filter(
@@ -38,7 +40,7 @@ export function MethodProportion({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row gap-3 items-center justify-between">
                 <span>Total</span>
@@ -47,6 +49,7 @@ export function MethodProportion({
                     <RHFInputCell
                       fieldName={`${name}.detail.proportionPct`}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
                     />
                   </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionModal.tsx
@@ -7,9 +7,11 @@ import type { FormValues } from '@/features/appraisal/components/tables/bType';
 export function MethodProportionModal({
   name,
   getOuterFormValues,
+  isReadOnly,
 }: {
   name: string;
   getOuterFormValues: UseFormGetValues<FormValues>;
+  isReadOnly?: boolean;
 }) {
   const sections = (getOuterFormValues('sections') ?? []).filter(
     (s: DCFSection) => s.identifier !== 'empty',
@@ -44,7 +46,7 @@ export function MethodProportionModal({
     <div className="flex flex-row gap-1.5 items-center">
       <span className={'w-44'}>Proportions</span>
       <div className={'w-44'}>
-        <RHFInputCell fieldName={`${name}.proportionPct`} inputType={'number'} />
+        <RHFInputCell fieldName={`${name}.proportionPct`} inputType={'number'} disabled={isReadOnly} />
       </div>
       <div className="flex flex-row gap-1.5 items-center">
         <span className={''}>% of</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCost.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCost.tsx
@@ -7,6 +7,7 @@ interface MethodProportionOfTheNewReplacementCostProps {
   totalNumberOfYears: number;
   method: MethodProportionOfTheNewReplacementCostWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodProportionOfTheNewReplacementCost({
   name = '',
@@ -19,7 +20,7 @@ export function MethodProportionOfTheNewReplacementCost({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>New Replacement Cost</td>
             {Array.from({ length: totalNumberOfYears }).map((_, idx) => {
               return (
@@ -35,7 +36,7 @@ export function MethodProportionOfTheNewReplacementCost({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {Array.from({ length: totalNumberOfYears }).map((_, idx) => {
               return (
@@ -51,7 +52,7 @@ export function MethodProportionOfTheNewReplacementCost({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Total</td>
             {(method.detail?.proportionOfNewReplacementCosts ?? []).map((val, idx) => {
               return (

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCostModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCostModal.tsx
@@ -2,9 +2,11 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodProportionOfTheNewReplacementCostModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodProportionOfTheNewReplacementCostModal({
   name,
+  isReadOnly,
 }: MethodProportionOfTheNewReplacementCostModalProps) {
   return (
     <div className="flex flex-col gap-2">
@@ -14,6 +16,7 @@ export function MethodProportionOfTheNewReplacementCostModal({
           <RHFInputCell
             fieldName={`${name}.proportionPct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{
               decimalPlaces: 2,
               maxIntegerDigits: 3,
@@ -31,6 +34,7 @@ export function MethodProportionOfTheNewReplacementCostModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{
               decimalPlaces: 2,
               maxIntegerDigits: 3,
@@ -43,6 +47,7 @@ export function MethodProportionOfTheNewReplacementCostModal({
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{
               decimalPlaces: 0,
               maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDay.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDay.tsx
@@ -7,6 +7,7 @@ interface MethodRoomCostBasedOnExpensesPerRoomPerDayProps {
   totalNumberOfYears: number;
   method: MethodRoomCostBasedOnExpensesPerRoomPerDayWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodRoomCostBasedOnExpensesPerRoomPerDay({
   expanded,
@@ -17,7 +18,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDay({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -27,7 +28,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Room Income</span>
               <span>({method.detail?.sumSaleableArea ?? 0} rooms)</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDayModal.tsx
@@ -10,10 +10,12 @@ import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameter
 interface MethodRoomCostBasedOnExpensesPerRoomPerDayModalProps {
   name: string;
   getOuterFormValues: (name: string) => object;
+  isReadOnly?: boolean;
 }
 export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
   name,
   getOuterFormValues,
+  isReadOnly,
 }: MethodRoomCostBasedOnExpensesPerRoomPerDayModalProps) {
   const { getValues } = useFormContext();
   const { fields, append, remove } = useFieldArray({ name: `${name}.roomDetails` });
@@ -143,6 +145,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                           <RHFInputCell
                             fieldName={`${name}.roomDetails.${index}.roomType`}
                             inputType="select"
+                            disabled={isReadOnly}
                             options={roomTypeParameters.map(p => ({
                               value: p.code,
                               label: p.description,
@@ -152,23 +155,27 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                             <RHFInputCell
                               fieldName={`${name}.roomDetails.${index}.roomTypeOther`}
                               inputType="text"
+                              disabled={isReadOnly}
                               text={{ maxLength: 50 }}
                             />
                           )}
-                          <button
-                            type="button"
-                            onClick={() => handleOnRemove(index)}
-                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
-                          >
-                            <Icon style="solid" name="trash" className="size-1" />
-                          </button>
+                          {!isReadOnly && (
+                            <button
+                              type="button"
+                              onClick={() => handleOnRemove(index)}
+                              className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                              title="Delete"
+                            >
+                              <Icon style="solid" name="trash" className="size-1" />
+                            </button>
+                          )}
                         </div>
                       </td>
                       <td className="px-1.5 py-1.5 border-b border-gray-300">
                         <RHFInputCell
                           fieldName={`${name}.roomDetails.${index}.roomExpensePerDay`}
                           inputType="number"
+                          disabled={isReadOnly}
                           number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
                         />
                       </td>
@@ -176,6 +183,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                         <RHFInputCell
                           fieldName={`${name}.roomDetails.${index}.saleableArea`}
                           inputType="number"
+                          disabled={isReadOnly}
                           number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
                         />
                       </td>
@@ -208,20 +216,22 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                     </tr>
                   );
                 })}
-                <tr>
-                  <td>
-                    <button
-                      type="button"
-                      onClick={() => handleOnAdd()}
-                      className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                    >
-                      + Add Room
-                    </button>
-                  </td>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                </tr>
+                {!isReadOnly && (
+                  <tr>
+                    <td>
+                      <button
+                        type="button"
+                        onClick={() => handleOnAdd()}
+                        className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                      >
+                        + Add Room
+                      </button>
+                    </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                )}
                 <tr>
                   <td className="sticky bottom-0 px-1.5 bg-white"></td>
                   <td className="sticky bottom-0 px-1.5 bg-white"></td>
@@ -284,6 +294,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -296,6 +307,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndex.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndex.tsx
@@ -7,18 +7,20 @@ interface MethodSpecifiedEnergyCostIndexProps {
   expanded: boolean;
   method: MethodSpecifiedEnergyCostIndexWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedEnergyCostIndex({
   name,
   expanded,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedEnergyCostIndexProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row gap-1.5 items-center">
                 <span>Increase Rate - 1st year amt</span>
@@ -26,6 +28,7 @@ export function MethodSpecifiedEnergyCostIndex({
                   <RHFInputCell
                     fieldName={`${name}.detail.energyCostIndex`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 15,
@@ -38,6 +41,7 @@ export function MethodSpecifiedEnergyCostIndex({
                   <RHFInputCell
                     fieldName={`${name}.detail.increaseRatePct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -50,6 +54,7 @@ export function MethodSpecifiedEnergyCostIndex({
                   <RHFInputCell
                     fieldName={`${name}.detail.increaseRateYrs`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 0,
                       maxIntegerDigits: 3,
@@ -69,7 +74,7 @@ export function MethodSpecifiedEnergyCostIndex({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Enegy Cost Index</span>
             </td>
@@ -81,7 +86,7 @@ export function MethodSpecifiedEnergyCostIndex({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total Energy Cost</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
@@ -2,16 +2,18 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedEnergyCostIndexModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedEnergyCostIndexModal({
   name,
+  isReadOnly,
 }: MethodSpecifiedEnergyCostIndexModalProps) {
   return (
     <div className="flex flex-col gap-2 mb-4">
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>Energy Cost Index</span>
         <div className={'w-44'}>
-          <RHFInputCell fieldName={`${name}.energyCostIndex`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.energyCostIndex`} inputType={'number'} disabled={isReadOnly} />
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
@@ -20,12 +22,13 @@ export function MethodSpecifiedEnergyCostIndexModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
         <span className={''}>% every</span>
         <div className="w-24">
-          <RHFInputCell fieldName={`${name}.increaseRateYrs`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.increaseRateYrs`} inputType={'number'} disabled={isReadOnly} />
         </div>
         <span className={''}>year(s)</span>
       </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay.tsx
@@ -7,6 +7,7 @@ interface MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay({
   expanded,
@@ -17,7 +18,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.increaseRate ?? []).map((val, idx) => {
               return (
@@ -27,7 +28,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total Food and Beverage per Room per Day</span>
             </td>
@@ -39,7 +40,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal.tsx
@@ -2,9 +2,11 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayPropsModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
   name,
+  isReadOnly,
 }: MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayPropsModalProps) {
   return (
     <div className="flex flex-col gap-1.5">
@@ -14,6 +16,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
           />
         </div>
@@ -25,6 +28,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
@@ -33,6 +37,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonth.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonth.tsx
@@ -7,6 +7,7 @@ interface MethodSpecifiedRentalIncomePerMonthProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRentalIncomePerMonthWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRentalIncomePerMonth({
   expanded,
@@ -17,7 +18,7 @@ export function MethodSpecifiedRentalIncomePerMonth({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -27,7 +28,7 @@ export function MethodSpecifiedRentalIncomePerMonth({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Room Income</span>
               <span>({method.detail?.sumSaleableArea ?? 0} rooms)</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
@@ -8,9 +8,11 @@ import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameter
 
 interface MethodSpecifiedRentalIncomePerMonthModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRentalIncomePerMonthModal({
   name = '',
+  isReadOnly,
 }: MethodSpecifiedRentalIncomePerMonthModalProps) {
   const { getValues } = useFormContext();
   const { fields, append, remove } = useFieldArray({ name: `${name}.roomDetails` });
@@ -133,6 +135,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                         <RHFInputCell
                           fieldName={`${name}.roomDetails.${index}.roomType`}
                           inputType="select"
+                          disabled={isReadOnly}
                           options={roomTypeParameters.map(p => ({
                             value: p.code,
                             label: p.description,
@@ -142,23 +145,27 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                           <RHFInputCell
                             fieldName={`${name}.roomDetails.${index}.roomTypeOther`}
                             inputType="text"
+                            disabled={isReadOnly}
                             text={{ maxLength: 50 }}
                           />
                         )}
-                        <button
-                          type="button"
-                          onClick={() => handleOnRemove(index)}
-                          className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                          title="Delete"
-                        >
-                          <Icon style="solid" name="trash" className="size-1" />
-                        </button>
+                        {!isReadOnly && (
+                          <button
+                            type="button"
+                            onClick={() => handleOnRemove(index)}
+                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                            title="Delete"
+                          >
+                            <Icon style="solid" name="trash" className="size-1" />
+                          </button>
+                        )}
                       </div>
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
                       <RHFInputCell
                         fieldName={`${name}.roomDetails.${index}.roomIncome`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
                       />
                     </td>
@@ -166,6 +173,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                       <RHFInputCell
                         fieldName={`${name}.roomDetails.${index}.saleableArea`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 5, maxIntegerDigits: 6, allowNegative: false }}
                       />
                     </td>
@@ -194,20 +202,22 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                   </tr>
                 );
               })}
-              <tr>
-                <td>
-                  <button
-                    type="button"
-                    onClick={() => handleOnAdd()}
-                    className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                  >
-                    + Add Room
-                  </button>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-              </tr>
+              {!isReadOnly && (
+                <tr>
+                  <td>
+                    <button
+                      type="button"
+                      onClick={() => handleOnAdd()}
+                      className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                    >
+                      + Add Room
+                    </button>
+                  </td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              )}
               <tr>
                 <td className="sticky bottom-0 px-1.5 bg-white"></td>
                 <td className="sticky bottom-0 px-1.5 bg-white"></td>
@@ -269,6 +279,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
             />
           </div>
@@ -279,6 +290,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -291,6 +303,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeter.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeter.tsx
@@ -8,6 +8,7 @@ interface MethodSpecifiedRentalIncomePerSquareMeterProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRentalIncomePerSquareMeterWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRentalIncomePerSquareMeter({
   name,
@@ -15,12 +16,13 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
   totalNumberOfYears,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedRentalIncomePerSquareMeterProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Saleable Area</td>
             {Array.from({ length: totalNumberOfYears }).map((_, idx) => {
               return (
@@ -34,7 +36,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row gap-1.5 items-center">
                 <span>Occupancy Rate - 1st year amt</span>
@@ -42,6 +44,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateFirstYearPct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -55,6 +58,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRatePct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -68,6 +72,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateYrs`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 0,
                       maxIntegerDigits: 3,
@@ -87,6 +92,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
                       <RHFInputCell
                         fieldName={`${name}.detail.occupancyRate.${idx}`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{
                           decimalPlaces: 2,
                           maxIntegerDigits: 3,
@@ -101,7 +107,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Total Number of Saleable Area</td>
             {(method.detail?.totalSaleableAreaDeductByOccRate ?? []).map((val, idx) => {
               return (
@@ -111,7 +117,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.rentalRateIncrease ?? []).map((val, idx) => {
               return (
@@ -123,7 +129,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Average Rental Rate</td>
             {(method.detail?.avgRentalRate ?? []).map((val, idx) => {
               return (
@@ -133,7 +139,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeter({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total Rental Income</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
@@ -8,9 +8,11 @@ import { toNumber } from '../../../domain/calculation';
 
 interface MethodSpecifiedRentalIncomePerSquareMeterModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRentalIncomePerSquareMeterModal({
   name,
+  isReadOnly,
 }: MethodSpecifiedRentalIncomePerSquareMeterModalProps) {
   const { fields, append, remove } = useFieldArray({ name: `${name}.areaDetail` });
 
@@ -158,22 +160,26 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                         <RHFInputCell
                           fieldName={`${name}.areaDetail.${index}.description`}
                           inputType="text"
+                          disabled={isReadOnly}
                           text={{ maxLength: 50 }}
                         />
-                        <button
-                          type="button"
-                          onClick={() => handleOnRemove(index)}
-                          className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                          title="Delete"
-                        >
-                          <Icon style="solid" name="trash" className="size-1" />
-                        </button>
+                        {!isReadOnly && (
+                          <button
+                            type="button"
+                            onClick={() => handleOnRemove(index)}
+                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                            title="Delete"
+                          >
+                            <Icon style="solid" name="trash" className="size-1" />
+                          </button>
+                        )}
                       </div>
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
                       <RHFInputCell
                         fieldName={`${name}.areaDetail.${index}.rentalPrice`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
                       />
                     </td>
@@ -181,6 +187,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                       <RHFInputCell
                         fieldName={`${name}.areaDetail.${index}.saleableArea`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
                       />
                     </td>
@@ -209,20 +216,22 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                   </tr>
                 );
               })}
-              <tr>
-                <td>
-                  <button
-                    type="button"
-                    onClick={() => handleOnAdd()}
-                    className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                  >
-                    + Add Room
-                  </button>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-              </tr>
+              {!isReadOnly && (
+                <tr>
+                  <td>
+                    <button
+                      type="button"
+                      onClick={() => handleOnAdd()}
+                      className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                    >
+                      + Add Room
+                    </button>
+                  </td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              )}
               <tr>
                 <td className="sticky bottom-0 px-1.5 bg-white"></td>
                 <td className="sticky bottom-0 px-1.5 bg-white">
@@ -294,6 +303,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
             />
           </div>
@@ -305,6 +315,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -317,6 +328,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,
@@ -333,6 +345,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -346,6 +359,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -359,6 +373,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRates.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRates.tsx
@@ -8,6 +8,7 @@ interface MethodSpecifiedRoomIncomeBySeasonalRatesProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRoomIncomeBySeasonalRatesWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomeBySeasonalRates({
   name,
@@ -15,12 +16,13 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
   totalNumberOfYears,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedRoomIncomeBySeasonalRatesProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Saleable Area</span>
               <RHFInputCell
@@ -37,7 +39,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row gap-1.5 items-center">
                 <span>Occupancy Rate - 1st year amt</span>
@@ -45,6 +47,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateFirstYearPct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -58,6 +61,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRatePct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -71,6 +75,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateYrs`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 0,
                       maxIntegerDigits: 3,
@@ -90,6 +95,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
                       <RHFInputCell
                         fieldName={`${name}.detail.occupancyRate.${idx}`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{
                           decimalPlaces: 2,
                           maxIntegerDigits: 3,
@@ -103,7 +109,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Total Number of Saleable Area</td>
             {(method.detail?.totalSaleableAreaDeductByOccRate ?? []).map((val, idx) => {
               return (
@@ -113,7 +119,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -123,7 +129,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Average Daily Rate (ADR)</td>
             {(method.detail?.avgDailyRate ?? []).map((val, idx) => {
               return (
@@ -133,7 +139,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRates({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total Room Income</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
@@ -86,7 +86,7 @@ function resizeRowSeasons(row: RoomIncomeRow, seasonCount: number): RoomIncomeRo
   };
 }
 
-export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: string }) {
+export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name, isReadOnly }: { name: string; isReadOnly?: boolean }) {
   const { control, getValues, setValue } = useFormContext();
 
   const { fields, append, remove, replace } = useFieldArray({
@@ -176,6 +176,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
           <RHFInputCell
             fieldName="seasonCount"
             inputType="number"
+            disabled={isReadOnly}
             onUserChange={v => {
               if (v) handleSeasonCountChange(v);
               return v;
@@ -205,6 +206,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.seasonName`}
                           inputType="text"
+                          disabled={isReadOnly}
                           text={{ maxLength: 50 }}
                         />
                       </div>
@@ -213,6 +215,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.numberOfMonths`}
                           inputType="number"
+                          disabled={isReadOnly}
                           number={{
                             decimalPlaces: 0,
                             maxIntegerDigits: 2,
@@ -226,6 +229,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.description`}
                           inputType="text"
+                          disabled={isReadOnly}
                           text={{ maxLength: 100 }}
                         />
                       </div>
@@ -261,6 +265,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                         <RHFInputCell
                           fieldName={`${name}.roomDetails.${rowIndex}.roomType`}
                           inputType="select"
+                          disabled={isReadOnly}
                           options={roomTypeParameters.map(p => ({
                             value: p.code,
                             label: p.description,
@@ -270,17 +275,20 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                           <RHFInputCell
                             fieldName={`${name}.roomDetails.${rowIndex}.roomTypeOther`}
                             inputType="text"
+                            disabled={isReadOnly}
                             text={{ maxLength: 50 }}
                           />
                         )}
-                        <button
-                          type="button"
-                          onClick={() => remove(rowIndex)}
-                          className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                          title="Delete"
-                        >
-                          <Icon style="solid" name="trash" className="size-1" />
-                        </button>
+                        {!isReadOnly && (
+                          <button
+                            type="button"
+                            onClick={() => remove(rowIndex)}
+                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                            title="Delete"
+                          >
+                            <Icon style="solid" name="trash" className="size-1" />
+                          </button>
+                        )}
                       </div>
                     </td>
 
@@ -296,6 +304,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                             <RHFInputCell
                               fieldName={`${name}.roomDetails.${rowIndex}.seasons.${seasonIndex}.roomIncome`}
                               inputType="number"
+                              disabled={isReadOnly}
                               number={{
                                 decimalPlaces: 2,
                                 maxIntegerDigits: 15,
@@ -307,6 +316,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                             <RHFInputCell
                               fieldName={`${name}.roomDetails.${rowIndex}.seasons.${seasonIndex}.saleableArea`}
                               inputType="number"
+                              disabled={isReadOnly}
                               number={{
                                 decimalPlaces: 0,
                                 maxIntegerDigits: 6,
@@ -328,6 +338,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                   </tr>
                 );
               })}
+              {!isReadOnly && (
               <tr>
                 <td className={clsx('border-b border-r border-gray-300 p-1')}>
                   <button
@@ -353,6 +364,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
                   );
                 })}
               </tr>
+              )}
             </tbody>
 
             <tfoot>
@@ -445,6 +457,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
             />
           </div>
@@ -455,6 +468,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -467,6 +481,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,
@@ -483,6 +498,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -496,6 +512,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -509,6 +526,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({ name }: { name: 
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDay.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDay.tsx
@@ -8,6 +8,7 @@ interface MethodSpecifiedRoomIncomePerDayProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRoomIncomePerDayWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomePerDay({
   name,
@@ -15,12 +16,13 @@ export function MethodSpecifiedRoomIncomePerDay({
   totalNumberOfYears,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedRoomIncomePerDayProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Saleable Area</span>
               <RHFInputCell
@@ -37,7 +39,7 @@ export function MethodSpecifiedRoomIncomePerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row gap-1.5 items-center">
                 <span>Occupancy Rate - 1st year amt</span>
@@ -45,6 +47,7 @@ export function MethodSpecifiedRoomIncomePerDay({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateFirstYearPct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -58,6 +61,7 @@ export function MethodSpecifiedRoomIncomePerDay({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRatePct`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 2,
                       maxIntegerDigits: 3,
@@ -71,6 +75,7 @@ export function MethodSpecifiedRoomIncomePerDay({
                   <RHFInputCell
                     fieldName={`${name}.detail.occupancyRateYrs`}
                     inputType="number"
+                    disabled={isReadOnly}
                     number={{
                       decimalPlaces: 0,
                       maxIntegerDigits: 3,
@@ -90,6 +95,7 @@ export function MethodSpecifiedRoomIncomePerDay({
                       <RHFInputCell
                         fieldName={`${name}.detail.occupancyRate.${idx}`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{
                           decimalPlaces: 2,
                           maxIntegerDigits: 3,
@@ -103,7 +109,7 @@ export function MethodSpecifiedRoomIncomePerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Total Number of Saleable Area</td>
             {(method.detail?.totalSaleableAreaDeductByOccRate ?? []).map((val, idx) => {
               return (
@@ -113,7 +119,7 @@ export function MethodSpecifiedRoomIncomePerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -123,7 +129,7 @@ export function MethodSpecifiedRoomIncomePerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Average Daily Rate (ADR)</td>
             {(method.detail?.avgDailyRate ?? []).map((val, idx) => {
               return (
@@ -133,7 +139,7 @@ export function MethodSpecifiedRoomIncomePerDay({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Total Room Income</span>
             </td>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
@@ -7,7 +7,7 @@ import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toNumber } from '../../../domain/calculation';
 import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameters';
 
-export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string }) {
+export function MethodSpecifyRoomIncomePerDayModal({ name = '', isReadOnly }: { name: string; isReadOnly?: boolean }) {
   const { getValues } = useFormContext();
   const { fields, append, remove } = useFieldArray({ name: `${name}.roomDetails` });
 
@@ -124,20 +124,23 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
                             text={{ maxLength: 50 }}
                           />
                         )}
-                        <button
-                          type="button"
-                          onClick={() => handleOnRemove(index)}
-                          className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                          title="Delete"
-                        >
-                          <Icon style="solid" name="trash" className="size-1" />
-                        </button>
+                        {!isReadOnly && (
+                          <button
+                            type="button"
+                            onClick={() => handleOnRemove(index)}
+                            className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
+                            title="Delete"
+                          >
+                            <Icon style="solid" name="trash" className="size-1" />
+                          </button>
+                        )}
                       </div>
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
                       <RHFInputCell
                         fieldName={`${name}.roomDetails.${index}.roomIncome`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
                       />
                     </td>
@@ -145,6 +148,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
                       <RHFInputCell
                         fieldName={`${name}.roomDetails.${index}.saleableArea`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
                       />
                     </td>
@@ -162,20 +166,22 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
                   </tr>
                 );
               })}
-              <tr>
-                <td>
-                  <button
-                    type="button"
-                    onClick={() => handleOnAdd()}
-                    className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
-                  >
-                    + Add Room
-                  </button>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-              </tr>
+              {!isReadOnly && (
+                <tr>
+                  <td>
+                    <button
+                      type="button"
+                      onClick={() => handleOnAdd()}
+                      className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
+                    >
+                      + Add Room
+                    </button>
+                  </td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              )}
               <tr>
                 <td className="sticky bottom-0 px-1.5 bg-white"></td>
                 <td className="sticky bottom-0 px-1.5 bg-white">
@@ -247,6 +253,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,
@@ -259,6 +266,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,
@@ -275,6 +283,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -288,6 +297,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 2,
                 maxIntegerDigits: 3,
@@ -301,6 +311,7 @@ export function MethodSpecifyRoomIncomePerDayModal({ name = '' }: { name: string
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
               inputType={'number'}
+              disabled={isReadOnly}
               number={{
                 decimalPlaces: 0,
                 maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowth.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowth.tsx
@@ -7,6 +7,7 @@ interface MethodSpecifiedRoomIncomeWithGrowthProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRoomIncomeWithGrowthWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomeWithGrowth({
   expanded,
@@ -17,7 +18,7 @@ export function MethodSpecifiedRoomIncomeWithGrowth({
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -27,7 +28,7 @@ export function MethodSpecifiedRoomIncomeWithGrowth({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Room Income</span>
               <span>({method.detail?.saleableArea ?? 0} rooms)</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate.tsx
@@ -8,6 +8,7 @@ interface MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateProps {
   totalNumberOfYears: number;
   method: MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
   name = '',
@@ -15,12 +16,13 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
   totalNumberOfYears,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Increase Rate</td>
             {(method.detail?.roomRateIncrease ?? []).map((val, idx) => {
               return (
@@ -30,7 +32,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Income Adjusted by Growth Rate</td>
             {(method.detail?.roomIncomeAdjustedValuedByGrowthRates ?? []).map((val, idx) => {
               return (
@@ -40,7 +42,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Occupancy Rate</td>
             {Array.from({ length: totalNumberOfYears }).map((_, idx) => {
               return (
@@ -50,6 +52,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
                       <RHFInputCell
                         fieldName={`${name}.detail.occupancyRate.${idx}`}
                         inputType="number"
+                        disabled={isReadOnly}
                         number={{
                           decimalPlaces: 2,
                           maxIntegerDigits: 3,
@@ -64,7 +67,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRate({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <span>Room Income</span>
               <span>({method.detail?.saleableArea ?? 0} rooms)</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
@@ -2,32 +2,34 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
   name,
+  isReadOnly,
 }: MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModalProps) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>Saleable Area</span>
         <div className={'w-44'}>
-          <RHFInputCell fieldName={`${name}.saleableArea`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.saleableArea`} inputType={'number'} disabled={isReadOnly} />
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>Total Number of Saleable Area</span>
         <div className={'w-44'}>
-          <RHFInputCell fieldName={`${name}.totalNumberOfSaleableArea`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.totalNumberOfSaleableArea`} inputType={'number'} disabled={isReadOnly} />
         </div>
         <span>Remark</span>
         <div className={'w-56'}>
-          <RHFInputCell fieldName={`${name}.remark`} inputType={'text'} />
+          <RHFInputCell fieldName={`${name}.remark`} inputType={'text'} disabled={isReadOnly} />
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>Room Income</span>
         <div className={'w-44'}>
-          <RHFInputCell fieldName={`${name}.firstYearAmt`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.firstYearAmt`} inputType={'number'} disabled={isReadOnly} />
         </div>
         <span className={''}>Bath/ Year</span>
       </div>
@@ -37,6 +39,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
@@ -45,6 +48,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
@@ -53,13 +57,14 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
       <div className="flex flex-row gap-1.5">
         <span className={'w-56'}>Occupancy Rate - First Year</span>
         <div className={'w-24'}>
-          <RHFInputCell fieldName={`${name}.occupancyRateFirstYearPct`} inputType={'number'} />
+          <RHFInputCell fieldName={`${name}.occupancyRateFirstYearPct`} inputType={'number'} disabled={isReadOnly} />
         </div>
         <span className={''}>% with growth</span>
         <div className={'w-24'}>
           <RHFInputCell
             fieldName={`${name}.occupancyRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
@@ -68,6 +73,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
           <RHFInputCell
             fieldName={`${name}.occupancyRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
@@ -2,9 +2,11 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedRoomIncomeWithGrowthModalProps {
   name: string;
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedRoomIncomeWithGrowthModal({
   name,
+  isReadOnly,
 }: MethodSpecifiedRoomIncomeWithGrowthModalProps) {
   return (
     <div className="flex flex-col gap-1.5">
@@ -14,6 +16,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.saleableArea`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
@@ -24,6 +27,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.totalNumberOfSaleableArea`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
@@ -32,6 +36,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.remark`}
             inputType={'text'}
+            disabled={isReadOnly}
             text={{ maxLength: 4000 }}
           />
         </div>
@@ -42,6 +47,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
           />
         </div>
@@ -53,6 +59,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
@@ -61,6 +68,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
+            disabled={isReadOnly}
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowth.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowth.tsx
@@ -7,18 +7,20 @@ interface MethodSpecifiedValueWithGrowthProps {
   expanded: boolean;
   method: MethodSpecifiedValueWithGrowthWrapper;
   baseStyles: { rowHeader: string; rowBody: string };
+  isReadOnly?: boolean;
 }
 export function MethodSpecifiedValueWithGrowth({
   name,
   expanded,
   method,
   baseStyles,
+  isReadOnly,
 }: MethodSpecifiedValueWithGrowthProps) {
   return (
     <>
       {expanded && (
         <>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>
               <div className="flex flex-row justify-between items-center gap-3">
                 <span>Increase Rate</span>
@@ -28,6 +30,7 @@ export function MethodSpecifiedValueWithGrowth({
                     <RHFInputCell
                       fieldName={`${name}.detail.firstYearAmt`}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 2,
                         maxIntegerDigits: 15,
@@ -40,6 +43,7 @@ export function MethodSpecifiedValueWithGrowth({
                     <RHFInputCell
                       fieldName={`${name}.detail.increaseRatePct`}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 2,
                         maxIntegerDigits: 3,
@@ -52,6 +56,7 @@ export function MethodSpecifiedValueWithGrowth({
                     <RHFInputCell
                       fieldName={`${name}.detail.increaseRateYrs`}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 0,
                         maxIntegerDigits: 3,
@@ -72,7 +77,7 @@ export function MethodSpecifiedValueWithGrowth({
               );
             })}
           </tr>
-          <tr>
+          <tr className="group transition-colors">
             <td className={clsx(baseStyles.rowHeader)}>Total</td>
             {(method.totalMethodValues ?? []).map((val, idx) => {
               return (

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
@@ -1,6 +1,6 @@
 import { RHFInputCell } from '../../table/RHFInputCell';
 
-export function MethodSpecifiedValueWithGrowthModal({ name }: { name: string }) {
+export function MethodSpecifiedValueWithGrowthModal({ name, isReadOnly }: { name: string; isReadOnly?: boolean }) {
   return (
     <div className="flex flex-row gap-1.5 items-center">
       <span className={'w-56'}>First year amount</span>
@@ -8,6 +8,7 @@ export function MethodSpecifiedValueWithGrowthModal({ name }: { name: string }) 
         <RHFInputCell
           fieldName={`${name}.firstYearAmt`}
           inputType={'number'}
+          disabled={isReadOnly}
           number={{
             decimalPlaces: 2,
             maxIntegerDigits: 15,
@@ -20,6 +21,7 @@ export function MethodSpecifiedValueWithGrowthModal({ name }: { name: string }) 
         <RHFInputCell
           fieldName={`${name}.increaseRatePct`}
           inputType={'number'}
+          disabled={isReadOnly}
           number={{
             decimalPlaces: 2,
             maxIntegerDigits: 3,
@@ -32,6 +34,7 @@ export function MethodSpecifiedValueWithGrowthModal({ name }: { name: string }) 
         <RHFInputCell
           fieldName={`${name}.increaseRateYrs`}
           inputType={'number'}
+          disabled={isReadOnly}
           number={{
             decimalPlaces: 0,
             maxIntegerDigits: 3,

--- a/src/features/pricingAnalysis/components/dcf/dcfSections/SectionExpense.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfSections/SectionExpense.tsx
@@ -10,6 +10,7 @@ interface SectionExpenseProps {
   totalNumberOfYears: number;
   icon: string;
   color: SectionColor;
+  isReadOnly?: boolean;
 }
 
 export function SectionExpense({
@@ -19,6 +20,7 @@ export function SectionExpense({
   totalNumberOfYears,
   icon,
   color,
+  isReadOnly,
 }: SectionExpenseProps) {
   return (
     <DynamicSection
@@ -38,6 +40,7 @@ export function SectionExpense({
             category={category}
             totalNumberOfYears={totalNumberOfYears}
             color={color}
+            isReadOnly={isReadOnly}
           />
         );
       })}

--- a/src/features/pricingAnalysis/components/dcf/dcfSections/SectionIncome.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfSections/SectionIncome.tsx
@@ -10,6 +10,7 @@ interface SectionIncomeProps {
   totalNumberOfYears: number;
   icon: string;
   color: SectionColor;
+  isReadOnly?: boolean;
 }
 
 export function SectionIncome({
@@ -19,6 +20,7 @@ export function SectionIncome({
   totalNumberOfYears,
   icon,
   color,
+  isReadOnly,
 }: SectionIncomeProps) {
   return (
     <DynamicSection
@@ -38,6 +40,7 @@ export function SectionIncome({
             category={category}
             totalNumberOfYears={totalNumberOfYears}
             color={color}
+            isReadOnly={isReadOnly}
           />
         );
       })}

--- a/src/features/pricingAnalysis/components/dcf/dcfSections/SectionSummaryDCF.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfSections/SectionSummaryDCF.tsx
@@ -4,16 +4,18 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 interface SectionSummaryDCFProps {
   name: string;
   totalNumberOfYears: number;
+  isReadOnly?: boolean;
 }
-export function SectionSummaryDCF({ name, totalNumberOfYears }: SectionSummaryDCFProps) {
-  return <SummarySectionTable name={name} totalNumberOfYears={totalNumberOfYears} />;
+export function SectionSummaryDCF({ name, totalNumberOfYears, isReadOnly }: SectionSummaryDCFProps) {
+  return <SummarySectionTable name={name} totalNumberOfYears={totalNumberOfYears} isReadOnly={isReadOnly} />;
 }
 
 interface SummarySectionTableProps {
   name: string;
   totalNumberOfYears: number;
+  isReadOnly?: boolean;
 }
-function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTableProps) {
+function SummarySectionTable({ name, totalNumberOfYears, isReadOnly }: SummarySectionTableProps) {
   const rowHeaderStyle = 'px-1.5 h-12 text-sm text-gray-700 border-b border-gray-300';
   const rowBodyStyle = 'px-1.5 h-12 text-sm text-right text-gray-700 border-b border-gray-300';
   const rowStyle = 'bg-white';
@@ -69,6 +71,7 @@ function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTablePr
               <RHFInputCell
                 fieldName="capitalizeRate"
                 inputType="number"
+                disabled={isReadOnly}
                 number={{
                   decimalPlaces: 2,
                   maxIntegerDigits: 5,
@@ -118,6 +121,7 @@ function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTablePr
               <RHFInputCell
                 fieldName="discountedRate"
                 inputType="number"
+                disabled={isReadOnly}
                 number={{
                   decimalPlaces: 2,
                   maxIntegerDigits: 5,
@@ -185,6 +189,7 @@ function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTablePr
                     <RHFInputCell
                       fieldName={'finalValueRounded'}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 2,
                         maxIntegerDigits: 15,

--- a/src/features/pricingAnalysis/components/dcf/dcfSections/SectionSummaryDirectCashFlow.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfSections/SectionSummaryDirectCashFlow.tsx
@@ -8,19 +8,22 @@ import { toNumber } from '../../../domain/calculation';
 interface SectionSummaryDirectCashFlowProps {
   name: string;
   totalNumberOfYears: number;
+  isReadOnly?: boolean;
 }
 export function SectionSummaryDirectCashFlow({
   name,
   totalNumberOfYears,
+  isReadOnly,
 }: SectionSummaryDirectCashFlowProps) {
-  return <SummarySectionTable name={name} totalNumberOfYears={totalNumberOfYears} />;
+  return <SummarySectionTable name={name} totalNumberOfYears={totalNumberOfYears} isReadOnly={isReadOnly} />;
 }
 
 interface SummarySectionTableProps {
   name: string;
   totalNumberOfYears: number;
+  isReadOnly?: boolean;
 }
-function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTableProps) {
+function SummarySectionTable({ name, totalNumberOfYears, isReadOnly }: SummarySectionTableProps) {
   const rowHeaderStyle = 'px-1.5 h-12 text-sm text-gray-700 border-b border-gray-300';
   const rowBodyStyle = 'px-1.5 h-12 text-sm text-right text-gray-700 border-b border-gray-300';
   const rowStyle = 'bg-white hover:bg-secondary/10';
@@ -48,6 +51,7 @@ function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTablePr
               <RHFInputCell
                 fieldName="capitalizeRate"
                 inputType="number"
+                disabled={isReadOnly}
                 number={{
                   decimalPlaces: 2,
                   maxIntegerDigits: 5,
@@ -90,6 +94,7 @@ function SummarySectionTable({ name, totalNumberOfYears }: SummarySectionTablePr
                     <RHFInputCell
                       fieldName={`finalValueRounded`}
                       inputType="number"
+                      disabled={isReadOnly}
                       number={{
                         decimalPlaces: 2,
                         maxIntegerDigits: 15,

--- a/src/features/pricingAnalysis/domain/dcf/createEmptyMethodDetail.ts
+++ b/src/features/pricingAnalysis/domain/dcf/createEmptyMethodDetail.ts
@@ -1,0 +1,239 @@
+import type { DCFMethod } from '../../types/dcf';
+import { getNewId } from '../getNewId';
+
+type MethodType = DCFMethod['methodType'];
+
+export function createDefaultMethod(methodType: MethodType): DCFMethod {
+  const id = getNewId();
+
+  switch (methodType) {
+    case '01':
+      return {
+        id,
+        methodType: '01',
+        totalMethodValues: [],
+        detail: {
+          roomDetails: [],
+          sumRoomIncome: 0,
+          sumSaleableArea: 0,
+          sumTotalRoomIncome: 0,
+          avgRoomRate: 0,
+          totalSaleableArea: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          occupancyRateFirstYearPct: 0,
+          occupancyRatePct: 0,
+          occupancyRateYrs: 0,
+          saleableArea: [],
+          occupancyRate: [],
+          totalSaleableAreaDeductByOccRate: [],
+          roomRateIncrease: [],
+          avgDailyRate: [],
+          roomIncome: [],
+          totalMethodValues: [],
+        },
+      };
+    case '03':
+      return {
+        id,
+        methodType: '03',
+        totalMethodValues: [],
+        detail: {
+          firstYearAmt: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          roomRateIncrease: [],
+          roomIncome: [],
+          totalMethodValues: [],
+        },
+      };
+    case '04':
+      return {
+        id,
+        methodType: '04',
+        totalMethodValues: [],
+        detail: {
+          saleableArea: 0,
+          totalNumberOfSaleableArea: 0,
+          remark: '',
+          firstYearAmt: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          occupancyRateFirstYearPct: 0,
+          occupancyRatePct: 0,
+          occupancyRateYrs: 0,
+          occupancyRate: [],
+          roomRateIncrease: [],
+          roomIncomeAdjustedValuedByGrowthRates: [],
+          roomIncome: [],
+        },
+      };
+    case '05':
+      return {
+        id,
+        methodType: '05',
+        totalMethodValues: [],
+        detail: {
+          roomDetails: {
+            roomType: '',
+            roomIncome: 0,
+            saleableArea: 0,
+            totalRoomIncomePerMonth: 0,
+            totalRoomIncomePerYear: 0,
+          },
+          sumSaleableArea: 0,
+          sumRoomIncomePerMonth: 0,
+          sumRoomIncomePerYear: 0,
+          totalSaleableArea: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          roomRateIncrease: [],
+          roomIncome: [],
+        },
+      };
+    case '06':
+      return {
+        id,
+        methodType: '06',
+        totalMethodValues: [],
+        detail: {
+          areaDetail: {
+            description: '',
+            rentalPrice: 0,
+            saleableArea: 0,
+            totalRentalIncomePerMonth: 0,
+            totalRentalIncomePerYear: 0,
+          },
+          sumRentalPrice: 0,
+          sumSaleableArea: 0,
+          sumTotalRentalIncomePerMonth: 0,
+          sumTotalRentalIncomePerYear: 0,
+          totalSaleableArea: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          avgRentalRatePerMonth: 0,
+          occupancyRateFirstYearPct: 0,
+          occupancyRatePct: 0,
+          occupancyRateYrs: 0,
+          occupancyRate: [],
+          totalSaleableAreaDeductByOccRate: [],
+          rentalRateIncrease: [],
+          avgRentalRate: [],
+          totalRentalIncome: [],
+          totalMethodValues: [],
+        },
+      };
+    case '07':
+      return {
+        id,
+        methodType: '07',
+        totalMethodValues: [],
+        detail: {
+          roomDetails: [],
+          sumSaleableArea: 0,
+          sumTotalRoomExpensePerDay: 0,
+          sumTotalRoomExpensePerYear: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          saleableArea: [],
+          roomRateIncrease: [],
+          roomExpense: [],
+          totalMethodValues: [],
+        },
+      };
+    case '08':
+      return {
+        id,
+        methodType: '08',
+        totalMethodValues: [],
+        detail: {
+          firstYearAmt: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          increaseRate: [],
+          totalFoodAndBeveragePerRoomPerDay: [],
+          totalFoodAndBeveragePerRoomPerYear: [],
+        },
+      };
+    case '09':
+      return {
+        id,
+        methodType: '09',
+        totalMethodValues: [],
+        detail: {
+          jobPositionDetails: [],
+          sumSalaryBahtPerPersonPerMonth: 0,
+          sumTotalSalaryPerYear: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          increaseRate: [],
+          totalPositionBasedSalaryPerYear: [],
+        },
+      };
+    case '10':
+      return {
+        id,
+        methodType: '10',
+        totalMethodValues: [],
+        detail: {},
+      };
+    case '11':
+      return {
+        id,
+        methodType: '11',
+        totalMethodValues: [],
+        detail: {
+          energyCostIndex: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+          increaseRate: [],
+          energyCostIndexIncrease: [],
+          totalEnegyCost: [],
+        },
+      };
+    case '12':
+      return {
+        id,
+        methodType: '12',
+        totalMethodValues: [],
+        detail: {
+          proportionPct: 0,
+          newReplacementCost: 0,
+          proportionOfNewReplacementCosts: [],
+          totalMethodValues: [],
+        },
+      };
+    case '13':
+      return {
+        id,
+        methodType: '13',
+        totalMethodValues: [],
+        detail: {
+          proportionPct: 0,
+          refTarget: { kind: 'assumption' },
+        },
+      };
+    case '14':
+      return {
+        id,
+        methodType: '14',
+        totalMethodValues: [],
+        detail: {
+          firstYearAmt: 0,
+          increaseRatePct: 0,
+          increaseRateYrs: 0,
+        },
+      };
+    case '15':
+      return {
+        id,
+        methodType: '15',
+        totalMethodValues: [],
+        detail: {},
+      };
+    default: {
+      const _exhaustive: never = methodType;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/features/pricingAnalysis/domain/dcf/useAssumptionEditor.ts
+++ b/src/features/pricingAnalysis/domain/dcf/useAssumptionEditor.ts
@@ -1,0 +1,26 @@
+import type { AssumptionEditDraft } from '../../components/DiscountedCashFlowMethodModal';
+import type { DCFAssumption, DCFCategory, DCFSection } from '../../types/dcf';
+
+interface UseAssumptionEditorProps {
+  section: DCFSection;
+  category: DCFCategory;
+  activeAssumption: DCFAssumption | null;
+}
+
+export function useAssumptionEditor({ section, category, activeAssumption }: UseAssumptionEditorProps) {
+  if (!activeAssumption) {
+    return { modalInitialData: null };
+  }
+
+  const modalInitialData: AssumptionEditDraft = {
+    targetSectionClientId: section.clientId,
+    targetCategoryClientId: category.clientId,
+    targetAssumptionClientId: activeAssumption.clientId,
+    assumptionType: activeAssumption.assumptionType ?? null,
+    assumptionName: activeAssumption.assumptionName ?? null,
+    displayName: activeAssumption.assumptionName ?? null,
+    method: activeAssumption.method ?? null,
+  };
+
+  return { modalInitialData };
+}

--- a/src/features/pricingAnalysis/domain/dcf/useAssumptionManagement.ts
+++ b/src/features/pricingAnalysis/domain/dcf/useAssumptionManagement.ts
@@ -1,10 +1,26 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useFieldArray } from 'react-hook-form';
+import { useFieldArray, type Control } from 'react-hook-form';
 import { getNewId } from '../getNewId';
 import { editAssumption } from './editAssumption';
+import { createDefaultMethod } from './createEmptyMethodDetail';
+import type { DCFAssumption } from '../../types/dcf';
 
-// Example of extracted logic
-export function useAssumptionManagement(name: string, getValues, setValue, control) {
+interface UseAssumptionManagementProps {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getValues: (path?: any) => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setValue: (path: string, value: any, options?: object) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>;
+}
+
+export function useAssumptionManagement({
+  name,
+  getValues,
+  setValue,
+  control,
+}: UseAssumptionManagementProps) {
   const { append, remove, fields } = useFieldArray({
     control,
     name: `${name}.assumptions`,
@@ -12,7 +28,6 @@ export function useAssumptionManagement(name: string, getValues, setValue, contr
 
   const [editing, setEditing] = useState<string | null>(null);
 
-  // Encapsulate the complex recalculation logic
   useEffect(() => {
     setValue(`${name}.assumptions`, getValues(`${name}.assumptions`), {
       shouldDirty: false,
@@ -20,26 +35,44 @@ export function useAssumptionManagement(name: string, getValues, setValue, contr
     });
   }, [fields.length, name, setValue, getValues]);
 
-  // All the handler functions
+  const activeAssumption: DCFAssumption | null = editing
+    ? ((getValues(`${name}.assumptions`) as DCFAssumption[] | undefined)?.find(
+        a => a.clientId === editing,
+      ) ?? null)
+    : null;
+
   const handleOnAddAssumption = useCallback(() => {
     const newAssumptionId = getNewId();
     append({
       clientId: newAssumptionId,
       assumptionType: null,
       displaySeq: fields.length,
-      method: { id: getNewId(), methodType: null },
+      method: createDefaultMethod('13'),
     });
     setEditing(newAssumptionId);
   }, [append, fields.length]);
 
+  const handleOnRemoveAssumption = useCallback(
+    (index: number) => {
+      const assumptions = getValues(`${name}.assumptions`) as DCFAssumption[] | undefined;
+      const assumption = assumptions?.[index];
+      if (assumption && editing === assumption.clientId) {
+        setEditing(null);
+      }
+      remove(index);
+    },
+    [remove, getValues, name, editing],
+  );
+
   return {
     fields,
     editing,
+    activeAssumption,
     handleOnAddAssumption,
-    handleOnRemoveAssumption: remove,
+    handleOnRemoveAssumption,
     handleOnOpenEditMode: setEditing,
     handleOnCancelEditMode: () => setEditing(null),
-    handleOnSaveEditMode: draft => {
+    handleOnSaveEditMode: (draft: Parameters<typeof editAssumption>[1]) => {
       const nextSections = editAssumption(getValues('sections'), draft);
       setValue('sections', nextSections, {
         shouldDirty: false,

--- a/src/features/pricingAnalysis/domain/mapDCFMethodCodeToSystemType.ts
+++ b/src/features/pricingAnalysis/domain/mapDCFMethodCodeToSystemType.ts
@@ -20,7 +20,8 @@ export const mapMethodCodeToValue = [
   { code: '15', value: 'grossOperatingProfit' },
 ];
 
-export function mapDCFMethodCodeToSystemType(methodCode: string) {
+export function mapDCFMethodCodeToSystemType(methodCode: string | null | undefined) {
+  if (!methodCode) return null;
   const mapping = new Map(mapMethodCodeToValue.map(c => [c.code, c.value]));
   return mapping.get(methodCode) ?? null;
 }


### PR DESCRIPTION
## Summary

Bundles four follow-up enhancements on top of the recently merged `feature/workflow-enhancement` (PR #111).

### 1. New Appraisal List Page (`/appraisals/list`)
Enhanced list/search UX distinct from the global `/appraisals/search`:
- `AppraisalListPage` — filters, sort, pagination, export
- `SmartViewBar`, `SavedSearchesDropdown`, `ActiveFilterChips`, `AppraisalResultsTable`
- `appraisalSearch` API hook
- New filter + column defs in `tabConfigs.ts`
- Route wired up in `src/app/router.tsx`

### 2. DCF enhancements
- Threaded `isReadOnly` through all DCF method components, modals, section renderers, category renderers, and the assumption panel so pages can render DCF in read-only mode without hiding the data
- New `DiscountedCashFlowSummaryAssumption` for read-only summary rendering
- Extracted `useAssumptionEditor` hook; added `createDefaultMethod` helper in `createEmptyMethodDetail.ts`
- `useAssumptionManagement` refactored to named-args + typed `Control`; tracks the active editing assumption and clears it on delete

### 3. Decision Summary Page refactor
- `ACTIVITY_SECTION_CONFIG` drives which sections are visible/editable per workflow activity (init, int/ext execution/check/verification, pending-approval, appraisal-book-verification)
- `SectionReadOnlyWrap` applies `FormReadOnlyContext` to force-read-only subsets (e.g. approval list on read-only activities)

### 4. Dashboard widget fixes
- `TotalAppraisalsWidget`: SVG now stretches with `preserveAspectRatio="none"`; data points moved to HTML overlay so dots stay circular under non-uniform scaling; lines use `vectorEffect="non-scaling-stroke"`
- `ReminderWidget`: tightened item header layout (appraisal number moved inline before title)

### Chore
- `.gitignore`: exclude `.claude/{agents,plans,tasks,worktrees}/` and `.claude/settings.local.json` (local Claude Code session state)

## Test plan

- [ ] Navigate to `/appraisals/list` — filters, smart views, saved searches, column sort, pagination
- [ ] Open an appraisal in a read-only activity (e.g. `ext-appraisal-check`) → DCF edit/delete buttons hidden, assumption fields read-only
- [ ] Open Decision Summary across activities (`ext-appraisal-execution`, `int-appraisal-check`, `appraisal-book-verification`, `pending-approval`) → correct sections shown; `reviewPrices` editable on `appraisal-book-verification` while rest are read-only
- [ ] Resize the dashboard window → `TotalAppraisalsWidget` dots stay circular; lines stay consistent width
- [ ] `ReminderWidget` overdue/normal states render correctly with appraisal number inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)