### PR TITLE
feat: collateral master, email composition, appeal exclusion & block enhancements

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -72,6 +72,9 @@ import CommitteeAdminPage from '@/features/committee/pages/CommitteeAdminPage';
 import RoleProtectedRoute from '@shared/components/RoleProtectedRoute';
 import MenuListPage from '@features/menuManagement/pages/MenuListPage';
 import MenuEditPage from '@features/menuManagement/pages/MenuEditPage';
+import CollateralCatalogPage from '@/features/collateralMaster/pages/CollateralCatalogPage';
+import CollateralMasterDetailPage from '@/features/collateralMaster/pages/CollateralMasterDetailPage';
+import BackfillReportPage from '@/features/collateralMaster/pages/BackfillReportPage';
 import QuotationSelectionPage from '@/features/quotation/pages/QuotationSelectionPage';
 import QuotationListingPage from '@/features/quotation/pages/QuotationListingPage';
 import NewQuotationPage from '@/features/quotation/pages/NewQuotationPage';
@@ -258,6 +261,16 @@ export const router = createBrowserRouter([
               { index: true, element: <MenuListPage /> },
               { path: 'new', element: <MenuEditPage /> },
               { path: ':menuId', element: <MenuEditPage /> },
+            ],
+          },
+          // Collateral master admin — gated by COLLATERAL_ADMIN permission
+          {
+            path: 'collateral-masters',
+            element: <RoleProtectedRoute allowedRoles={['Admin', 'IntAdmin']} requiredPermission="COLLATERAL_ADMIN" />,
+            children: [
+              { index: true, element: <CollateralCatalogPage /> },
+              { path: 'backfill', element: <BackfillReportPage /> },
+              { path: ':masterId', element: <CollateralMasterDetailPage /> },
             ],
           },
         ],

--- a/src/features/appraisal/components/CreateQuotationModal.tsx
+++ b/src/features/appraisal/components/CreateQuotationModal.tsx
@@ -7,6 +7,7 @@ import DateTimePickerInput from '@/shared/components/inputs/DateTimePickerInput'
 import NumberInput from '@/shared/components/inputs/NumberInput';
 import toast from 'react-hot-toast';
 import { useCreateQuotation, useGetEligibleCompanies } from '../api/administration';
