### PR TITLE
fix: hypothesis pricing stale values, loading indicators, and preview debounce

### DIFF
--- a/src/features/pricingAnalysis/components/hypothesis/_shared/summaryAtoms.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/_shared/summaryAtoms.tsx
@@ -6,12 +6,41 @@
  * Suffix slot uses a negative left margin to sit flush against the rate-unit
  * label; long suffixes wrap to a second line within the slot.
  */
-import type { ReactNode } from 'react';
+import { type ReactNode, createContext, useContext } from 'react';
 import { Controller } from 'react-hook-form';
 import NumberInput from '@/shared/components/inputs/NumberInput';
 import { Icon } from '@/shared/components';
 import { fmt } from '../../../domain/formatters';
 import { FieldTooltip } from './FieldTooltip';
+
+// ─── Calculating context ──────────────────────────────────────────────────────
+// Wrap a summary tab in <IsCalculatingProvider value={true}> while a preview
+// request is in-flight; all derived-value atoms read from this context and
+// swap their number with an animated placeholder.
+
+const IsCalculatingContext = createContext(false);
+
+export function IsCalculatingProvider({
+  value,
+  children,
+}: {
+  value: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <IsCalculatingContext.Provider value={value}>
+      {children}
+    </IsCalculatingContext.Provider>
+  );
+}
+
+function CalcPlaceholder({ wide }: { wide?: boolean }) {
+  return (
+    <span
+      className={`inline-block h-3.5 ${wide ? 'w-28' : 'w-16'} rounded bg-gray-200 animate-pulse align-middle`}
+    />
+  );
+}
 
 // ─── Shared column widths ─────────────────────────────────────────────────────
 
