### PR TITLE
chore(ci): migrate CI from npm to pnpm with corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
         continue-on-error: true
 
       - name: Test
-        run: npm test
+        run: pnpm test
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
@@ -39,4 +43,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build
-        run: npm run build
+        run: pnpm run build


### PR DESCRIPTION
## Summary
- Enable corepack and add `cache: 'pnpm'` to `setup-node`
- Switch install to `pnpm install --frozen-lockfile`
- Run lint, test, and build via `pnpm` instead of `npm`

Aligns CI with the repo's pnpm-only policy (package.json preinstall: `only-allow pnpm`).

## Test plan
- [ ] CI workflow succeeds on this branch
- [ ] `pnpm` cache hit logged in setup-node step
- [ ] Lint / test / build steps all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)