+import { useAppealExclusionStore } from '@/features/collateralMaster/store/appealExclusionStore';
 
 interface CreateQuotationModalProps {
   isOpen: boolean;
@@ -51,15 +52,21 @@ const CreateQuotationModal = ({
   const [maxAppraisalDays, setMaxAppraisalDays] = useState<number | null>(null);
   const [remarks, setRemarks] = useState('');
 
+  // Appeal exclusion: most-recent prior company id captured at collateral lookup time.
+  // Wrapped in single-element array for the v1 plural-list contract on start-from-task.
+  const excludedCompanyId = useAppealExclusionStore(s => s.excludedCompanyId);
+
   const { data: rawCompanies, isLoading: isLoadingCompanies } = useGetEligibleCompanies(
     bankingSegment,
     isOpen,
   );
 
-  // Map raw company data to the SelectedCompany shape
+  // Map raw company data to the SelectedCompany shape, filtering out the appeal-excluded company
   const allCompanies: SelectedCompany[] = useMemo(
-    () => (rawCompanies ?? []).map(c => ({ id: c.id, companyName: c.companyName })),
-    [rawCompanies],
+    () => (rawCompanies ?? [])
+      .filter(c => c.id !== excludedCompanyId)
+      .map(c => ({ id: c.id, companyName: c.companyName })),
+    [rawCompanies, excludedCompanyId],
   );
 
   const companyList = useMemo(() => {
@@ -117,6 +124,8 @@ const CreateQuotationModal = ({
         assignmentType: assignmentType ?? null,
         assignmentMethod: assignmentMethod ?? null,
         internalFollowupAssignmentMethod: internalFollowupAssignmentMethod ?? null,
+        // Appeal exclusion — most-recent prior company only; wrapped in array for v1 contract
+        excludedCompanyIds: excludedCompanyId ? [excludedCompanyId] : null,
       },
       {
         onSuccess: () => {

--- a/src/features/appraisal/components/QuotationSection.tsx
+++ b/src/features/appraisal/components/QuotationSection.tsx
@@ -28,6 +28,8 @@ import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import InvitedCompaniesPopover from '@/features/quotation/components/InvitedCompaniesPopover';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import Modal from '@/shared/components/Modal';
+import EmailCompositionModal from '@/shared/components/EmailCompositionModal';
+import type { EmailFormValues } from '@/shared/schemas/email';
 import { useAuthStore } from '@/features/auth/store';
 
 // ─── ShareDocumentsStep ───────────────────────────────────────────────────────
@@ -413,6 +415,7 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
   const { i18n } = useTranslation();
   const currentUser = useAuthStore(s => s.user);
   const [sendStep, setSendStep] = useState<SendStep | null>(null);
+  const [pendingEmailData, setPendingEmailData] = useState<EmailFormValues | null>(null);
   /** appraisalId → { documentId → { level } }; outer key tracks per-appraisal coverage */
   const [shareSelections, setShareSelections] = useState<ShareSelections>({});
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
@@ -825,8 +828,9 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
     const canSend = appraisalCount >= 1 && companyCount >= 1 && hasDueDate;
     const draftAppraisals = draftDetail?.appraisals ?? [];
 
-    /** Step 1 → Step 2: open the share-docs step */
-    const handleProceedToShareDocs = () => {
+    /** Step 1 (email compose) → Step 2: store email data and open the share-docs step */
+    const handleEmailComposed = (values: EmailFormValues) => {
+      setPendingEmailData(values);
       setShareSelections({});
       setSendStep('share-docs');
     };
@@ -835,6 +839,7 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
     const handleCancelSendFlow = () => {
       setSendStep(null);
       setShareSelections({});
+      setPendingEmailData(null);
     };
 
     /**
@@ -850,7 +855,7 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
 
     /** Step 2 → final send: PUT shared-docs then POST send */
     const handleFinalSend = () => {
-      if (!allAppraisalsCovered) return;
+      if (!allAppraisalsCovered || !pendingEmailData) return;
       const selections: SharedDocumentSelectionDto[] = draftAppraisals.flatMap(ap =>
         Object.entries(shareSelections[ap.appraisalId] ?? {}).map(([documentId, { level }]) => ({
           appraisalId: ap.appraisalId,
@@ -860,16 +865,26 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
       );
       setSharedDocuments(selections, {
         onSuccess: () => {
-          sendQuotation(undefined, {
-            onSuccess: () => {
-              toast.success('Quotation sent — bidding is now open');
-              setSendStep(null);
+          sendQuotation(
+            {
+              from: pendingEmailData.from,
+              to: pendingEmailData.to,
+              cc: pendingEmailData.cc,
+              subject: pendingEmailData.subject,
+              content: pendingEmailData.content,
             },
-            onError: (err: unknown) => {
-              const apiErr = err as { apiError?: { detail?: string } };
-              toast.error(apiErr?.apiError?.detail ?? 'Failed to send quotation');
+            {
+              onSuccess: () => {
+                toast.success('Quotation sent — bidding is now open');
+                setSendStep(null);
+                setPendingEmailData(null);
+              },
+              onError: (err: unknown) => {
+                const apiErr = err as { apiError?: { detail?: string } };
+                toast.error(apiErr?.apiError?.detail ?? 'Failed to send quotation');
+              },
             },
-          });
+          );
         },
         onError: (err: unknown) => {
           const apiErr = err as { apiError?: { detail?: string } };
@@ -1087,41 +1102,17 @@ const QuotationSection = ({ appraisalId, onCreateNew }: QuotationSectionProps) =
           isLoading={isRemoving}
         />
 
-        {/* ── Step 1: Confirm send ── */}
-        {sendStep === 'confirm' && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-            <div className="bg-white rounded-xl shadow-xl max-w-sm w-full mx-4 p-6">
-              <div className="flex items-center gap-3 mb-3">
-                <div className="size-10 rounded-full bg-purple-100 flex items-center justify-center">
-                  <Icon name="paper-plane" style="solid" className="size-5 text-purple-600" />
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-gray-900">Send Quotation</h3>
-                  <p className="text-xs text-gray-500">Step 1 of 2 — Confirm details</p>
-                </div>
-              </div>
-              <p className="text-sm text-gray-500 mb-5">
-                This will open bidding for{' '}
-                <strong>{companyCount} {companyCount === 1 ? 'company' : 'companies'}</strong>.
-                You will not be able to add or remove appraisals after sending.
-              </p>
-              <div className="flex gap-3 justify-end">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  type="button"
-                  onClick={handleCancelSendFlow}
-                >
-                  Cancel
-                </Button>
-                <Button size="sm" type="button" onClick={handleProceedToShareDocs}>
-                  Next: Share Documents
-                  <Icon name="arrow-right" style="solid" className="size-3.5 ml-1.5" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
+        {/* ── Step 1: Email composition ── */}
+        <EmailCompositionModal
+          isOpen={sendStep === 'confirm'}
+          onClose={handleCancelSendFlow}
+          title="Drafting email to send to external appraisal company"
+          showCc={true}
+          showAttachments={false}
+          subjectLabel="Subject"
+          isPending={false}
+          onSubmit={handleEmailComposed}
+        />
 
         {/* ── Step 2: Share documents ── */}
         {sendStep === 'share-docs' && (

--- a/src/features/appraisal/context/AppraisalContext.tsx
+++ b/src/features/appraisal/context/AppraisalContext.tsx
@@ -76,6 +76,14 @@ export function useAppraisalContext(): AppraisalContextValue {
 }
 
 /**
+ * Hook to access appraisal context without throwing.
+ * Returns null when used outside an AppraisalProvider (e.g. dev/stub routes).
+ */
+export function useAppraisalContextSafe(): AppraisalContextValue | null {
+  return useContext(AppraisalContext);
+}
+
+/**
  * Hook to get the requestId from appraisal context
  * Returns undefined if not in appraisal context or still loading
  */

--- a/src/features/appraisal/pages/CreateBuildingPage.tsx
+++ b/src/features/appraisal/pages/CreateBuildingPage.tsx
@@ -3,7 +3,9 @@ import { type SubmitHandler, useForm } from 'react-hook-form';
 import { FormProvider } from '@shared/components/form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { useBasePath, useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { useBasePath, useAppraisalId, useAppraisalContextSafe } from '@/features/appraisal/context/AppraisalContext';
+import { useCollateralPrefillStore } from '@/features/collateralMaster/store/collateralPrefillStore';
+import { useProgressivePrefill } from '@/features/collateralMaster/hooks/useProgressivePrefill';
 
 import ResizableSidebar from '@/shared/components/ResizableSidebar';
 import NavAnchors from '@/shared/components/sections/NavAnchors';
@@ -50,7 +52,7 @@ const CreateBuildingPage = () => {
 
   const isEditMode = Boolean(propertyId);
 
-  const { data: propertyData, isLoading } = useGetBuildingPropertyById(appraisalId, propertyId);
+  const { data: propertyData, isLoading } = useGetBuildingPropertyById(appraisalId ?? '', propertyId);
 
   const formDefaults = useMemo(() => {
     if (isEditMode && propertyData) {
@@ -78,6 +80,70 @@ const CreateBuildingPage = () => {
       reset(mapBuildingPropertyResponseToForm(propertyData));
     }
   }, [isEditMode, propertyData, reset]);
+
+  // ── Progressive appraisal prefill ──────────────────────────────────────────
+  // In create mode for a Progressive appraisal, seed the construction inspection
+  // fields from the prior inspection stored on the CollateralMaster.
+  const appraisalCtx = useAppraisalContextSafe();
+  const appraisal = appraisalCtx?.appraisal ?? null;
+  const isProgressive = appraisal?.appraisalType === 'Progressive';
+  const lastConstructionInspectionId = useCollateralPrefillStore(
+    s => s.lastConstructionInspectionId,
+  );
+  // Only call the hook when conditions warrant a prefill — null disables the query
+  const prefillInspectionId =
+    !isEditMode && isProgressive ? lastConstructionInspectionId : null;
+
+  const { buildSeedRows, isSummaryMode, summaryPreviousProgressPct, priorDetails } =
+    useProgressivePrefill(prefillInspectionId);
+
+  // Guard: apply prefill only once per create-mode mount
+  const prefillAppliedRef = useRef(false);
+
+  useEffect(() => {
+    if (prefillAppliedRef.current) return;
+    if (!priorDetails) return;
+    if (isEditMode) return;
+
+    prefillAppliedRef.current = true;
+
+    if (!isSummaryMode) {
+      const seeds = buildSeedRows();
+      if (seeds && seeds.length > 0) {
+        methods.setValue('constructionEnterDetail', true, { shouldDirty: true });
+        methods.setValue(
+          'constructionSubItems',
+          seeds.map(s => ({
+            id: null,
+            constructionWorkGroupId: s.constructionWorkGroupId ?? '',
+            constructionWorkItemId: s.constructionWorkItemId ?? null,
+            workItemName: s.workItemName ?? '',
+            displayOrder: s.displayOrder ?? 0,
+            proportionPct: s.proportionPct ?? 0,
+            previousProgressPct: s.previousProgressPct ?? 0,
+            currentProgressPct: 0, // fresh inspection starts at 0 delta from previous
+          })),
+          { shouldDirty: true },
+        );
+      }
+    } else {
+      // Summary mode: seed the previous progress from prior summary
+      methods.setValue('constructionEnterDetail', false, { shouldDirty: true });
+      methods.setValue(
+        'constructionSummary.summaryPreviousProgressPct',
+        summaryPreviousProgressPct ?? 0,
+        { shouldDirty: true },
+      );
+    }
+  }, [
+    priorDetails,
+    isEditMode,
+    isSummaryMode,
+    buildSeedRows,
+    summaryPreviousProgressPct,
+    methods,
+  ]);
+  // ──────────────────────────────────────────────────────────────────────────
 
   const { mutate: createBuildingProperties, isPending: isCreating } = useCreateBuildingProperty();
   const { mutate: updateBuildingProperties, isPending: isUpdating } = useUpdateBuildingProperty();

--- a/src/features/appraisal/types/administration.ts
+++ b/src/features/appraisal/types/administration.ts
@@ -185,6 +185,13 @@ export interface StartQuotationFromTaskRequest {
   assignmentMethod?: string | null;
   /** Pre-registers the internal follow-up method (e.g. 'roundrobin', 'manual'). */
   internalFollowupAssignmentMethod?: string | null;
+  /**
+   * Company IDs previously engaged on this collateral (from CollateralMaster lookup).
+   * Passed as a workflow variable so the engine can enforce appeal-exclusion rules.
+   * NOTE: backend extension needed — POST /quotations/start-from-task must accept and
+   * store this field before it becomes functional.
+   */
+  excludedCompanyIds?: string[] | null;
 }
 
 /**

--- a/src/features/blockProject/components/tabs/ModelListingTab.tsx
+++ b/src/features/blockProject/components/tabs/ModelListingTab.tsx
@@ -5,8 +5,9 @@ import clsx from 'clsx';
 import type { AxiosError } from 'axios';
 
 import { useAppraisalId, useBasePath } from '@/features/appraisal/context/AppraisalContext';
-import { useGetProjectModels } from '../../api/projectModel';
+import { useGetProjectModels, useDeleteProjectModel } from '../../api/projectModel';
 import { useCreateProjectModelPricingAnalysis } from '../../api/projectPricingAnalysis';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { useGetGalleryPhotos } from '@/features/appraisal/api/gallery';
 import { toGalleryImage } from '@/features/appraisal/types/gallery';
 import { useParameterDescription } from '@/shared/utils/parameterUtils';
@@ -55,6 +56,7 @@ interface ModelCardProps {
   onClick: () => void;
   onPricingAnalysis: () => void;
   isPricingAnalysisPending: boolean;
+  onDelete: (e: React.MouseEvent) => void;
 }
 
 /** Pricing-analysis CTA. Stops propagation so the card click doesn't navigate. */
@@ -101,6 +103,7 @@ function ModelCard({
   onClick,
   onPricingAnalysis,
   isPricingAnalysisPending,
+  onDelete,
 }: ModelCardProps) {
   const icon = projectType === 'Condo' ? 'layer-group' : 'house';
   const hasAnalysis = Boolean(model.pricingAnalysisId);
@@ -199,6 +202,15 @@ function ModelCard({
           onClick={onPricingAnalysis}
         />
 
+        <button
+          type="button"
+          onClick={onDelete}
+          className="p-1.5 rounded-md text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0"
+          title="Delete model"
+        >
+          <Icon name="trash-can" style="regular" className="size-4" />
+        </button>
+
         <Icon name="chevron-right" style="solid" className="text-gray-400 w-4 h-4 shrink-0" />
       </div>
     );
@@ -209,7 +221,7 @@ function ModelCard({
       {...cardProps}
       className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:border-primary/40 hover:shadow-md transition-all text-left group cursor-pointer"
     >
-      <div className="aspect-video bg-gray-100 flex items-center justify-center overflow-hidden">
+      <div className="relative aspect-video bg-gray-100 flex items-center justify-center overflow-hidden">
         {thumbnailSrc ? (
           <img
             src={thumbnailSrc}
@@ -223,6 +235,14 @@ function ModelCard({
             className="text-gray-300 w-10 h-10 group-hover:text-gray-400 transition-colors"
           />
         )}
+        <button
+          type="button"
+          onClick={onDelete}
+          className="absolute top-2 right-2 p-1.5 rounded-md bg-white/80 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100"
+          title="Delete model"
+        >
+          <Icon name="trash-can" style="regular" className="size-3.5" />
+        </button>
       </div>
 
       <div className="p-4">
@@ -303,8 +323,10 @@ export default function ModelListingTab({ projectType }: ModelListingTabProps) {
   const basePath = useBasePath();
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
 
   const { data: modelsData, isLoading, isError } = useGetProjectModels(appraisalId ?? '');
+  const { mutate: deleteModel, isPending: isDeleting } = useDeleteProjectModel();
   const models = useMemo(
     () =>
       (Array.isArray(modelsData) ? [...modelsData] : []).sort((a, b) =>
@@ -337,6 +359,24 @@ export default function ModelListingTab({ projectType }: ModelListingTabProps) {
 
   const handleAddModel = () => {
     navigate(`${basePath}/${routeSegment}/model/new`);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!appraisalId || !deleteTarget) return;
+    deleteModel(
+      { appraisalId, modelId: deleteTarget.id },
+      {
+        onSuccess: () => {
+          toast.success(`Model "${deleteTarget.name}" deleted`);
+          setDeleteTarget(null);
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? 'Failed to delete model');
+          setDeleteTarget(null);
+        },
+      },
+    );
   };
 
   const handlePricingAnalysis = (model: ProjectModel) => {
@@ -456,6 +496,7 @@ export default function ModelListingTab({ projectType }: ModelListingTabProps) {
               isPricingAnalysisPending={
                 isCreatingPricingAnalysis && pricingMutationVars?.modelId === model.id
               }
+              onDelete={e => { e.stopPropagation(); setDeleteTarget({ id: model.id, name: model.modelName ?? 'this model' }); }}
             />
           ))}
         </div>
@@ -473,10 +514,21 @@ export default function ModelListingTab({ projectType }: ModelListingTabProps) {
               isPricingAnalysisPending={
                 isCreatingPricingAnalysis && pricingMutationVars?.modelId === model.id
               }
+              onDelete={e => { e.stopPropagation(); setDeleteTarget({ id: model.id, name: model.modelName ?? 'this model' }); }}
             />
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete Model"
+        message={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
+        confirmText="Delete"
+        isLoading={isDeleting}
+      />
     </div>
   );
 }

--- a/src/features/blockProject/components/tabs/TowerListingTab.tsx
+++ b/src/features/blockProject/components/tabs/TowerListingTab.tsx
@@ -1,15 +1,21 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
 import clsx from 'clsx';
+import type { AxiosError } from 'axios';
 
 import { useAppraisalId, useBasePath } from '@/features/appraisal/context/AppraisalContext';
-import { useGetProjectTowers } from '../../api/projectTower';
+import { useGetProjectTowers, useDeleteProjectTower } from '../../api/projectTower';
 import { useGetGalleryPhotos } from '@/features/appraisal/api/gallery';
 import { toGalleryImage } from '@/features/appraisal/types/gallery';
 import type { GalleryPhotoDtoType } from '@shared/schemas/v1';
 import type { ProjectTower } from '../../types';
+import type { ApiError } from '@/shared/types/api';
 import Icon from '@shared/components/Icon';
 import Button from '@shared/components/Button';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+
+type AppError = AxiosError & { apiError?: ApiError };
 
 type ViewMode = 'grid' | 'list';
 
@@ -20,15 +26,27 @@ interface TowerCardProps {
   viewMode: ViewMode;
   thumbnailSrc?: string;
   onClick: () => void;
+  onDelete: (e: React.MouseEvent) => void;
 }
 
-function TowerCard({ tower, viewMode, thumbnailSrc, onClick }: TowerCardProps) {
+function TowerCard({ tower, viewMode, thumbnailSrc, onClick, onDelete }: TowerCardProps) {
+  const cardProps = {
+    role: 'button' as const,
+    tabIndex: 0,
+    onClick,
+    onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    },
+  };
+
   if (viewMode === 'list') {
     return (
-      <button
-        type="button"
-        onClick={onClick}
-        className="w-full flex items-center gap-4 bg-white border border-gray-200 rounded-lg p-4 hover:border-primary/40 hover:shadow-sm transition-all text-left"
+      <div
+        {...cardProps}
+        className="w-full flex items-center gap-4 bg-white border border-gray-200 rounded-lg p-4 hover:border-primary/40 hover:shadow-sm transition-all text-left cursor-pointer"
       >
         <div className="w-16 h-16 rounded-lg bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
           {thumbnailSrc ? (
@@ -68,18 +86,26 @@ function TowerCard({ tower, viewMode, thumbnailSrc, onClick }: TowerCardProps) {
           </div>
         </div>
 
+        <button
+          type="button"
+          onClick={onDelete}
+          className="p-1.5 rounded-md text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors shrink-0"
+          title="Delete tower"
+        >
+          <Icon name="trash-can" style="regular" className="size-4" />
+        </button>
+
         <Icon name="chevron-right" style="solid" className="text-gray-400 w-4 h-4 shrink-0" />
-      </button>
+      </div>
     );
   }
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:border-primary/40 hover:shadow-md transition-all text-left group"
+    <div
+      {...cardProps}
+      className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:border-primary/40 hover:shadow-md transition-all text-left group cursor-pointer"
     >
-      <div className="aspect-video bg-gray-100 flex items-center justify-center overflow-hidden">
+      <div className="relative aspect-video bg-gray-100 flex items-center justify-center overflow-hidden">
         {thumbnailSrc ? (
           <img
             src={thumbnailSrc}
@@ -93,6 +119,14 @@ function TowerCard({ tower, viewMode, thumbnailSrc, onClick }: TowerCardProps) {
             className="text-gray-300 w-10 h-10 group-hover:text-gray-400 transition-colors"
           />
         )}
+        <button
+          type="button"
+          onClick={onDelete}
+          className="absolute top-2 right-2 p-1.5 rounded-md bg-white/80 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100"
+          title="Delete tower"
+        >
+          <Icon name="trash-can" style="regular" className="size-3.5" />
+        </button>
       </div>
 
       <div className="p-4">
@@ -120,7 +154,7 @@ function TowerCard({ tower, viewMode, thumbnailSrc, onClick }: TowerCardProps) {
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -135,8 +169,10 @@ export default function TowerListingTab() {
   const basePath = useBasePath();
   const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
 
   const { data: towersData, isLoading, isError } = useGetProjectTowers(appraisalId ?? '');
+  const { mutate: deleteTower, isPending: isDeleting } = useDeleteProjectTower();
   const towers = useMemo(
     () =>
       [...(towersData ?? [])].sort((a, b) =>
@@ -164,6 +200,24 @@ export default function TowerListingTab() {
 
   const handleAddTower = () => {
     navigate(`${basePath}/block-condo/tower/new`);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!appraisalId || !deleteTarget) return;
+    deleteTower(
+      { appraisalId, towerId: deleteTarget.id },
+      {
+        onSuccess: () => {
+          toast.success(`Tower "${deleteTarget.name}" deleted`);
+          setDeleteTarget(null);
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? 'Failed to delete tower');
+          setDeleteTarget(null);
+        },
+      },
+    );
   };
 
   if (isLoading) {
@@ -247,6 +301,7 @@ export default function TowerListingTab() {
               thumbnailSrc={thumbnailByTowerId.get(tower.id)}
               viewMode="grid"
               onClick={() => handleTowerClick(tower.id)}
+              onDelete={e => { e.stopPropagation(); setDeleteTarget({ id: tower.id, name: tower.towerName ?? 'this tower' }); }}
             />
           ))}
         </div>
@@ -259,10 +314,21 @@ export default function TowerListingTab() {
               thumbnailSrc={thumbnailByTowerId.get(tower.id)}
               viewMode="list"
               onClick={() => handleTowerClick(tower.id)}
+              onDelete={e => { e.stopPropagation(); setDeleteTarget({ id: tower.id, name: tower.towerName ?? 'this tower' }); }}
             />
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete Tower"
+        message={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
+        confirmText="Delete"
+        isLoading={isDeleting}
+      />
     </div>
   );
 }

--- a/src/features/blockProject/components/tabs/UnitPriceTab.tsx
+++ b/src/features/blockProject/components/tabs/UnitPriceTab.tsx
@@ -89,11 +89,11 @@ function ModelAssumptionsTable({ assumptions, projectType }: ModelAssumptionsTab
             </th>
             {projectType === 'LandAndBuilding' && (
               <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                Std Land Price (Baht/sq.wa)
+                Standard Land (sq.wa)
               </th>
             )}
             <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-              Standard Price (Baht/sq.m.)
+              Standard Price (Baht)
             </th>
             <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
               Coverage Amount (Baht/Sq.m)
@@ -144,8 +144,8 @@ function ModelAssumptionsTable({ assumptions, projectType }: ModelAssumptionsTab
 
 // ── Unit Price Result Table ───────────────────────────────────────────────────
 // NOTE: UnitPriceResultTable is intentionally OUTSIDE <FormProvider>.
-// Flag checkboxes (Condo) directly call saveUnitFlags + calculatePrices and do
-// not participate in RHF state. LB flags are read-only check icons.
+// Flag checkboxes (Condo + LB) directly call saveUnitFlags + calculatePrices and do
+// not participate in RHF state.
 
 function fmt(value?: number | null) {
   return (
@@ -178,20 +178,8 @@ function FlagCell({
   );
 }
 
-// LB: read-only check icon cell
-function CheckIconCell({ checked }: { checked: boolean }) {
-  return (
-    <td className="py-2 px-3 text-center">
-      {checked ? (
-        <Icon name="check" style="solid" className="w-3.5 h-3.5 text-green-500 mx-auto" />
-      ) : (
-        <span className="text-gray-300">-</span>
-      )}
-    </td>
-  );
-}
 
-type CondoFlag = 'isCorner' | 'isEdge' | 'isPoolView' | 'isSouth' | 'isOther';
+type CondoFlag = 'isCorner' | 'isEdge' | 'isPoolView' | 'isSouth' | 'isOther' | 'isNearGarden';
 
 interface UnitPriceResultTableProps {
   unitPrices: ProjectUnitPrice[];
@@ -203,6 +191,7 @@ interface UnitPriceResultTableProps {
     poolViewAdjustment?: number | null;
     southAdjustment?: number | null;
     otherAdjustment?: number | null;
+    nearGardenAdjustment?: number | null;
   } | null | undefined;
   onToggleFlag: (unitId: string, flag: CondoFlag, value: boolean) => void;
   isDisabled: boolean;
@@ -253,10 +242,15 @@ function UnitPriceResultTable({
               <>
                 <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Plot No</th>
                 <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">House No</th>
+                <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Model</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">No. of Floors</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Land Area (sq.wa)</th>
               </>
             )}
-            <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Model</th>
-            <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Usable Area</th>
+            {projectType === 'Condo' && (
+              <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Model</th>
+            )}
+            <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Usable Area (sq.m)</th>
             <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Selling Price</th>
             {/* Common flags */}
             {projectType === 'Condo' ? (
@@ -278,8 +272,14 @@ function UnitPriceResultTable({
             ) : (
               <>
                 <th className="text-center py-2.5 px-3 text-gray-500 font-medium">Corner</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium" />
                 <th className="text-center py-2.5 px-3 text-gray-500 font-medium">Edge</th>
-                <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Near Garden</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium" />
+                <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Near Garden/Clubhouse</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium" />
+                <th className="text-center py-2.5 px-3 text-gray-500 font-medium">Other</th>
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium" />
+                <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Land Diff (sq.wa)</th>
                 <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Land +/- (Baht)</th>
                 <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Location Adj.</th>
                 <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">Standard Price</th>
@@ -307,9 +307,14 @@ function UnitPriceResultTable({
                 <>
                   <td className="py-2 px-3 text-gray-700">{up.plotNumber ?? '-'}</td>
                   <td className="py-2 px-3 text-gray-700">{up.houseNumber ?? '-'}</td>
+                  <td className="py-2 px-3 text-gray-700">{up.modelType ?? '-'}</td>
+                  <td className="py-2 px-3 text-right text-gray-700">{up.numberOfFloors ?? '-'}</td>
+                  <td className="py-2 px-3 text-right text-gray-700">{fmt(up.landArea)}</td>
                 </>
               )}
-              <td className="py-2 px-3 text-gray-700">{up.modelType ?? '-'}</td>
+              {projectType === 'Condo' && (
+                <td className="py-2 px-3 text-gray-700">{up.modelType ?? '-'}</td>
+              )}
               <td className="py-2 px-3 text-right text-gray-700">{fmt(up.usableArea)}</td>
               <td className="py-2 px-3 text-right text-gray-700">{fmt(up.sellingPrice)}</td>
               {projectType === 'Condo' ? (
@@ -350,9 +355,33 @@ function UnitPriceResultTable({
                 </>
               ) : (
                 <>
-                  <CheckIconCell checked={up.isCorner} />
-                  <CheckIconCell checked={up.isEdge} />
-                  <CheckIconCell checked={up.isNearGarden} />
+                  <FlagCell
+                    checked={up.isCorner}
+                    amount={pricingAssumption?.cornerAdjustment}
+                    onChange={v => onToggleFlag(up.projectUnitId, 'isCorner', v)}
+                    disabled={isDisabled}
+                  />
+                  <FlagCell
+                    checked={up.isEdge}
+                    amount={pricingAssumption?.edgeAdjustment}
+                    onChange={v => onToggleFlag(up.projectUnitId, 'isEdge', v)}
+                    disabled={isDisabled}
+                  />
+                  <FlagCell
+                    checked={up.isNearGarden}
+                    amount={pricingAssumption?.nearGardenAdjustment}
+                    onChange={v => onToggleFlag(up.projectUnitId, 'isNearGarden', v)}
+                    disabled={isDisabled}
+                  />
+                  <FlagCell
+                    checked={up.isOther}
+                    amount={pricingAssumption?.otherAdjustment}
+                    onChange={v => onToggleFlag(up.projectUnitId, 'isOther', v)}
+                    disabled={isDisabled}
+                  />
+                  <td className="py-2 px-3 text-right text-gray-800">
+                    {up.landAreaDifference != null ? fmt(up.landAreaDifference) : '-'}
+                  </td>
                   <td className="py-2 px-3 text-right text-gray-800">
                     {up.landIncreaseDecreaseAmount?.toLocaleString() ?? '-'}
                   </td>
@@ -513,14 +542,54 @@ export default function UnitPriceTab({ projectType }: UnitPriceTabProps) {
     setFlagsDirty(true);
   };
 
+  const modelAssumptions = pricingAssumption?.modelAssumptions ?? [];
+
+  // Lookup: modelType → model assumption fields needed for LB preview enrichment.
+  const modelLookup = useMemo(
+    () => new Map(
+      modelAssumptions.map(m => [
+        m.modelType ?? '',
+        {
+          standardPrice: m.finalAppraisedValue,
+          coverageAmount: m.coverageAmount,
+          // standardLandPrice holds the standard land AREA (sq.wa) — see DeriveFromModels
+          standardLandArea: m.standardLandPrice,
+        },
+      ]),
+    ),
+    [modelAssumptions],
+  );
+
   // Derived display rows: re-run the preview calc whenever the local flag set
   // OR the watched assumption form values change.
   const displayedUnitPrices = useMemo(
-    () => localUnitPrices.map(up => recomputeUnitPrice(up, watchedAssumption, projectType)),
-    [localUnitPrices, watchedAssumption, projectType],
+    () => localUnitPrices.map(up => {
+      const lookup = modelLookup.get(up.modelType ?? '');
+      // For LB: compute land area diff and land +/- live from model standard land area.
+      // Always recompute so it responds to rate / assumption changes in the form.
+      const landAreaDifference =
+        projectType === 'LandAndBuilding' &&
+        up.landArea != null &&
+        lookup?.standardLandArea != null
+          ? up.landArea - lookup.standardLandArea
+          : up.landAreaDifference;
+      const landIncreaseDecreaseAmount =
+        landAreaDifference != null &&
+        (watchedAssumption as AssumptionInputs).landIncreaseDecreaseRate != null
+          ? landAreaDifference *
+            ((watchedAssumption as AssumptionInputs).landIncreaseDecreaseRate as number)
+          : up.landIncreaseDecreaseAmount;
+      const enriched: typeof up = {
+        ...up,
+        standardPrice: up.standardPrice ?? lookup?.standardPrice ?? undefined,
+        coverageAmount: up.coverageAmount ?? lookup?.coverageAmount ?? undefined,
+        landAreaDifference,
+        landIncreaseDecreaseAmount,
+      };
+      return recomputeUnitPrice(enriched, watchedAssumption, projectType);
+    }),
+    [localUnitPrices, watchedAssumption, projectType, modelLookup],
   );
-
-  const modelAssumptions = pricingAssumption?.modelAssumptions ?? [];
   const isBusy = isSaving || isSavingFlags || isCalculating;
 
   return (
@@ -574,7 +643,7 @@ export default function UnitPriceTab({ projectType }: UnitPriceTabProps) {
                 unitPrices={displayedUnitPrices}
                 projectType={projectType}
                 isLoading={pricesLoading}
-                pricingAssumption={pricingAssumption}
+                pricingAssumption={watchedAssumption}
                 onToggleFlag={handleToggleFlag}
                 isDisabled={isReadOnly || isBusy}
               />

--- a/src/features/blockProject/data/options.ts
+++ b/src/features/blockProject/data/options.ts
@@ -94,10 +94,15 @@ export const LB_FLOOR_STRUCTURE_TYPE_OPTIONS = [
   { value: 'Other', label: 'Other' },
 ];
 
-export const LB_FIRE_INSURANCE_OPTIONS = [
-  { value: 'WithInsurance', label: 'With insurance' },
-  { value: 'WithoutInsurance', label: 'Without insurance' },
-  { value: 'Unknown', label: 'Unknown' },
+export const LB_FIRE_INSURANCE_OPTIONS: ListBoxItem[] = [
+  { id: 'OneTwoStoreyTownhouse',         value: 'OneTwoStoreyTownhouse',         label: '1-2 Storey Townhouse' },
+  { id: 'ThreeStoreyTownhouse',          value: 'ThreeStoreyTownhouse',          label: '3 Storey Townhouse' },
+  { id: 'SemiDetachedHouse',             value: 'SemiDetachedHouse',             label: 'Semi-detached house' },
+  { id: 'SingleHouseAreaLessThan150',    value: 'SingleHouseAreaLessThan150',    label: 'Single house, Area < 150 Sq.m' },
+  { id: 'SingleHouseArea150To200',       value: 'SingleHouseArea150To200',       label: 'Single house, Area ≥ 150 < 200 Sq.m' },
+  { id: 'SingleHouseArea200To400',       value: 'SingleHouseArea200To400',       label: 'Single house, Area ≥ 200 < 400 Sq.m' },
+  { id: 'SingleHouseArea400To500',       value: 'SingleHouseArea400To500',       label: 'Single house, Area ≥ 400 < 500 Sq.m' },
+  { id: 'SingleHouseAreaGreaterThan500', value: 'SingleHouseAreaGreaterThan500', label: 'Single house, Area > 500 Sq.m' },
 ];
 
 export const LB_FIRE_INSURANCE_LABEL_BY_VALUE: Record<string, string> =

--- a/src/features/blockProject/forms/PricingAssumptionForm.tsx
+++ b/src/features/blockProject/forms/PricingAssumptionForm.tsx
@@ -79,14 +79,49 @@ const CONDO_LOCATION_ROWS: LocationRow[] = [
 const LB_LOCATION_ROWS: LocationRow[] = [
   { name: 'cornerAdjustment', label: 'Corner' },
   { name: 'edgeAdjustment', label: 'Edge' },
-  { name: 'nearGardenAdjustment', label: 'Near Garden' },
+  { name: 'nearGardenAdjustment', label: 'Near Garden/Clubhouse' },
   { name: 'otherAdjustment', label: 'Other' },
-  {
-    name: 'landIncreaseDecreaseRate',
-    label: 'Land Increase / Decrease Rate',
-    unit: '%',
-  },
 ];
+
+// ── Land Assumption Table (LB only) ──────────────────────────────────────────
+
+const LandAssumptionTable = () => {
+  const { control } = useFormContext();
+
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden">
+      <table className="w-full table-fixed">
+        <colgroup>
+          <col className="w-2/5" />
+          <col />
+        </colgroup>
+        <tbody className="bg-white">
+          <tr>
+            <td className="px-4 py-2 text-sm text-gray-700">
+              Land Increase / Decrease
+              <span className="text-gray-400 ml-1">(Baht/sq.wa)</span>
+            </td>
+            <td className="px-3 py-1.5">
+              <Controller
+                control={control}
+                name="landIncreaseDecreaseRate"
+                render={({ field, fieldState }) => (
+                  <NumberInput
+                    decimalPlaces={2}
+                    value={field.value ?? ''}
+                    onChange={e => field.onChange(e.target.value)}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                  />
+                )}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 interface LocationAssumptionsTableProps {
   projectType: ProjectType;
@@ -177,6 +212,16 @@ const PricingAssumptionForm = ({ projectType }: PricingAssumptionFormProps) => (
       </p>
       <LocationAssumptionsTable projectType={projectType} />
     </section>
+
+    {projectType === 'LandAndBuilding' && (
+      <section>
+        <SectionHeader title="Land Assumption" icon="mountain-city" />
+        <p className="text-xs text-gray-400 mb-3">
+          Land price adjustment applied to each unit based on land area.
+        </p>
+        <LandAssumptionTable />
+      </section>
+    )}
 
     <div className="h-px bg-gray-200" />
 

--- a/src/features/blockProject/pages/ModelDetailPage.tsx
+++ b/src/features/blockProject/pages/ModelDetailPage.tsx
@@ -24,7 +24,10 @@ import {
   useGetProjectModelById,
   useCreateProjectModel,
   useUpdateProjectModel,
+  useDeleteProjectModel,
 } from '../api/projectModel';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+import DeleteButton from '@/shared/components/buttons/DeleteButton';
 import { useGetProjectTowers } from '../api/projectTower';
 import ModelDetailForm from '../forms/ModelDetailForm';
 import ProjectModelPhotoSection, {
@@ -79,9 +82,11 @@ export default function ModelDetailPage({ projectType }: ModelDetailPageProps) {
 
   const { mutate: createModel, isPending: isCreating } = useCreateProjectModel();
   const { mutate: updateModel, isPending: isUpdating } = useUpdateProjectModel();
+  const { mutate: deleteModel, isPending: isDeleting } = useDeleteProjectModel();
 
   const isPending = isCreating || isUpdating;
   const [saveAction, setSaveAction] = useState<'draft' | 'submit' | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const photoSectionRef = useRef<ProjectModelPhotoSectionRef>(null);
 
   const formDefaults = useMemo(() => {
@@ -185,6 +190,25 @@ export default function ModelDetailPage({ projectType }: ModelDetailPageProps) {
 
   const handleNavigateBack = () => {
     navigate(`${basePath}/${routeSegment}?tab=models`);
+  };
+
+  const handleDelete = () => {
+    if (!appraisalId || !modelId) return;
+    deleteModel(
+      { appraisalId, modelId },
+      {
+        onSuccess: () => {
+          toast.success('Model deleted successfully');
+          skipWarning();
+          navigate(`${basePath}/${routeSegment}?tab=models`);
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? 'Failed to delete model');
+          setIsDeleteDialogOpen(false);
+        },
+      },
+    );
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -303,6 +327,9 @@ export default function ModelDetailPage({ projectType }: ModelDetailPageProps) {
               <Button variant="ghost" type="button" onClick={handleNavigateBack}>
                 Cancel
               </Button>
+              {isEditMode && !isReadOnly && (
+                <DeleteButton onClick={() => setIsDeleteDialogOpen(true)} disabled={isPending || isDeleting} />
+              )}
               {!isReadOnly && (
                 <>
                   <ActionBar.Divider />
@@ -334,6 +361,15 @@ export default function ModelDetailPage({ projectType }: ModelDetailPageProps) {
             )}
           </ActionBar>
 
+          <ConfirmDialog
+            isOpen={isDeleteDialogOpen}
+            onClose={() => setIsDeleteDialogOpen(false)}
+            onConfirm={handleDelete}
+            title="Delete Model"
+            message="Are you sure you want to delete this model? This action cannot be undone."
+            confirmText="Delete"
+            isLoading={isDeleting}
+          />
           <UnsavedChangesDialog blocker={blocker} />
         </form>
       </FormProvider>

--- a/src/features/blockProject/pages/TowerDetailPage.tsx
+++ b/src/features/blockProject/pages/TowerDetailPage.tsx
@@ -24,7 +24,10 @@ import {
   useGetProjectTowerById,
   useCreateProjectTower,
   useUpdateProjectTower,
+  useDeleteProjectTower,
 } from '../api/projectTower';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
+import DeleteButton from '@/shared/components/buttons/DeleteButton';
 import TowerDetailForm from '../forms/TowerDetailForm';
 import { projectTowerForm, projectTowerFormDefaults, type ProjectTowerFormType } from '../schemas/form';
 import ProjectTowerPhotoSection, {
@@ -61,9 +64,11 @@ export default function TowerDetailPage() {
   );
   const { mutate: createTower, isPending: isCreating } = useCreateProjectTower();
   const { mutate: updateTower, isPending: isUpdating } = useUpdateProjectTower();
+  const { mutate: deleteTower, isPending: isDeleting } = useDeleteProjectTower();
 
   const isPending = isCreating || isUpdating;
   const [saveAction, setSaveAction] = useState<'draft' | 'submit' | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const photoSectionRef = useRef<ProjectTowerPhotoSectionRef>(null);
 
   const formDefaults = useMemo<ProjectTowerFormType>(() => {
@@ -120,6 +125,25 @@ export default function TowerDetailPage() {
 
   const handleNavigateBack = () => {
     navigate(`${basePath}/block-condo?tab=towers`);
+  };
+
+  const handleDelete = () => {
+    if (!appraisalId || !towerId) return;
+    deleteTower(
+      { appraisalId, towerId },
+      {
+        onSuccess: () => {
+          toast.success('Tower deleted successfully');
+          skipWarning();
+          navigate(`${basePath}/block-condo?tab=towers`);
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? 'Failed to delete tower');
+          setIsDeleteDialogOpen(false);
+        },
+      },
+    );
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -239,6 +263,9 @@ export default function TowerDetailPage() {
               <Button variant="ghost" type="button" onClick={handleNavigateBack}>
                 Cancel
               </Button>
+              {isEditMode && !isReadOnly && (
+                <DeleteButton onClick={() => setIsDeleteDialogOpen(true)} disabled={isPending || isDeleting} />
+              )}
               {!isReadOnly && (
                 <>
                   <ActionBar.Divider />
@@ -270,6 +297,15 @@ export default function TowerDetailPage() {
             )}
           </ActionBar>
 
+          <ConfirmDialog
+            isOpen={isDeleteDialogOpen}
+            onClose={() => setIsDeleteDialogOpen(false)}
+            onConfirm={handleDelete}
+            title="Delete Tower"
+            message="Are you sure you want to delete this tower? This action cannot be undone."
+            confirmText="Delete"
+            isLoading={isDeleting}
+          />
           <UnsavedChangesDialog blocker={blocker} />
         </form>
       </FormProvider>

--- a/src/features/blockProject/types/index.ts
+++ b/src/features/blockProject/types/index.ts
@@ -321,6 +321,7 @@ export interface ProjectUnitPrice {
   priceIncrementPerFloor?: number;
   // LB-only calculated
   landIncreaseDecreaseAmount?: number;
+  landAreaDifference?: number;
 }
 
 /** Request shape for saving location flags on unit prices. */

--- a/src/features/blockProject/utils/recomputeUnitPrice.ts
+++ b/src/features/blockProject/utils/recomputeUnitPrice.ts
@@ -110,13 +110,9 @@ const recomputeCondo = (
 };
 
 /**
- * LB: ProjectUnitPrice.standardPrice is stored as the area-based total
- * (per-sq.m. rate × usableArea, see Project.cs:CalculateLandAndBuildingUnitPrices).
+ * LB: ProjectUnitPrice.standardPrice is the model's FinalAppraisedValue directly (total Baht).
+ * It is NOT multiplied by usable area — see Project.cs:CalculateLandAndBuildingUnitPrices.
  * Location adjustments scale by LandArea (sq.wa), not UsableArea.
- *
- * landIncreaseDecreaseAmount depends on standardLandArea (only on the model),
- * which isn't denormalized onto the unit-price record. Toggling a flag doesn't
- * affect this value, so we preserve whatever the backend last computed.
  */
 const recomputeLB = (
   unit: ProjectUnitPrice,

--- a/src/features/collateralMaster/api/hooks.ts
+++ b/src/features/collateralMaster/api/hooks.ts
@@ -1,0 +1,295 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import { collateralMasterKeys } from './keys';
+import type {
+  BackfillReportPage,
+  CollateralCatalogPage,
+  CollateralCatalogParams,
+  CollateralEngagementSnapshotDto,
+  CollateralEngagementSummaryDto,
+  CollateralLookupParams,
+  CollateralLookupResult,
+  CollateralMasterDto,
+  ConstructionInspectionWorkDetailsDto,
+  EditCollateralMasterBody,
+  RestoreBody,
+  SoftDeleteBody,
+} from './types';
+
+// ─── GET /collateral-masters/lookup ──────────────────────────────────────────
+
+/**
+ * Type-aware autocomplete lookup. Returns the matched master + last engagement
+ * + prior company IDs. Returns null on miss (new collateral).
+ *
+ * Only fires when at least the minimum identifying fields are provided per type.
+ */
+export const useLookupCollateralMaster = (
+  params: CollateralLookupParams | null,
+  enabled = true,
+) => {
+  // Determine whether we have enough fields for a meaningful lookup
+  const hasMinFields = (() => {
+    if (!params) return false;
+    switch (params.type) {
+      case 'Land':
+        return !!(params.titleDeedNo && params.province);
+      case 'Condo':
+        return !!(params.titleNumber && params.landOfficeCode);
+      case 'Leasehold':
+        return !!(params.contractNo);
+      case 'Machine':
+        return !!(params.machineRegistrationNo || params.serialNo);
+      default:
+        return false;
+    }
+  })();
+
+  return useQuery({
+    queryKey: collateralMasterKeys.lookup(params ?? { type: 'Land' }),
+    queryFn: async (): Promise<CollateralLookupResult | null> => {
+      if (!params) return null;
+      try {
+        const { data } = await axios.get<CollateralLookupResult>(
+          '/collateral-masters/lookup',
+          { params: flattenLookupParams(params) },
+        );
+        return data;
+      } catch (err: any) {
+        if (err?.response?.status === 404) return null;
+        throw err;
+      }
+    },
+    enabled: enabled && hasMinFields,
+    staleTime: 30_000,
+    retry: false,
+  });
+};
+
+/** Flatten the discriminated union params into a flat query-string object */
+function flattenLookupParams(params: CollateralLookupParams): Record<string, string> {
+  const flat: Record<string, string> = {};
+  for (const [k, v] of Object.entries(params as unknown as Record<string, unknown>)) {
+    if (v !== undefined && v !== null && v !== '') flat[k] = String(v);
+  }
+  return flat;
+}
+
+// ─── GET /collateral-masters/{id} ────────────────────────────────────────────
+
+export const useCollateralMaster = (id: string | null | undefined) => {
+  return useQuery({
+    queryKey: collateralMasterKeys.detail(id ?? ''),
+    queryFn: async (): Promise<CollateralMasterDto> => {
+      const { data } = await axios.get<CollateralMasterDto>(`/collateral-masters/${id}`);
+      return data;
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+};
+
+// ─── GET /collateral-masters (catalog, admin) ─────────────────────────────────
+
+export const useCollateralCatalog = (params: CollateralCatalogParams = {}) => {
+  return useQuery({
+    queryKey: collateralMasterKeys.catalog(params),
+    queryFn: async (): Promise<CollateralCatalogPage> => {
+      const { data } = await axios.get<CollateralCatalogPage>('/collateral-masters', {
+        params: {
+          ...(params.type && { type: params.type }),
+          ...(params.province && { province: params.province }),
+          ...(params.owner && { owner: params.owner }),
+          ...(params.isUnderConstruction != null && {
+            isUnderConstruction: params.isUnderConstruction,
+          }),
+          ...(params.minAppraisals != null && { minAppraisals: params.minAppraisals }),
+          ...(params.lastAppraisedFrom && { lastAppraisedFrom: params.lastAppraisedFrom }),
+          ...(params.lastAppraisedTo && { lastAppraisedTo: params.lastAppraisedTo }),
+          page: params.page ?? 0,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+};
+
+// ─── GET /collateral-masters/{id}/engagements ─────────────────────────────────
+
+export const useCollateralEngagements = (
+  masterId: string | null | undefined,
+  page = 0,
+  pageSize = 10,
+) => {
+  return useQuery({
+    queryKey: [...collateralMasterKeys.engagements(masterId ?? ''), { page, pageSize }],
+    queryFn: async (): Promise<{
+      items: CollateralEngagementSummaryDto[];
+      count: number;
+      pageNumber: number;
+      pageSize: number;
+    }> => {
+      const { data } = await axios.get(`/collateral-masters/${masterId}/engagements`, {
+        params: { page, pageSize },
+      });
+      return data;
+    },
+    enabled: !!masterId,
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+};
+
+// ─── GET /collateral-masters/{id}/engagements/{engagementId} ─────────────────
+
+export const useEngagementSnapshot = (
+  masterId: string | null | undefined,
+  engagementId: string | null | undefined,
+) => {
+  return useQuery({
+    queryKey: collateralMasterKeys.engagement(masterId ?? '', engagementId ?? ''),
+    queryFn: async (): Promise<CollateralEngagementSnapshotDto> => {
+      const { data } = await axios.get(
+        `/collateral-masters/${masterId}/engagements/${engagementId}`,
+      );
+      return data;
+    },
+    enabled: !!masterId && !!engagementId,
+    staleTime: 60_000,
+  });
+};
+
+// ─── PATCH /collateral-masters/{id} ──────────────────────────────────────────
+
+export const useEditCollateralMaster = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: EditCollateralMasterBody }) => {
+      const { data } = await axios.patch(`/collateral-masters/${id}`, body);
+      return data;
+    },
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.catalogs() });
+    },
+  });
+};
+
+// ─── DELETE /collateral-masters/{id} ─────────────────────────────────────────
+
+export const useSoftDeleteCollateralMaster = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, reason }: { id: string; reason: string }) => {
+      const { data } = await axios.delete(`/collateral-masters/${id}`, {
+        params: { reason },
+      });
+      return data;
+    },
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.catalogs() });
+    },
+  });
+};
+
+// ─── POST /collateral-masters/{id}/restore ───────────────────────────────────
+
+export const useRestoreCollateralMaster = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: RestoreBody }) => {
+      const { data } = await axios.post(`/collateral-masters/${id}/restore`, body);
+      return data;
+    },
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.catalogs() });
+    },
+  });
+};
+
+// ─── POST /collateral-masters/admin/backfill ──────────────────────────────────
+
+export const useStartBackfill = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post('/collateral-masters/admin/backfill');
+      return data as { jobId?: string };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.backfillReports() });
+    },
+  });
+};
+
+// ─── GET /collateral-masters/admin/backfill-report ───────────────────────────
+
+export const useGetBackfillReport = (
+  params: { status?: string; page?: number; pageSize?: number } = {},
+) => {
+  return useQuery({
+    queryKey: collateralMasterKeys.backfillReport(params),
+    queryFn: async (): Promise<BackfillReportPage> => {
+      const { data } = await axios.get('/collateral-masters/admin/backfill-report', {
+        params: {
+          ...(params.status && { status: params.status }),
+          page: params.page ?? 0,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 15_000,
+  });
+};
+
+// ─── POST /collateral-masters/admin/replay/{appraisalId} ─────────────────────
+
+export const useReplayBackfill = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (appraisalId: string) => {
+      const { data } = await axios.post(
+        `/collateral-masters/admin/replay/${appraisalId}`,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.backfillReports() });
+      queryClient.invalidateQueries({ queryKey: collateralMasterKeys.catalogs() });
+    },
+  });
+};
+
+// ─── GET /appraisal/construction-inspections/{inspectionId}/work-details ──────
+
+/**
+ * Fetch prior construction work details for Progressive appraisal prefill.
+ * Called when lookup returns a master with LastConstructionInspectionId set.
+ */
+export const useConstructionInspectionWorkDetails = (
+  inspectionId: string | null | undefined,
+) => {
+  return useQuery({
+    queryKey: collateralMasterKeys.inspectionWorkDetails(inspectionId ?? ''),
+    queryFn: async (): Promise<ConstructionInspectionWorkDetailsDto> => {
+      const { data } = await axios.get(
+        `/appraisal/construction-inspections/${inspectionId}/work-details`,
+      );
+      return data;
+    },
+    enabled: !!inspectionId,
+    staleTime: 60_000,
+    retry: false, // 404 means inspection was deleted — UI handles gracefully
+  });
+};
+
+// ─── Unused body type re-export ───────────────────────────────────────────────
+
+export type { SoftDeleteBody };

--- a/src/features/collateralMaster/api/index.ts
+++ b/src/features/collateralMaster/api/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './keys';
+export * from './hooks';

--- a/src/features/collateralMaster/api/keys.ts
+++ b/src/features/collateralMaster/api/keys.ts
@@ -1,0 +1,37 @@
+import type { CollateralCatalogParams, CollateralLookupParams } from './types';
+
+/**
+ * Query key factory for all collateral master queries.
+ * Centralizes key construction so keys are consistent and easy to invalidate.
+ */
+export const collateralMasterKeys = {
+  all: ['collateral-masters'] as const,
+
+  // Lookup (debounced autocomplete by type + dedup params)
+  lookup: (params: CollateralLookupParams) =>
+    [...collateralMasterKeys.all, 'lookup', params] as const,
+
+  // Catalog (admin paginated list)
+  catalogs: () => [...collateralMasterKeys.all, 'catalog'] as const,
+  catalog: (params: CollateralCatalogParams) =>
+    [...collateralMasterKeys.catalogs(), params] as const,
+
+  // Single master detail
+  details: () => [...collateralMasterKeys.all, 'detail'] as const,
+  detail: (id: string) => [...collateralMasterKeys.details(), id] as const,
+
+  // Engagement history for a master
+  engagements: (masterId: string) =>
+    [...collateralMasterKeys.detail(masterId), 'engagements'] as const,
+  engagement: (masterId: string, engagementId: string) =>
+    [...collateralMasterKeys.engagements(masterId), engagementId] as const,
+
+  // Backfill report
+  backfillReports: () => [...collateralMasterKeys.all, 'backfill-report'] as const,
+  backfillReport: (params: Record<string, unknown>) =>
+    [...collateralMasterKeys.backfillReports(), params] as const,
+
+  // Construction inspection work details (Appraisal-side)
+  inspectionWorkDetails: (inspectionId: string) =>
+    ['construction-inspections', inspectionId, 'work-details'] as const,
+};

--- a/src/features/collateralMaster/api/types.ts
+++ b/src/features/collateralMaster/api/types.ts
@@ -1,0 +1,318 @@
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export type CollateralType = 'Land' | 'Condo' | 'Leasehold' | 'Machine';
+
+export type TitleDeedType = 'Chanote' | 'NorSor3' | 'NorSor3Kor' | 'SorKor1';
+
+export type BackfillStatus = 'Processed' | 'SkippedMissingKey' | 'Error';
+
+// ─── Type-specific detail DTOs ────────────────────────────────────────────────
+
+export interface LandDetailDto {
+  collateralMasterId: string;
+  // Identity (dedup key)
+  landOfficeCode: string;
+  province: string;
+  amphur: string;
+  tambon: string;
+  titleDeedType: TitleDeedType;
+  titleDeedNo: string;
+  surveyOrParcelNo?: string | null;
+  // Address
+  street?: string | null;
+  village?: string | null;
+  postalCode?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  // Last-known context
+  landShapeType?: string | null;
+  landZoneType?: string | null;
+  urbanPlanningType?: string | null;
+  accessRoadWidth?: number | null;
+  roadFrontage?: number | null;
+  landArea?: number | null;
+  // Construction tracking
+  isUnderConstructionAtLastAppraisal: boolean;
+  overallConstructionProgressPercent?: number | null;
+  lastConstructionInspectionId?: string | null;
+  // Appraisal summary
+  lastAppraisalId?: string | null;
+  lastAppraisalNumber?: string | null;
+  lastAppraisedDate?: string | null;
+  lastAppraisedValue?: number | null;
+  lastTotalAppraisedValue?: number | null;
+}
+
+export interface CondoDetailDto {
+  collateralMasterId: string;
+  // Identity (dedup key)
+  landOfficeCode: string;
+  condoRegistrationNumber: string;
+  buildingNumber: string;
+  floorNumber: string;
+  unitNumber: string;
+  titleNumber: string;
+  titleType: string;
+  // Identity-extra
+  condoName?: string | null;
+  province?: string | null;
+  // Last-known
+  usableArea?: number | null;
+  locationType?: string | null;
+  buildingAge?: number | null;
+  constructionYear?: number | null;
+  modelName?: string | null;
+  // Appraisal summary
+  lastAppraisalId?: string | null;
+  lastAppraisalNumber?: string | null;
+  lastAppraisedDate?: string | null;
+  lastAppraisedValue?: number | null;
+}
+
+export interface LeaseholdDetailDto {
+  collateralMasterId: string;
+  // Identity (dedup key)
+  leaseRegistrationNo: string;
+  underlyingMasterId: string;
+  lessor: string;
+  lessee: string;
+  leaseTermStart: string;
+  // Last-known
+  leaseTermEnd?: string | null;
+  leaseTermMonths?: number | null;
+  annualRent?: number | null;
+  leasePurpose?: string | null;
+  // Appraisal summary
+  lastAppraisalId?: string | null;
+  lastAppraisalNumber?: string | null;
+  lastAppraisedDate?: string | null;
+  lastAppraisedValue?: number | null;
+}
+
+export interface MachineDetailDto {
+  collateralMasterId: string;
+  // Identity (dedup key — tier 1)
+  machineRegistrationNo?: string | null;
+  // Identity (dedup key — tier 2, used when tier 1 missing)
+  serialNo?: string | null;
+  brand?: string | null;
+  model?: string | null;
+  manufacturer?: string | null;
+  // Identity-extra & last-known
+  engineNo?: string | null;
+  chassisNo?: string | null;
+  yearOfManufacture?: number | null;
+  machineCondition?: string | null;
+  machineAge?: number | null;
+  // Appraisal summary
+  lastAppraisalId?: string | null;
+  lastAppraisalNumber?: string | null;
+  lastAppraisedDate?: string | null;
+  lastAppraisedValue?: number | null;
+}
+
+// ─── Engagement ───────────────────────────────────────────────────────────────
+
+export interface CollateralEngagementSummaryDto {
+  id: string;
+  collateralMasterId: string;
+  appraisalId: string;
+  appraisalNumber: string;
+  requestId: string;
+  requestNumber: string;
+  propertyId: string;
+  appraisalType: string;
+  appraisalDate: string;
+  appraisedValue?: number | null;
+  appraiserUserId?: string | null;
+  appraisalCompanyId?: string | null;
+  appraisalCompanyName?: string | null;
+  createdOn: string;
+}
+
+export interface CollateralEngagementSnapshotDto extends CollateralEngagementSummaryDto {
+  snapshot: unknown; // Parsed JSON blob — shape varies by type
+}
+
+// ─── Master ───────────────────────────────────────────────────────────────────
+
+export interface CollateralMasterDto {
+  id: string;
+  collateralType: CollateralType;
+  ownerName?: string | null;
+  isDeleted: boolean;
+  createdOn: string;
+  createdBy?: string | null;
+  updatedOn?: string | null;
+  updatedBy?: string | null;
+  // Populated by detail join
+  landDetail?: LandDetailDto | null;
+  condoDetail?: CondoDetailDto | null;
+  leaseholdDetail?: LeaseholdDetailDto | null;
+  machineDetail?: MachineDetailDto | null;
+}
+
+// ─── Lookup ───────────────────────────────────────────────────────────────────
+
+export interface CollateralLookupResult {
+  master: CollateralMasterDto;
+  lastEngagement?: CollateralEngagementSummaryDto | null;
+  /** IDs of all companies that have engaged this collateral — used for appeal exclusion */
+  priorAppraisalCompanyIds: string[];
+}
+
+// ─── Catalog (paginated list) ─────────────────────────────────────────────────
+
+export interface CollateralCatalogItem {
+  id: string;
+  collateralType: CollateralType;
+  ownerName?: string | null;
+  isDeleted: boolean;
+  // Denormalized from detail + view
+  dedupKeySnippet: string;
+  province?: string | null;
+  engagementCount: number;
+  lastAppraisedDate?: string | null;
+  lastAppraisedValue?: number | null;
+  isUnderConstructionAtLastAppraisal?: boolean | null;
+  lastAppraisalNumber?: string | null;
+}
+
+export interface CollateralCatalogPage {
+  items: CollateralCatalogItem[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+// ─── Lookup params (per type) ─────────────────────────────────────────────────
+
+export interface LandLookupParams {
+  type: 'Land';
+  landOfficeCode?: string;
+  province?: string;
+  amphur?: string;
+  tambon?: string;
+  titleDeedType?: string;
+  titleDeedNo?: string;
+  surveyOrParcelNo?: string;
+}
+
+export interface CondoLookupParams {
+  type: 'Condo';
+  landOfficeCode?: string;
+  condoRegistrationNumber?: string;
+  building?: string;
+  floor?: string;
+  unit?: string;
+  titleNumber?: string;
+  titleType?: string;
+}
+
+export interface LeaseholdLookupParams {
+  type: 'Leasehold';
+  contractNo?: string;
+  underlyingMasterId?: string;
+  lessor?: string;
+  lessee?: string;
+  leaseTermStart?: string;
+}
+
+export interface MachineLookupParams {
+  type: 'Machine';
+  machineRegistrationNo?: string;
+  serialNo?: string;
+  brand?: string;
+  model?: string;
+  manufacturer?: string;
+}
+
+export type CollateralLookupParams =
+  | LandLookupParams
+  | CondoLookupParams
+  | LeaseholdLookupParams
+  | MachineLookupParams;
+
+// ─── Catalog filter params ────────────────────────────────────────────────────
+
+export interface CollateralCatalogParams {
+  type?: CollateralType;
+  province?: string;
+  owner?: string;
+  isUnderConstruction?: boolean;
+  minAppraisals?: number;
+  lastAppraisedFrom?: string;
+  lastAppraisedTo?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+// ─── Admin op request bodies ──────────────────────────────────────────────────
+
+export interface EditCollateralMasterBody {
+  reason: string;
+  ownerName?: string | null;
+  landDetail?: Partial<LandDetailDto> | null;
+  condoDetail?: Partial<CondoDetailDto> | null;
+  leaseholdDetail?: Partial<LeaseholdDetailDto> | null;
+  machineDetail?: Partial<MachineDetailDto> | null;
+}
+
+export interface SoftDeleteBody {
+  reason: string;
+}
+
+export interface RestoreBody {
+  reason: string;
+}
+
+// ─── Backfill report ──────────────────────────────────────────────────────────
+
+export interface BackfillReportItem {
+  id: string;
+  appraisalId: string;
+  status: BackfillStatus;
+  message?: string | null;
+  runAt: string;
+}
+
+export interface BackfillReportPage {
+  items: BackfillReportItem[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+// ─── Construction inspection work details (Appraisal-side prefill) ────────────
+
+export interface ConstructionWorkDetailDto {
+  workDetailId: string;
+  constructionWorkGroupId?: string | null;
+  groupCode?: string | null;
+  constructionWorkItemId?: string | null;
+  itemCode?: string | null;
+  workItemName: string;
+  displayOrder: number;
+  proportionPct: number;
+  previousProgressPct: number;
+  currentProgressPct: number;
+  currentProportionPct?: number | null;
+  constructionValue?: number | null;
+  previousPropertyValue?: number | null;
+  currentPropertyValue?: number | null;
+}
+
+export interface ConstructionInspectionWorkDetailsDto {
+  inspectionId: string;
+  isFullDetail: boolean;
+  totalValue?: number | null;
+  overallCurrentProgressPercent?: number | null;
+  remark?: string | null;
+  // Full-detail mode
+  workDetails?: ConstructionWorkDetailDto[] | null;
+  // Summary mode
+  summaryCurrentProgressPct?: number | null;
+  summaryPreviousProgressPct?: number | null;
+  summaryCurrentValue?: number | null;
+  summaryPreviousValue?: number | null;
+}

--- a/src/features/collateralMaster/components/CollateralLookupBanner.tsx
+++ b/src/features/collateralMaster/components/CollateralLookupBanner.tsx
@@ -1,0 +1,118 @@
+import Icon from '@shared/components/Icon';
+import { formatLocaleDate } from '@shared/utils/dateUtils';
+import { useTranslation } from 'react-i18next';
+import type { CollateralLookupResult } from '../api/types';
+
+interface CollateralLookupBannerProps {
+  result: CollateralLookupResult;
+  onUsePriorData: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * "Previously appraised" info banner shown when the lookup finds an existing
+ * collateral master for the identity fields the user just entered.
+ *
+ * Shows appraisal count, last date, last value, prior companies.
+ * "Use prior data" prefills the form from the master; "×" dismisses without prefilling.
+ */
+export function CollateralLookupBanner({
+  result,
+  onUsePriorData,
+  onDismiss,
+}: CollateralLookupBannerProps) {
+  const { i18n } = useTranslation();
+  const { master, lastEngagement } = result;
+
+  const detail =
+    master.landDetail ??
+    master.condoDetail ??
+    master.leaseholdDetail ??
+    master.machineDetail;
+
+  const lastValue =
+    (master.landDetail?.lastTotalAppraisedValue ?? master.landDetail?.lastAppraisedValue) ||
+    (detail as any)?.lastAppraisedValue;
+
+  const lastDate = (detail as any)?.lastAppraisedDate ?? lastEngagement?.appraisalDate;
+
+  const isUnderConstruction =
+    master.collateralType === 'Land' && master.landDetail?.isUnderConstructionAtLastAppraisal;
+
+  return (
+    <div className="flex items-start gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl text-sm text-blue-900">
+      {/* Icon */}
+      <div className="shrink-0 mt-0.5">
+        <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
+          <Icon name="clock-rotate-left" style="solid" className="size-4 text-blue-600" />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-blue-800 leading-tight">Previously appraised</p>
+
+        <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-blue-700">
+          {lastEngagement && (
+            <span>
+              <span className="font-medium">Appraisals:</span>{' '}
+              {result.priorAppraisalCompanyIds.length} prior{' '}
+              {result.priorAppraisalCompanyIds.length === 1 ? 'company' : 'companies'}
+            </span>
+          )}
+          {lastDate && (
+            <span>
+              <span className="font-medium">Last appraisal:</span>{' '}
+              {formatLocaleDate(lastDate, i18n.language)}
+            </span>
+          )}
+          {lastValue != null && (
+            <span>
+              <span className="font-medium">Last value:</span>{' '}
+              ฿{lastValue.toLocaleString('th-TH')}
+            </span>
+          )}
+          {master.ownerName && (
+            <span>
+              <span className="font-medium">Owner:</span> {master.ownerName}
+            </span>
+          )}
+          {isUnderConstruction && master.landDetail?.overallConstructionProgressPercent != null && (
+            <span className="flex items-center gap-1 text-amber-700 font-medium">
+              <Icon name="hard-hat" style="solid" className="size-3" />
+              Under construction (
+              {master.landDetail.overallConstructionProgressPercent.toFixed(1)}%)
+            </span>
+          )}
+        </div>
+
+        {result.priorAppraisalCompanyIds.length > 0 && (
+          <p className="mt-1 text-xs text-blue-600">
+            Prior company IDs will be sent to the workflow for appeal exclusion.
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="shrink-0 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onUsePriorData}
+          className="px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors whitespace-nowrap"
+        >
+          Use prior data
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="w-7 h-7 flex items-center justify-center rounded-lg text-blue-400 hover:bg-blue-100 hover:text-blue-600 transition-colors"
+          title="Dismiss"
+        >
+          <Icon name="xmark" style="solid" className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CollateralLookupBanner;

--- a/src/features/collateralMaster/components/CollateralLookupContext.tsx
+++ b/src/features/collateralMaster/components/CollateralLookupContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import type { CollateralLookupResult } from '../api/types';
+
+/**
+ * Carries the most-recent collateral lookup result across components.
+ * The appeal company exclusion filter reads `priorAppraisalCompanyIds` from here.
+ * Populated by TitleInformationForm when a lookup hit occurs.
+ */
+interface CollateralLookupContextValue {
+  lookupResult: CollateralLookupResult | null;
+  setLookupResult: (result: CollateralLookupResult | null) => void;
+  /** Convenience accessor — set populated by the active lookup */
+  priorAppraisalCompanyIds: string[];
+}
+
+const CollateralLookupContext = createContext<CollateralLookupContextValue>({
+  lookupResult: null,
+  setLookupResult: () => {},
+  priorAppraisalCompanyIds: [],
+});
+
+export function CollateralLookupProvider({ children }: { children: ReactNode }) {
+  const [lookupResult, setLookupResult] = useState<CollateralLookupResult | null>(null);
+
+  return (
+    <CollateralLookupContext.Provider
+      value={{
+        lookupResult,
+        setLookupResult,
+        priorAppraisalCompanyIds: lookupResult?.priorAppraisalCompanyIds ?? [],
+      }}
+    >
+      {children}
+    </CollateralLookupContext.Provider>
+  );
+}
+
+export function useCollateralLookup() {
+  return useContext(CollateralLookupContext);
+}

--- a/src/features/collateralMaster/components/TitleLookupIntegration.tsx
+++ b/src/features/collateralMaster/components/TitleLookupIntegration.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from 'react';
+import { useWatch, useFormContext } from 'react-hook-form';
+import { CollateralLookupBanner } from './CollateralLookupBanner';
+import { useCollateralLookup } from './CollateralLookupContext';
+import { useLookupCollateralMaster } from '../api/hooks';
+import { useAppealExclusionStore } from '../store/appealExclusionStore';
+import { useCollateralPrefillStore } from '../store/collateralPrefillStore';
+import type { CollateralLookupParams } from '../api/types';
+
+interface TitleLookupIntegrationProps {
+  /** Index of this title in the `titles` field array */
+  titleIndex: number;
+}
+
+/**
+ * Mounted inside the title detail view (TitleInformationForm).
+ * Watches collateral-type-specific identity fields via useWatch,
+ * debounces lookup, and renders the "previously appraised" banner.
+ *
+ * When "Use prior data" is clicked the form values are prefilled using setValue.
+ * Identity fields are NOT locked here — locking is handled by the appraisal start flow.
+ */
+export function TitleLookupIntegration({ titleIndex }: TitleLookupIntegrationProps) {
+  const { setValue } = useFormContext();
+  const { setLookupResult } = useCollateralLookup();
+  const setExcludedCompanyId = useAppealExclusionStore(s => s.setExcludedCompanyId);
+  const setLastConstructionInspectionId = useCollateralPrefillStore(
+    s => s.setLastConstructionInspectionId,
+  );
+
+  const prefix = `titles.${titleIndex}`;
+
+  // Watch the collateral type selector
+  const collateralType: string = useWatch({ name: `${prefix}.collateralType` }) ?? '';
+
+  // Watch identity fields (all types — only active one will be non-empty)
+  const titleNumber: string = useWatch({ name: `${prefix}.titleNumber` }) ?? '';
+  const titleType: string = useWatch({ name: `${prefix}.titleType` }) ?? '';
+  const province: string = useWatch({ name: `${prefix}.titleAddress.provinceName` }) ?? '';
+
+  // Machine fields
+  const registrationNo: string = useWatch({ name: `${prefix}.registrationNo` }) ?? '';
+
+  // Debounced params
+  const [lookupParams, setLookupParams] = useState<CollateralLookupParams | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Banner dismiss state
+  const [dismissed, setDismissed] = useState(false);
+
+  // Reset dismiss when identity fields change
+  const identityKey = `${collateralType}|${titleNumber}|${province}|${registrationNo}`;
+  const prevIdentityKeyRef = useRef(identityKey);
+  if (prevIdentityKeyRef.current !== identityKey) {
+    prevIdentityKeyRef.current = identityKey;
+    setDismissed(false);
+  }
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      const params = buildLookupParams(collateralType, {
+        titleNumber,
+        titleType,
+        province,
+        registrationNo,
+      });
+      setLookupParams(params);
+    }, 600);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [collateralType, titleNumber, titleType, province, registrationNo]);
+
+  const { data: lookupResult } = useLookupCollateralMaster(lookupParams, !dismissed);
+
+  // Push result to context and stores for downstream consumption
+  useEffect(() => {
+    setLookupResult(lookupResult ?? null);
+
+    // Appeal exclusion: most-recent prior company id only (per business rule)
+    setExcludedCompanyId(lookupResult?.lastEngagement?.appraisalCompanyId ?? null);
+
+    // Progressive prefill: last construction inspection ID (Land only)
+    const inspectionId =
+      lookupResult?.master?.collateralType === 'Land'
+        ? (lookupResult.master.landDetail?.lastConstructionInspectionId ?? null)
+        : null;
+    setLastConstructionInspectionId(inspectionId);
+  }, [lookupResult, setLookupResult, setExcludedCompanyId, setLastConstructionInspectionId]);
+
+  const handleUsePriorData = () => {
+    if (!lookupResult) return;
+    const { master } = lookupResult;
+
+    // Prefill owner
+    if (master.ownerName) {
+      setValue(`${prefix}.ownerName`, master.ownerName, { shouldDirty: true });
+    }
+
+    // Land prefill
+    if (master.collateralType === 'Land' && master.landDetail) {
+      const d = master.landDetail;
+      setValue(`${prefix}.titleNumber`, d.titleDeedNo, { shouldDirty: true });
+      setValue(`${prefix}.titleType`, d.titleDeedType, { shouldDirty: true });
+      if (d.landArea) setValue(`${prefix}.areaSquareWa`, d.landArea, { shouldDirty: true });
+    }
+
+    // Condo prefill
+    if (master.collateralType === 'Condo' && master.condoDetail) {
+      const d = master.condoDetail;
+      setValue(`${prefix}.titleNumber`, d.titleNumber, { shouldDirty: true });
+      setValue(`${prefix}.titleType`, d.titleType, { shouldDirty: true });
+      setValue(`${prefix}.condoName`, d.condoName ?? '', { shouldDirty: true });
+      setValue(`${prefix}.buildingNumber`, d.buildingNumber, { shouldDirty: true });
+      setValue(`${prefix}.floorNumber`, d.floorNumber, { shouldDirty: true });
+      setValue(`${prefix}.roomNumber`, d.unitNumber, { shouldDirty: true });
+      if (d.usableArea) setValue(`${prefix}.usableArea`, d.usableArea, { shouldDirty: true });
+    }
+
+    // Machine prefill
+    if (master.collateralType === 'Machine' && master.machineDetail) {
+      const d = master.machineDetail;
+      if (d.machineRegistrationNo) {
+        setValue(`${prefix}.registrationNo`, d.machineRegistrationNo, { shouldDirty: true });
+      }
+    }
+
+    setDismissed(true);
+  };
+
+  if (!lookupResult || dismissed) return null;
+
+  return (
+    <CollateralLookupBanner
+      result={lookupResult}
+      onUsePriorData={handleUsePriorData}
+      onDismiss={() => setDismissed(true)}
+    />
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildLookupParams(
+  collateralType: string,
+  fields: {
+    titleNumber: string;
+    titleType: string;
+    province: string;
+    registrationNo: string;
+  },
+): CollateralLookupParams | null {
+  // Map request-form collateral types to collateral master types
+  switch (collateralType) {
+    case 'L':
+    case 'LB':
+    case 'LSL':
+    case 'LS': {
+      if (!fields.titleNumber || !fields.province) return null;
+      return {
+        type: 'Land',
+        titleDeedNo: fields.titleNumber,
+        titleDeedType: fields.titleType || undefined,
+        province: fields.province || undefined,
+      };
+    }
+    case 'U': {
+      if (!fields.titleNumber) return null;
+      return {
+        type: 'Condo',
+        titleNumber: fields.titleNumber,
+        titleType: fields.titleType || undefined,
+      };
+    }
+    case 'MAC': {
+      if (!fields.registrationNo) return null;
+      return {
+        type: 'Machine',
+        machineRegistrationNo: fields.registrationNo || undefined,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export default TitleLookupIntegration;

--- a/src/features/collateralMaster/components/identity/CondoIdentityFields.tsx
+++ b/src/features/collateralMaster/components/identity/CondoIdentityFields.tsx
@@ -1,0 +1,152 @@
+import clsx from 'clsx';
+
+export interface CondoIdentityValues {
+  landOfficeCode?: string;
+  condoRegistrationNumber?: string;
+  buildingNumber?: string;
+  floorNumber?: string;
+  unitNumber?: string;
+  titleNumber?: string;
+  titleType?: string;
+}
+
+interface CondoIdentityFieldsProps {
+  values: CondoIdentityValues;
+  onChange: (partial: Partial<CondoIdentityValues>) => void;
+  locked?: boolean;
+  className?: string;
+}
+
+const TITLE_TYPE_OPTIONS = [
+  { value: 'OwnershipCertificate', label: 'หนังสือกรรมสิทธิ์ห้องชุด' },
+  { value: 'Other', label: 'อื่น ๆ' },
+];
+
+export function CondoIdentityFields({
+  values,
+  onChange,
+  locked = false,
+  className,
+}: CondoIdentityFieldsProps) {
+  const inputClass = clsx(
+    'w-full px-3 py-2 text-sm border rounded-lg outline-none transition-colors',
+    locked
+      ? 'bg-gray-50 border-gray-200 text-gray-600 cursor-not-allowed'
+      : 'border-gray-300 focus:border-primary focus:ring-2 focus:ring-primary/20 bg-white',
+  );
+
+  return (
+    <div className={clsx('grid grid-cols-2 gap-3', className)}>
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Land Office Code <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.landOfficeCode ?? ''}
+          onChange={e => onChange({ landOfficeCode: e.target.value })}
+          disabled={locked}
+          placeholder="e.g. BKK01"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Condo Registration Number <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.condoRegistrationNumber ?? ''}
+          onChange={e => onChange({ condoRegistrationNumber: e.target.value })}
+          disabled={locked}
+          placeholder="เลขที่จดทะเบียนอาคารชุด"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Building <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.buildingNumber ?? ''}
+          onChange={e => onChange({ buildingNumber: e.target.value })}
+          disabled={locked}
+          placeholder="อาคาร"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Floor <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.floorNumber ?? ''}
+          onChange={e => onChange({ floorNumber: e.target.value })}
+          disabled={locked}
+          placeholder="ชั้น"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Unit <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.unitNumber ?? ''}
+          onChange={e => onChange({ unitNumber: e.target.value })}
+          disabled={locked}
+          placeholder="เลขห้อง"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Title Number <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.titleNumber ?? ''}
+          onChange={e => onChange({ titleNumber: e.target.value })}
+          disabled={locked}
+          placeholder="เลขที่ห้องชุด"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Title Type <span className="text-danger">*</span>
+        </label>
+        <select
+          value={values.titleType ?? ''}
+          onChange={e => onChange({ titleType: e.target.value })}
+          disabled={locked}
+          className={inputClass}
+        >
+          <option value="">Select type...</option>
+          {TITLE_TYPE_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {locked && (
+        <p className="col-span-2 text-xs text-amber-600">
+          Identity fields are locked for reappraisal
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default CondoIdentityFields;

--- a/src/features/collateralMaster/components/identity/LandIdentityFields.tsx
+++ b/src/features/collateralMaster/components/identity/LandIdentityFields.tsx
@@ -1,0 +1,176 @@
+import clsx from 'clsx';
+
+// ─── Static data ──────────────────────────────────────────────────────────────
+
+export const TITLE_DEED_TYPE_OPTIONS = [
+  { value: 'Chanote', label: 'โฉนดที่ดิน (Chanote)' },
+  { value: 'NorSor3', label: 'น.ส.3 (NorSor3)' },
+  { value: 'NorSor3Kor', label: 'น.ส.3ก (NorSor3Kor)' },
+  { value: 'SorKor1', label: 'ส.ค.1 (SorKor1)' },
+] as const;
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface LandIdentityValues {
+  landOfficeCode?: string;
+  province?: string;
+  amphur?: string;
+  tambon?: string;
+  titleDeedType?: string;
+  titleDeedNo?: string;
+  surveyOrParcelNo?: string;
+}
+
+interface LandIdentityFieldsProps {
+  values: LandIdentityValues;
+  onChange: (partial: Partial<LandIdentityValues>) => void;
+  locked?: boolean;
+  className?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Renders the Land dedup-key identity fields.
+ * Used standalone in lookup/prefill and reappraisal flows.
+ * `locked` renders all fields as read-only (reappraisal identity lock).
+ */
+export function LandIdentityFields({
+  values,
+  onChange,
+  locked = false,
+  className,
+}: LandIdentityFieldsProps) {
+  const inputClass = clsx(
+    'w-full px-3 py-2 text-sm border rounded-lg outline-none transition-colors',
+    locked
+      ? 'bg-gray-50 border-gray-200 text-gray-600 cursor-not-allowed'
+      : 'border-gray-300 focus:border-primary focus:ring-2 focus:ring-primary/20 bg-white',
+  );
+
+  const selectClass = clsx(inputClass, 'pr-8 appearance-none');
+
+  return (
+    <div className={clsx('grid grid-cols-2 gap-3', className)}>
+      {/* Land Office Code */}
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Land Office Code <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.landOfficeCode ?? ''}
+          onChange={e => onChange({ landOfficeCode: e.target.value })}
+          disabled={locked}
+          placeholder="e.g. BKK01"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Province */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Province <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.province ?? ''}
+          onChange={e => onChange({ province: e.target.value })}
+          disabled={locked}
+          placeholder="จังหวัด"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Amphur */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Amphur <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.amphur ?? ''}
+          onChange={e => onChange({ amphur: e.target.value })}
+          disabled={locked}
+          placeholder="อำเภอ/เขต"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Tambon */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Tambon <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.tambon ?? ''}
+          onChange={e => onChange({ tambon: e.target.value })}
+          disabled={locked}
+          placeholder="ตำบล/แขวง"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Title Deed Type */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Title Deed Type <span className="text-danger">*</span>
+        </label>
+        <div className="relative">
+          <select
+            value={values.titleDeedType ?? ''}
+            onChange={e => onChange({ titleDeedType: e.target.value })}
+            disabled={locked}
+            className={selectClass}
+          >
+            <option value="">Select type...</option>
+            {TITLE_DEED_TYPE_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Title Deed No */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Title Deed No <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.titleDeedNo ?? ''}
+          onChange={e => onChange({ titleDeedNo: e.target.value })}
+          disabled={locked}
+          placeholder="เลขที่โฉนด"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Survey / Parcel No */}
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Survey / Parcel No
+        </label>
+        <input
+          type="text"
+          value={values.surveyOrParcelNo ?? ''}
+          onChange={e => onChange({ surveyOrParcelNo: e.target.value })}
+          disabled={locked}
+          placeholder="เลขที่ดิน / ระวาง (optional)"
+          className={inputClass}
+        />
+      </div>
+
+      {locked && (
+        <p className="col-span-2 text-xs text-amber-600 flex items-center gap-1">
+          <span>Identity fields are locked for reappraisal</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default LandIdentityFields;

--- a/src/features/collateralMaster/components/identity/LeaseholdIdentityFields.tsx
+++ b/src/features/collateralMaster/components/identity/LeaseholdIdentityFields.tsx
@@ -1,0 +1,126 @@
+import clsx from 'clsx';
+
+export interface LeaseholdIdentityValues {
+  contractNo?: string;
+  underlyingMasterId?: string;
+  lessor?: string;
+  lessee?: string;
+  leaseTermStart?: string;
+}
+
+interface LeaseholdIdentityFieldsProps {
+  values: LeaseholdIdentityValues;
+  onChange: (partial: Partial<LeaseholdIdentityValues>) => void;
+  locked?: boolean;
+  /** Optional display label for the underlying master (resolved from ID) */
+  underlyingLabel?: string;
+  className?: string;
+}
+
+export function LeaseholdIdentityFields({
+  values,
+  onChange,
+  locked = false,
+  underlyingLabel,
+  className,
+}: LeaseholdIdentityFieldsProps) {
+  const inputClass = clsx(
+    'w-full px-3 py-2 text-sm border rounded-lg outline-none transition-colors',
+    locked
+      ? 'bg-gray-50 border-gray-200 text-gray-600 cursor-not-allowed'
+      : 'border-gray-300 focus:border-primary focus:ring-2 focus:ring-primary/20 bg-white',
+  );
+
+  return (
+    <div className={clsx('grid grid-cols-2 gap-3', className)}>
+      {/* Lease Registration No (Tor Dor 11) */}
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Lease Registration No (ท.ด.11) <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.contractNo ?? ''}
+          onChange={e => onChange({ contractNo: e.target.value })}
+          disabled={locked}
+          placeholder="เลขที่สัญญาเช่า"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Underlying master ID / picker */}
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Underlying Property (Land or Condo) <span className="text-danger">*</span>
+        </label>
+        {locked && underlyingLabel ? (
+          <div className={inputClass}>{underlyingLabel}</div>
+        ) : (
+          <input
+            type="text"
+            value={values.underlyingMasterId ?? ''}
+            onChange={e => onChange({ underlyingMasterId: e.target.value })}
+            disabled={locked}
+            placeholder="Underlying master ID"
+            className={inputClass}
+          />
+        )}
+        <p className="text-xs text-gray-400 mt-0.5">
+          Enter the collateral master ID of the underlying Land or Condo
+        </p>
+      </div>
+
+      {/* Lessor */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Lessor <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.lessor ?? ''}
+          onChange={e => onChange({ lessor: e.target.value })}
+          disabled={locked}
+          placeholder="ผู้ให้เช่า"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Lessee */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Lessee <span className="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={values.lessee ?? ''}
+          onChange={e => onChange({ lessee: e.target.value })}
+          disabled={locked}
+          placeholder="ผู้เช่า"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Lease Term Start */}
+      <div className="col-span-2">
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Lease Term Start <span className="text-danger">*</span>
+        </label>
+        <input
+          type="date"
+          value={values.leaseTermStart ?? ''}
+          onChange={e => onChange({ leaseTermStart: e.target.value })}
+          disabled={locked}
+          className={inputClass}
+        />
+      </div>
+
+      {locked && (
+        <p className="col-span-2 text-xs text-amber-600">
+          Identity fields are locked for reappraisal
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default LeaseholdIdentityFields;

--- a/src/features/collateralMaster/components/identity/MachineIdentityFields.tsx
+++ b/src/features/collateralMaster/components/identity/MachineIdentityFields.tsx
@@ -1,0 +1,146 @@
+import clsx from 'clsx';
+
+export interface MachineIdentityValues {
+  machineRegistrationNo?: string;
+  serialNo?: string;
+  brand?: string;
+  model?: string;
+  manufacturer?: string;
+}
+
+interface MachineIdentityFieldsProps {
+  values: MachineIdentityValues;
+  onChange: (partial: Partial<MachineIdentityValues>) => void;
+  locked?: boolean;
+  className?: string;
+}
+
+export function MachineIdentityFields({
+  values,
+  onChange,
+  locked = false,
+  className,
+}: MachineIdentityFieldsProps) {
+  const inputClass = clsx(
+    'w-full px-3 py-2 text-sm border rounded-lg outline-none transition-colors',
+    locked
+      ? 'bg-gray-50 border-gray-200 text-gray-600 cursor-not-allowed'
+      : 'border-gray-300 focus:border-primary focus:ring-2 focus:ring-primary/20 bg-white',
+  );
+
+  const hasRegistrationNo = !!values.machineRegistrationNo?.trim();
+  const usingComposite = !hasRegistrationNo;
+
+  return (
+    <div className={clsx('flex flex-col gap-3', className)}>
+      {/* Hint */}
+      <p className="text-xs text-gray-500 bg-gray-50 rounded-lg px-3 py-2 border border-gray-100">
+        Provide <strong>Machine Registration No</strong> (preferred) OR fill in the composite key
+        (Serial No + Brand + Model + Manufacturer). At least one path is required.
+      </p>
+
+      {/* Tier 1 — Registration No */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Machine Registration No{' '}
+          {!usingComposite && <span className="text-danger">*</span>}
+          {usingComposite && <span className="text-gray-400 font-normal">(optional)</span>}
+        </label>
+        <input
+          type="text"
+          value={values.machineRegistrationNo ?? ''}
+          onChange={e => onChange({ machineRegistrationNo: e.target.value })}
+          disabled={locked}
+          placeholder="จดทะเบียนเครื่องจักร"
+          className={inputClass}
+        />
+      </div>
+
+      {/* Divider */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 border-t border-gray-200" />
+        <span className="text-xs text-gray-400 shrink-0">OR use composite key</span>
+        <div className="flex-1 border-t border-gray-200" />
+      </div>
+
+      {/* Tier 2 — Composite */}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Serial No{usingComposite && <span className="text-danger"> *</span>}
+          </label>
+          <input
+            type="text"
+            value={values.serialNo ?? ''}
+            onChange={e => onChange({ serialNo: e.target.value })}
+            disabled={locked || hasRegistrationNo}
+            placeholder="Serial number"
+            className={clsx(
+              inputClass,
+              hasRegistrationNo && !locked && 'opacity-50 cursor-not-allowed',
+            )}
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Brand{usingComposite && <span className="text-danger"> *</span>}
+          </label>
+          <input
+            type="text"
+            value={values.brand ?? ''}
+            onChange={e => onChange({ brand: e.target.value })}
+            disabled={locked || hasRegistrationNo}
+            placeholder="Brand"
+            className={clsx(
+              inputClass,
+              hasRegistrationNo && !locked && 'opacity-50 cursor-not-allowed',
+            )}
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Model{usingComposite && <span className="text-danger"> *</span>}
+          </label>
+          <input
+            type="text"
+            value={values.model ?? ''}
+            onChange={e => onChange({ model: e.target.value })}
+            disabled={locked || hasRegistrationNo}
+            placeholder="Model"
+            className={clsx(
+              inputClass,
+              hasRegistrationNo && !locked && 'opacity-50 cursor-not-allowed',
+            )}
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Manufacturer{usingComposite && <span className="text-danger"> *</span>}
+          </label>
+          <input
+            type="text"
+            value={values.manufacturer ?? ''}
+            onChange={e => onChange({ manufacturer: e.target.value })}
+            disabled={locked || hasRegistrationNo}
+            placeholder="Manufacturer"
+            className={clsx(
+              inputClass,
+              hasRegistrationNo && !locked && 'opacity-50 cursor-not-allowed',
+            )}
+          />
+        </div>
+      </div>
+
+      {locked && (
+        <p className="text-xs text-amber-600">
+          Identity fields are locked for reappraisal
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default MachineIdentityFields;

--- a/src/features/collateralMaster/hooks/useProgressivePrefill.ts
+++ b/src/features/collateralMaster/hooks/useProgressivePrefill.ts
@@ -1,0 +1,99 @@
+import { useConstructionInspectionWorkDetails } from '../api/hooks';
+import type { ConstructionWorkDetailDto } from '../api/types';
+
+/**
+ * For Progressive appraisal start:
+ * - Fetches prior work details from `lastConstructionInspectionId`
+ * - Provides a `buildSeedRows` function that maps prior work details into
+ *   new row seeds: `PreviousProgressPct = prior.CurrentProgressPct`
+ *
+ * Match priority:
+ * 1. By `constructionWorkItemId` (template FK)
+ * 2. Fallback by `workItemName` (free-text items)
+ *
+ * For summary-mode inspections: copies `summaryCurrentProgressPct → new summaryPreviousProgressPct`.
+ */
+export function useProgressivePrefill(inspectionId: string | null | undefined) {
+  const { data: priorDetails, isLoading, isError } = useConstructionInspectionWorkDetails(
+    inspectionId,
+  );
+
+  /**
+   * Builds seed rows for the new construction inspection.
+   * Returns null when data is not yet ready or not available.
+   */
+  function buildSeedRows(
+    /** Optionally pass a partial template list to match against — if omitted all prior rows are returned */
+    templateItems?: Array<{
+      constructionWorkItemId?: string | null;
+      workItemName?: string | null;
+    }>,
+  ): Array<Partial<ConstructionWorkDetailDto>> | null {
+    if (!priorDetails) return null;
+
+    if (priorDetails.isFullDetail && priorDetails.workDetails) {
+      // Match prior rows to template (if provided), else return all prior rows
+      const rows = templateItems
+        ? templateItems.map(tmpl => {
+            // Try match by constructionWorkItemId first
+            const byId = priorDetails.workDetails!.find(
+              d => d.constructionWorkItemId && d.constructionWorkItemId === tmpl.constructionWorkItemId,
+            );
+            // Fallback by workItemName
+            const byName = !byId
+              ? priorDetails.workDetails!.find(
+                  d =>
+                    d.workItemName.trim().toLowerCase() ===
+                    (tmpl.workItemName ?? '').trim().toLowerCase(),
+                )
+              : null;
+
+            const matched = byId ?? byName;
+            if (!matched) return null;
+
+            return {
+              constructionWorkItemId: matched.constructionWorkItemId ?? undefined,
+              constructionWorkGroupId: matched.constructionWorkGroupId ?? undefined,
+              workItemName: matched.workItemName,
+              proportionPct: matched.proportionPct,
+              constructionValue: matched.constructionValue ?? undefined,
+              displayOrder: matched.displayOrder,
+              previousProgressPct: matched.currentProgressPct, // <-- key: prior current → new previous
+              currentProgressPct: 0,
+            };
+          }).filter(Boolean) as Array<Partial<ConstructionWorkDetailDto>>
+        : priorDetails.workDetails.map(d => ({
+            constructionWorkItemId: d.constructionWorkItemId ?? undefined,
+            constructionWorkGroupId: d.constructionWorkGroupId ?? undefined,
+            workItemName: d.workItemName,
+            proportionPct: d.proportionPct,
+            constructionValue: d.constructionValue ?? undefined,
+            displayOrder: d.displayOrder,
+            previousProgressPct: d.currentProgressPct,
+            currentProgressPct: 0,
+          }));
+
+      return rows;
+    }
+
+    // Summary mode — return a single summary seed
+    return [
+      {
+        workItemName: 'Summary',
+        previousProgressPct: priorDetails.summaryCurrentProgressPct ?? 0,
+        currentProgressPct: 0,
+        proportionPct: 100,
+        displayOrder: 0,
+      },
+    ];
+  }
+
+  return {
+    priorDetails,
+    isLoading,
+    isError,
+    buildSeedRows,
+    isSummaryMode: priorDetails ? !priorDetails.isFullDetail : false,
+    summaryPreviousProgressPct: priorDetails?.summaryCurrentProgressPct ?? null,
+  };
+}

--- a/src/features/collateralMaster/hooks/useReappraisalPrefill.ts
+++ b/src/features/collateralMaster/hooks/useReappraisalPrefill.ts
@@ -1,0 +1,166 @@
+import { formatLocaleDate } from '@shared/utils/dateUtils';
+import type { CollateralMasterDto } from '../api/types';
+
+/**
+ * For Reappraisal appraisal start:
+ * - Provides locked identity values (read-only — same as dedup key)
+ * - Provides editable last-known values (pre-populated from master)
+ * - Provides a reference-value label string (shown read-only to avoid anchoring bias)
+ *
+ * Caller uses `reset()` in RHF to apply these values to the form.
+ * Identity fields should be rendered as `disabled` inputs.
+ */
+export function useReappraisalPrefill(master: CollateralMasterDto | null | undefined) {
+  if (!master) {
+    return {
+      lockedIdentity: null,
+      editableLastKnown: null,
+      referenceValueLabel: null,
+      dataAgeYears: null,
+    };
+  }
+
+  const land = master.landDetail;
+  const condo = master.condoDetail;
+  const leasehold = master.leaseholdDetail;
+  const machine = master.machineDetail;
+
+  // Compute data age in years (from last appraisal date)
+  const lastDate =
+    land?.lastAppraisedDate ??
+    condo?.lastAppraisedDate ??
+    leasehold?.lastAppraisedDate ??
+    machine?.lastAppraisedDate;
+
+  const dataAgeYears = lastDate
+    ? Math.floor(
+        (Date.now() - new Date(lastDate).getTime()) / (365.25 * 24 * 60 * 60 * 1000),
+      )
+    : null;
+
+  // Reference value (land uses total)
+  const lastValue =
+    (land?.lastTotalAppraisedValue ?? land?.lastAppraisedValue) ||
+    condo?.lastAppraisedValue ||
+    leasehold?.lastAppraisedValue ||
+    machine?.lastAppraisedValue;
+
+  const lastAppraisalNo =
+    land?.lastAppraisalNumber ??
+    condo?.lastAppraisalNumber ??
+    leasehold?.lastAppraisalNumber ??
+    machine?.lastAppraisalNumber;
+
+  const referenceValueLabel =
+    lastValue != null && lastDate
+      ? `Previous: ฿${lastValue.toLocaleString('th-TH')} (Appraisal ${lastAppraisalNo ?? '—'} on ${formatLocaleDate(lastDate, 'th')})`
+      : null;
+
+  // Locked identity per type
+  const lockedIdentity = (() => {
+    if (land) {
+      return {
+        type: 'Land' as const,
+        landOfficeCode: land.landOfficeCode,
+        province: land.province,
+        amphur: land.amphur,
+        tambon: land.tambon,
+        titleDeedType: land.titleDeedType,
+        titleDeedNo: land.titleDeedNo,
+        surveyOrParcelNo: land.surveyOrParcelNo ?? undefined,
+      };
+    }
+    if (condo) {
+      return {
+        type: 'Condo' as const,
+        landOfficeCode: condo.landOfficeCode,
+        condoRegistrationNumber: condo.condoRegistrationNumber,
+        buildingNumber: condo.buildingNumber,
+        floorNumber: condo.floorNumber,
+        unitNumber: condo.unitNumber,
+        titleNumber: condo.titleNumber,
+        titleType: condo.titleType,
+      };
+    }
+    if (leasehold) {
+      return {
+        type: 'Leasehold' as const,
+        contractNo: leasehold.leaseRegistrationNo,
+        underlyingMasterId: leasehold.underlyingMasterId,
+        lessor: leasehold.lessor,
+        lessee: leasehold.lessee,
+        leaseTermStart: leasehold.leaseTermStart,
+      };
+    }
+    if (machine) {
+      return {
+        type: 'Machine' as const,
+        machineRegistrationNo: machine.machineRegistrationNo ?? undefined,
+        serialNo: machine.serialNo ?? undefined,
+        brand: machine.brand ?? undefined,
+        model: machine.model ?? undefined,
+        manufacturer: machine.manufacturer ?? undefined,
+      };
+    }
+    return null;
+  })();
+
+  // Editable last-known fields per type
+  const editableLastKnown = (() => {
+    if (land) {
+      return {
+        ownerName: master.ownerName,
+        street: land.street,
+        village: land.village,
+        postalCode: land.postalCode,
+        latitude: land.latitude,
+        longitude: land.longitude,
+        landShapeType: land.landShapeType,
+        landZoneType: land.landZoneType,
+        urbanPlanningType: land.urbanPlanningType,
+        accessRoadWidth: land.accessRoadWidth,
+        roadFrontage: land.roadFrontage,
+        landArea: land.landArea,
+      };
+    }
+    if (condo) {
+      return {
+        ownerName: master.ownerName,
+        condoName: condo.condoName,
+        province: condo.province,
+        usableArea: condo.usableArea,
+        locationType: condo.locationType,
+        buildingAge: condo.buildingAge,
+        constructionYear: condo.constructionYear,
+        modelName: condo.modelName,
+      };
+    }
+    if (leasehold) {
+      return {
+        ownerName: master.ownerName,
+        leaseTermEnd: leasehold.leaseTermEnd,
+        leaseTermMonths: leasehold.leaseTermMonths,
+        annualRent: leasehold.annualRent,
+        leasePurpose: leasehold.leasePurpose,
+      };
+    }
+    if (machine) {
+      return {
+        ownerName: master.ownerName,
+        engineNo: machine.engineNo,
+        chassisNo: machine.chassisNo,
+        yearOfManufacture: machine.yearOfManufacture,
+        machineCondition: machine.machineCondition,
+        machineAge: machine.machineAge,
+      };
+    }
+    return null;
+  })();
+
+  return {
+    lockedIdentity,
+    editableLastKnown,
+    referenceValueLabel,
+    dataAgeYears,
+  };
+}

--- a/src/features/collateralMaster/index.ts
+++ b/src/features/collateralMaster/index.ts
@@ -1,0 +1,20 @@
+// API
+export * from './api';
+
+// Hooks
+export * from './hooks/useProgressivePrefill';
+export * from './hooks/useReappraisalPrefill';
+
+// Components
+export { CollateralLookupBanner } from './components/CollateralLookupBanner';
+export { CollateralLookupProvider, useCollateralLookup } from './components/CollateralLookupContext';
+export { TitleLookupIntegration } from './components/TitleLookupIntegration';
+
+// Identity field components
+export { LandIdentityFields } from './components/identity/LandIdentityFields';
+export { CondoIdentityFields } from './components/identity/CondoIdentityFields';
+export { LeaseholdIdentityFields } from './components/identity/LeaseholdIdentityFields';
+export { MachineIdentityFields } from './components/identity/MachineIdentityFields';
+
+// Stores
+export { useAppealExclusionStore } from './store/appealExclusionStore';

--- a/src/features/collateralMaster/pages/BackfillReportPage.tsx
+++ b/src/features/collateralMaster/pages/BackfillReportPage.tsx
@@ -1,0 +1,237 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import Pagination from '@shared/components/Pagination';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import { formatLocaleDateTime } from '@shared/utils/dateUtils';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { useGetBackfillReport, useStartBackfill, useReplayBackfill } from '../api/hooks';
+import type { BackfillStatus } from '../api/types';
+
+const STATUS_OPTIONS: { value: BackfillStatus | ''; label: string }[] = [
+  { value: '', label: 'All statuses' },
+  { value: 'Processed', label: 'Processed' },
+  { value: 'SkippedMissingKey', label: 'Skipped (missing key)' },
+  { value: 'Error', label: 'Error' },
+];
+
+function StatusBadge({ status }: { status: BackfillStatus }) {
+  const cfg = {
+    Processed: { bg: 'bg-green-50 text-green-700 ring-green-200', icon: 'check' },
+    SkippedMissingKey: { bg: 'bg-amber-50 text-amber-700 ring-amber-200', icon: 'exclamation' },
+    Error: { bg: 'bg-red-50 text-red-700 ring-red-200', icon: 'triangle-exclamation' },
+  }[status] ?? { bg: 'bg-gray-50 text-gray-600 ring-gray-200', icon: 'circle-question' };
+
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs ring-1',
+        cfg.bg,
+      )}
+    >
+      <Icon name={cfg.icon} style="solid" className="size-2.5" />
+      {status}
+    </span>
+  );
+}
+
+export default function BackfillReportPage() {
+  const { i18n } = useTranslation();
+
+  const [status, setStatus] = useState<BackfillStatus | ''>('');
+  const [page, setPage] = useState(0);
+  const [pageSize] = useState(20);
+
+  const [confirmBackfill, setConfirmBackfill] = useState(false);
+  const [replayId, setReplayId] = useState<string | null>(null);
+
+  const { data, isLoading, isFetching, isError } = useGetBackfillReport({
+    status: status || undefined,
+    page,
+    pageSize,
+  });
+
+  const { mutate: startBackfill, isPending: isStarting } = useStartBackfill();
+  const { mutate: replayBackfill, isPending: isReplaying } = useReplayBackfill();
+
+  const items = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  const isFirstLoad = isLoading && items.length === 0;
+  const isRefetching = isFetching && !isFirstLoad;
+
+  const handleStartBackfill = () => {
+    startBackfill(undefined, {
+      onSuccess: () => {
+        toast.success('Backfill started — results will appear as they are processed.');
+        setConfirmBackfill(false);
+      },
+      onError: (e: any) => {
+        toast.error(e.apiError?.detail ?? 'Failed to start backfill');
+        setConfirmBackfill(false);
+      },
+    });
+  };
+
+  const handleReplay = (appraisalId: string) => {
+    setReplayId(appraisalId);
+    replayBackfill(appraisalId, {
+      onSuccess: () => {
+        toast.success('Replay submitted');
+        setReplayId(null);
+      },
+      onError: (e: any) => {
+        toast.error(e.apiError?.detail ?? 'Failed to replay');
+        setReplayId(null);
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 gap-3">
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">Backfill Report</h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            One-shot backfill of historical completed appraisals into the collateral master registry
+          </p>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => setConfirmBackfill(true)}
+          isLoading={isStarting}
+        >
+          <Icon style="solid" name="play" className="size-3.5 mr-1.5" />
+          Start Backfill
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="shrink-0 flex gap-3">
+        <select
+          value={status}
+          onChange={e => { setStatus(e.target.value as BackfillStatus | ''); setPage(0); }}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300 min-w-44"
+        >
+          {STATUS_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {isError && (
+        <div className="flex items-center gap-2 px-4 py-3 bg-red-50 rounded-lg text-sm text-red-700">
+          <Icon name="triangle-exclamation" style="solid" className="size-4" />
+          Failed to load backfill report
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
+        <div className="flex-1 min-h-0 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
+              <tr className="border-b border-gray-200">
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Appraisal ID</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Status</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Message</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Run At</th>
+                <th className="w-20 px-4 py-2.5" />
+              </tr>
+            </thead>
+            <tbody
+              className={clsx(
+                'divide-y divide-gray-100',
+                isRefetching && 'opacity-50 pointer-events-none',
+              )}
+            >
+              {isFirstLoad ? (
+                <TableRowSkeleton
+                  columns={[
+                    { width: 'w-64' },
+                    { width: 'w-24' },
+                    { width: 'w-60' },
+                    { width: 'w-32' },
+                    { width: 'w-16' },
+                  ]}
+                  rows={6}
+                />
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="text-center py-16">
+                    <div className="flex flex-col items-center gap-2">
+                      <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
+                      <p className="text-gray-500 font-medium">No backfill records found</p>
+                      <p className="text-xs text-gray-400">
+                        {status ? 'Try a different status filter' : 'Run backfill to start processing historical appraisals'}
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                items.map(item => (
+                  <tr key={item.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-2.5 font-mono text-xs text-gray-700">
+                      {item.appraisalId}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <StatusBadge status={item.status} />
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-500 max-w-xs truncate">
+                      {item.message ?? '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 whitespace-nowrap">
+                      {formatLocaleDateTime(item.runAt, i18n.language)}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {(item.status === 'SkippedMissingKey' || item.status === 'Error') && (
+                        <button
+                          type="button"
+                          onClick={() => handleReplay(item.appraisalId)}
+                          disabled={isReplaying && replayId === item.appraisalId}
+                          className="px-2 py-1 text-xs text-primary border border-primary/30 rounded hover:bg-primary/10 transition-colors disabled:opacity-50"
+                        >
+                          {isReplaying && replayId === item.appraisalId ? (
+                            <Icon name="spinner" style="solid" className="size-3 animate-spin" />
+                          ) : (
+                            'Replay'
+                          )}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          showPageSizeSelector={false}
+        />
+      </div>
+
+      {/* Backfill confirm */}
+      <ConfirmDialog
+        isOpen={confirmBackfill}
+        onClose={() => setConfirmBackfill(false)}
+        onConfirm={handleStartBackfill}
+        title="Start Backfill?"
+        message="This will process all completed appraisals that have not yet been registered in the collateral master. It is idempotent — safe to re-run."
+        confirmText="Start Backfill"
+        variant="primary"
+        isLoading={isStarting}
+      />
+    </div>
+  );
+}

--- a/src/features/collateralMaster/pages/CollateralCatalogPage.tsx
+++ b/src/features/collateralMaster/pages/CollateralCatalogPage.tsx
@@ -1,0 +1,313 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import clsx from 'clsx';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import Pagination from '@shared/components/Pagination';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import { formatLocaleDate } from '@shared/utils/dateUtils';
+import { useTranslation } from 'react-i18next';
+import { useCollateralCatalog } from '../api/hooks';
+import type { CollateralCatalogParams, CollateralType } from '../api/types';
+
+const TYPE_OPTIONS: { value: CollateralType | ''; label: string }[] = [
+  { value: '', label: 'All types' },
+  { value: 'Land', label: 'Land' },
+  { value: 'Condo', label: 'Condo' },
+  { value: 'Leasehold', label: 'Leasehold' },
+  { value: 'Machine', label: 'Machine' },
+];
+
+const TYPE_ICON: Record<CollateralType, string> = {
+  Land: 'mountain-sun',
+  Condo: 'building-user',
+  Leasehold: 'file-contract',
+  Machine: 'gear',
+};
+
+export default function CollateralCatalogPage() {
+  const navigate = useNavigate();
+  const { i18n } = useTranslation();
+
+  // Filters
+  const [type, setType] = useState<CollateralType | ''>('');
+  const [province, setProvince] = useState('');
+  const [owner, setOwner] = useState('');
+  const [isUnderConstruction, setIsUnderConstruction] = useState<boolean | undefined>();
+  const [lastAppraisedFrom, setLastAppraisedFrom] = useState('');
+  const [lastAppraisedTo, setLastAppraisedTo] = useState('');
+
+  // Pagination
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+
+  const params: CollateralCatalogParams = {
+    ...(type && { type }),
+    ...(province && { province }),
+    ...(owner && { owner }),
+    ...(isUnderConstruction != null && { isUnderConstruction }),
+    ...(lastAppraisedFrom && { lastAppraisedFrom }),
+    ...(lastAppraisedTo && { lastAppraisedTo }),
+    page,
+    pageSize,
+  };
+
+  const { data, isLoading, isFetching, isError, error } = useCollateralCatalog(params);
+
+  const items = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  const isFirstLoad = isLoading && items.length === 0;
+  const isRefetching = isFetching && !isFirstLoad;
+
+  const handleClearFilters = () => {
+    setType('');
+    setProvince('');
+    setOwner('');
+    setIsUnderConstruction(undefined);
+    setLastAppraisedFrom('');
+    setLastAppraisedTo('');
+    setPage(0);
+  };
+
+  const hasFilters = type || province || owner || isUnderConstruction != null || lastAppraisedFrom || lastAppraisedTo;
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-4">
+        <Icon style="solid" name="triangle-exclamation" className="size-12 text-red-500" />
+        <p className="text-gray-600">Failed to load collateral masters</p>
+        <p className="text-sm text-gray-400">{(error as Error)?.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0 gap-3">
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-3">
+            <h3 className="text-sm font-semibold text-gray-900">Collateral Masters</h3>
+            <span className="px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded-full">
+              {totalCount}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Admin catalog of all collateral masters (Land / Condo / Leasehold / Machine)
+          </p>
+        </div>
+        <Button size="sm" onClick={() => navigate('/admin/collateral-masters/backfill')} variant="outline">
+          <Icon style="solid" name="database" className="size-3.5 mr-1.5" />
+          Backfill Report
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="shrink-0 flex flex-wrap gap-3 pb-1">
+        {/* Type */}
+        <select
+          value={type}
+          onChange={e => { setType(e.target.value as CollateralType | ''); setPage(0); }}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300 min-w-32"
+        >
+          {TYPE_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+
+        {/* Province */}
+        <input
+          type="text"
+          placeholder="Province..."
+          value={province}
+          onChange={e => { setProvince(e.target.value); setPage(0); }}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300 w-36"
+        />
+
+        {/* Owner */}
+        <input
+          type="text"
+          placeholder="Owner..."
+          value={owner}
+          onChange={e => { setOwner(e.target.value); setPage(0); }}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300 w-40"
+        />
+
+        {/* Under construction filter */}
+        <select
+          value={isUnderConstruction == null ? '' : String(isUnderConstruction)}
+          onChange={e => {
+            setIsUnderConstruction(e.target.value === '' ? undefined : e.target.value === 'true');
+            setPage(0);
+          }}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300 min-w-40"
+        >
+          <option value="">Construction (all)</option>
+          <option value="true">Under construction</option>
+          <option value="false">Not under construction</option>
+        </select>
+
+        {/* Last appraised from */}
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 shrink-0">From</span>
+          <input
+            type="date"
+            value={lastAppraisedFrom}
+            onChange={e => { setLastAppraisedFrom(e.target.value); setPage(0); }}
+            className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300"
+          />
+        </div>
+
+        {/* Last appraised to */}
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 shrink-0">To</span>
+          <input
+            type="date"
+            value={lastAppraisedTo}
+            onChange={e => { setLastAppraisedTo(e.target.value); setPage(0); }}
+            className="px-3 py-2 text-sm border border-gray-200 rounded-lg outline-none bg-white hover:border-gray-300"
+          />
+        </div>
+
+        {hasFilters && (
+          <Button variant="ghost" size="xs" onClick={handleClearFilters}>
+            <Icon style="solid" name="xmark" className="size-3 mr-1" />
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
+        <div className="flex-1 min-h-0 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
+              <tr className="border-b border-gray-200">
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Type</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Identity</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Owner</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Province</th>
+                <th className="text-center font-medium text-gray-600 px-4 py-2.5">Engagements</th>
+                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Last Appraised</th>
+                <th className="text-right font-medium text-gray-600 px-4 py-2.5">Last Value</th>
+                <th className="text-center font-medium text-gray-600 px-4 py-2.5">Status</th>
+              </tr>
+            </thead>
+            <tbody
+              className={clsx(
+                'divide-y divide-gray-100',
+                isRefetching && 'opacity-50 pointer-events-none',
+              )}
+            >
+              {isFirstLoad ? (
+                <TableRowSkeleton
+                  columns={[
+                    { width: 'w-20' },
+                    { width: 'w-40' },
+                    { width: 'w-32' },
+                    { width: 'w-24' },
+                    { width: 'w-12' },
+                    { width: 'w-28' },
+                    { width: 'w-24' },
+                    { width: 'w-16' },
+                  ]}
+                  rows={8}
+                />
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="text-center py-16">
+                    <div className="flex flex-col items-center gap-2">
+                      <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
+                      <p className="text-gray-500 font-medium">No collateral masters found</p>
+                      <p className="text-xs text-gray-400">
+                        {hasFilters ? 'Try different filters' : 'Run backfill to import existing appraisals'}
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                items.map(item => (
+                  <tr
+                    key={item.id}
+                    onClick={() => navigate(`/admin/collateral-masters/${item.id}`)}
+                    className={clsx(
+                      'hover:bg-gray-50 transition-colors cursor-pointer even:bg-gray-50/40',
+                      item.isDeleted && 'opacity-50',
+                    )}
+                  >
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-2">
+                        <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center">
+                          <Icon
+                            style="solid"
+                            name={TYPE_ICON[item.collateralType]}
+                            className="size-3.5 text-primary"
+                          />
+                        </div>
+                        <span className="font-medium text-gray-900 text-xs">{item.collateralType}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-gray-700 max-w-[220px] truncate">
+                      {item.dedupKeySnippet}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600 text-xs max-w-[140px] truncate">
+                      {item.ownerName ?? '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600 text-xs">
+                      {item.province ?? '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-center tabular-nums text-gray-700">
+                      {item.engagementCount}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600 text-xs whitespace-nowrap">
+                      {formatLocaleDate(item.lastAppraisedDate, i18n.language)}
+                    </td>
+                    <td className="px-4 py-2.5 text-right tabular-nums text-gray-700 text-xs">
+                      {item.lastAppraisedValue != null
+                        ? `฿${item.lastAppraisedValue.toLocaleString('th-TH')}`
+                        : '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-center">
+                      {item.isDeleted ? (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-red-50 text-red-600 ring-1 ring-red-200">
+                          <Icon name="trash" style="solid" className="size-2.5" />
+                          Deleted
+                        </span>
+                      ) : item.isUnderConstructionAtLastAppraisal ? (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-amber-50 text-amber-600 ring-1 ring-amber-200">
+                          <Icon name="hard-hat" style="solid" className="size-2.5" />
+                          Construction
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-green-50 text-green-600 ring-1 ring-green-200">
+                          <Icon name="check" style="solid" className="size-2.5" />
+                          Active
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+          {isRefetching && (
+            <div className="flex justify-center py-2">
+              <Icon style="solid" name="spinner" className="size-4 text-primary animate-spin" />
+            </div>
+          )}
+        </div>
+
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={size => { setPageSize(size); setPage(0); }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/collateralMaster/pages/CollateralMasterDetailPage.tsx
+++ b/src/features/collateralMaster/pages/CollateralMasterDetailPage.tsx
@@ -1,0 +1,594 @@
+import { useState, type ReactNode } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import clsx from 'clsx';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import Pagination from '@shared/components/Pagination';
+import { formatLocaleDate, formatLocaleDateTime } from '@shared/utils/dateUtils';
+import { useTranslation } from 'react-i18next';
+import { useAuthStore } from '@features/auth/store';
+import toast from 'react-hot-toast';
+import {
+  useCollateralMaster,
+  useCollateralEngagements,
+  useEngagementSnapshot,
+  useEditCollateralMaster,
+  useSoftDeleteCollateralMaster,
+  useRestoreCollateralMaster,
+} from '../api/hooks';
+import type { CollateralMasterDto } from '../api/types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex gap-3 py-1.5 border-b border-gray-50 last:border-0">
+      <span className="text-xs font-medium text-gray-500 w-44 shrink-0">{label}</span>
+      <span className="text-xs text-gray-800 break-all">{value ?? '—'}</span>
+    </div>
+  );
+}
+
+// ─── Type-aware detail panel ──────────────────────────────────────────────────
+
+function MasterDetailPanel({ master }: { master: CollateralMasterDto }) {
+  const { i18n } = useTranslation();
+
+  if (master.collateralType === 'Land' && master.landDetail) {
+    const d = master.landDetail;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Land Identity</p>
+        <DetailRow label="Land Office Code" value={d.landOfficeCode} />
+        <DetailRow label="Province" value={d.province} />
+        <DetailRow label="Amphur" value={d.amphur} />
+        <DetailRow label="Tambon" value={d.tambon} />
+        <DetailRow label="Title Deed Type" value={d.titleDeedType} />
+        <DetailRow label="Title Deed No" value={d.titleDeedNo} />
+        <DetailRow label="Survey / Parcel No" value={d.surveyOrParcelNo} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last-known</p>
+        <DetailRow label="Land Area (m²)" value={d.landArea} />
+        <DetailRow label="Road Frontage (m)" value={d.roadFrontage} />
+        <DetailRow label="Land Shape" value={d.landShapeType} />
+        <DetailRow label="Zone" value={d.landZoneType} />
+        <DetailRow label="Urban Planning" value={d.urbanPlanningType} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Construction</p>
+        <DetailRow
+          label="Under Construction"
+          value={d.isUnderConstructionAtLastAppraisal ? 'Yes (at last appraisal)' : 'No'}
+        />
+        <DetailRow
+          label="Overall Progress"
+          value={
+            d.overallConstructionProgressPercent != null
+              ? `${d.overallConstructionProgressPercent.toFixed(1)}%`
+              : null
+          }
+        />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last Appraisal</p>
+        <DetailRow label="Appraisal No" value={d.lastAppraisalNumber} />
+        <DetailRow label="Date" value={formatLocaleDate(d.lastAppraisedDate, i18n.language)} />
+        <DetailRow
+          label="Value (Land only)"
+          value={d.lastAppraisedValue != null ? `฿${d.lastAppraisedValue.toLocaleString('th-TH')}` : null}
+        />
+        <DetailRow
+          label="Value (Land + Buildings)"
+          value={
+            d.lastTotalAppraisedValue != null
+              ? `฿${d.lastTotalAppraisedValue.toLocaleString('th-TH')}`
+              : null
+          }
+        />
+      </div>
+    );
+  }
+
+  if (master.collateralType === 'Condo' && master.condoDetail) {
+    const d = master.condoDetail;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Condo Identity</p>
+        <DetailRow label="Land Office Code" value={d.landOfficeCode} />
+        <DetailRow label="Condo Registration No" value={d.condoRegistrationNumber} />
+        <DetailRow label="Building" value={d.buildingNumber} />
+        <DetailRow label="Floor" value={d.floorNumber} />
+        <DetailRow label="Unit" value={d.unitNumber} />
+        <DetailRow label="Title Number" value={d.titleNumber} />
+        <DetailRow label="Title Type" value={d.titleType} />
+        <DetailRow label="Condo Name" value={d.condoName} />
+        <DetailRow label="Province" value={d.province} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last-known</p>
+        <DetailRow label="Usable Area (m²)" value={d.usableArea} />
+        <DetailRow label="Location Type" value={d.locationType} />
+        <DetailRow label="Building Age" value={d.buildingAge} />
+        <DetailRow label="Construction Year" value={d.constructionYear} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last Appraisal</p>
+        <DetailRow label="Appraisal No" value={d.lastAppraisalNumber} />
+        <DetailRow label="Date" value={formatLocaleDate(d.lastAppraisedDate, i18n.language)} />
+        <DetailRow
+          label="Value"
+          value={d.lastAppraisedValue != null ? `฿${d.lastAppraisedValue.toLocaleString('th-TH')}` : null}
+        />
+      </div>
+    );
+  }
+
+  if (master.collateralType === 'Leasehold' && master.leaseholdDetail) {
+    const d = master.leaseholdDetail;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Leasehold Identity</p>
+        <DetailRow label="Lease Registration No" value={d.leaseRegistrationNo} />
+        <DetailRow label="Underlying Master ID" value={d.underlyingMasterId} />
+        <DetailRow label="Lessor" value={d.lessor} />
+        <DetailRow label="Lessee" value={d.lessee} />
+        <DetailRow label="Lease Term Start" value={formatLocaleDate(d.leaseTermStart, i18n.language)} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last-known</p>
+        <DetailRow label="Lease Term End" value={formatLocaleDate(d.leaseTermEnd, i18n.language)} />
+        <DetailRow label="Lease Term (months)" value={d.leaseTermMonths} />
+        <DetailRow
+          label="Annual Rent"
+          value={d.annualRent != null ? `฿${d.annualRent.toLocaleString('th-TH')}` : null}
+        />
+        <DetailRow label="Lease Purpose" value={d.leasePurpose} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last Appraisal</p>
+        <DetailRow label="Appraisal No" value={d.lastAppraisalNumber} />
+        <DetailRow label="Date" value={formatLocaleDate(d.lastAppraisedDate, i18n.language)} />
+        <DetailRow
+          label="Value"
+          value={d.lastAppraisedValue != null ? `฿${d.lastAppraisedValue.toLocaleString('th-TH')}` : null}
+        />
+      </div>
+    );
+  }
+
+  if (master.collateralType === 'Machine' && master.machineDetail) {
+    const d = master.machineDetail;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Machine Identity</p>
+        <DetailRow label="Registration No" value={d.machineRegistrationNo} />
+        <DetailRow label="Serial No" value={d.serialNo} />
+        <DetailRow label="Brand" value={d.brand} />
+        <DetailRow label="Model" value={d.model} />
+        <DetailRow label="Manufacturer" value={d.manufacturer} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last-known</p>
+        <DetailRow label="Engine No" value={d.engineNo} />
+        <DetailRow label="Chassis No" value={d.chassisNo} />
+        <DetailRow label="Year of Manufacture" value={d.yearOfManufacture} />
+        <DetailRow label="Condition" value={d.machineCondition} />
+        <DetailRow label="Age (years)" value={d.machineAge} />
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mt-4 mb-2">Last Appraisal</p>
+        <DetailRow label="Appraisal No" value={d.lastAppraisalNumber} />
+        <DetailRow label="Date" value={formatLocaleDate(d.lastAppraisedDate, i18n.language)} />
+        <DetailRow
+          label="Value"
+          value={d.lastAppraisedValue != null ? `฿${d.lastAppraisedValue.toLocaleString('th-TH')}` : null}
+        />
+      </div>
+    );
+  }
+
+  return <p className="text-sm text-gray-400">No detail available.</p>;
+}
+
+// ─── Snapshot modal ───────────────────────────────────────────────────────────
+
+function SnapshotModal({
+  masterId,
+  engagementId,
+  onClose,
+}: {
+  masterId: string;
+  engagementId: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = useEngagementSnapshot(masterId, engagementId);
+
+  return (
+    <dialog className="modal modal-open z-[60]">
+      <div className="modal-box bg-white rounded-2xl shadow-xl max-w-3xl w-full max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-semibold text-gray-900">Engagement Snapshot</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500"
+          >
+            <Icon name="xmark" style="solid" className="size-4" />
+          </button>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Icon name="spinner" style="solid" className="size-6 animate-spin text-primary" />
+            </div>
+          ) : (
+            <pre className="text-xs text-gray-700 bg-gray-50 rounded-lg p-4 overflow-x-auto whitespace-pre-wrap">
+              {JSON.stringify(data?.snapshot, null, 2)}
+            </pre>
+          )}
+        </div>
+      </div>
+      <div className="modal-backdrop bg-black/40" onClick={onClose}>
+        <button type="button">close</button>
+      </div>
+    </dialog>
+  );
+}
+
+// ─── Reason dialog ────────────────────────────────────────────────────────────
+
+function ReasonDialog({
+  isOpen,
+  title,
+  onClose,
+  onConfirm,
+  isLoading,
+  variant = 'primary',
+}: {
+  isOpen: boolean;
+  title: string;
+  onClose: () => void;
+  onConfirm: (reason: string) => void;
+  isLoading: boolean;
+  variant?: 'danger' | 'primary' | 'warning';
+}) {
+  const [reason, setReason] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    if (!reason.trim()) return;
+    onConfirm(reason.trim());
+  };
+
+  const btnClass = {
+    danger: 'bg-danger hover:bg-danger/80 text-white',
+    primary: 'bg-primary hover:bg-primary/80 text-white',
+    warning: 'bg-amber-500 hover:bg-amber-600 text-white',
+  }[variant];
+
+  return (
+    <dialog className="modal modal-open z-[60]">
+      <div className="modal-box bg-white rounded-2xl shadow-xl max-w-sm">
+        <h3 className="font-semibold text-gray-900 mb-4">{title}</h3>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          Reason <span className="text-danger">*</span>
+        </label>
+        <textarea
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+          rows={3}
+          placeholder="Required — explain the reason for this action..."
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 resize-none"
+        />
+        <div className="flex gap-3 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isLoading}
+            className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isLoading || !reason.trim()}
+            className={clsx(
+              'flex-1 px-4 py-2.5 font-medium rounded-xl transition-colors disabled:opacity-50',
+              btnClass,
+            )}
+          >
+            {isLoading ? (
+              <span className="flex items-center justify-center gap-2">
+                <Icon name="spinner" style="solid" className="size-4 animate-spin" />
+                Processing...
+              </span>
+            ) : (
+              'Confirm'
+            )}
+          </button>
+        </div>
+      </div>
+      <div className="modal-backdrop bg-black/40" onClick={onClose}>
+        <button type="button">close</button>
+      </div>
+    </dialog>
+  );
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function CollateralMasterDetailPage() {
+  const { masterId } = useParams<{ masterId: string }>();
+  const navigate = useNavigate();
+  const { i18n } = useTranslation();
+  const user = useAuthStore(s => s.user);
+
+  const isAdmin = user?.permissions?.includes('COLLATERAL_ADMIN') ?? false;
+
+  const { data: master, isLoading, isError } = useCollateralMaster(masterId);
+
+  // Engagement history
+  const [engPage, setEngPage] = useState(0);
+  const { data: engData } = useCollateralEngagements(masterId, engPage, 10);
+  const engItems = engData?.items ?? [];
+  const engTotal = engData?.count ?? 0;
+  const engTotalPages = Math.ceil(engTotal / 10);
+
+  // Snapshot modal
+  const [snapshotEngagementId, setSnapshotEngagementId] = useState<string | null>(null);
+
+  // Admin dialogs
+  const [editDialog, setEditDialog] = useState(false);
+  const [deleteDialog, setDeleteDialog] = useState(false);
+  const [restoreDialog, setRestoreDialog] = useState(false);
+
+  const { mutate: doEdit, isPending: isEditing } = useEditCollateralMaster();
+  const { mutate: doDelete, isPending: isDeleting } = useSoftDeleteCollateralMaster();
+  const { mutate: doRestore, isPending: isRestoring } = useRestoreCollateralMaster();
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Icon name="spinner" style="solid" className="size-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (isError || !master) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-4">
+        <Icon style="solid" name="triangle-exclamation" className="size-12 text-red-500" />
+        <p className="text-gray-600">Collateral master not found</p>
+        <Button onClick={() => navigate('/admin/collateral-masters')}>Back to Catalog</Button>
+      </div>
+    );
+  }
+
+  const handleEdit = (reason: string) => {
+    if (!masterId) return;
+    doEdit(
+      { id: masterId, body: { reason, ownerName: master.ownerName } },
+      {
+        onSuccess: () => {
+          toast.success('Master updated');
+          setEditDialog(false);
+        },
+        onError: (e: any) => {
+          toast.error(e.apiError?.detail ?? 'Failed to edit');
+          setEditDialog(false);
+        },
+      },
+    );
+  };
+
+  const handleDelete = (reason: string) => {
+    if (!masterId) return;
+    doDelete(
+      { id: masterId, reason },
+      {
+        onSuccess: () => {
+          toast.success('Master soft-deleted');
+          setDeleteDialog(false);
+        },
+        onError: (e: any) => {
+          toast.error(e.apiError?.detail ?? 'Failed to delete');
+          setDeleteDialog(false);
+        },
+      },
+    );
+  };
+
+  const handleRestore = (reason: string) => {
+    if (!masterId) return;
+    doRestore(
+      { id: masterId, body: { reason } },
+      {
+        onSuccess: () => {
+          toast.success('Master restored');
+          setRestoreDialog(false);
+        },
+        onError: (e: any) => {
+          toast.error(e.apiError?.detail ?? 'Failed to restore');
+          setRestoreDialog(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6 pb-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/admin/collateral-masters')}
+            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 text-gray-500"
+          >
+            <Icon name="arrow-left" style="solid" className="size-4" />
+          </button>
+          <div>
+            <h2 className="text-base font-semibold text-gray-900">
+              {master.collateralType} Master
+              {master.isDeleted && (
+                <span className="ml-2 text-xs font-normal text-red-500">(deleted)</span>
+              )}
+            </h2>
+            <p className="text-xs text-gray-400 font-mono mt-0.5">{master.id}</p>
+          </div>
+        </div>
+
+        {/* Admin actions */}
+        {isAdmin && (
+          <div className="flex gap-2">
+            {master.isDeleted ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setRestoreDialog(true)}
+                isLoading={isRestoring}
+              >
+                <Icon name="rotate-right" style="solid" className="size-3.5 mr-1.5" />
+                Restore
+              </Button>
+            ) : (
+              <>
+                <Button size="sm" variant="outline" onClick={() => setEditDialog(true)}>
+                  <Icon name="pen" style="solid" className="size-3.5 mr-1.5" />
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDeleteDialog(true)}
+                  className="text-red-600 border-red-200 hover:bg-red-50"
+                >
+                  <Icon name="trash" style="solid" className="size-3.5 mr-1.5" />
+                  Delete
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Content grid */}
+      <div className="grid grid-cols-3 gap-6">
+        {/* Detail panel */}
+        <div className="col-span-2 bg-white rounded-xl border border-gray-200 p-5">
+          <MasterDetailPanel master={master} />
+        </div>
+
+        {/* Meta panel */}
+        <div className="bg-white rounded-xl border border-gray-200 p-5">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+            Master Record
+          </p>
+          <DetailRow label="Type" value={master.collateralType} />
+          <DetailRow label="Owner / Lessee" value={master.ownerName} />
+          <DetailRow label="Created" value={formatLocaleDateTime(master.createdOn, i18n.language)} />
+          <DetailRow label="Created by" value={master.createdBy} />
+          <DetailRow
+            label="Updated"
+            value={master.updatedOn ? formatLocaleDateTime(master.updatedOn, i18n.language) : null}
+          />
+          <DetailRow label="Updated by" value={master.updatedBy} />
+        </div>
+      </div>
+
+      {/* Engagement history */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-gray-100">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Engagement History{' '}
+            <span className="text-xs font-normal text-gray-400">({engTotal} total)</span>
+          </h3>
+        </div>
+
+        {engItems.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10">
+            <Icon style="regular" name="folder-open" className="size-8 text-gray-300 mb-2" />
+            <p className="text-sm text-gray-400">No engagements yet</p>
+          </div>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr className="border-b border-gray-200">
+                  <th className="text-left font-medium text-gray-600 px-4 py-2.5">Appraisal #</th>
+                  <th className="text-left font-medium text-gray-600 px-4 py-2.5">Type</th>
+                  <th className="text-left font-medium text-gray-600 px-4 py-2.5">Company</th>
+                  <th className="text-left font-medium text-gray-600 px-4 py-2.5">Date</th>
+                  <th className="text-right font-medium text-gray-600 px-4 py-2.5">Value</th>
+                  <th className="w-16 px-4 py-2.5" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {engItems.map(eng => (
+                  <tr key={eng.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-2.5 font-medium text-primary text-xs">
+                      {eng.appraisalNumber}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600">{eng.appraisalType}</td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 max-w-[160px] truncate">
+                      {eng.appraisalCompanyName ?? '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 whitespace-nowrap">
+                      {formatLocaleDate(eng.appraisalDate, i18n.language)}
+                    </td>
+                    <td className="px-4 py-2.5 text-right tabular-nums text-xs text-gray-700">
+                      {eng.appraisedValue != null
+                        ? `฿${eng.appraisedValue.toLocaleString('th-TH')}`
+                        : '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-center">
+                      <button
+                        type="button"
+                        onClick={() => setSnapshotEngagementId(eng.id)}
+                        className="px-2 py-1 text-xs text-primary border border-primary/30 rounded hover:bg-primary/10 transition-colors"
+                        title="View snapshot"
+                      >
+                        Snapshot
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {engTotalPages > 1 && (
+              <Pagination
+                currentPage={engPage}
+                totalPages={engTotalPages}
+                totalCount={engTotal}
+                pageSize={10}
+                onPageChange={setEngPage}
+                showPageSizeSelector={false}
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Snapshot modal */}
+      {snapshotEngagementId && masterId && (
+        <SnapshotModal
+          masterId={masterId}
+          engagementId={snapshotEngagementId}
+          onClose={() => setSnapshotEngagementId(null)}
+        />
+      )}
+
+      {/* Admin dialogs */}
+      <ReasonDialog
+        isOpen={editDialog}
+        title="Edit Collateral Master"
+        onClose={() => setEditDialog(false)}
+        onConfirm={handleEdit}
+        isLoading={isEditing}
+        variant="primary"
+      />
+      <ReasonDialog
+        isOpen={deleteDialog}
+        title="Soft-Delete Collateral Master"
+        onClose={() => setDeleteDialog(false)}
+        onConfirm={handleDelete}
+        isLoading={isDeleting}
+        variant="danger"
+      />
+      <ReasonDialog
+        isOpen={restoreDialog}
+        title="Restore Collateral Master"
+        onClose={() => setRestoreDialog(false)}
+        onConfirm={handleRestore}
+        isLoading={isRestoring}
+        variant="primary"
+      />
+    </div>
+  );
+}

--- a/src/features/collateralMaster/store/appealExclusionStore.ts
+++ b/src/features/collateralMaster/store/appealExclusionStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+/**
+ * Stores the most-recent prior company id for appeal exclusion.
+ * Populated when the collateral lookup hits during request creation.
+ *
+ * Business rule: an appeal excludes only the company that did the most recent
+ * appraisal — not the full history. Older companies remain eligible.
+ *
+ * Source: lookupResult.lastEngagement.appraisalCompanyId.
+ *
+ * Session-scoped — cleared on TitleInformationForm mount to prevent cross-flow leak.
+ */
+interface AppealExclusionStore {
+  excludedCompanyId: string | null;
+  setExcludedCompanyId: (id: string | null) => void;
+  clearExclusions: () => void;
+}
+
+export const useAppealExclusionStore = create<AppealExclusionStore>(set => ({
+  excludedCompanyId: null,
+  setExcludedCompanyId: id => set({ excludedCompanyId: id }),
+  clearExclusions: () => set({ excludedCompanyId: null }),
+}));

--- a/src/features/collateralMaster/store/collateralPrefillStore.ts
+++ b/src/features/collateralMaster/store/collateralPrefillStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+/**
+ * Stores collateral lookup data needed for Progressive appraisal prefill.
+ * Populated by TitleLookupIntegration when a Land master with an active
+ * construction inspection is found.
+ *
+ * Session-scoped — values remain until a new lookup overwrites them or the
+ * user navigates to a fresh request/appraisal.
+ */
+interface CollateralPrefillStore {
+  /** ID of the last construction inspection from the collateral master.
+   *  Used by CreateBuildingPage to seed previousProgressPct values. */
+  lastConstructionInspectionId: string | null;
+  setLastConstructionInspectionId: (id: string | null) => void;
+  clearPrefill: () => void;
+}
+
+export const useCollateralPrefillStore = create<CollateralPrefillStore>(set => ({
+  lastConstructionInspectionId: null,
+  setLastConstructionInspectionId: id => set({ lastConstructionInspectionId: id }),
+  clearPrefill: () => set({ lastConstructionInspectionId: null }),
+}));

--- a/src/features/meeting/api/meetings.ts
+++ b/src/features/meeting/api/meetings.ts
@@ -234,8 +234,28 @@ export const useSendInvitation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ id }: { id: string }): Promise<SendInvitationResponse> => {
-      const { data } = await axios.post(`/meetings/${id}/send-invitation`);
+    mutationFn: async ({
+      id,
+      from,
+      to,
+      subject,
+      content,
+      attachments,
+    }: {
+      id: string;
+      from: string;
+      to: string;
+      subject: string;
+      content?: string;
+      attachments?: string[];
+    }): Promise<SendInvitationResponse> => {
+      const { data } = await axios.post(`/meetings/${id}/send-invitation`, {
+        from,
+        to,
+        subject,
+        content,
+        attachments,
+      });
       return data;
     },
     onSuccess: (_data, variables) => {

--- a/src/features/meeting/components/SendInvitationDialog.tsx
+++ b/src/features/meeting/components/SendInvitationDialog.tsx
@@ -1,9 +1,8 @@
 import toast from 'react-hot-toast';
 
-import Modal from '@/shared/components/Modal';
-import Button from '@/shared/components/Button';
-import Icon from '@/shared/components/Icon';
+import EmailCompositionModal from '@/shared/components/EmailCompositionModal';
 import { useSendInvitation } from '../api/meetings';
+import type { EmailFormValues } from '@/shared/schemas/email';
 import type { SendInvitationResponse } from '../api/types';
 
 interface SendInvitationDialogProps {
@@ -11,6 +10,8 @@ interface SendInvitationDialogProps {
   onClose: () => void;
   meetingId: string;
   meetingNo: string;
+  /** Pre-filled To field — comma-separated member emails. */
+  memberEmails?: string;
   /** When true, renders as a resend confirmation (idempotent on the backend). */
   isResend?: boolean;
   onSuccess?: (response: SendInvitationResponse) => void;
@@ -20,19 +21,23 @@ const SendInvitationDialog = ({
   isOpen,
   onClose,
   meetingId,
-  meetingNo,
+  meetingNo: _meetingNo,
+  memberEmails,
   isResend = false,
   onSuccess,
 }: SendInvitationDialogProps) => {
   const sendInvitation = useSendInvitation();
 
-  const handleClose = () => {
-    if (!sendInvitation.isPending) onClose();
-  };
-
-  const handleConfirm = () => {
+  const handleSubmit = (values: EmailFormValues) => {
     sendInvitation.mutate(
-      { id: meetingId },
+      {
+        id: meetingId,
+        from: values.from,
+        to: values.to,
+        subject: values.subject,
+        content: values.content,
+        attachments: values.attachments,
+      },
       {
         onSuccess: data => {
           toast.success(
@@ -51,54 +56,18 @@ const SendInvitationDialog = ({
     );
   };
 
-  const title = isResend ? 'Resend Invitation' : 'Send Invitation';
-  const actionLabel = isResend ? 'Resend Invitation' : 'Send Invitation';
-  const pendingLabel = isResend ? 'Resending...' : 'Sending...';
-
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title={title} size="sm">
-      <div className="space-y-4">
-        <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">
-          <span className="text-xs font-medium text-gray-500 uppercase">Meeting No.</span>
-          <span className="text-sm font-semibold text-gray-900">{meetingNo}</span>
-        </div>
-
-        <div className="flex items-start gap-3 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
-          <Icon
-            name="triangle-exclamation"
-            style="solid"
-            className="w-5 h-5 text-amber-500 shrink-0 mt-0.5"
-          />
-          <p className="text-sm text-amber-800">
-            {isResend ? (
-              <>
-                The invitation will be <strong>re-sent</strong> to all committee members. The
-                meeting status will remain unchanged.
-              </>
-            ) : (
-              <>
-                The invitation will be emailed to all committee members and the meeting status will
-                move to <strong>Invitation Sent</strong>. This action cannot be undone.
-              </>
-            )}
-          </p>
-        </div>
-
-        <div className="flex justify-end gap-3 pt-2">
-          <Button
-            variant="ghost"
-            type="button"
-            onClick={handleClose}
-            disabled={sendInvitation.isPending}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleConfirm} disabled={sendInvitation.isPending}>
-            {sendInvitation.isPending ? pendingLabel : actionLabel}
-          </Button>
-        </div>
-      </div>
-    </Modal>
+    <EmailCompositionModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isResend ? 'Resend Invitation' : 'New Email'}
+      showAttachments={true}
+      showCc={false}
+      subjectLabel="Title"
+      defaultValues={{ to: memberEmails ?? '' }}
+      isPending={sendInvitation.isPending}
+      onSubmit={handleSubmit}
+    />
   );
 };
 

--- a/src/features/quotation/api/quotation.ts
+++ b/src/features/quotation/api/quotation.ts
@@ -654,8 +654,14 @@ export const useSendQuotation = (quotationId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async () => {
-      const { data } = await axios.post(`/quotations/${quotationId}/send`);
+    mutationFn: async (emailData: {
+      from: string;
+      to: string;
+      cc?: string;
+      subject: string;
+      content?: string;
+    }) => {
+      const { data } = await axios.post(`/quotations/${quotationId}/send`, emailData);
       return data;
     },
     onSuccess: () => {

--- a/src/features/quotation/pages/NewQuotationPage.tsx
+++ b/src/features/quotation/pages/NewQuotationPage.tsx
@@ -13,6 +13,7 @@ import DateTimePickerInput from '@/shared/components/inputs/DateTimePickerInput'
 import axios from '@shared/api/axiosInstance';
 import { useAuthStore } from '@features/auth/store.ts';
 import { useCreateQuotation, useGetLoanTypeMatchedCompanies } from '../api/quotation';
+import { useAppealExclusionStore } from '@/features/collateralMaster/store/appealExclusionStore';
 import type { SharedDocumentSelectionDto } from '../schemas/quotation';
 import {
   AppraisalPicker,
@@ -51,11 +52,16 @@ function CompanyPicker({ selected, onToggle, onSetAllVisible, error }: CompanyPi
   const [query, setQuery] = useState('');
   const selectedIds = new Set(selected.map(c => c.id));
 
+  // Appeal exclusion: hide the most-recent prior company so the user can't reselect it
+  const excludedCompanyId = useAppealExclusionStore(s => s.excludedCompanyId);
+
   const { data: rawCompanies, isLoading } = useGetLoanTypeMatchedCompanies(undefined, true);
 
   const companies: SelectedCompany[] = useMemo(
-    () => (rawCompanies ?? []).map(c => ({ id: c.id, companyName: c.name })),
-    [rawCompanies],
+    () => (rawCompanies ?? [])
+      .filter(c => c.id !== excludedCompanyId)
+      .map(c => ({ id: c.id, companyName: c.name })),
+    [rawCompanies, excludedCompanyId],
   );
 
   const filtered = useMemo(() => {
@@ -66,6 +72,14 @@ function CompanyPicker({ selected, onToggle, onSetAllVisible, error }: CompanyPi
 
   return (
     <div className="flex flex-col gap-2">
+      {excludedCompanyId && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-700">
+          <span>
+            1 prior company excluded (appeal flow — most recent appraiser of this collateral).
+          </span>
+        </div>
+      )}
+
       {/* Selected chips */}
       {selected.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
@@ -179,6 +193,11 @@ function CompanyPicker({ selected, onToggle, onSetAllVisible, error }: CompanyPi
 function NewQuotationPage() {
   const navigate = useNavigate();
   const currentUser = useAuthStore(state => state.user);
+
+  // Note: appeal exclusion on this non-task quotation flow is NOT wired in v1.1.
+  // Use CreateQuotationModal (start-from-task) for appeal flows. If this page ever needs
+  // to support appeals, pull from useAppealExclusionStore.excludedCompanyId and extend
+  // POST /quotations to accept it.
 
   const [selectedAppraisals, setSelectedAppraisals] = useState<SelectedAppraisal[]>([]);
   const [selectedCompanies, setSelectedCompanies] = useState<SelectedCompany[]>([]);

--- a/src/features/quotation/pages/QuotationSelectionPage.tsx
+++ b/src/features/quotation/pages/QuotationSelectionPage.tsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast';
 import Icon from '@/shared/components/Icon';
 import Button from '@/shared/components/Button';
 import Modal from '@/shared/components/Modal';
+import EmailCompositionModal from '@/shared/components/EmailCompositionModal';
 import {
   useGetQuotationById,
   usePickTentativeWinner,
@@ -221,8 +222,14 @@ const QuotationSelectionPage = () => {
     return `${p(d.getDate())}/${p(d.getMonth() + 1)}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`;
   };
 
-  const handleSendConfirm = () => {
-    sendQuotation(undefined, {
+  const handleSendConfirm = (emailData: {
+    from: string;
+    to: string;
+    cc?: string;
+    subject: string;
+    content?: string;
+  }) => {
+    sendQuotation(emailData, {
       onSuccess: () => {
         toast.success('Quotation sent — companies have been notified');
         setIsSendConfirmOpen(false);
@@ -233,7 +240,6 @@ const QuotationSelectionPage = () => {
           apiErr?.apiError?.detail ??
             'Failed to send quotation. Set shared documents via the task page before sending.',
         );
-        setIsSendConfirmOpen(false);
       },
     });
   };
@@ -941,54 +947,17 @@ const QuotationSelectionPage = () => {
         />
       )}
 
-      {/* Send confirmation */}
-      <Modal
+      {/* Send confirmation — email composition */}
+      <EmailCompositionModal
         isOpen={isSendConfirmOpen}
         onClose={() => setIsSendConfirmOpen(false)}
-        title="Send Quotation"
-        size="sm"
-      >
-        <div className="flex flex-col gap-4">
-          <div className="p-3 bg-blue-50 rounded-lg border border-blue-100 flex items-start gap-2">
-            <Icon
-              name="paper-plane"
-              style="solid"
-              className="size-4 text-blue-500 shrink-0 mt-0.5"
-            />
-            <p className="text-sm text-blue-700">
-              Send this quotation to{' '}
-              <strong>
-                {quotation.invitedCompanies?.length ?? quotation.totalCompaniesInvited}
-              </strong>{' '}
-              invited{' '}
-              {(quotation.invitedCompanies?.length ?? quotation.totalCompaniesInvited) === 1
-                ? 'company'
-                : 'companies'}
-              ? They will be notified to submit their bids.
-            </p>
-          </div>
-          <p className="text-xs text-gray-500">
-            Note: each appraisal with uploaded documents must have at least one shared document
-            configured before sending. If the send fails, use the task page to set up shared
-            documents first.
-          </p>
-          <div className="flex justify-end gap-3 pt-2">
-            <Button
-              variant="outline"
-              onClick={() => setIsSendConfirmOpen(false)}
-              disabled={isSendPending}
-            >
-              Go Back
-            </Button>
-            <Button onClick={handleSendConfirm} disabled={isSendPending} isLoading={isSendPending}>
-              {!isSendPending && (
-                <Icon name="paper-plane" style="solid" className="size-4 mr-1.5" />
-              )}
-              Send
-            </Button>
-          </div>
-        </div>
-      </Modal>
+        title="Drafting email to send to external appraisal company"
+        showCc={true}
+        showAttachments={false}
+        subjectLabel="Subject"
+        isPending={isSendPending}
+        onSubmit={handleSendConfirm}
+      />
 
       {/* Draft cancel confirmation */}
       <Modal

--- a/src/features/request/configs/fields.ts
+++ b/src/features/request/configs/fields.ts
@@ -1,5 +1,4 @@
 import type { FieldArrayField, FormField } from '@/shared/components/form';
-import { mapCollateral } from '../data/mapCollateral';
 
 // =============================================================================
 // Utility
@@ -336,11 +335,107 @@ export const propertiesFieldConfig: FieldArrayField = {
 // Title field configs
 // =============================================================================
 
-// Collateral type groups for conditional validation
-const LAND_TYPES = ['L', 'LB', 'LSL', 'LSB', 'LS'];
-const TITLE_NUMBER_TYPES = ['L', 'LB', 'LSL', 'LS'];
-const OWNER_NAME_TYPES = ['L', 'LB', 'LSL', 'LSB', 'LS', 'U', 'B'];
-const BUILDING_REQUIRED_TYPES = ['B', 'LB', 'LSB', 'LS'];
+// Collateral type groups for conditional validation (new 33-code parameter table)
+// Land family: codes that capture land area / title deed info
+const LAND_TYPES = [
+  '01',
+  '02',
+  '03',
+  '04',
+  '09',
+  '13',
+  '14',
+  '17',
+  '19',
+  '21',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '29',
+  '30',
+  '31',
+  '32',
+];
+// Codes that require a TitleNumber (land + lease types)
+const TITLE_NUMBER_TYPES = [
+  '01',
+  '02',
+  '03',
+  '04',
+  '09',
+  '13',
+  '14',
+  '17',
+  '19',
+  '21',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '29',
+  '30',
+  '31',
+  '32',
+];
+// Codes that capture owner name (all non-movable types)
+const OWNER_NAME_TYPES = [
+  '01',
+  '02',
+  '03',
+  '04',
+  '05',
+  '06',
+  '07',
+  '08',
+  '09',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '20',
+  '21',
+  '22',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '28',
+  '29',
+  '30',
+  '31',
+  '32',
+  '33',
+];
+// Codes that capture building type / usable area / number of buildings
+const BUILDING_REQUIRED_TYPES = [
+  '02',
+  '03',
+  '04',
+  '05',
+  '06',
+  '07',
+  '09',
+  '15',
+  '16',
+  '18',
+  '20',
+  '22',
+  '23',
+  '24',
+  '25',
+  '30',
+  '31',
+  '32',
+];
+// Condo-specific codes (room/floor/building number, condo name)
+const CONDO_TYPES = ['08', '33'];
 
 // --- Rendering configs (used by sub-form components for <FormFields>) ---
 
@@ -349,15 +444,9 @@ export const titleInfoFields: FormField[] = [
     type: 'dropdown',
     label: 'Collateral Type',
     name: 'collateralType',
-    group: 'PropertyType',
+    group: 'CollateralType',
     wrapperClassName: 'col-span-3',
     required: true,
-    filterOptions: {
-      type: 'dynamic-array',
-      field: 'properties',
-      itemField: 'propertyType',
-      map: mapCollateral,
-    },
   },
   {
     type: 'boolean-toggle',
@@ -376,7 +465,7 @@ export const titleLandFields: FormField[] = [
     name: 'titleType',
     group: 'DeedType',
     wrapperClassName: 'col-span-2',
-    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, 'U'], operator: 'in' },
+    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, ...CONDO_TYPES], operator: 'in' },
   },
   {
     type: 'text-input',
@@ -384,7 +473,11 @@ export const titleLandFields: FormField[] = [
     name: 'titleNumber',
     wrapperClassName: 'col-span-2',
     maxLength: 200,
-    requiredWhen: { field: 'collateralType', is: [...TITLE_NUMBER_TYPES, 'U'], operator: 'in' },
+    requiredWhen: {
+      field: 'collateralType',
+      is: [...TITLE_NUMBER_TYPES, ...CONDO_TYPES],
+      operator: 'in',
+    },
   },
   {
     type: 'text-input',
@@ -468,7 +561,7 @@ export const titleLandFields: FormField[] = [
     name: 'notes',
     wrapperClassName: 'col-span-6',
     maxLength: 200,
-    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, 'U'], operator: 'in' },
+    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, ...CONDO_TYPES], operator: 'in' },
   },
 ];
 
@@ -489,7 +582,7 @@ export const titleBuildingFields: FormField[] = [
     requiredWhen: {
       field: 'collateralType',
       operator: 'in',
-      is: [...BUILDING_REQUIRED_TYPES, 'U'],
+      is: [...BUILDING_REQUIRED_TYPES, ...CONDO_TYPES],
     },
     decimalPlaces: 2,
     maxIntegerDigits: 3,
@@ -526,7 +619,7 @@ export const titleCondoFields: FormField[] = [
     name: 'titleType',
     group: 'DeedType',
     wrapperClassName: 'col-span-2',
-    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, 'U'], operator: 'in' },
+    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, ...CONDO_TYPES], operator: 'in' },
   },
   {
     type: 'text-input',
@@ -534,14 +627,18 @@ export const titleCondoFields: FormField[] = [
     name: 'titleNumber',
     wrapperClassName: 'col-span-4',
     maxLength: 40,
-    requiredWhen: { field: 'collateralType', is: [...TITLE_NUMBER_TYPES, 'U'], operator: 'in' },
+    requiredWhen: {
+      field: 'collateralType',
+      is: [...TITLE_NUMBER_TYPES, ...CONDO_TYPES],
+      operator: 'in',
+    },
   },
   {
     type: 'text-input',
     label: 'Room Number',
     name: 'roomNumber',
     wrapperClassName: 'col-span-2',
-    requiredWhen: { field: 'collateralType', is: 'U' },
+    requiredWhen: { field: 'collateralType', is: CONDO_TYPES, operator: 'in' },
     maxLength: 10,
   },
   {
@@ -549,7 +646,7 @@ export const titleCondoFields: FormField[] = [
     label: 'Floor Number',
     name: 'floorNumber',
     wrapperClassName: 'col-span-2',
-    requiredWhen: { field: 'collateralType', is: 'U' },
+    requiredWhen: { field: 'collateralType', is: CONDO_TYPES, operator: 'in' },
     maxLength: 10,
   },
   {
@@ -557,7 +654,7 @@ export const titleCondoFields: FormField[] = [
     label: 'Building Number',
     name: 'buildingNumber',
     wrapperClassName: 'col-span-2',
-    requiredWhen: { field: 'collateralType', is: 'U' },
+    requiredWhen: { field: 'collateralType', is: CONDO_TYPES, operator: 'in' },
     maxLength: 10,
   },
   {
@@ -566,7 +663,7 @@ export const titleCondoFields: FormField[] = [
     name: 'condoName',
     wrapperClassName: 'col-span-4',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'U' },
+    requiredWhen: { field: 'collateralType', is: CONDO_TYPES, operator: 'in' },
     maxLength: 100,
   },
   {
@@ -577,7 +674,7 @@ export const titleCondoFields: FormField[] = [
     requiredWhen: {
       field: 'collateralType',
       operator: 'in',
-      is: [...BUILDING_REQUIRED_TYPES, 'U'],
+      is: [...BUILDING_REQUIRED_TYPES, ...CONDO_TYPES],
     },
     decimalPlaces: 2,
     maxIntegerDigits: 3,
@@ -596,7 +693,7 @@ export const titleCondoFields: FormField[] = [
     name: 'notes',
     wrapperClassName: 'col-span-6',
     maxLength: 200,
-    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, 'U'], operator: 'in' },
+    requiredWhen: { field: 'collateralType', is: [...LAND_TYPES, ...CONDO_TYPES], operator: 'in' },
   },
 ];
 
@@ -608,7 +705,7 @@ export const titleVehicleFields: FormField[] = [
     group: 'VehicleType',
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'VEH' },
+    requiredWhen: { field: 'collateralType', is: '10' },
   },
   {
     type: 'text-input',
@@ -616,7 +713,7 @@ export const titleVehicleFields: FormField[] = [
     name: 'licensePlateNumber',
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'VEH' },
+    requiredWhen: { field: 'collateralType', is: '10' },
     maxLength: 50,
   },
   {
@@ -636,7 +733,7 @@ export const titleMachineFields: FormField[] = [
     group: 'MachineStatus',
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'MAC' },
+    requiredWhen: { field: 'collateralType', is: '11' },
   },
   {
     type: 'dropdown',
@@ -645,7 +742,7 @@ export const titleMachineFields: FormField[] = [
     group: 'MachineType',
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'MAC' },
+    requiredWhen: { field: 'collateralType', is: '11' },
   },
   {
     type: 'boolean-toggle',
@@ -654,7 +751,7 @@ export const titleMachineFields: FormField[] = [
     options: ['Unregistered', 'Registered'],
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'MAC' },
+    requiredWhen: { field: 'collateralType', is: '11' },
   },
   {
     type: 'text-input',
@@ -685,7 +782,7 @@ export const titleMachineFields: FormField[] = [
     name: 'numberOfMachine',
     wrapperClassName: 'col-span-3',
     required: true,
-    requiredWhen: { field: 'collateralType', is: 'MAC' },
+    requiredWhen: { field: 'collateralType', is: '11' },
     decimalPlaces: 0,
     maxIntegerDigits: 5,
   },

--- a/src/features/request/data/mapCollateral.ts
+++ b/src/features/request/data/mapCollateral.ts
@@ -1,11 +1,34 @@
-export const mapCollateral = {
-  L: ['L', 'LB'],
-  LB: ['L', 'LB', 'B'],
-  LSL: ['LSL', 'LS'],
-  LSB: ['LSB'],
-  LS: ['LS', 'LSL', 'LSB'],
-  B: ['B', 'LB'],
-  VEH: ['VEH'],
-  MAC: ['MAC'],
-  U: ['U'],
+// Maps property type codes (from properties form) to allowed collateral type codes (in titles form).
+// Keys = PropertyType parameter codes (old letter codes, unchanged).
+// Values = CollateralType parameter codes (new 33-code numeric set).
+
+const LAND_CODES = ['01', '13', '14', '17', '19', '21', '26', '27'];
+const LB_CODES = ['02', '03', '04', '23', '24', '32'];
+const BUILDING_CODES = ['05', '06', '07', '15', '16', '18', '20', '22'];
+const CONDO_CODES = ['08', '33'];
+const LEASE_LS_CODES = ['09', '25', '30', '31'];
+const LEASE_LAND_CODE = ['29'];
+const LEASE_CONDO_CODE = ['28'];
+
+export const mapCollateral: Record<string, string[]> = {
+  // Land → land titles + land-with-building titles
+  L: [...LAND_CODES, ...LB_CODES],
+  // Land and Building → land + land-with-building + building titles
+  LB: [...LAND_CODES, ...LB_CODES, ...BUILDING_CODES],
+  // Building → land-with-building + building titles
+  B: [...LB_CODES, ...BUILDING_CODES],
+  // Condominium → condo titles only
+  U: CONDO_CODES,
+  // Lease Agreement (Land and Building) → all leasehold types
+  LS: [...LEASE_LS_CODES, ...LEASE_LAND_CODE],
+  // Lease Agreement (Land) → all leasehold types
+  LSL: [...LEASE_LS_CODES, ...LEASE_LAND_CODE],
+  // Lease Agreement (Building) → all leasehold types
+  LSB: [...LEASE_LS_CODES, ...LEASE_LAND_CODE],
+  // Lease Agreement Condo → lease condo only
+  LSU: LEASE_CONDO_CODE,
+  // Movables
+  VEH: ['10'],
+  MAC: ['11'],
+  VES: ['12'],
 };

--- a/src/features/request/forms/RequestForm.tsx
+++ b/src/features/request/forms/RequestForm.tsx
@@ -1,26 +1,13 @@
-import { useMemo } from 'react';
 import { FormFields } from '@/shared/components/form';
 import SectionHeader from '@/shared/components/sections/SectionHeader';
 import { requestFields } from '../configs/fields';
 
-interface RequestFormProps {
-  /** When true, the AppraisalSelector field is disabled (edit mode). */
-  disableAppraisalSelector?: boolean;
-}
-
-const RequestForm = ({ disableAppraisalSelector = false }: RequestFormProps) => {
-  const fields = useMemo(() => {
-    if (!disableAppraisalSelector) return requestFields;
-    return requestFields.map(f =>
-      f.type === 'appraisal-selector' ? { ...f, disabled: true } : f,
-    );
-  }, [disableAppraisalSelector]);
-
+const RequestForm = () => {
   return (
     <div>
       <SectionHeader title="Request" />
       <div className="grid grid-cols-3 gap-4">
-        <FormFields fields={fields} />
+        <FormFields fields={requestFields} />
       </div>
     </div>
   );

--- a/src/features/request/forms/TitleInformationForm.tsx
+++ b/src/features/request/forms/TitleInformationForm.tsx
@@ -12,6 +12,10 @@ import Icon from '@/shared/components/Icon';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import TitleDocumentAddressForm from './TitleDocumentAddressForm';
 import DopaAddressForm from './DopaAddressForm';
+import { TitleLookupIntegration } from '@/features/collateralMaster/components/TitleLookupIntegration';
+import { CollateralLookupProvider } from '@/features/collateralMaster/components/CollateralLookupContext';
+import { useAppealExclusionStore } from '@/features/collateralMaster/store/appealExclusionStore';
+import { useCollateralPrefillStore } from '@/features/collateralMaster/store/collateralPrefillStore';
 import {
   requestTitleDefault,
   RequestTitleDto,
@@ -53,6 +57,13 @@ const TitleInformationForm = () => {
   if (editIndex !== undefined && titles.length > editIndex) {
     currentFormType = titles[editIndex]?.collateralType;
   }
+
+  // Reset cross-flow stores on mount so stale data from a previous request
+  // creation doesn't leak into the current one (lookup-driven exclusions / prefill).
+  useEffect(() => {
+    useAppealExclusionStore.getState().clearExclusions();
+    useCollateralPrefillStore.getState().clearPrefill();
+  }, []);
 
   // Auto scroll to bottom when new item is added
   useEffect(() => {
@@ -123,28 +134,28 @@ const TitleInformationForm = () => {
   };
 
   const getCollateralTypeIcon = (type: string | undefined) => {
-    switch (type) {
-      case 'L':
-        return 'mountain-sun';
-      case 'B':
-        return 'building';
-      case 'LB':
-        return 'city';
-      case 'U':
-        return 'building-user';
-      case 'VEH':
-        return 'car';
-      case 'MAC':
-        return 'gear';
-      case 'LSL':
-        return 'file-contract';
-      case 'LS':
-        return 'file-signature';
-      case 'LSB':
-        return 'file-lines';
-      default:
-        return 'file-circle-question';
-    }
+    if (!type) return 'file-circle-question';
+    // Land family
+    if (['01','13','14','17','19','21','26','27'].includes(type)) return 'mountain-sun';
+    // Land+Building family
+    if (['02','03','04','23','24','32'].includes(type)) return 'city';
+    // Building family
+    if (['05','06','07','15','16','18','20','22'].includes(type)) return 'building';
+    // Condo family
+    if (['08','33'].includes(type)) return 'building-user';
+    // Vehicle
+    if (type === '10') return 'car';
+    // Machine
+    if (type === '11') return 'gear';
+    // Vessel
+    if (type === '12') return 'ship';
+    // Lease land
+    if (type === '29') return 'file-contract';
+    // Lease land+building
+    if (['09','25','30','31'].includes(type)) return 'file-signature';
+    // Lease condo
+    if (type === '28') return 'file-lines';
+    return 'file-circle-question';
   };
 
   // Context menu state
@@ -171,6 +182,7 @@ const TitleInformationForm = () => {
   }, [contextMenu]);
 
   return (
+    <CollateralLookupProvider>
     <>
       {/* Initialize required documents for all titles */}
       {titles?.map((_: any, index: number) => (
@@ -328,6 +340,12 @@ const TitleInformationForm = () => {
 
             {/* Right Panel - Detail Form */}
             <div className="flex-1 min-w-0">
+              {/* Collateral lookup banner — fires when dedup-key fields fill in */}
+              {!isReadOnly && editIndex !== undefined && (
+                <div className="mb-3 pr-2">
+                  <TitleLookupIntegration titleIndex={editIndex} />
+                </div>
+              )}
               <div key={`title-form-${editIndex}`} className="grid grid-cols-6 gap-3 pr-2">
                 <FormFields fields={titleInfoFields} namePrefix="titles" index={editIndex} />
                 <TitleForm index={editIndex} currentFormType={currentFormType} />
@@ -381,6 +399,7 @@ const TitleInformationForm = () => {
         />
       </FormCard>
     </>
+    </CollateralLookupProvider>
   );
 };
 
@@ -459,8 +478,12 @@ const TitleTableView = ({
     const details: { label: string; value: string }[] = [];
     const type = title?.collateralType;
 
-    // Title info (land types + condo)
-    if (['L', 'LB', 'LSL', 'LS', 'LSB', 'B', 'U'].includes(type)) {
+    const LAND_AREA_TYPES = ['01','02','03','04','09','13','14','17','19','21','23','24','25','26','27','29','30','31','32'];
+    const BUILDING_USABLE_TYPES = ['02','03','04','05','06','07','09','15','16','18','20','22','23','24','25','30','31','32'];
+    const CONDO_TYPES_LOCAL = ['08','33'];
+
+    // Title info (non-movable types)
+    if (!['10','11','12'].includes(type)) {
       const titleStr =
         title?.titleType || title?.titleNumber
           ? `${title?.titleType ? `${title.titleType}: ` : ''}${title?.titleNumber || ''}`
@@ -479,7 +502,7 @@ const TitleTableView = ({
     }
 
     // Area (land types)
-    if (['L', 'LB', 'LSL', 'LS', 'LSB'].includes(type)) {
+    if (LAND_AREA_TYPES.includes(type)) {
       const hasArea = title?.areaRai || title?.areaNgan || title?.areaSquareWa;
       if (hasArea) {
         details.push({
@@ -489,13 +512,13 @@ const TitleTableView = ({
       }
     }
 
-    // Usable area (condo + building types)
-    if (['U', 'B', 'LB', 'LSB', 'LS'].includes(type) && title?.usableArea) {
+    // Usable area (building + land+building types)
+    if (BUILDING_USABLE_TYPES.includes(type) && title?.usableArea) {
       details.push({ label: 'Usable Area', value: `${title.usableArea} sq.m` });
     }
 
     // Condo-specific
-    if (type === 'U') {
+    if (CONDO_TYPES_LOCAL.includes(type)) {
       if (title?.condoName) details.push({ label: 'Condo', value: title.condoName });
       const room = [
         title?.roomNumber && `Room ${title.roomNumber}`,
@@ -507,14 +530,14 @@ const TitleTableView = ({
     }
 
     // Vehicle-specific
-    if (type === 'VEH') {
+    if (type === '10') {
       if (title?.licensePlateNumber)
         details.push({ label: 'License Plate', value: title.licensePlateNumber });
       if (title?.vehicleType) details.push({ label: 'Vehicle Type', value: title.vehicleType });
     }
 
     // Machine-specific
-    if (type === 'MAC') {
+    if (type === '11') {
       if (title?.machineType) details.push({ label: 'Machine Type', value: title.machineType });
       if (title?.numberOfMachine)
         details.push({ label: 'Qty', value: String(title.numberOfMachine) });
@@ -677,56 +700,74 @@ const TitleRequiredDocsInitializer = ({ index }: { index: number }) => {
   return null;
 };
 
+const LAND_ONLY_CODES = ['01','13','14','17','19','21','26','27','29'];
+const LAND_AND_BUILDING_CODES = ['02','03','04','09','23','24','25','30','31','32'];
+const BUILDING_ONLY_CODES = ['05','06','07','15','16','18','20','22'];
+const CONDO_FORM_CODES = ['08','28','33'];
+
 const TitleForm = ({ index, currentFormType }: TitleFormProps) => {
-  switch (currentFormType) {
-    case 'L':
-      return <TitleLandForm index={index} />;
-    case 'B':
-      return <TitleBuildingForm index={index} />;
-    case 'LB':
-      return (
-        <>
-          <TitleLandForm index={index} variant="landAndBuilding" />
-          <TitleBuildingForm index={index} variant={2} />
-        </>
-      );
-    case 'U':
-      return <TitleCondoForm index={index} />;
-    case 'VEH':
-      return <TitleVehicleForm index={index} />;
-    case 'MAC':
-      return <TitleMachineForm index={index} />;
-    case 'LSL':
-      return <TitleLandForm index={index} />;
-    case 'LS':
-      return (
-        <>
-          <TitleLandForm index={index} variant="landAndBuilding" />
-          <TitleBuildingForm index={index} variant={2} />
-        </>
-      );
-    case 'LSB':
-      return <TitleBuildingForm index={index} />;
-    default:
-      return (
-        <div className="col-span-6 text-center py-8 text-gray-500">
-          <Icon style="regular" name="hand-pointer" className="size-8 mx-auto mb-2 text-gray-400" />
-          <p>Please select a collateral type to continue</p>
-        </div>
-      );
+  if (!currentFormType) {
+    return (
+      <div className="col-span-6 text-center py-8 text-gray-500">
+        <Icon style="regular" name="hand-pointer" className="size-8 mx-auto mb-2 text-gray-400" />
+        <p>Please select a collateral type to continue</p>
+      </div>
+    );
   }
+  if (LAND_ONLY_CODES.includes(currentFormType)) return <TitleLandForm index={index} />;
+  if (LAND_AND_BUILDING_CODES.includes(currentFormType))
+    return (
+      <>
+        <TitleLandForm index={index} variant="landAndBuilding" />
+        <TitleBuildingForm index={index} variant={2} />
+      </>
+    );
+  if (BUILDING_ONLY_CODES.includes(currentFormType)) return <TitleBuildingForm index={index} />;
+  if (CONDO_FORM_CODES.includes(currentFormType)) return <TitleCondoForm index={index} />;
+  if (currentFormType === '10') return <TitleVehicleForm index={index} />;
+  if (currentFormType === '11') return <TitleMachineForm index={index} />;
+  return (
+    <div className="col-span-6 text-center py-8 text-gray-500">
+      <Icon style="regular" name="hand-pointer" className="size-8 mx-auto mb-2 text-gray-400" />
+      <p>Please select a collateral type to continue</p>
+    </div>
+  );
 };
 
-const collateralTypeOptions = [
-  { value: 'L', label: 'Land' },
-  { value: 'LB', label: 'Land and Building' },
-  { value: 'B', label: 'Building' },
-  { value: 'U', label: 'Condominium' },
-  { value: 'VEH', label: 'Vehicle' },
-  { value: 'MAC', label: 'Machine' },
-  { value: 'LSL', label: 'Lease Agreement Land' },
-  { value: 'LS', label: 'Lease Agreement Land and Building' },
-  { value: 'LSB', label: 'Lease Agreement Building' },
+const collateralTypeOptions: { value: string; label: string }[] = [
+  { value: '01', label: 'Land' },
+  { value: '02', label: 'Land with buildings' },
+  { value: '03', label: 'Land with buildings (blueprint)' },
+  { value: '04', label: 'Land allocation (whole project)' },
+  { value: '05', label: 'Buildings' },
+  { value: '06', label: 'Building (blueprint)' },
+  { value: '07', label: 'Building (whole project)' },
+  { value: '08', label: 'Apartment' },
+  { value: '09', label: 'Leasehold rights, real estate' },
+  { value: '10', label: 'Car' },
+  { value: '11', label: 'Machinery' },
+  { value: '12', label: 'Ship' },
+  { value: '13', label: 'Land (Part 1)' },
+  { value: '14', label: 'Land (Part 2)' },
+  { value: '15', label: 'Building (Part 1)' },
+  { value: '16', label: 'Building (Part 2)' },
+  { value: '17', label: 'Land (Part 2)' },
+  { value: '18', label: 'Building (Part 2)' },
+  { value: '19', label: 'Land (Group 1)' },
+  { value: '20', label: 'Building (Group 1)' },
+  { value: '21', label: 'Land (Group 2)' },
+  { value: '22', label: 'Building (Group 2)' },
+  { value: '23', label: 'Land with buildings (Group 1)' },
+  { value: '24', label: 'Land with buildings (Group 2)' },
+  { value: '25', label: 'Leasehold rights (land with buildings)' },
+  { value: '26', label: 'Land (Group 3)' },
+  { value: '27', label: 'Land (Group 4)' },
+  { value: '28', label: 'Leasehold rights (condominium)' },
+  { value: '29', label: 'Land lease rights' },
+  { value: '30', label: 'Leasehold rights' },
+  { value: '31', label: 'Lease rights for space within shopping center' },
+  { value: '32', label: 'Land with buildings (BlockLand)' },
+  { value: '33', label: 'Condominium (BlockCondo)' },
 ];
 
 export default TitleInformationForm;

--- a/src/features/request/pages/RequestPage.tsx
+++ b/src/features/request/pages/RequestPage.tsx
@@ -602,7 +602,7 @@ function RequestPage() {
                       {/* In create mode, wrap with AppraisalCopyProvider so AppraisalSelector
                           can receive the full copy callback via context */}
                       {isEditMode ? (
-                        <RequestForm disableAppraisalSelector />
+                        <RequestForm />
                       ) : (
                         <AppraisalCopyProvider onCopySelect={handleCopySelect}>
                           <RequestForm />

--- a/src/features/request/utils/mappers.ts
+++ b/src/features/request/utils/mappers.ts
@@ -27,7 +27,7 @@ export const mapRequestResponseToForm = (
         totalSellingPrice: response.detail?.loanDetail?.totalSellingPrice ?? 0,
       },
       prevAppraisalId: response.detail?.prevAppraisalId ?? null,
-      prevAppraisalReportNo: response.detail?.prevAppraisalReportNo ?? null,
+      prevAppraisalReportNo: response.detail?.prevAppraisalNumber ?? null,
       prevAppraisalValue: response.detail?.prevAppraisalValue ?? null,
       prevAppraisalDate: response.detail?.prevAppraisalDate ?? null,
       address: (() => {

--- a/src/shared/components/EmailCompositionModal.tsx
+++ b/src/shared/components/EmailCompositionModal.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Modal from './Modal';
+import Button from './Button';
+import { emailFormSchema, type EmailFormValues } from '@/shared/schemas/email';
+
+interface EmailCompositionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  defaultValues?: Partial<EmailFormValues>;
+  showCc?: boolean;
+  showAttachments?: boolean;
+  subjectLabel?: string;
+  isPending?: boolean;
+  onSubmit: (values: EmailFormValues) => void;
+}
+
+const inputClass =
+  'w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+
+const EmailCompositionModal = ({
+  isOpen,
+  onClose,
+  title,
+  defaultValues,
+  showCc = false,
+  showAttachments = false,
+  subjectLabel = 'Subject',
+  isPending = false,
+  onSubmit,
+}: EmailCompositionModalProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<EmailFormValues>({
+    resolver: zodResolver(emailFormSchema),
+    defaultValues: {
+      from: '',
+      to: '',
+      cc: '',
+      subject: '',
+      content: '',
+      attachments: [],
+      ...defaultValues,
+    },
+  });
+
+  const attachments = watch('attachments') ?? [];
+  const [attachmentInput, setAttachmentInput] = useState('');
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        from: '',
+        to: '',
+        cc: '',
+        subject: '',
+        content: '',
+        attachments: [],
+        ...defaultValues,
+      });
+      setAttachmentInput('');
+    }
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleAddAttachment = () => {
+    const trimmed = attachmentInput.trim();
+    if (!trimmed) return;
+    if (attachments.length >= 10) return;
+    if (trimmed.length > 200) return;
+    setValue('attachments', [...attachments, trimmed]);
+    setAttachmentInput('');
+    attachmentInputRef.current?.focus();
+  };
+
+  const handleAttachmentKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddAttachment();
+    }
+  };
+
+  const handleRemoveAttachment = (index: number) => {
+    setValue(
+      'attachments',
+      attachments.filter((_: string, i: number) => i !== index),
+    );
+  };
+
+  const handleClose = () => {
+    if (!isPending) onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title={title} size="lg">
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div className="flex flex-col gap-3">
+          {/* From */}
+          <div className="flex items-start gap-3">
+            <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+              From
+            </label>
+            <div className="flex-1">
+              <input {...register('from')} type="text" className={inputClass} />
+              {errors.from && (
+                <p className="mt-1 text-xs text-red-500">{errors.from.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* To */}
+          <div className="flex items-start gap-3">
+            <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+              To
+            </label>
+            <div className="flex-1">
+              <input {...register('to')} type="text" className={inputClass} />
+              {errors.to && (
+                <p className="mt-1 text-xs text-red-500">{errors.to.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* CC (conditional) */}
+          {showCc && (
+            <div className="flex items-start gap-3">
+              <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+                CC
+              </label>
+              <div className="flex-1">
+                <input {...register('cc')} type="text" className={inputClass} />
+                {errors.cc && (
+                  <p className="mt-1 text-xs text-red-500">{errors.cc.message}</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Subject / Title */}
+          <div className="flex items-start gap-3">
+            <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+              {subjectLabel}
+            </label>
+            <div className="flex-1">
+              <input {...register('subject')} type="text" className={inputClass} />
+              {errors.subject && (
+                <p className="mt-1 text-xs text-red-500">{errors.subject.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Attachments (conditional) */}
+          {showAttachments && (
+            <div className="flex items-start gap-3">
+              <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+                Attachments
+              </label>
+              <div className="flex-1">
+                <div className="flex flex-wrap items-center gap-1.5 min-h-[38px] border border-gray-300 rounded-md px-3 py-1.5 focus-within:ring-2 focus-within:ring-blue-500">
+                  {attachments.map((chip: string, i: number) => (
+                    <span
+                      key={i}
+                      className="bg-blue-100 text-blue-800 rounded-full px-3 py-0.5 text-sm flex items-center gap-1"
+                    >
+                      {chip}
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAttachment(i)}
+                        className="ml-0.5 text-blue-600 hover:text-blue-800 leading-none"
+                        aria-label={`Remove ${chip}`}
+                      >
+                        &times;
+                      </button>
+                    </span>
+                  ))}
+                  <input
+                    ref={attachmentInputRef}
+                    type="text"
+                    value={attachmentInput}
+                    onChange={e => setAttachmentInput(e.target.value)}
+                    onKeyDown={handleAttachmentKeyDown}
+                    placeholder={attachments.length === 0 ? 'Type and press Enter to add' : ''}
+                    className="flex-1 min-w-[120px] text-sm outline-none bg-transparent py-0.5"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Content */}
+          <div className="flex items-start gap-3">
+            <label className="w-24 shrink-0 text-right text-sm font-medium text-gray-600 pt-2">
+              Content
+            </label>
+            <div className="flex-1">
+              <textarea
+                {...register('content')}
+                rows={6}
+                className={inputClass + ' resize-none'}
+              />
+              {errors.content && (
+                <p className="mt-1 text-xs text-red-500">{errors.content.message}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 pt-5 mt-2 border-t border-gray-100">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleClose}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={isPending}
+            isLoading={isPending}
+            className="bg-orange-500 hover:bg-orange-600 text-white"
+          >
+            {!isPending && 'Send'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EmailCompositionModal;

--- a/src/shared/schemas/email.ts
+++ b/src/shared/schemas/email.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const containsAt = (v: string) =>
+  v
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .every(s => s.includes('@'));
+
+export const emailFormSchema = z.object({
+  from: z
+    .string()
+    .min(1, 'Required')
+    .max(500)
+    .refine(containsAt, { message: 'From must contain valid email address(es)' }),
+  to: z
+    .string()
+    .min(1, 'Required')
+    .max(500)
+    .refine(containsAt, { message: 'To must contain valid email address(es)' }),
+  cc: z
+    .string()
+    .max(500)
+    .refine(v => !v || containsAt(v), { message: 'CC must contain valid email address(es)' })
+    .optional(),
+  subject: z.string().min(1, 'Required').max(500),
+  content: z.string().max(4000).optional(),
+  attachments: z.array(z.string().max(200)).max(10).optional(),
+});
+
+export type EmailFormValues = z.infer<typeof emailFormSchema>;


### PR DESCRIPTION
## Summary

- **Collateral Master** — new feature module with lookup banner, identity fields (Land/Condo/Leasehold/Machine), appeal exclusion store, progressive prefill hooks, and admin pages (catalog, detail, backfill report); router updated with 3 new routes gated by `COLLATERAL_ADMIN`
- **Email Composition** — shared `EmailCompositionModal` + Zod schema wired into quotation send and meeting invitation flows (replaces ad-hoc confirm dialogs)
- **Appeal Exclusion** — filters prior appraiser company from quotation company pickers; passes `excludedCompanyIds` to API; amber info banner in `NewQuotationPage`
- **Progressive Appraisal Prefill** — seeds construction inspection form fields from prior inspection on create; safe `useAppraisalContextSafe()` hook added
- **Request collateral code migration** — all validation/mapping migrated from letter codes (L, B, U…) to 33-code numeric system; `prevAppraisalNumber` field mapping fixed; unused `disableAppraisalSelector` prop removed
- **blockProject enhancements** — delete model/tower from listing + detail pages; interactive condo flags in `UnitPriceTab`; LB land assumption section in `PricingAssumptionForm`; `landAreaDifference` field; fire insurance options data fix

## Test plan

- [ ] New collateral master routes load: `/collateral-masters`, `/collateral-masters/:id`, `/collateral-masters/backfill`
- [ ] `EmailCompositionModal` appears when sending a quotation (QuotationSection + QuotationSelectionPage) and meeting invitation
- [ ] Appeal exclusion amber banner shows in `NewQuotationPage` when a prior company is stored; company absent from picker
- [ ] Progressive appraisal form pre-populates on create for Progressive appraisal type
- [ ] Request form collateral type validation works correctly with new 33-code system
- [ ] Delete model/tower works from both listing cards and detail page (with confirmation dialog + toast)
- [ ] `pnpm tsc --noEmit` passes without new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)