### PR TITLE
fix: align QuotationDraftSummary field names with backend response

### DIFF
--- a/src/features/quotation/components/ExistingDraftPicker.tsx
+++ b/src/features/quotation/components/ExistingDraftPicker.tsx
@@ -115,16 +115,16 @@ const ExistingDraftPicker = ({
                     </div>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-sm text-gray-600">{formatDate(draft.createdOn)}</span>
+                    <span className="text-sm text-gray-600">{formatDate(draft.requestDate)}</span>
                   </td>
                   <td className="px-4 py-3">
                     <div>
                       <span className="text-sm font-medium text-gray-900">
-                        {draft.appraisalCount}
+                        {draft.totalAppraisals}
                       </span>
-                      {draft.appraisalPreview.length > 0 && (
+                      {draft.appraisalNumberPreview.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-0.5">
-                          {draft.appraisalPreview.slice(0, 5).map(no => (
+                          {draft.appraisalNumberPreview.slice(0, 5).map(no => (
                             <span
                               key={no}
                               className="inline-flex items-center px-1.5 py-0.5 bg-primary/5 rounded text-[10px] font-medium text-primary"
@@ -132,9 +132,9 @@ const ExistingDraftPicker = ({
                               {no}
                             </span>
                           ))}
-                          {draft.appraisalCount > 5 && (
+                          {draft.totalAppraisals > 5 && (
                             <span className="text-[10px] text-gray-400">
-                              +{draft.appraisalCount - 5} more
+                              +{draft.totalAppraisals - 5} more
                             </span>
                           )}
                         </div>
@@ -142,7 +142,7 @@ const ExistingDraftPicker = ({
                     </div>
                   </td>
                   <td className="px-4 py-3 text-center">
-                    <span className="text-sm text-gray-600">{draft.invitedCompanyCount}</span>
+                    <span className="text-sm text-gray-600">{draft.totalCompaniesInvited}</span>
                   </td>
                   <td className="px-4 py-3">
                     <span className="text-sm text-gray-600">

--- a/src/features/quotation/schemas/quotation.ts
+++ b/src/features/quotation/schemas/quotation.ts
@@ -127,12 +127,12 @@ export type InvitedCompanyDto = z.infer<typeof InvitedCompanySchema>;
 export const QuotationDraftSummarySchema = z.object({
   id: z.string().uuid(),
   quotationNumber: z.string(),
-  createdOn: z.string(),
+  requestDate: z.string(),
   dueDate: z.string().nullable().optional(),
   bankingSegment: z.string().nullable().optional(),
-  appraisalCount: z.number().int(),
-  appraisalPreview: z.array(z.string()).optional().default([]), // first 3–5 appraisal numbers
-  invitedCompanyCount: z.number().int(),
+  totalAppraisals: z.number().int(),
+  appraisalNumberPreview: z.array(z.string()).default([]),
+  totalCompaniesInvited: z.number().int(),
 });
 
 export type QuotationDraftSummaryDto = z.infer<typeof QuotationDraftSummarySchema>;


### PR DESCRIPTION
## Summary
- Frontend `QuotationDraftSummarySchema` had 4 field names that didn't match the actual JSON the backend sends
- `appraisalNumberPreview` was arriving as `undefined` (the old name `appraisalPreview` never existed in the response), crashing `ExistingDraftPicker` with `TypeError: Cannot read properties of undefined (reading 'length')`
- Data bypasses Zod parsing so `.default([])` never applied — `undefined` reached the component directly

## Changes
| Old (wrong) | Correct (backend) |
|---|---|
| `createdOn` | `requestDate` |
| `appraisalCount` | `totalAppraisals` |
| `appraisalPreview` | `appraisalNumberPreview` |
| `invitedCompanyCount` | `totalCompaniesInvited` |

**Files:** `schemas/quotation.ts`, `components/ExistingDraftPicker.tsx`

## Test plan
- [ ] Open the quotation entry modal
- [ ] Switch to "Existing Draft" tab — table should render without crash
- [ ] Verify appraisal count, preview chips, company count, and date display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)