@@ -100,6 +129,7 @@ export function DerivedValue({
   unit?: string;
   emphasize?: boolean;
 }) {
+  const isCalculating = useContext(IsCalculatingContext);
   return (
     <div className="ml-auto flex items-center gap-2">
       <span
@@ -107,7 +137,7 @@ export function DerivedValue({
           emphasize ? 'font-semibold text-primary' : 'font-medium text-gray-800'
         }`}
       >
-        {fmt(value)}
+        {isCalculating ? <CalcPlaceholder /> : fmt(value)}
       </span>
       {unit && <span className="text-[11px] text-gray-500 w-[68px]">{unit}</span>}
     </div>
@@ -167,6 +197,7 @@ export function PdcDerivedRow({
   compact?: boolean;
   tooltip?: string;
 }) {
+  const isCalculating = useContext(IsCalculatingContext);
   return (
     <div className="flex items-center px-5 py-2.5 gap-2">
       <div className="flex-1 text-xs font-medium text-gray-700 min-w-0 flex items-center gap-0.5">
@@ -196,7 +227,7 @@ export function PdcDerivedRow({
         )}
       </div>
       <span className={`${COL.total} text-right tabular-nums text-xs font-medium text-gray-800 shrink-0`}>
-        {total !== null && total !== undefined ? fmt(total) : ''}
+        {isCalculating ? <CalcPlaceholder /> : (total !== null && total !== undefined ? fmt(total) : '')}
       </span>
       <span className={`${COL.totalUnit} text-[11px] text-gray-500 shrink-0`}>
         {total !== null && total !== undefined ? 'Baht' : ''}
@@ -204,7 +235,7 @@ export function PdcDerivedRow({
       {!compact && (
         <>
           <span className={`${COL.ratio} text-right tabular-nums text-xs font-medium text-gray-800 shrink-0`}>
-            {ratioPercent !== null && ratioPercent !== undefined ? `${Number(ratioPercent).toFixed(2)} %` : ''}
+            {isCalculating ? <CalcPlaceholder /> : (ratioPercent !== null && ratioPercent !== undefined ? `${Number(ratioPercent).toFixed(2)} %` : '')}
           </span>
           <span className={`${COL.remove} shrink-0`} />
         </>
@@ -222,17 +253,18 @@ export function PdcTotalRow({
   total?: number | null;
   ratioPercent?: number | null;
 }) {
+  const isCalculating = useContext(IsCalculatingContext);
   return (
     <div className="grid grid-cols-12 gap-3 px-5 py-3 bg-gray-200/70 border-t border-gray-300 items-center">
       <div className="col-span-4 text-xs font-bold text-gray-900">{label}</div>
       <div className="col-span-8 flex items-center gap-2 ml-auto justify-end">
         <span className="min-w-[140px] text-right tabular-nums text-sm font-bold text-gray-900">
-          {fmt(total)}
+          {isCalculating ? <CalcPlaceholder wide /> : fmt(total)}
         </span>
         <span className="text-[11px] text-gray-600 whitespace-nowrap">Baht</span>
         {ratioPercent !== null && ratioPercent !== undefined && (
           <span className="min-w-[80px] text-right tabular-nums text-sm font-bold text-gray-900">
-            {`${Number(ratioPercent).toFixed(2)} %`}
+            {isCalculating ? <CalcPlaceholder /> : `${Number(ratioPercent).toFixed(2)} %`}
           </span>
         )}
       </div>
@@ -312,6 +344,7 @@ export function FvDerivedRow({
   emphasize?: boolean;
   tooltip?: string;
 }) {
+  const isCalculating = useContext(IsCalculatingContext);
   return (
     <div
       className={`flex items-center px-5 py-2.5 gap-2 ${
@@ -331,7 +364,7 @@ export function FvDerivedRow({
           emphasize ? 'text-sm font-bold text-primary' : 'text-xs font-medium text-gray-800'
         }`}
       >
-        {fmt(value)}
+        {isCalculating ? <CalcPlaceholder wide /> : fmt(value)}
       </span>
       {unit && (
         <span

--- a/src/features/pricingAnalysis/components/hypothesis/condominium/CondominiumSummaryTab.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/condominium/CondominiumSummaryTab.tsx
@@ -19,6 +19,7 @@ import {
   FvDerivedRow,
   FvInputRow,
   InlineNumberInput,
+  IsCalculatingProvider,
 } from '../_shared/summaryAtoms';
 import { HypothesisResidualWaterfall } from '../../viz/HypothesisResidualWaterfall';
 import { HypothesisCostDonut } from '../../viz/HypothesisCostDonut';
@@ -28,11 +29,13 @@ interface CondominiumSummaryTabProps {
   previewSummary?: CondominiumSummaryDto | null;
   /** System-derived land area from title deeds (Sq.Wa) — preferred over persisted input. */
   totalLandAreaFromTitles?: number | null;
+  isCalculating?: boolean;
 }
 
 export function CondominiumSummaryTab({
   previewSummary: s,
   totalLandAreaFromTitles,
+  isCalculating,
 }: CondominiumSummaryTabProps) {
   const { control } = useFormContext<CondominiumFormValues>();
   // E01 prefers the live title-sum; fall back to the snapshot's persisted value.
@@ -41,6 +44,7 @@ export function CondominiumSummaryTab({
     s?.areaSqM ?? (areaTitleDeedSqWa !== null ? Number(areaTitleDeedSqWa) * 4 : null);
 
   return (
+    <IsCalculatingProvider value={isCalculating ?? false}>
     <div className="space-y-5">
       {/* ── Visual residual story + cost composition ────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
@@ -467,6 +471,7 @@ export function CondominiumSummaryTab({
         />
       </SectionPrimary>
     </div>
+    </IsCalculatingProvider>
   );
 }
 

--- a/src/features/pricingAnalysis/components/hypothesis/condominium/CondominiumTabs.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/condominium/CondominiumTabs.tsx
@@ -123,6 +123,13 @@ export function CondominiumTabs({
   const watchedFields = watch(['summary']);
   const prevWatchKey = useRef<string | null>(null);
 
+  // Stable refs so the debounce timer survives re-renders:
+  //   runPreviewRef — always holds the latest runPreview without being a dep
+  //   debounceTimerRef — stores the timer id so a new re-render (different watchedFields
+  //     reference but same JSON value) can't cancel it via useEffect cleanup
+  const runPreviewRef = useRef<() => void>(() => {});
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const runPreview = useCallback(() => {
     const values = getValues();
     const request: PreviewHypothesisAnalysisRequest = {
@@ -164,20 +171,21 @@ export function CondominiumTabs({
       },
     );
   }, [pricingAnalysisId, methodId, previewMutation, getValues]);
+  runPreviewRef.current = runPreview;
 
   useEffect(() => {
     const key = JSON.stringify(watchedFields);
-    if (prevWatchKey.current === null) {
-      prevWatchKey.current = key;
-      return;
-    }
-    if (!isDirty) return;
+    if (prevWatchKey.current === null) { prevWatchKey.current = key; return; }
     if (key === prevWatchKey.current) return;
     prevWatchKey.current = key;
 
-    const timer = setTimeout(runPreview, 400);
-    return () => clearTimeout(timer);
-  }, [watchedFields, isDirty, runPreview]);
+    if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      runPreviewRef.current();
+    }, 400);
+  }, [watchedFields]);
+  useEffect(() => () => { if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current); }, []);
 
   // Single-shot init: reset the form from saved data, then immediately fire the
   // initial preview so Summary tab populates even when navigating in via React
@@ -243,9 +251,10 @@ export function CondominiumTabs({
     try {
       const result = await saveMutation.mutateAsync({ pricingAnalysisId, methodId, request });
       const finalValue = result.condominiumSummary?.totalAssetValueRounded ?? 0;
-      // Allow next savedData change to re-hydrate from server (picks up any server-side changes).
-      isInitialized.current = false;
-      reset(values);
+      reset(mapSavedToFormValues({
+        ...savedData,
+        condominiumSummary: result.condominiumSummary ?? savedData.condominiumSummary,
+      }));
       onSaveSuccess(finalValue);
     } catch {
       toast.error('Failed to save');
@@ -309,6 +318,7 @@ export function CondominiumTabs({
             <CondominiumSummaryTab
               previewSummary={effectiveSummary}
               totalLandAreaFromTitles={effectiveTotalLandAreaFromTitles}
+              isCalculating={previewMutation.isPending}
             />
           )}
         </div>

--- a/src/features/pricingAnalysis/components/hypothesis/landBuilding/LandBuildingSummaryTab.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/landBuilding/LandBuildingSummaryTab.tsx
@@ -24,6 +24,7 @@ import {
   FvDerivedRow,
   FvInputRow,
   InlineNumberInput,
+  IsCalculatingProvider,
 } from '../_shared/summaryAtoms';
 import { HypothesisResidualWaterfall } from '../../viz/HypothesisResidualWaterfall';
 import { HypothesisCostDonut } from '../../viz/HypothesisCostDonut';
@@ -36,6 +37,7 @@ interface LandBuildingSummaryTabProps {
   totalLandAreaFromTitles?: number | null;
   /** Server snapshot of cost items — used to read computed categoryRatio for user-added rows. */
   costItems?: CostItemDto[] | null;
+  isCalculating?: boolean;
 }
 
 export function LandBuildingSummaryTab({
@@ -43,6 +45,7 @@ export function LandBuildingSummaryTab({
   models,
   totalLandAreaFromTitles,
   costItems,
+  isCalculating,
 }: LandBuildingSummaryTabProps) {
   const { control } = useFormContext<LandBuildingFormValues>();
   const modelList = models ? Object.values(models) : [];
@@ -105,6 +108,7 @@ export function LandBuildingSummaryTab({
   const totalArea = totalLandAreaFromTitles ?? s?.totalArea ?? null;
 
   return (
+    <IsCalculatingProvider value={isCalculating ?? false}>
     <div className="space-y-5">
       {/* ── Visual residual story + cost composition ────────────────────── */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
@@ -481,6 +485,7 @@ export function LandBuildingSummaryTab({
       </SectionPrimary>
 
     </div>
+    </IsCalculatingProvider>
   );
 }
 

--- a/src/features/pricingAnalysis/components/hypothesis/landBuilding/LandBuildingTabs.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/landBuilding/LandBuildingTabs.tsx
@@ -252,6 +252,13 @@ export function LandBuildingTabs({
   const watchedFields = watch(['summary', 'costOfBuildingItems', 'otherCostItems']);
   const prevWatchKey = useRef<string | null>(null);
 
+  // Stable refs so the debounce timer survives re-renders:
+  //   runPreviewRef — always holds the latest runPreview without being a dep
+  //   debounceTimerRef — stores the timer id so a new re-render (different watchedFields
+  //     reference but same JSON value) can't cancel it via useEffect cleanup
+  const runPreviewRef = useRef<() => void>(() => {});
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const runPreview = useCallback(() => {
     const values = getValues();
     const request: PreviewHypothesisAnalysisRequest = {
@@ -327,21 +334,22 @@ export function LandBuildingTabs({
       },
     );
   }, [pricingAnalysisId, methodId, previewMutation, getValues]);
+  runPreviewRef.current = runPreview;
 
   // Watch inputs and debounce preview calls
   useEffect(() => {
     const key = JSON.stringify(watchedFields);
-    if (prevWatchKey.current === null) {
-      prevWatchKey.current = key;
-      return;
-    }
-    if (!isDirty) return;
+    if (prevWatchKey.current === null) { prevWatchKey.current = key; return; }
     if (key === prevWatchKey.current) return;
     prevWatchKey.current = key;
 
-    const timer = setTimeout(runPreview, 400);
-    return () => clearTimeout(timer);
-  }, [watchedFields, isDirty, runPreview]);
+    if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      runPreviewRef.current();
+    }, 400);
+  }, [watchedFields]);
+  useEffect(() => () => { if (debounceTimerRef.current !== null) clearTimeout(debounceTimerRef.current); }, []);
 
   // Single-shot init: reset the form from saved data, then immediately fire the
   // initial preview so per-model aggregates (Cost of Building, Summary tab) populate
@@ -451,9 +459,10 @@ export function LandBuildingTabs({
     try {
       const result = await saveMutation.mutateAsync({ pricingAnalysisId, methodId, request });
       const finalValue = result.landBuildingSummary?.totalAssetValueRounded ?? 0;
-      // Allow next savedData change to re-hydrate — picks up server-assigned ids for new rows.
-      isInitialized.current = false;
-      reset(values); // clear dirty state immediately so UI shows "saved"
+      reset(mapSavedToFormValues({
+        ...savedData,
+        landBuildingSummary: result.landBuildingSummary ?? savedData.landBuildingSummary,
+      }));
       onSaveSuccess(finalValue);
     } catch {
       toast.error('Failed to save');
@@ -530,6 +539,7 @@ export function LandBuildingTabs({
               models={effectiveModels}
               totalLandAreaFromTitles={effectiveTotalLandAreaFromTitles}
               costItems={previewCostItems ?? savedData.costItems}
+              isCalculating={previewMutation.isPending}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

- **Stale values after save** — After saving, `reset(values)` was resetting the form with the user's submitted data while simultaneously setting `isInitialized.current = false`. React Query's `invalidateQueries` would immediately return stale cache data, re-triggering the init effect and overwriting the form with old values. Fixed by resetting from the server response merged with `savedData` and keeping `isInitialized = true`.

- **Loading indicator on all computed fields** — Added `IsCalculatingProvider` context wrapping both summary tabs. All derived-value atoms (`DerivedValue`, `PdcDerivedRow`, `PdcTotalRow`, `FvDerivedRow`) read from this context and show an animated grey pulse placeholder while `previewMutation.isPending` is true.

- **Preview not firing reliably** — Two compounding bugs: (1) `isDirty` gate prevented preview after reverting a field to its saved value; (2) `runPreview` was a dependency of the debounce `useEffect`, so when a previous preview completed (`previewMutation` state change → `runPreview` recreated → effect cleanup ran → timer cancelled). Also, `watch()` returns a new array reference on every render, meaning any re-render during the 400ms window would cancel the timer. Fixed by storing the timer in a `debounceTimerRef` (survives re-renders) and accessing `runPreview` via a stable ref (not a dep).

## Test plan

- [ ] Change a field value and confirm preview fires (pulse shown → values update)
- [ ] Change a field rapidly multiple times — confirm preview fires once after settling
- [ ] Change a field while a previous preview is still in-flight — confirm new preview fires correctly
- [ ] Save, then immediately edit a field — confirm preview fires (no stale values)
- [ ] Save — confirm form shows server values immediately, no flash to old values on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)