### PR TITLE
feat: bundle appraisal fee, WQS overrides, and workflow edge updates

### DIFF
--- a/src/features/appraisal/api/decisionSummary.ts
+++ b/src/features/appraisal/api/decisionSummary.ts
@@ -40,14 +40,28 @@ export interface BlockModelPriceRow {
   buildingInsurance: number;
 }
 
+export interface ConstructionSummaryRow {
+  label: string;
+  constructionProgressPct: number;
+  totalAppraisalValue: number;
+  totalLandValue: number;
+  totalBuildingValue: number;
+  buildingValueConstructing: number;
+}
+
+export interface ConstructionSummary {
+  rows: ConstructionSummaryRow[];
+}
+
 /**
  * Augments the auto-generated `GetDecisionSummaryResponse` with block-appraisal
- * fields that v1.ts has not yet picked up.
+ * and construction-summary fields that v1.ts has not yet picked up.
  */
 export type DecisionSummaryData = GetDecisionSummaryResponse & {
   isBlock: boolean;
   blockApproachMatrix: BlockApproachMatrixRow[] | null;
   blockModelPrices: BlockModelPriceRow[] | null;
+  constructionSummary: ConstructionSummary | null;
 };
 
 /**

--- a/src/features/appraisal/api/fee.ts
+++ b/src/features/appraisal/api/fee.ts
@@ -78,6 +78,36 @@ export const useUpdateAppraisalFee = () => {
 };
 
 /**
+ * Update the Construction Inspection Fee on a fee record.
+ * PATCH /appraisals/{appraisalId}/fees/{feeId}/construction-inspection-fee
+ */
+export const useUpdateConstructionInspectionFee = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      appraisalId,
+      feeId,
+      amount,
+    }: {
+      appraisalId: string;
+      feeId: string;
+      amount: number | null;
+    }): Promise<void> => {
+      await axios.patch(
+        `/appraisals/${appraisalId}/fees/${feeId}/construction-inspection-fee`,
+        { amount },
+      );
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['appraisal', variables.appraisalId, 'fees'],
+      });
+    },
+  });
+};
+
+/**
  * Approve a fee item
  * PATCH /appraisals/{appraisalId}/fees/{feeId}/items/{itemId}/approve
  */

--- a/src/features/appraisal/components/FeeInformationSection.tsx
+++ b/src/features/appraisal/components/FeeInformationSection.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import Icon from '@shared/components/Icon';
 import Dropdown from '@shared/components/inputs/Dropdown';
+import NumberInput from '@shared/components/inputs/NumberInput';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import type { FeeItem } from '../types/appointmentAndFee';
 import { FEE_ITEM_TYPE_OPTIONS, VAT_PERCENTAGE } from '../types/appointmentAndFee';
@@ -28,6 +29,16 @@ interface FeeInformationSectionProps {
   onApproveFeeItem?: (feeId: string, itemId: string) => void;
   onRejectFeeItem?: (feeId: string, itemId: string, reason: string) => void;
   isFeePaymentTypeUpdating?: boolean;
+
+  /**
+   * Show the Construction Inspection Fee input. Driven by the backend's
+   * AppraisalFeeDto.hasBuildingUnderConstruction flag (true when at least one
+   * Building or Land+Building property has IsUnderConstruction=true).
+   */
+  showConstructionInspectionFee?: boolean;
+  constructionInspectionFeeAmount?: number | null;
+  onUpdateConstructionInspectionFee?: (amount: number | null) => Promise<void>;
+  isConstructionInspectionFeeUpdating?: boolean;
 }
 
 /**
@@ -44,11 +55,35 @@ export default function FeeInformationSection({
   onApproveFeeItem,
   onRejectFeeItem,
   isFeePaymentTypeUpdating,
+  showConstructionInspectionFee = false,
+  constructionInspectionFeeAmount = null,
+  onUpdateConstructionInspectionFee,
+  isConstructionInspectionFeeUpdating,
 }: FeeInformationSectionProps) {
   const readOnly = usePageReadOnly();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [editingFee, setEditingFee] = useState<{ index: number; data: FeeItem } | null>(null);
   const [deletingFeeIndex, setDeletingFeeIndex] = useState<number | null>(null);
+
+  // Local-buffered editor for the CI fee. Hydrate from server, commit on blur to avoid
+  // a server round-trip per keystroke. Resync whenever the server value changes
+  // (e.g. another tab edits or the fees query refetches).
+  const [ciFeeDraft, setCiFeeDraft] = useState<number | null>(constructionInspectionFeeAmount);
+  useEffect(() => {
+    setCiFeeDraft(constructionInspectionFeeAmount);
+  }, [constructionInspectionFeeAmount]);
+
+  const handleCiFeeBlur = async () => {
+    if (!onUpdateConstructionInspectionFee) return;
+    if (ciFeeDraft === constructionInspectionFeeAmount) return;
+    try {
+      await onUpdateConstructionInspectionFee(ciFeeDraft);
+      toast.success('Construction inspection fee saved');
+    } catch (error: any) {
+      toast.error(error?.apiError?.detail || 'Failed to save construction inspection fee.');
+      setCiFeeDraft(constructionInspectionFeeAmount); // rollback
+    }
+  };
 
   // Calculate totals from API items
   const subtotal = items.reduce((sum, item) => sum + (item.feeAmount || 0), 0);
@@ -378,6 +413,27 @@ export default function FeeInformationSection({
           <span className="hidden md:block" />
         </div>
       </div>
+
+      {/* Construction Inspection Fee — only visible when at least one building property is under construction */}
+      {showConstructionInspectionFee && (
+        <div className="border border-amber-200 bg-amber-50/40 rounded-lg p-4">
+          <NumberInput
+            name="constructionInspectionFee"
+            label="Construction Inspection Fee"
+            decimalPlaces={2}
+            min={0}
+            value={ciFeeDraft}
+            onChange={e => setCiFeeDraft(e.target.value)}
+            onBlur={handleCiFeeBlur}
+            disabled={readOnly || isConstructionInspectionFeeUpdating}
+            placeholder="0.00"
+          />
+          <p className="mt-2 text-xs text-gray-500">
+            This fee is reused as the appraisal fee on the next Construction Inspection
+            application for this collateral.
+          </p>
+        </div>
+      )}
 
       {/* Add/Edit Fee Modal */}
       <AddFeeModal

--- a/src/features/appraisal/components/PaymentInformationSection.tsx
+++ b/src/features/appraisal/components/PaymentInformationSection.tsx
@@ -43,8 +43,6 @@ export default function PaymentInformationSection({
   const [isAddPaymentModalOpen, setIsAddPaymentModalOpen] = useState(false);
   const [editingPaymentId, setEditingPaymentId] = useState<string | null>(null);
   const [deletingPaymentId, setDeletingPaymentId] = useState<string | null>(null);
-  const [inspectionFee, setInspectionFee] = useState<number>(fee?.inspectionFeeAmount ?? 0);
-
   const bankAbsorbAmount = fee?.bankAbsorbAmount ?? 0;
   const payments = fee?.paymentHistory ?? [];
 
@@ -360,18 +358,6 @@ export default function PaymentInformationSection({
           </div>
         </div>
       </div>
-
-      {/* Inspection Fee Input */}
-      {/*<NumberInput*/}
-      {/*  label="Inspection Fee"*/}
-      {/*  required*/}
-      {/*  decimalPlaces={2}*/}
-      {/*  value={fee?.inspectionFeeAmount ?? inspectionFee}*/}
-      {/*  onChange={e => {*/}
-      {/*    const value = e.target.value ?? 0;*/}
-      {/*    setInspectionFee(value);*/}
-      {/*  }}*/}
-      {/*/>*/}
 
       {/* Add / Edit Payment Modal */}
       <AddPaymentModal

--- a/src/features/appraisal/components/construction/ConstructionDetailTable.tsx
+++ b/src/features/appraisal/components/construction/ConstructionDetailTable.tsx
@@ -26,6 +26,7 @@ interface CategorySubtotal {
   constructionWorkGroupId: string;
   totalConstructionValue: number;
   totalProportion: number;
+  totalCurrentProportion: number;
   averagePreviousProgress: number;
   averageCurrentProgress: number;
   totalPreviousPropertyValue: number;
@@ -40,6 +41,9 @@ interface ConstructionDetailTableProps {
   grandTotal: {
     totalConstructionValue: number;
     totalProportion: number;
+    totalCurrentProportion: number;
+    weightedPreviousProgress: number;
+    weightedCurrentProgress: number;
     totalPreviousPropertyValue: number;
     totalCurrentPropertyValue: number;
   };
@@ -235,9 +239,15 @@ export function ConstructionDetailTable({
               {formatNumber(grandTotal.totalProportion, 2)}
               {isOverLimit && ' !'}
             </td>
-            <td className="text-right px-3 py-2.5" />
-            <td className="text-right px-3 py-2.5" />
-            <td className="text-right px-3 py-2.5" />
+            <td className="text-right px-3 py-2.5 tabular-nums">
+              {formatNumber(grandTotal.weightedPreviousProgress, 2)} %
+            </td>
+            <td className="text-right px-3 py-2.5 tabular-nums">
+              {formatNumber(grandTotal.weightedCurrentProgress, 2)} %
+            </td>
+            <td className="text-right px-3 py-2.5 tabular-nums">
+              {formatNumber(grandTotal.totalCurrentProportion, 2)}
+            </td>
             <td className="text-right px-3 py-2.5 tabular-nums">
               {formatNumber(grandTotal.totalPreviousPropertyValue, 2)}
             </td>
@@ -386,7 +396,9 @@ function CategorySection({
           <td className="text-right px-3 py-2 tabular-nums">
             {formatNumber(subtotal.averageCurrentProgress, 2)} %
           </td>
-          <td className="text-right px-3 py-2" />
+          <td className="text-right px-3 py-2 tabular-nums">
+            {formatNumber(subtotal.totalCurrentProportion, 2)}
+          </td>
           <td className="text-right px-3 py-2 tabular-nums">
             {formatNumber(subtotal.totalPreviousPropertyValue, 2)}
           </td>

--- a/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
+++ b/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
@@ -1,0 +1,57 @@
+import { formatNumber } from '@/shared/utils/formatUtils';
+import type { ConstructionSummaryRow } from '../../api/decisionSummary';
+
+interface Props {
+  rows: ConstructionSummaryRow[];
+}
+
+const ConstructionSummaryTable = ({ rows }: Props) => (
+  <div className="overflow-x-auto">
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="bg-[#5f9ea0] text-white">
+          <th className="px-4 py-3 text-left font-medium w-44" />
+          <th className="px-4 py-3 text-center font-medium">Construction<br />Progress (%)</th>
+          <th className="px-4 py-3 text-center font-medium">Total Appraisal Value</th>
+          <th className="px-4 py-3 text-center font-medium">Total Land Value</th>
+          <th className="px-4 py-3 text-center font-medium">Total Building Value</th>
+          <th className="px-4 py-3 text-center font-medium">Building Value<br />Constructing</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const isCurrent = row.label === 'Current';
+          return (
+            <tr
+              key={row.label}
+              className={
+                isCurrent
+                  ? 'bg-gray-100 font-semibold border-b border-gray-200'
+                  : 'border-b border-gray-100'
+              }
+            >
+              <td className="px-4 py-3 text-gray-700">{row.label}</td>
+              <td className="px-4 py-3 text-right text-gray-700">
+                {formatNumber(row.constructionProgressPct, 2)}&nbsp;%
+              </td>
+              <td className="px-4 py-3 text-right text-gray-700">
+                {formatNumber(row.totalAppraisalValue, 2)}
+              </td>
+              <td className="px-4 py-3 text-right text-gray-700">
+                {formatNumber(row.totalLandValue, 2)}
+              </td>
+              <td className="px-4 py-3 text-right text-gray-700">
+                {formatNumber(row.totalBuildingValue, 2)}
+              </td>
+              <td className="px-4 py-3 text-right text-gray-700">
+                {formatNumber(row.buildingValueConstructing, 2)}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default ConstructionSummaryTable;

--- a/src/features/appraisal/components/tabs/ConstructionInspectionTab.tsx
+++ b/src/features/appraisal/components/tabs/ConstructionInspectionTab.tsx
@@ -113,6 +113,7 @@ export function ConstructionInspectionTab({ readOnly, ciMode }: ConstructionInsp
           constructionWorkGroupId: gId,
           totalConstructionValue: items.reduce((s: number, i: any) => s + i.constructionValue, 0),
           totalProportion: items.reduce((s: number, i: any) => s + i.proportionPct, 0),
+          totalCurrentProportion: items.reduce((s: number, i: any) => s + (Number(i.currentProportionPct) || 0), 0),
           averagePreviousProgress: items.reduce((s: number, i: any) => s + (Number(i.previousProgressPct) || 0), 0) / items.length,
           averageCurrentProgress: items.reduce((s: number, i: any) => s + (Number(i.currentProgressPct) || 0), 0) / items.length,
           totalPreviousPropertyValue: items.reduce((s: number, i: any) => s + i.previousPropertyValue, 0),
@@ -122,12 +123,20 @@ export function ConstructionInspectionTab({ readOnly, ciMode }: ConstructionInsp
       .filter(Boolean) as any[];
   }, [computedSubItems, workGroups]);
 
-  const grandTotal = useMemo(() => ({
-    totalConstructionValue: computedSubItems.reduce((s: number, i: any) => s + i.constructionValue, 0),
-    totalProportion: computedSubItems.reduce((s: number, i: any) => s + i.proportionPct, 0),
-    totalPreviousPropertyValue: computedSubItems.reduce((s: number, i: any) => s + i.previousPropertyValue, 0),
-    totalCurrentPropertyValue: computedSubItems.reduce((s: number, i: any) => s + i.currentPropertyValue, 0),
-  }), [computedSubItems]);
+  const grandTotal = useMemo(() => {
+    const totalConstructionValue = computedSubItems.reduce((s: number, i: any) => s + i.constructionValue, 0);
+    const totalPreviousPropertyValue = computedSubItems.reduce((s: number, i: any) => s + i.previousPropertyValue, 0);
+    const totalCurrentPropertyValue = computedSubItems.reduce((s: number, i: any) => s + i.currentPropertyValue, 0);
+    return {
+      totalConstructionValue,
+      totalProportion: computedSubItems.reduce((s: number, i: any) => s + i.proportionPct, 0),
+      totalCurrentProportion: computedSubItems.reduce((s: number, i: any) => s + (Number(i.currentProportionPct) || 0), 0),
+      weightedPreviousProgress: totalConstructionValue > 0 ? (totalPreviousPropertyValue / totalConstructionValue) * 100 : 0,
+      weightedCurrentProgress: totalConstructionValue > 0 ? (totalCurrentPropertyValue / totalConstructionValue) * 100 : 0,
+      totalPreviousPropertyValue,
+      totalCurrentPropertyValue,
+    };
+  }, [computedSubItems]);
 
   const summaryCurrentValue = useMemo(
     () => totalValue * ((summary?.summaryCurrentProgressPct ?? 0) / 100),

--- a/src/features/appraisal/pages/AppointmentAndFeePage.tsx
+++ b/src/features/appraisal/pages/AppointmentAndFeePage.tsx
@@ -24,6 +24,7 @@ import {
   useRemoveFeeItem,
   useRemovePayment,
   useUpdateAppraisalFee,
+  useUpdateConstructionInspectionFee,
   useUpdateFeeItem,
   useUpdatePayment,
 } from '../api/fee';
@@ -57,6 +58,7 @@ export default function AppointmentAndFeePage() {
   const approveFeeItem = useApproveFeeItem();
   const rejectFeeItem = useRejectFeeItem();
   const updateAppraisalFee = useUpdateAppraisalFee();
+  const updateConstructionInspectionFee = useUpdateConstructionInspectionFee();
 
   const isNewAppointment = !appointment;
 
@@ -245,6 +247,15 @@ export default function AppointmentAndFeePage() {
     }
   };
 
+  const handleUpdateConstructionInspectionFee = async (amount: number | null) => {
+    if (!currentFee) return;
+    await updateConstructionInspectionFee.mutateAsync({
+      appraisalId,
+      feeId: currentFee.id!,
+      amount,
+    });
+  };
+
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Main Content - Scrollable */}
@@ -274,6 +285,14 @@ export default function AppointmentAndFeePage() {
               onApproveFeeItem={handleApproveFeeItem}
               onRejectFeeItem={handleRejectFeeItem}
               isFeePaymentTypeUpdating={updateAppraisalFee.isPending}
+              showConstructionInspectionFee={
+                currentFee?.hasBuildingUnderConstruction ?? false
+              }
+              constructionInspectionFeeAmount={
+                currentFee?.constructionInspectionFeeAmount ?? null
+              }
+              onUpdateConstructionInspectionFee={handleUpdateConstructionInspectionFee}
+              isConstructionInspectionFeeUpdating={updateConstructionInspectionFee.isPending}
             />
 
             {/* Payment Information (Right Column) */}

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -30,6 +30,7 @@ import BlockPriceSummaryTable from '../components/summary/BlockPriceSummaryTable
 import GovernmentPriceTable from '../components/summary/GovernmentPriceTable';
 import ApprovalListSection from '../components/summary/ApprovalListSection';
 import DecisionSection from '../components/summary/DecisionSection';
+import ConstructionSummaryTable from '../components/summary/ConstructionSummaryTable';
 
 // ==================== Field Definitions ====================
 
@@ -150,6 +151,7 @@ const additionalAssumptionsFields: FormField[] = [
 type SectionKey =
   | 'decisionApproach'
   | 'priceSummary'
+  | 'constructionSummary'
   | 'priceVerification'
   | 'governmentPrice'
   | 'condition'
@@ -171,13 +173,13 @@ const ACTIVITY_SECTION_CONFIG: Record<string, ActivitySectionConfig> = {
   'appraisal-initiation':       { sections: [] },
   'appraisal-assignment':        { sections: [] },
   'ext-appraisal-assignment':    { sections: [] },
-  'ext-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'] },
-  'ext-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
-  'ext-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
-  'appraisal-book-verification': { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true, editableSections: ['priceVerification', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'] },
-  'int-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'additionalAssumptions'] },
-  'int-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true },
-  'int-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true },
+  'ext-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'] },
+  'ext-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
+  'ext-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'governmentPrice', 'appraiserOpinion', 'additionalAssumptions'], readOnly: true },
+  'appraisal-book-verification': { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true, editableSections: ['priceVerification', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'] },
+  'int-appraisal-execution':     { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'additionalAssumptions'] },
+  'int-appraisal-check':         { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true },
+  'int-appraisal-verification':  { sections: ['decisionApproach', 'priceSummary', 'constructionSummary', 'priceVerification', 'governmentPrice', 'condition', 'remark', 'appraiserOpinion', 'committeeOpinion', 'reviewPrices', 'additionalAssumptions'], readOnly: true },
   'pending-approval':            { sections: ['committeeApproval'] },
 };
 
@@ -521,6 +523,13 @@ const DecisionSummaryPage = () => {
                           : <EmptyLine text="No government price data available." />}
                       </InlineSubSection>
                     )}
+                </GroupCard>
+              )}
+
+              {/* Construction Summary — standalone, shown only when CI data exists */}
+              {showSection('constructionSummary') && data?.constructionSummary && (
+                <GroupCard icon="helmet-safety" iconColor="teal" title="Construction Summary">
+                  <ConstructionSummaryTable rows={data.constructionSummary.rows} />
                 </GroupCard>
               )}
 

--- a/src/features/appraisal/schemas/appointmentAndFee.ts
+++ b/src/features/appraisal/schemas/appointmentAndFee.ts
@@ -34,7 +34,10 @@ export const FeeSchema = z.object({
   feeType: z.string().min(1, 'Fee type is required').nullable(),
   items: z.array(FeeItemSchema),
   bankAbsorbAmount: z.number().min(0, 'Bank absorb amount must be non-negative'),
-  inspectionFee: z.number().min(0, 'Inspection fee must be non-negative').nullable(),
+  constructionInspectionFee: z
+    .number()
+    .min(0, 'Construction inspection fee must be non-negative')
+    .nullable(),
 });
 
 /**
@@ -58,7 +61,7 @@ export const appointmentAndFeeFormDefaults = {
     feeType: null,
     items: [],
     bankAbsorbAmount: 0,
-    inspectionFee: null,
+    constructionInspectionFee: null,
   },
   payments: [],
 };

--- a/src/features/appraisal/types/appointmentAndFee.ts
+++ b/src/features/appraisal/types/appointmentAndFee.ts
@@ -40,7 +40,7 @@ export interface FeeData {
   feeType: string | null;
   items: FeeItem[];
   bankAbsorbAmount: number;
-  inspectionFee: number | null;
+  constructionInspectionFee: number | null;
 }
 
 /**

--- a/src/features/appraisal/types/construction.ts
+++ b/src/features/appraisal/types/construction.ts
@@ -21,6 +21,7 @@ export interface CategorySubtotal {
   constructionWorkGroupId: string;
   totalConstructionValue: number;
   totalProportion: number;
+  totalCurrentProportion: number;
   averagePreviousProgress: number;
   averageCurrentProgress: number;
   totalPreviousPropertyValue: number;

--- a/src/features/pricingAnalysis/adapters/buildWQSDerivedRules.ts
+++ b/src/features/pricingAnalysis/adapters/buildWQSDerivedRules.ts
@@ -4,7 +4,6 @@ import {
   calcAdjustedValueFromSellingPrice,
   calcSum,
   calcWeightedScore,
-  floorToTenThousands,
   floorToThousands,
   round2,
   toFiniteNumber,
@@ -14,7 +13,6 @@ import { forecast } from '../domain/forecast';
 import { INTERCEPT, RSQ, SLOPE, STEYX } from '../domain/regression';
 import { wqsFieldPath } from './wqsFieldPath';
 import type { DerivedFieldRule } from '@features/pricingAnalysis/adapters/useDerivedFieldArray.tsx';
-import { shouldAutoDefault } from '@features/pricingAnalysis/domain/shouldAutoDefault.ts';
 import type { WQSScore } from '../types/wqs';
 
 export function buildWQSScoringSurveyDerivedRules(args: {
@@ -340,19 +338,19 @@ export function buildWQSFinalValueDerivedRules(args: {
       },
     },
     {
+      // System-calculated: always floor(finalValue). Never overridden by user.
       targetPath: finalValueFinalValueRoundedPath(),
       deps: [finalValueFinalValuePath()],
-      when: ({ getValues, getFieldState, formState }) => {
-        const target = finalValueFinalValueRoundedPath();
-        const curr = getValues(target) ?? 0;
-        const { isDirty } = getFieldState(target, formState);
-        return shouldAutoDefault({ value: curr, isDirty });
-      },
       compute: ({ getValues }) => {
         const finalValue = getValues(finalValueFinalValuePath()) ?? 0;
         return floorToThousands(finalValue);
       },
     },
+    // NOTE: the finalValueAdjusted seed rule lives in WQSAdjustFinalValueSection.tsx
+    // alongside the other ref-guarded user-seed rules (landValue, appraisalPrice).
+    // Co-locating them lets all three use the same "did upstream actually change"
+    // pattern via React refs, which is required to prevent reset(value) and rule
+    // array re-creation from clobbering the user's saved override.
     {
       targetPath: finalValueCoefficientOfDecisionPath(),
       deps: [

--- a/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
+++ b/src/features/pricingAnalysis/adapters/initializeWQSForm.ts
@@ -28,17 +28,17 @@ function buildCalculations(comparativeSurveys: MarketComparableDetailType[]): WQ
     const surveyMap = new Map(
       (survey.factorData ?? []).map((s: FactorDataType) => [
         s.factorCode,
-        readFactorValue({ dataType: s.dataType, value: s.value, fieldDecimal: s.fieldDecimal }),
-      ]),
+        readFactorValue({ dataType: s.dataType as string, value: s.value, fieldDecimal: s.fieldDecimal }),
+      ] as [string, string | undefined]),
     );
     return {
       marketId: survey.id ?? '',
       offeringPrice: survey.offerPrice ?? 0,
-      offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
+      offeringPriceMeasurementUnit: survey.offerPriceUnit ?? (surveyMap.get('20') as string) ?? '',
       offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
       offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: survey.salePrice ?? 0,
-      sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
+      sellingPriceMeasurementUnit: survey.salePriceUnit ?? (surveyMap.get('20') as string) ?? '',
       sellingPriceAdjustmentYear: toNum(surveyMap.get('23'), 3),
       numberOfYears: yearDiffFromToday(survey.saleDate),
     } as WQSCalculation;
@@ -61,8 +61,9 @@ function buildFinalValue(property: Record<string, unknown>) {
     slope: 0,
     lowestEstimate: 0,
     highestEstimate: 0,
-    appraisalPriceRounded: 0,
-    priceDifferentiate: 0,
+    landValue: 0,
+    buildingCost: 0,
+    appraisalPrice: 0,
   };
 }
 
@@ -133,8 +134,8 @@ export function initializeWQSForm({
     WQSScores: template.calculationFactors?.map(calFact => ({
       factorId: factorIdMap.get(calFact.factorCode) ?? '',
       factorCode: calFact.factorCode,
-      weight: calFact.weight,
-      intensity: calFact.intensity,
+      weight: calFact.weight ?? undefined,
+      intensity: calFact.intensity ?? undefined,
       surveys: surveyEntries,
       collateral: 0,
     })),

--- a/src/features/pricingAnalysis/adapters/restoreWQSFromSavedData.ts
+++ b/src/features/pricingAnalysis/adapters/restoreWQSFromSavedData.ts
@@ -121,13 +121,13 @@ export function restoreWQSFromSavedData({
       marketId: survey.id ?? '',
       offeringPrice: saved?.offeringPrice ?? survey.offerPrice ?? 0,
       offeringPriceMeasurementUnit:
-        saved?.offeringPriceUnit ?? (surveyMap.get('20') as string) ?? '',
+        saved?.offeringPriceUnit ?? survey.offerPriceUnit ?? (surveyMap.get('20') as string) ?? '',
       offeringPriceAdjustmentPct:
         saved?.adjustOfferPricePct ?? survey.offerPriceAdjustmentPercent ?? 0,
       offeringPriceAdjustmentAmt:
         saved?.adjustOfferPriceAmt ?? survey.offerPriceAdjustmentAmount ?? 0,
       sellingPrice: saved?.sellingPrice ?? survey.salePrice ?? 0,
-      sellingPriceMeasurementUnit: (surveyMap.get('20') as string) ?? '',
+      sellingPriceMeasurementUnit: survey.salePriceUnit ?? (surveyMap.get('20') as string) ?? '',
       sellingPriceAdjustmentYear: saved?.adjustedPeriodPct ?? toNum(surveyMap.get('23'), 3),
       numberOfYears: saved?.buySellYear ?? yearDiffFromToday(survey.saleDate),
       totalAdjustedSellingPrice: saved?.cumulativeAdjPeriod ?? 0,
@@ -177,8 +177,9 @@ export function restoreWQSFromSavedData({
         slope: 0,
         lowestEstimate: 0,
         highestEstimate: 0,
-        appraisalPriceRounded: 0,
-        priceDifferentiate: 0,
+        landValue: 0,
+        buildingCost: 0,
+        appraisalPrice: 0,
       },
       generateAt: new Date().toISOString(),
     },

--- a/src/features/pricingAnalysis/adapters/syncWQSFormSurveys.ts
+++ b/src/features/pricingAnalysis/adapters/syncWQSFormSurveys.ts
@@ -85,11 +85,11 @@ export function syncWQSFormSurveys({
           return {
             marketId: survey.id.toString(),
             offeringPrice: survey.offerPrice ?? 0,
-            offeringPriceMeasurementUnit: surveyMap.get('20') ?? '',
+            offeringPriceMeasurementUnit: survey.offerPriceUnit ?? (surveyMap.get('20') as string) ?? '',
             offeringPriceAdjustmentPct: survey.offerPriceAdjustmentPercent ?? 5,
             offeringPriceAdjustmentAmt: survey.offerPriceAdjustmentAmount ?? 0,
             sellingPrice: survey.salePrice ?? 0,
-            sellingPriceMeasurementUnit: surveyMap.get('20') ?? '',
+            sellingPriceMeasurementUnit: survey.salePriceUnit ?? (surveyMap.get('20') as string) ?? '',
             sellingPriceAdjustmentYear: toNum(surveyMap.get('23'), 3),
             numberOfYears: yearDiffFromToday(survey.saleDate),
           };

--- a/src/features/pricingAnalysis/adapters/wqsFieldPath.ts
+++ b/src/features/pricingAnalysis/adapters/wqsFieldPath.ts
@@ -59,6 +59,7 @@ export const wqsFieldPath = {
   /** final value section */
   finalValueFinalValue: () => `WQSFinalValue.finalValue`,
   finalValueFinalValueRounded: () => `WQSFinalValue.finalValueRounded`,
+  finalValueFinalValueAdjusted: () => `WQSFinalValue.finalValueAdjusted`,
   finalValueCoefficientOfDecision: () => `WQSFinalValue.coefficientOfDecision`,
   finalValueStandardError: () => `WQSFinalValue.standardError`,
   finalValueIntersectionPoint: () => `WQSFinalValue.intersectionPoint`,
@@ -69,14 +70,7 @@ export const wqsFieldPath = {
   finalValueIncludeLandArea: () => `WQSFinalValue.includeLandArea`,
   finalValueLandArea: () => `WQSFinalValue.landArea`,
   finalValueUsableArea: () => `WQSFinalValue.usableArea`,
+  finalValueLandValue: () => `WQSFinalValue.landValue`,
+  finalValueBuildingCost: () => `WQSFinalValue.buildingCost`,
   finalValueAppraisalPrice: () => `WQSFinalValue.appraisalPrice`,
-  finalValueAppraisalPriceRounded: () => `WQSFinalValue.appraisalPriceRounded`,
-  finalValuePriceDifferentiate: () => `WQSFinalValue.priceDifferentiate`,
-  finalValueTotalBuildingCost: () => `WQSFinalValue.totalBuildingCost`,
-  finalValueAppraisalPriceIncludeBuildingCost: () =>
-    `WQSFinalValue.appraisalPriceIncludeBuildingCost`,
-  finalValueAppraisalPriceIncludeBuildingCostRounded: () =>
-    `WQSFinalValue.appraisalPriceIncludeBuildingCostRounded`,
-  finalValuePriceIncludeBuildingCostDifferentiate: () =>
-    `WQSFinalValue.priceIncludeBuildingCostDifferentiate`,
 };

--- a/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
@@ -57,7 +57,8 @@ export function MethodSectionRenderer({
     savedCalculations: calculationMethodData.comparativeFactors?.calculations,
     savedComparativeAnalysisTemplateId:
       calculationMethodData.comparativeFactors?.comparativeAnalysisTemplateId,
-    savedMethodValue: calculationMethodData.comparativeFactors?.methodValue ?? null,
+    savedFinalValueAdjusted: (calculationMethodData.comparativeFactors as any)?.finalValue?.finalValueAdjusted ?? null,
+    savedLandValue: (calculationMethodData.comparativeFactors as any)?.finalValue?.landValue ?? null,
     onCalculationSave,
     onCalculationMethodDirty,
     onCancelCalculationMethod,
@@ -65,7 +66,15 @@ export function MethodSectionRenderer({
 
   switch (state.activeMethod?.methodType) {
     case 'WQS_MARKET':
-      return <WQSPanel {...panelProps} />;
+      return (
+        <WQSPanel
+          {...panelProps}
+          savedBuildingCost={(calculationMethodData.comparativeFactors as any)?.finalValue?.buildingCost ?? null}
+          savedAppraisalPrice={(calculationMethodData.comparativeFactors as any)?.finalValue?.appraisalPrice ?? null}
+          savedHasBuildingCost={(calculationMethodData.comparativeFactors as any)?.finalValue?.hasBuildingCost ?? null}
+          savedIncludeLandArea={(calculationMethodData.comparativeFactors as any)?.finalValue?.includeLandArea ?? null}
+        />
+      );
     case 'SAG_MARKET':
       return <SaleAdjustmentGridPanel {...panelProps} />;
     case 'DC_MARKET':
@@ -75,7 +84,15 @@ export function MethodSectionRenderer({
     case 'MC_COST':
       return <CostMachinePanel {...panelProps} propertiesMap={serverData.propertiesMap} />;
     case 'WQS_COST':
-      return <WQSPanel {...panelProps} />;
+      return (
+        <WQSPanel
+          {...panelProps}
+          savedBuildingCost={(calculationMethodData.comparativeFactors as any)?.finalValue?.buildingCost ?? null}
+          savedAppraisalPrice={(calculationMethodData.comparativeFactors as any)?.finalValue?.appraisalPrice ?? null}
+          savedHasBuildingCost={(calculationMethodData.comparativeFactors as any)?.finalValue?.hasBuildingCost ?? null}
+          savedIncludeLandArea={(calculationMethodData.comparativeFactors as any)?.finalValue?.includeLandArea ?? null}
+        />
+      );
     case 'SAG_COST':
       return <SaleAdjustmentGridPanel {...panelProps} />;
     case 'DC_COST':
@@ -84,9 +101,8 @@ export function MethodSectionRenderer({
       return (
         <LeaseholdPanel
           {...panelProps}
-          propertiesMap={serverData.propertiesMap}
-          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId}
-          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType}
+          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId ?? undefined}
+          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType ?? undefined}
         />
       );
     case 'PR':
@@ -94,8 +110,8 @@ export function MethodSectionRenderer({
         <ProfitRentPanel
           {...panelProps}
           propertiesMap={serverData.propertiesMap}
-          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId}
-          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType}
+          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId ?? undefined}
+          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType ?? undefined}
         />
       );
     case 'Hypothesis':

--- a/src/features/pricingAnalysis/components/WQSAdjustFinalValueSection.tsx
+++ b/src/features/pricingAnalysis/components/WQSAdjustFinalValueSection.tsx
@@ -1,19 +1,16 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { Icon } from '@/shared/components';
 import { RHFInputCell } from './table/RHFInputCell';
 import { wqsFieldPath } from '../adapters/wqsFieldPath';
 import {
   floorToThousands,
-  round2,
   toFiniteNumber,
 } from '@features/pricingAnalysis/domain/calculateWQS.ts';
 import {
   type DerivedFieldRule,
   useDerivedFields,
 } from '@features/pricingAnalysis/adapters/useDerivedFieldArray.tsx';
-import { ServerDataCtx } from '../store/selectionContext';
-import { deriveGroupCollateralType } from '../domain/deriveGroupCollateralType';
 import { BuildingCostTable } from './BuildingCostTable';
 
 interface AdjustFinalValueSectionProp {
@@ -23,7 +20,7 @@ interface AdjustFinalValueSectionProp {
 }
 
 export const AdjustFinalValueSection = ({
-  property,
+  property: _property,
   buildingCost,
   isCostApproach,
 }: AdjustFinalValueSectionProp) => {
@@ -33,24 +30,51 @@ export const AdjustFinalValueSection = ({
     finalValueHasBuildingCost: hasBuildingCostPath,
     finalValueLandArea: landAreaPath,
     finalValueUsableArea: usableAreaPath,
-    finalValueFinalValueRounded: finalValueRoundedPath,
-    finalValueAppraisalPrice: finalValueAppraisalPricePath,
-    finalValueAppraisalPriceRounded: appraisalPriceRoundedPath,
-    finalValuePriceDifferentiate: priceDifferentiatePath,
-    finalValueTotalBuildingCost: totalBuildingCostPath,
-    finalValueAppraisalPriceIncludeBuildingCost: appraisalPriceIncludeBuildingCostPath,
-    finalValueAppraisalPriceIncludeBuildingCostRounded:
-      appraisalPriceIncludeBuildingCostRoundedPath,
-    finalValuePriceIncludeBuildingCostDifferentiate: priceIncludeBuildingCostDifferentiatePath,
+    finalValueFinalValueAdjusted: finalValueAdjustedPath,
+    finalValueFinalValue: finalValueFinalValuePath,
+    finalValueFinalValueRounded: finalValueFinalValueRoundedPath,
+    finalValueLandValue: landValuePath,
+    finalValueBuildingCost: buildingCostPath,
+    finalValueAppraisalPrice: appraisalPricePath,
   } = wqsFieldPath;
 
   const { control, setValue } = useFormContext();
-  const includeLandArea = useWatch({ control, name: includeLandAreaPath() });
   const includeBuildingCost = useWatch({ control, name: hasBuildingCostPath() });
+  const calculations = useWatch({ control, name: 'WQSCalculations' });
 
+  // Detect price unit from calculation rows (used by both cost and market approaches
+  // to decide whether the price is per-unit (01/02) or total (03)).
+  const detectedUnit = useMemo(() => {
+    if (!(calculations as any[])?.length) return null;
+    const units: string[] = (calculations as any[])
+      .map((c: any) =>
+        c.offeringPrice && Number(c.offeringPrice) !== 0
+          ? c.offeringPriceMeasurementUnit
+          : c.sellingPriceMeasurementUnit,
+      )
+      .filter(Boolean);
+    if (!units.length) return null;
+    const freq = new Map<string, number>();
+    for (const u of units) freq.set(u, (freq.get(u) ?? 0) + 1);
+    return [...freq.entries()].sort((a, b) => b[1] - a[1])[0][0];
+  }, [calculations]);
+
+  const isUnitPrice = detectedUnit === '01' || detectedUnit === '02'; // per Sq.Wa or per Sq.m
+  const unitAreaPath = detectedUnit === '02' ? usableAreaPath() : landAreaPath();
+  const unitAreaLabel = detectedUnit === '02' ? 'Sq.m' : 'Sq.Wa';
+
+  // The "Include Area" toggle is auto-derived from the comparables' measure unit
+  // (01/02 → land area applies; 03 → total price, no area). Keeps the form field
+  // populated so the backend persists the right value, even though the UI no longer
+  // exposes a manual toggle.
+  useEffect(() => {
+    setValue(includeLandAreaPath(), isUnitPrice, { shouldDirty: false });
+  }, [isUnitPrice, setValue, includeLandAreaPath]);
+
+  // Sync buildingCost from the BuildingCostTable computation into the form field
   useEffect(() => {
     if (!buildingCost?.length) {
-      setValue(totalBuildingCostPath(), 0, { shouldDirty: false });
+      setValue(buildingCostPath(), 0, { shouldDirty: false });
       return;
     }
 
@@ -67,7 +91,6 @@ export const AdjustFinalValueSection = ({
       for (let rowIndex = 0; rowIndex < rawRows.length; rowIndex++) {
         const row = { ...rawRows[rowIndex] };
 
-        // Pass 1: compute priceBeforeDepreciation and priceDepreciation
         const priceBeforeDepreciation =
           toNum(row['area']) * toNum(row['pricePerSqMBeforeDepreciation']);
 
@@ -77,233 +100,338 @@ export const AdjustFinalValueSection = ({
           0,
         );
 
-        // Pass 2: priceAfterDepreciation = before - depreciation
         const priceAfterDepreciation = priceBeforeDepreciation - priceDepreciation;
         grandTotal += priceAfterDepreciation;
       }
     }
 
-    setValue(totalBuildingCostPath(), grandTotal, { shouldDirty: false });
-  }, [buildingCost, totalBuildingCostPath, setValue]);
+    setValue(buildingCostPath(), grandTotal, { shouldDirty: false });
+  }, [buildingCost, buildingCostPath, setValue]);
 
-  // Track previous finalValueRounded to detect actual changes.
-  // On initial load: preserve saved appraisalPriceRounded (auto-fill only if 0).
-  // After initial load: always auto-default when finalValueRounded changes.
-  const prevFinalValueRef = useRef<number | null>(null);
-  const prevValueIncludeCostRef = useRef<number | null>(null);
+  // Always pair the per-unit price with its matching area (Sq.Wa for unit 01,
+  // Sq.m for unit 02). Drives both cost and market approach now that the
+  // "Include Area" toggle is auto-derived from the comparables' measure unit.
+  const rawLandPriceAreaPath = unitAreaPath;
+
+  // Track previous upstream values so seed rules only re-fire on actual upstream change.
+  // Without these guards, useDerivedFields re-runs on every render and overwrites user edits
+  // because landValue/appraisalPrice are themselves deps of other rules in this group,
+  // and finalValueAdjusted is restored via setValue post-reset (so rule re-fires on it).
+  const prevFinalValueRoundedRef = useRef<number | null>(null);
+  const prevRawLandPriceRef = useRef<number | null>(null);
+  const prevTotalPriceRef = useRef<number | null>(null);
+
+  // Resolves the upstream value that drives the user's rounded "Appraisal Price":
+  // - hasBuildingCost  → _totalPrice (landValue + buildingCost)
+  // - !hasBuildingCost → _rawLandPrice (which already encodes case 1 vs 2)
+  const getAppraisalUpstream = (getValues: any): number => {
+    const hbc = !!getValues(hasBuildingCostPath());
+    if (hbc) return Number(getValues('WQSFinalValue._totalPrice')) || 0;
+    return Number(getValues('WQSFinalValue._rawLandPrice')) || 0;
+  };
 
   const rules: DerivedFieldRule[] = [
     {
-      targetPath: finalValueAppraisalPricePath(),
-      deps: [finalValueRoundedPath()],
-      compute: ({ getValues }) => {
-        const finalValueRounded = getValues(finalValueRoundedPath()) ?? 0;
-
-        const isIncludeLandArea = getValues(includeLandAreaPath());
-        const landArea = getValues(landAreaPath());
-        if (isIncludeLandArea && !!landArea) {
-          return floorToThousands(finalValueRounded * (landArea ?? 0));
-        }
-
-        const usableArea = getValues(usableAreaPath());
-        if (isIncludeLandArea && !!usableArea) {
-          return floorToThousands(finalValueRounded * (usableArea ?? 0));
-        }
-
-        return finalValueRounded;
-      },
-    },
-    {
-      targetPath: appraisalPriceRoundedPath(),
-      deps: [finalValueAppraisalPricePath()],
-      compute: ({ getValues }) => Number(getValues(finalValueAppraisalPricePath())) || 0,
+      // finalValueAdjusted: re-seed from finalValueRounded only when it actually changes.
+      // Lives here (rather than in buildWQSDerivedRules) so it shares the ref-guard
+      // pattern with landValue/appraisalPrice; otherwise reset(value) and rule-array
+      // re-creation after save would clobber the user's saved override.
+      targetPath: finalValueAdjustedPath(),
+      deps: [finalValueFinalValueRoundedPath()],
       when: ({ getValues }) => {
-        const depValue = Number(getValues(finalValueAppraisalPricePath())) || 0;
-        const current = Number(getValues(appraisalPriceRoundedPath())) || 0;
-
-        if (prevFinalValueRef.current === null) {
-          prevFinalValueRef.current = depValue;
-          return current === 0;
+        const rounded = Number(getValues(finalValueFinalValueRoundedPath())) || 0;
+        if (prevFinalValueRoundedRef.current === null) {
+          prevFinalValueRoundedRef.current = rounded;
+          return false;
         }
-
-        if (prevFinalValueRef.current !== depValue) {
-          prevFinalValueRef.current = depValue;
+        if (prevFinalValueRoundedRef.current !== rounded) {
+          prevFinalValueRoundedRef.current = rounded;
           return true;
         }
-
         return false;
       },
+      compute: ({ getValues }) => Number(getValues(finalValueFinalValueRoundedPath())) || 0,
     },
     {
-      targetPath: priceDifferentiatePath(),
-      deps: [appraisalPriceRoundedPath(), finalValueAppraisalPricePath()],
+      // rawLandPrice: computed display value (not stored). Same logic for cost and market.
+      // unit 01/02 (per-unit price): finalValueAdjusted × matchingArea
+      // unit 03 (total price):       finalValue (RSQ result; user's rounded total is
+      //                              bound to appraisalPrice and synced to finalValueAdjusted)
+      targetPath: 'WQSFinalValue._rawLandPrice',
+      deps: [finalValueAdjustedPath(), finalValueFinalValuePath(), rawLandPriceAreaPath],
       compute: ({ getValues }) => {
-        const appraisalPriceRounded = getValues(appraisalPriceRoundedPath()) ?? 0;
-        const finalValueRounded = getValues(finalValueAppraisalPricePath()) ?? 0;
-        return appraisalPriceRounded - finalValueRounded;
+        const fvAdj = Number(getValues(finalValueAdjustedPath())) || 0;
+        const fv = Number(getValues(finalValueFinalValuePath())) || 0;
+        const area = Number(getValues(rawLandPriceAreaPath)) || 0;
+        return isUnitPrice && area ? floorToThousands(fvAdj * area) : fv;
       },
     },
     {
-      targetPath: appraisalPriceIncludeBuildingCostPath(),
-      deps: [appraisalPriceRoundedPath(), totalBuildingCostPath()],
-      compute: ({ getValues }) => {
-        const landPrice = Number(getValues(appraisalPriceRoundedPath())) || 0;
-        const buildingCost = Number(getValues(totalBuildingCostPath())) || 0;
-        return landPrice + buildingCost;
-      },
-    },
-    {
-      targetPath: appraisalPriceIncludeBuildingCostRoundedPath(),
-      deps: [appraisalPriceIncludeBuildingCostPath()],
-      compute: ({ getValues }) => Number(getValues(appraisalPriceIncludeBuildingCostPath())) || 0,
+      // landValue: re-seed from rawLandPrice only when rawLandPrice actually changes.
+      // The ref-based guard is required because landValue is a dep of _totalPrice/_landDiff,
+      // so the effect re-runs when the user types here; without the guard the seed
+      // would overwrite the user's edit.
+      targetPath: landValuePath(),
+      deps: ['WQSFinalValue._rawLandPrice'],
       when: ({ getValues }) => {
-        const depValue = Number(getValues(appraisalPriceIncludeBuildingCostPath())) || 0;
-        const current = Number(getValues(appraisalPriceIncludeBuildingCostRoundedPath())) || 0;
-
-        if (prevValueIncludeCostRef.current === null) {
-          prevValueIncludeCostRef.current = depValue;
-          return current === 0;
+        const rawPrice = Number(getValues('WQSFinalValue._rawLandPrice')) || 0;
+        if (prevRawLandPriceRef.current === null) {
+          prevRawLandPriceRef.current = rawPrice;
+          return false;
         }
-
-        if (prevValueIncludeCostRef.current !== depValue) {
-          prevValueIncludeCostRef.current = depValue;
+        if (prevRawLandPriceRef.current !== rawPrice) {
+          prevRawLandPriceRef.current = rawPrice;
           return true;
         }
-
         return false;
+      },
+      compute: ({ getValues }) => Number(getValues('WQSFinalValue._rawLandPrice')) || 0,
+    },
+    {
+      // totalPrice: landValue + buildingCost (hasBuildingCost display).
+      targetPath: 'WQSFinalValue._totalPrice',
+      deps: [landValuePath(), buildingCostPath()],
+      compute: ({ getValues }) => {
+        const landVal = Number(getValues(landValuePath())) || 0;
+        const bCost = Number(getValues(buildingCostPath())) || 0;
+        return landVal + bCost;
       },
     },
     {
-      targetPath: priceIncludeBuildingCostDifferentiatePath(),
-      deps: [
-        appraisalPriceIncludeBuildingCostPath(),
-        appraisalPriceIncludeBuildingCostRoundedPath(),
-      ],
+      // landDiff: landValue − rawLandPrice (negative = user rounded down).
+      targetPath: 'WQSFinalValue._landDiff',
+      deps: ['WQSFinalValue._rawLandPrice', landValuePath()],
       compute: ({ getValues }) => {
-        const appraisalPriceRounded =
-          getValues(appraisalPriceIncludeBuildingCostRoundedPath()) ?? 0;
-        const finalValueRounded = getValues(appraisalPriceIncludeBuildingCostPath()) ?? 0;
-        return appraisalPriceRounded - finalValueRounded;
+        const rawPrice = Number(getValues('WQSFinalValue._rawLandPrice')) || 0;
+        const landVal = Number(getValues(landValuePath())) || 0;
+        return landVal - rawPrice;
+      },
+    },
+    {
+      // appraisalPrice: re-seed from the case-appropriate upstream when it changes.
+      // - hasBuildingCost: from _totalPrice (= landValue + buildingCost)
+      // - !hasBuildingCost: from _rawLandPrice (case 1: fvAdj × area; case 2: finalValue)
+      targetPath: appraisalPricePath(),
+      deps: ['WQSFinalValue._totalPrice', 'WQSFinalValue._rawLandPrice', hasBuildingCostPath()],
+      when: ({ getValues }) => {
+        const upstream = getAppraisalUpstream(getValues);
+        if (prevTotalPriceRef.current === null) {
+          prevTotalPriceRef.current = upstream;
+          return false;
+        }
+        if (prevTotalPriceRef.current !== upstream) {
+          prevTotalPriceRef.current = upstream;
+          return true;
+        }
+        return false;
+      },
+      compute: ({ getValues }) => getAppraisalUpstream(getValues),
+    },
+    {
+      // appraisalDiff: appraisalPrice − upstream (negative = user rounded down).
+      targetPath: 'WQSFinalValue._appraisalDiff',
+      deps: ['WQSFinalValue._totalPrice', 'WQSFinalValue._rawLandPrice', appraisalPricePath(), hasBuildingCostPath()],
+      compute: ({ getValues }) => {
+        const upstream = getAppraisalUpstream(getValues);
+        const appraisalVal = Number(getValues(appraisalPricePath())) || 0;
+        return appraisalVal - upstream;
       },
     },
   ];
   useDerivedFields({ rules });
 
-  const serverData = useContext(ServerDataCtx);
-  const groupCollateralType = deriveGroupCollateralType(serverData?.groupDetail?.properties ?? []);
+  const diffBadge = (fieldPath: string) => (
+    <RHFInputCell
+      fieldName={fieldPath}
+      inputType="display"
+      accessor={({ value }) => {
+        const num = Number(value) || 0;
+        if (num === 0) return <span />;
+        const color = num > 0 ? 'text-green-600' : 'text-red-500';
+        const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
+        const icon = num > 0 ? 'arrow-up' : 'arrow-down';
+        return (
+          <span
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
+          >
+            <Icon name={icon} style="solid" className="size-3" />
+            {Math.abs(num).toLocaleString()}
+          </span>
+        );
+      }}
+    />
+  );
 
-  const isLand = groupCollateralType === 'L';
-  const isUsable = groupCollateralType === 'U';
-  const areaUnit = isLand ? 'Sq. Wa' : 'Sq. m.';
-  const areaFieldPath = isLand ? landAreaPath() : usableAreaPath();
+  const valueDisplay = (fieldPath: string) => (
+    <div className="w-40 text-right">
+      <RHFInputCell
+        fieldName={fieldPath}
+        inputType="display"
+        accessor={({ value }) => (
+          <span className="font-semibold text-gray-800 tabular-nums">
+            {value ? Number(value).toLocaleString() : '0'}
+          </span>
+        )}
+      />
+    </div>
+  );
 
   return (
     <div className="flex flex-col gap-3 text-sm">
+
       {/* Coefficient of decision */}
       <div className="flex items-center gap-4">
-        <span className="w-48 text-gray-500">Coefficient of decision</span>
+        <span className="w-48 shrink-0 text-gray-500">Coefficient of decision</span>
         <RHFInputCell
           fieldName={coeffPath()}
           inputType="display"
           accessor={({ value }) => {
             const coeff = toFiniteNumber(value);
             return coeff < 0.85 ? (
-              <div className="flex items-center gap-4 text-danger">
-                <span className="font-medium">{value}</span>
-                <span className="text-xs">{'Consider for the market survey data'}</span>
-              </div>
+              <span className="inline-flex items-center gap-2">
+                <span className="font-semibold text-red-500">{value}</span>
+                <span className="rounded-full bg-red-50 px-2 py-0.5 text-xs text-red-500">
+                  Low — review market survey data
+                </span>
+              </span>
             ) : (
-              <span className="font-medium text-gray-800">{value}</span>
+              <span className="font-semibold text-gray-800">{value}</span>
             );
           }}
         />
       </div>
 
-      {/* Include Area toggle */}
-      {(isLand || isUsable) && (
-        <div className="flex items-center gap-4">
-          <span className="w-48 text-gray-500">Include Area</span>
-          <RHFInputCell
-            fieldName={includeLandAreaPath()}
-            inputType="toggle"
-            toggle={{ checked: includeLandArea, options: ['No', 'Yes'] }}
-          />
-        </div>
+      {/* ── COST APPROACH, no building cost, unit=01/02 ── */}
+      {isCostApproach && !includeBuildingCost && isUnitPrice && (
+        <>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Final Value</span>
+            <div className="w-40">
+              <RHFInputCell
+                fieldName={finalValueAdjustedPath()}
+                inputType="number"
+                number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
+              />
+            </div>
+            <span className="text-gray-500">Baht/{unitAreaLabel}</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Area</span>
+            {valueDisplay(unitAreaPath)}
+            <span className="text-gray-500">{unitAreaLabel}</span>
+          </div>
+        </>
       )}
 
-      {/* Area (shown when include area is on) */}
-      {includeLandArea && (isLand || isUsable) && (
+      {/* ── COST APPROACH, no building cost, unit=03 (machinery) ──
+          No separate "Final Value" input: the rounded "Appraisal Price (rounded)"
+          input below writes to BOTH appraisalPrice AND finalValueAdjusted. */}
+
+      {/* ── MARKET APPROACH ──
+          Include-area is auto-derived from the comparables' measure unit
+          (isUnitPrice = unit 01 or 02). Same gating as cost approach. */}
+      {!isCostApproach && isUnitPrice && (
+        <>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Final Value</span>
+            <div className="w-40">
+              <RHFInputCell
+                fieldName={finalValueAdjustedPath()}
+                inputType="number"
+                number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
+              />
+            </div>
+            <span className="text-gray-500">Baht/{unitAreaLabel}</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Area</span>
+            {valueDisplay(unitAreaPath)}
+            <span className="text-gray-500">{unitAreaLabel}</span>
+          </div>
+        </>
+      )}
+      {/* Market approach: rawLandPrice computed row */}
+      {!isCostApproach && (
         <div className="flex items-center gap-4">
-          <span className="w-48 text-gray-500">Area</span>
-          <span className="font-medium text-gray-800">
-            <RHFInputCell
-              fieldName={areaFieldPath}
-              inputType="display"
-              accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
-            />
+          <span className="w-48 shrink-0 text-gray-500">
+            Appraisal Price{isUnitPrice ? '' : ' (RSQ)'}
           </span>
-          <span className="text-gray-500">{areaUnit}</span>
+          {valueDisplay('WQSFinalValue._rawLandPrice')}
+          <span className="text-gray-500">Baht</span>
         </div>
       )}
 
-      {/* Final Value (Rounded) */}
-      <div className="flex items-center gap-4">
-        <span className="w-48 text-gray-500">
-          Final Value (Rounded) {includeLandArea ? 'x Area' : ''}
-        </span>
-        <span className="font-medium text-gray-800">
-          <RHFInputCell
-            fieldName={finalValueAppraisalPricePath()}
-            inputType="display"
-            accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
-          />
-        </span>
-        <span className="text-gray-500">Baht</span>
-      </div>
+      {/* ── COST APPROACH, no building cost: Appraisal Price display + appraisalPrice input ── */}
+      {isCostApproach && !includeBuildingCost && (
+        <>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Appraisal Price</span>
+            {valueDisplay('WQSFinalValue._rawLandPrice')}
+            <span className="text-gray-500">Baht</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 font-semibold text-gray-800">
+              Appraisal Price
+              <span className="ml-1 text-xs font-normal text-gray-400">(rounded)</span>
+            </span>
+            <div className="w-40">
+              <RHFInputCell
+                fieldName={appraisalPricePath()}
+                inputType="number"
+                number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
+                onUserChange={
+                  // For unit 03 (machinery) the rounded appraisal price IS the user's
+                  // adjusted final value — sync them so finalValueAdjusted persists too.
+                  !isUnitPrice
+                    ? (next: any) => {
+                        setValue(finalValueAdjustedPath(), next, { shouldDirty: true });
+                        return next;
+                      }
+                    : undefined
+                }
+              />
+            </div>
+            <span className="text-gray-500">Baht</span>
+            {diffBadge('WQSFinalValue._appraisalDiff')}
+          </div>
+        </>
+      )}
 
-      {/* Appraisal Price */}
-      <div className="flex items-center gap-4 rounded-lg bg-primary/5 border border-primary/20 px-4 py-3 -mx-4">
-        <span className="w-48 shrink-0 font-semibold text-gray-800">Appraisal Price</span>
-        <div className="w-40">
-          <RHFInputCell
-            fieldName={appraisalPriceRoundedPath()}
-            inputType="number"
-            number={{
-              decimalPlaces: 2,
-              maxIntegerDigits: 15,
-              maxValue: 999_999_999_999_999.0,
-              allowNegative: false,
-            }}
-          />
-        </div>
-        <span className="text-gray-500">Baht</span>
-        <div className="flex items-center">
-          <RHFInputCell
-            fieldName={priceDifferentiatePath()}
-            inputType="display"
-            accessor={({ value }) => {
-              const num = Number(value) || 0;
-              if (num === 0) return <span className="text-gray-400"></span>;
-              const color = num > 0 ? 'text-green-600' : 'text-red-600';
-              const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
-              const icon = num > 0 ? 'arrow-up' : 'arrow-down';
-              return (
-                <span
-                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
-                >
-                  <Icon name={icon} style="solid" className="size-3" />
-                  {Math.abs(num).toLocaleString()}
-                </span>
-              );
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Include building cost toggle */}
-      {isCostApproach && (
+      {/* ── MARKET APPROACH: appraisalPrice editable ── */}
+      {!isCostApproach && (
         <div className="flex items-center gap-4">
-          <span className="w-48 text-gray-500">Include building cost</span>
+          <span className="w-48 shrink-0 font-semibold text-gray-800">
+            Appraisal Price
+            <span className="ml-1 text-xs font-normal text-gray-400">(rounded)</span>
+          </span>
+          <div className="w-40">
+            <RHFInputCell
+              fieldName={appraisalPricePath()}
+              inputType="number"
+              number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
+              onUserChange={
+                // For unit 03 (total price comparables) the rounded appraisal price
+                // IS the user's adjusted final value — sync them on input.
+                !isUnitPrice
+                  ? (next: any) => {
+                      setValue(finalValueAdjustedPath(), next, { shouldDirty: true });
+                      return next;
+                    }
+                  : undefined
+              }
+            />
+          </div>
+          <span className="text-gray-500">Baht</span>
+          {diffBadge('WQSFinalValue._appraisalDiff')}
+        </div>
+      )}
+
+      {/* ── INCLUDE BUILDING COST TOGGLE — only when toggle is OFF.
+            When ON, the toggle is rendered after "Land Price (rounded)" inside
+            the includeBuildingCost section below for better visual grouping. */}
+      {isCostApproach && !includeBuildingCost && (
+        <div className="flex items-center gap-4">
+          <span className="w-48 shrink-0 text-gray-500">Include building cost</span>
           <RHFInputCell
             fieldName={hasBuildingCostPath()}
             inputType="toggle"
@@ -312,93 +440,88 @@ export const AdjustFinalValueSection = ({
         </div>
       )}
 
-      {includeBuildingCost && isCostApproach && (
-        <div className="flex flex-col gap-3 text-sm">
-          <div className="">
-            {includeBuildingCost && (
-              <div className="flex flex-col gap-3 text-sm">
-                <div>
-                  <BuildingCostTable buildingCost={buildingCost ?? []} />
-                </div>
+      {/* ── COST APPROACH, with building cost ── */}
+      {isCostApproach && includeBuildingCost && (
+        <>
+          {isUnitPrice && (
+            <div className="flex items-center gap-4">
+              <span className="w-48 shrink-0 text-gray-500">Price/{unitAreaLabel}</span>
+              <div className="w-40">
+                <RHFInputCell
+                  fieldName={finalValueAdjustedPath()}
+                  inputType="number"
+                  number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
+                />
               </div>
-            )}
+              <span className="text-gray-500">Baht/{unitAreaLabel}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Area</span>
+            {valueDisplay(unitAreaPath)}
+            <span className="text-gray-500">{unitAreaLabel}</span>
           </div>
           <div className="flex items-center gap-4">
-            <span className="w-48 text-gray-500">Land Price</span>
-            <span className="font-medium text-gray-800">
-              <RHFInputCell
-                fieldName={appraisalPriceRoundedPath()}
-                inputType="display"
-                accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
-              />
-            </span>
+            <span className="w-48 shrink-0 text-gray-500">Land Price</span>
+            {valueDisplay('WQSFinalValue._rawLandPrice')}
             <span className="text-gray-500">Baht</span>
           </div>
-
           <div className="flex items-center gap-4">
-            <span className="w-48 text-gray-500">Building Cost</span>
-            <span className="font-medium text-gray-800">
-              <RHFInputCell
-                fieldName={totalBuildingCostPath()}
-                inputType="display"
-                accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
-              />
-            </span>
-            <span className="text-gray-500">Baht</span>
-          </div>
-
-          <div className="flex items-center gap-4">
-            <span className="w-48 text-gray-500">Appraisal Price Include Building Cost</span>
-            <span className="font-medium text-gray-800">
-              <RHFInputCell
-                fieldName={appraisalPriceIncludeBuildingCostPath()}
-                inputType="display"
-                accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
-              />
-            </span>
-            <span className="text-gray-500">Baht</span>
-          </div>
-
-          <div className="flex items-center gap-4 rounded-lg bg-primary/5 border border-primary/20 px-4 py-3 -mx-4">
-            <span className="w-48 text-xs shrink-0 font-semibold text-gray-800">
-              Appraisal Price Include Building Cost (rounded)
+            <span className="w-48 shrink-0 font-semibold text-gray-800">
+              Land Price
+              <span className="ml-1 text-xs font-normal text-gray-400">(rounded)</span>
             </span>
             <div className="w-40">
               <RHFInputCell
-                fieldName={appraisalPriceIncludeBuildingCostRoundedPath()}
+                fieldName={landValuePath()}
                 inputType="number"
-                number={{
-                  decimalPlaces: 2,
-                  maxIntegerDigits: 15,
-                  maxValue: 999_999_999_999_999.0,
-                  allowNegative: false,
-                }}
+                number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
               />
             </div>
             <span className="text-gray-500">Baht</span>
-            <div className="flex items-center">
+            {diffBadge('WQSFinalValue._landDiff')}
+          </div>
+
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Include building cost</span>
+            <RHFInputCell
+              fieldName={hasBuildingCostPath()}
+              inputType="toggle"
+              toggle={{ checked: includeBuildingCost, options: ['No', 'Yes'] }}
+            />
+          </div>
+
+          <BuildingCostTable buildingCost={buildingCost ?? []} />
+
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">
+              <span className="mr-1 text-gray-400">+</span>Building Cost
+            </span>
+            {valueDisplay(buildingCostPath())}
+            <span className="text-gray-500">Baht</span>
+          </div>
+          <div className="border-t border-gray-200 -mx-1" />
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 text-gray-500">Appraisal Price</span>
+            {valueDisplay('WQSFinalValue._totalPrice')}
+            <span className="text-gray-500">Baht</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="w-48 shrink-0 font-semibold text-gray-800">
+              Appraisal Price
+              <span className="ml-1 text-xs font-normal text-gray-400">(rounded)</span>
+            </span>
+            <div className="w-40">
               <RHFInputCell
-                fieldName={priceIncludeBuildingCostDifferentiatePath()}
-                inputType="display"
-                accessor={({ value }) => {
-                  const num = Number(value) || 0;
-                  if (num === 0) return <span className="text-gray-400"></span>;
-                  const color = num > 0 ? 'text-green-600' : 'text-red-600';
-                  const bgColor = num > 0 ? 'bg-green-50' : 'bg-red-50';
-                  const icon = num > 0 ? 'arrow-up' : 'arrow-down';
-                  return (
-                    <span
-                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color} ${bgColor}`}
-                    >
-                      <Icon name={icon} style="solid" className="size-3" />
-                      {Math.abs(num).toLocaleString()}
-                    </span>
-                  );
-                }}
+                fieldName={appraisalPricePath()}
+                inputType="number"
+                number={{ decimalPlaces: 2, maxIntegerDigits: 15, maxValue: 999_999_999_999_999.0, allowNegative: false }}
               />
             </div>
+            <span className="text-gray-500">Baht</span>
+            {diffBadge('WQSFinalValue._appraisalDiff')}
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/features/pricingAnalysis/components/WQSPanel.tsx
+++ b/src/features/pricingAnalysis/components/WQSPanel.tsx
@@ -46,7 +46,12 @@ interface WQSPanelProps {
   savedFactorScores?: FactorScoreType[];
   savedCalculations?: CalculationType[];
   savedComparativeAnalysisTemplateId?: string | null;
-  savedMethodValue?: number | null;
+  savedFinalValueAdjusted?: number | null;
+  savedLandValue?: number | null;
+  savedBuildingCost?: number | null;
+  savedAppraisalPrice?: number | null;
+  savedHasBuildingCost?: boolean | null;
+  savedIncludeLandArea?: boolean | null;
   onCalculationSave: (payload: {
     approachType: string;
     methodType: string;
@@ -67,7 +72,12 @@ export function WQSPanel({
   savedFactorScores,
   savedCalculations,
   savedComparativeAnalysisTemplateId,
-  savedMethodValue,
+  savedFinalValueAdjusted,
+  savedLandValue,
+  savedBuildingCost,
+  savedAppraisalPrice,
+  savedHasBuildingCost,
+  savedIncludeLandArea,
   onCalculationSave,
   onCalculationMethodDirty,
   onCancelCalculationMethod,
@@ -130,24 +140,23 @@ export function WQSPanel({
     const value = getValues();
 
     try {
-      const appraisalValue = value.WQSFinalValue?.appraisalPriceRounded ?? null;
+      const landValue = ((value.WQSFinalValue as any)?.landValue as number | undefined) ?? null;
 
       const request = mapWQSFormToSubmitSchema({
         WQSForm: value,
         comparativeAnalysisTemplateId: selectedTemplateId,
       });
-      request.appraisalValue = appraisalValue;
 
       await saveMutation.mutateAsync({
         id: activeMethod.pricingAnalysisId,
         methodId,
         request,
       });
-      if (appraisalValue && activeMethod?.approachType && activeMethod?.methodType) {
+      if (landValue && activeMethod?.approachType && activeMethod?.methodType) {
         onCalculationSave({
           approachType: activeMethod.approachType,
           methodType: activeMethod.methodType,
-          appraisalValue,
+          appraisalValue: landValue,
         });
       }
       toast.success('Saved!');
@@ -242,12 +251,30 @@ export function WQSPanel({
         savedCalculations,
         reset,
       });
-      // Set appraisal price from saved method value AFTER reset, with shouldDirty
-      // so derived rules won't overwrite it with the calculated final value
-      if (savedMethodValue != null && savedMethodValue !== 0) {
-        setValue('WQSFinalValue.appraisalPriceRounded' as any, savedMethodValue, {
+      // Restore landValue (only meaningful when hasBuildingCost; for cases 1/2 the user's
+      // rounded value is bound to appraisalPrice, restored separately below).
+      if (savedLandValue != null && savedLandValue !== 0) {
+        setValue('WQSFinalValue.landValue' as any, savedLandValue, { shouldDirty: true });
+      }
+      // Restore user-overridden final value adjusted so derive rules don't reseed it
+      if (savedFinalValueAdjusted != null && savedFinalValueAdjusted !== 0) {
+        setValue('WQSFinalValue.finalValueAdjusted' as any, savedFinalValueAdjusted, {
           shouldDirty: true,
         });
+      }
+      // Restore building cost fields
+      if (savedBuildingCost != null && savedBuildingCost !== 0) {
+        setValue('WQSFinalValue.buildingCost' as any, savedBuildingCost, { shouldDirty: true });
+      }
+      if (savedAppraisalPrice != null && savedAppraisalPrice !== 0) {
+        setValue('WQSFinalValue.appraisalPrice' as any, savedAppraisalPrice, { shouldDirty: true });
+      }
+      // Restore toggles
+      if (savedHasBuildingCost != null) {
+        setValue('WQSFinalValue.hasBuildingCost' as any, savedHasBuildingCost, { shouldDirty: false });
+      }
+      if (savedIncludeLandArea != null) {
+        setValue('WQSFinalValue.includeLandArea' as any, savedIncludeLandArea, { shouldDirty: false });
       }
       // Restore template selection from saved data
       if (savedComparativeAnalysisTemplateId) {

--- a/src/features/pricingAnalysis/components/WQSScoringSection.tsx
+++ b/src/features/pricingAnalysis/components/WQSScoringSection.tsx
@@ -998,16 +998,11 @@ export function WQSScoringSection({
               {comparativeSurveys.map(survey => (
                 <td key={survey.id} className={clsx('bg-gray-100', surveyStyle)}></td>
               ))}
-              <td className={clsx('bg-gray-100 border-b border-gray-300 px-1 py-1')}>
+              <td className={clsx('bg-gray-100 border-b border-gray-300 px-3 py-1.5 text-right font-semibold')}>
                 <RHFInputCell
                   fieldName={finalValueFinalValueRoundedPath()}
-                  inputType="number"
-                  number={{
-                    decimalPlaces: 2,
-                    maxIntegerDigits: 15,
-                    allowNegative: false,
-                    maxValue: 999_999_999_999_999.0,
-                  }}
+                  inputType="display"
+                  accessor={({ value }) => (value ? Number(value).toLocaleString() : '0')}
                 />
               </td>
             </tr>

--- a/src/features/pricingAnalysis/domain/mapWQSFormToSubmitSchema.ts
+++ b/src/features/pricingAnalysis/domain/mapWQSFormToSubmitSchema.ts
@@ -13,19 +13,36 @@ export function mapWQSFormToSubmitSchema({
   // Build set of factorIds used for scoring (WQSScores)
   const scoringFactorIds = new Set((WQSForm.WQSScores ?? []).map(s => s.factorId).filter(Boolean));
 
+  const fv = WQSForm.WQSFinalValue;
+
+  // The Adjust Final Value UI now binds the user-rounded total to `appraisalPrice`
+  // in all cases (unit 01/02, unit 03 machinery, with/without building cost).
+  // `landValue` is only meaningful when hasBuildingCost = true (separate Land Price input).
+  const hasBuildingCost = !!fv?.hasBuildingCost;
+  const userRoundedAppraisalPrice = fv?.appraisalPrice ?? null;
+  const landValueToSend = hasBuildingCost ? (fv?.landValue ?? null) : null;
+
   return {
     comparativeAnalysisTemplateId: comparativeAnalysisTemplateId ?? null,
+    appraisalValue: userRoundedAppraisalPrice,
+    finalValueAdjusted: (fv?.finalValueAdjusted as number | undefined) ?? null,
+    hasBuildingCost: fv?.hasBuildingCost ?? null,
+    buildingCost: fv?.buildingCost ?? null,
+    appraisalPrice: userRoundedAppraisalPrice,
+    includeLandArea: fv?.includeLandArea ?? null,
+    landArea: fv?.landArea ?? null,
+    landValue: landValueToSend,
     comparativeFactors: (WQSForm.comparativeFactors ?? []).map((cf, index) => ({
       id: cf.id || null,
-      factorId: cf.factorId || null,
+      factorId: cf.factorId || '',
       displaySequence: index,
-      isSelectedForScoring: scoringFactorIds.has(cf.factorId),
+      isSelectedForScoring: scoringFactorIds.has(cf.factorId ?? ''),
       remarks: null,
     })),
 
     factorScores: WQSForm.WQSScores.flatMap((score, index) => {
       const entries: SaveComparativeAnalysisRequestType['factorScores'] = [];
-      const fid = score.factorId || null;
+      const fid = score.factorId || '';
 
       // One entry per survey for this factor
       for (const survey of score.surveys ?? []) {
@@ -37,6 +54,11 @@ export function mapWQSFormToSubmitSchema({
           displaySequence: index,
           score: survey.surveyScore,
           intensity: score.intensity ?? null,
+          value: null,
+          adjustmentPct: null,
+          remarks: null,
+          adjustmentAmt: null,
+          comparisonResult: null,
         });
       }
 
@@ -49,6 +71,11 @@ export function mapWQSFormToSubmitSchema({
         displaySequence: index,
         score: score.collateral ?? 0,
         intensity: score.intensity ?? null,
+        value: null,
+        adjustmentPct: null,
+        remarks: null,
+        adjustmentAmt: null,
+        comparisonResult: null,
       });
 
       return entries;
@@ -57,19 +84,31 @@ export function mapWQSFormToSubmitSchema({
     calculations: (WQSForm.WQSCalculations ?? []).map(calc => {
       const hasOfferingPrice = calc.offeringPrice != null && calc.offeringPrice !== 0;
       return {
-        marketComparableId: calc.marketId,
-        offeringPrice: hasOfferingPrice ? calc.offeringPrice : null,
+        marketComparableId: calc.marketId ?? '',
+        offeringPrice: hasOfferingPrice ? (calc.offeringPrice ?? null) : null,
         offeringPriceUnit: calc.offeringPriceMeasurementUnit ?? null,
         adjustOfferPricePct: hasOfferingPrice ? (calc.offeringPriceAdjustmentPct ?? null) : null,
         adjustOfferPriceAmt: hasOfferingPrice ? (calc.offeringPriceAdjustmentAmt ?? null) : null,
         sellingPrice: hasOfferingPrice ? null : (calc.sellingPrice ?? null),
+        sellingPriceUnit: null,
         buySellYear:
           !hasOfferingPrice && calc.numberOfYears != null ? Math.trunc(calc.numberOfYears) : null,
         buySellMonth: null,
         adjustedPeriodPct: !hasOfferingPrice ? (calc.sellingPriceAdjustmentYear ?? null) : null,
         cumulativeAdjPeriod: !hasOfferingPrice ? (calc.totalAdjustedSellingPrice ?? null) : null,
+        landAreaDeficient: null,
+        landAreaDeficientUnit: null,
+        landPrice: null,
+        landValueAdjustment: null,
+        usableAreaDeficient: null,
+        usableAreaDeficientUnit: null,
+        usableAreaPrice: null,
+        buildingValueAdjustment: null,
+        totalFactorDiffPct: null,
+        totalFactorDiffAmt: null,
         totalAdjustedValue: calc.adjustedValue ?? null,
         weight: null,
+        weightedAdjustedValue: null,
       };
     }),
   };

--- a/src/features/pricingAnalysis/schemas/wqsForm.ts
+++ b/src/features/pricingAnalysis/schemas/wqsForm.ts
@@ -41,7 +41,9 @@ const WQSScore = z.object({
 const WQSFinalValue = z
   .object({
     finalValueRounded: z.number(requireMsg('Final value (rounded)')),
-    appraisalPriceRounded: z.number(requireMsg('Appraisal price (rounded)')),
+    landValue: z.number(requireMsg('Land value')).optional(),
+    buildingCost: z.number(requireMsg('Building cost')).optional(),
+    appraisalPrice: z.number(requireMsg('Appraisal price')).optional(),
   })
   .passthrough();
 

--- a/src/features/pricingAnalysis/types/wqs.ts
+++ b/src/features/pricingAnalysis/types/wqs.ts
@@ -65,6 +65,7 @@ export interface WQSTotalScore {
 export interface WQSFinalValue {
   finalValue: number;
   finalValueRounded: number;
+  finalValueAdjusted?: number;
   coefficientOfDecision: number;
   standardError: number;
   intersectionPoint: number;
@@ -75,8 +76,10 @@ export interface WQSFinalValue {
   includeLandArea: boolean;
   landArea?: number;
   usableArea?: number;
-  appraisalPrice: number;
-  appraisalPriceRounded: number;
+  // stored fields (backend persists these)
+  landValue?: number;       // user-edited land price
+  buildingCost?: number;    // user-edited building cost
+  appraisalPrice?: number;  // user-edited final total (hasBuildingCost only)
 }
 
 export interface WQS {

--- a/src/features/workflowBuilder/adapters/toReactFlow.ts
+++ b/src/features/workflowBuilder/adapters/toReactFlow.ts
@@ -26,20 +26,16 @@ export function transitionToEdge(
   sourceActivity?: Activity,
 ): Edge {
   const isConditional = transition.type === 'Conditional';
-
   return {
     id: transition.id,
     source: transition.from,
     target: transition.to,
-    type: 'workflow',
+    type: 'draggable',
+    animated: !isConditional,
+    style: { stroke: isConditional ? '#6366f1' : '#94a3b8', strokeWidth: 2 },
     label: transition.condition
       ? truncateLabel(transition.condition, 30)
       : undefined,
-    animated: !isConditional,
-    style: {
-      stroke: isConditional ? '#6366f1' : '#94a3b8',
-      strokeWidth: 2,
-    },
     markerEnd: { type: 'arrowclosed' as MarkerType },
     data: { ...transition },
     sourceHandle: resolveSourceHandle(transition, sourceActivity),

--- a/src/features/workflowBuilder/components/canvas/WorkflowCanvas.tsx
+++ b/src/features/workflowBuilder/components/canvas/WorkflowCanvas.tsx
@@ -39,6 +39,7 @@ import { RequestSubmissionNode } from './nodes/RequestSubmissionNode';
 import { AdminReviewNode } from './nodes/AdminReviewNode';
 import { TimerNode } from './nodes/TimerNode';
 import { WorkflowEdge } from './edges/WorkflowEdge';
+import { DraggableEdge } from './edges/DraggableEdge';
 
 const nodeTypes: NodeTypes = {
   StartActivity: StartNode,
@@ -65,10 +66,11 @@ const nodeTypes: NodeTypes = {
 
 const edgeTypes: EdgeTypes = {
   workflow: WorkflowEdge,
+  draggable: DraggableEdge,
 };
 
 const defaultEdgeOptions: DefaultEdgeOptions = {
-  type: 'workflow',
+  type: 'draggable',
   markerEnd: { type: MarkerType.ArrowClosed },
 };
 

--- a/src/features/workflowBuilder/components/canvas/edges/DraggableEdge.tsx
+++ b/src/features/workflowBuilder/components/canvas/edges/DraggableEdge.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useState } from 'react';
+import {
+  type Edge,
+  type EdgeProps,
+  getSmoothStepPath,
+  EdgeLabelRenderer,
+  useReactFlow,
+} from '@xyflow/react';
+import { useWorkflowStore } from '../../../hooks/useWorkflowStore';
+
+function buildWaypointPath(
+  sx: number, sy: number,
+  tx: number, ty: number,
+  wx: number, wy: number,
+): string {
+  const c1x = (sx + wx) / 2;
+  const c2x = (wx + tx) / 2;
+  return `M${sx},${sy} C${c1x},${sy} ${c1x},${wy} ${wx},${wy} C${c2x},${wy} ${c2x},${ty} ${tx},${ty}`;
+}
+
+export function DraggableEdge({
+  id,
+  sourceX, sourceY, sourcePosition,
+  targetX, targetY, targetPosition,
+  data, style, markerEnd, label, selected,
+}: EdgeProps) {
+  const [hovered, setHovered] = useState(false);
+  const { setEdges: rfSetEdges, screenToFlowPosition } = useReactFlow();
+  const storeSetEdges = useWorkflowStore((s) => s.setEdges);
+
+  const [defaultPath, labelX, labelY] = getSmoothStepPath({
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+    borderRadius: 16,
+  });
+
+  const edgeProps = data?.properties as Record<string, unknown> | undefined;
+  const wx = edgeProps?._uiWaypointX as number | undefined;
+  const wy = edgeProps?._uiWaypointY as number | undefined;
+  const hasWaypoint = wx !== undefined && wy !== undefined;
+
+  const edgePath = hasWaypoint
+    ? buildWaypointPath(sourceX, sourceY, targetX, targetY, wx, wy)
+    : defaultPath;
+
+  const dotX = hasWaypoint ? wx : labelX;
+  const dotY = hasWaypoint ? wy : labelY;
+
+  const stroke = (style?.stroke as string) ?? '#94a3b8';
+  const strokeWidth = (hovered || selected) ? 2.5 : 2;
+  const isConditional = (data?.type as string) === 'Conditional';
+  const strokeDash = isConditional ? '6,4' : undefined;
+
+  const onHandleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGCircleElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      const startFlow = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+      const offX = dotX - startFlow.x;
+      const offY = dotY - startFlow.y;
+
+      let lastX = dotX;
+      let lastY = dotY;
+
+      const onMove = (me: MouseEvent) => {
+        const f = screenToFlowPosition({ x: me.clientX, y: me.clientY });
+        lastX = f.x + offX;
+        lastY = f.y + offY;
+
+        rfSetEdges((edges) =>
+          edges.map((edge) => {
+            if (edge.id !== id) return edge;
+            return {
+              ...edge,
+              data: {
+                ...edge.data,
+                properties: {
+                  ...((edge.data?.properties as Record<string, unknown>) ?? {}),
+                  _uiWaypointX: lastX,
+                  _uiWaypointY: lastY,
+                },
+              },
+            };
+          }),
+        );
+      };
+
+      const onUp = () => {
+        // Persist final position to Zustand store so "Save Draft" includes it
+        const current = useWorkflowStore.getState().edges;
+        storeSetEdges(
+          current.map((edge) => {
+            if (edge.id !== id) return edge;
+            return {
+              ...edge,
+              data: {
+                ...edge.data,
+                properties: {
+                  ...((edge.data?.properties as Record<string, unknown>) ?? {}),
+                  _uiWaypointX: lastX,
+                  _uiWaypointY: lastY,
+                },
+              },
+            };
+          }),
+        );
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [id, dotX, dotY, screenToFlowPosition, rfSetEdges, storeSetEdges],
+  );
+
+  const onHandleDblClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const removeWaypoint = (edges: Edge[]) =>
+        edges.map((edge) => {
+          if (edge.id !== id) return edge;
+          const newProps = { ...((edge.data?.properties as Record<string, unknown>) ?? {}) };
+          delete newProps._uiWaypointX;
+          delete newProps._uiWaypointY;
+          return { ...edge, data: { ...edge.data, properties: newProps } };
+        });
+      rfSetEdges(removeWaypoint);
+      storeSetEdges(removeWaypoint(useWorkflowStore.getState().edges));
+    },
+    [id, rfSetEdges, storeSetEdges],
+  );
+
+  const onDelete = useCallback(() => {
+    rfSetEdges((es) => es.filter((e) => e.id !== id));
+  }, [id, rfSetEdges]);
+
+  return (
+    <>
+      {/* Wide invisible hit area */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={20}
+        className="cursor-pointer"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+
+      {/* Glow when hovered/selected */}
+      {(hovered || selected) && (
+        <path
+          d={edgePath}
+          fill="none"
+          stroke={stroke}
+          strokeOpacity={0.15}
+          strokeWidth={8}
+          pointerEvents="none"
+        />
+      )}
+
+      {/* Visible edge path */}
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={edgePath}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeDasharray={strokeDash}
+        markerEnd={markerEnd as string}
+        style={{ transition: 'stroke-width 150ms ease-out' }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+
+      {/* Drag handle — faint dot always, bright on hover */}
+      <circle
+        cx={dotX}
+        cy={dotY}
+        r={5}
+        fill="#1e1f24"
+        stroke={stroke}
+        strokeWidth={2}
+        className="nodrag nopan"
+        style={{
+          cursor: 'grab',
+          pointerEvents: 'all',
+          opacity: hovered ? 1 : 0.25,
+          transition: 'opacity 150ms ease-out',
+        }}
+        onMouseDown={onHandleMouseDown}
+        onDoubleClick={onHandleDblClick}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+
+      <EdgeLabelRenderer>
+        {label && (
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'none',
+            }}
+          >
+            <div className="whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium leading-none text-gray-300 bg-zinc-800/80">
+              {label as string}
+            </div>
+          </div>
+        )}
+
+        {hovered && (
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${label ? labelY + 22 : labelY}px)`,
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            <button
+              onClick={onDelete}
+              className="flex h-5 w-5 items-center justify-center rounded-full bg-error text-[11px] font-bold leading-none text-white shadow-lg ring-2 ring-zinc-900/50 transition-transform hover:scale-110"
+              title="Delete edge"
+            >
+              ×
+            </button>
+          </div>
+        )}
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/src/features/workflowBuilder/components/panels/ApprovalForm.tsx
+++ b/src/features/workflowBuilder/components/panels/ApprovalForm.tsx
@@ -22,6 +22,31 @@ function arrayToRecord(arr: { key: string; value: string }[]): Record<string, st
   return record;
 }
 
+function buildDefaults(
+  data: ActivityNodeData | undefined,
+  props: ApprovalProperties | undefined,
+): ApprovalFormValues {
+  return {
+    name: data?.name ?? '',
+    description: data?.description ?? '',
+    activityName: props?.activityName ?? '',
+    memberSourceType: props?.memberSource?.type ?? 'inline',
+    valueExpression: props?.memberSource?.valueExpression ?? '',
+    thresholds: (props?.memberSource?.thresholds ?? []).map((t) => ({
+      committeeCode: t.committeeCode,
+      maxValue: t.maxValue != null ? String(t.maxValue) : '',
+    })),
+    quorumType: props?.quorum?.type ?? 'count',
+    quorumValue: props?.quorum?.value ?? 1,
+    majorityType: props?.majority?.type ?? 'count',
+    majorityValue: props?.majority?.value ?? 1,
+    voteOptions: props?.voteOptions ?? ['approve', 'reject', 'route_back'],
+    voteMovements: recordToArray(props?.voteMovements ?? {}),
+    decisionConditions: recordToArray(props?.decisionConditions ?? {}),
+    timeoutDuration: props?.timeoutDuration ?? 'PT72H',
+  };
+}
+
 export function ApprovalForm({ nodeId }: Props) {
   const nodes = useWorkflowStore((s) => s.nodes);
   const updateActivityData = useWorkflowStore((s) => s.updateActivityData);
@@ -30,28 +55,62 @@ export function ApprovalForm({ nodeId }: Props) {
   const data = node?.data as ActivityNodeData | undefined;
   const props = data?.properties as ApprovalProperties | undefined;
 
-  const { register, handleSubmit, reset, control, formState: { errors } } =
-    useForm<ApprovalFormValues>({
-      resolver: zodResolver(approvalFormSchema),
-      defaultValues: buildDefaults(data, props),
-    });
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    watch,
+    formState: { errors },
+  } = useForm<ApprovalFormValues>({
+    resolver: zodResolver(approvalFormSchema),
+    defaultValues: buildDefaults(data, props),
+  });
 
   const { fields: decisionFields, append: appendDecision, remove: removeDecision } =
     useFieldArray({ control, name: 'decisionConditions' });
+
+  const { fields: voteMovementFields, append: appendVoteMovement, remove: removeVoteMovement } =
+    useFieldArray({ control, name: 'voteMovements' });
+
+  const { fields: thresholdFields, append: appendThreshold, remove: removeThreshold } =
+    useFieldArray({ control, name: 'thresholds' });
 
   useEffect(() => {
     reset(buildDefaults(data, props));
   }, [nodeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const memberSourceType = watch('memberSourceType');
+
   const onSubmit = (values: ApprovalFormValues) => {
+    const memberSource =
+      values.memberSourceType === 'threshold'
+        ? {
+            type: 'threshold' as const,
+            valueExpression: values.valueExpression,
+            thresholds: values.thresholds.map((t) => ({
+              committeeCode: t.committeeCode,
+              maxValue: t.maxValue !== '' ? Number(t.maxValue) : null,
+            })),
+          }
+        : {
+            type: values.memberSourceType,
+            parameters: props?.memberSource?.parameters ?? {},
+          };
+
+    const voteMovementsRecord = arrayToRecord(values.voteMovements);
+
     updateActivityData(nodeId, {
       name: values.name,
       description: values.description,
       properties: {
-        memberSource: { type: values.memberSourceType, parameters: props?.memberSource?.parameters ?? {} },
-        quorum: { type: values.quorumType, value: values.quorumValue },
-        majority: { type: values.majorityType, value: values.majorityValue },
+        ...(props ?? {}),
+        activityName: values.activityName || undefined,
+        memberSource,
+        quorum: props?.quorum,
+        majority: props?.majority,
         voteOptions: values.voteOptions,
+        voteMovements: Object.keys(voteMovementsRecord).length > 0 ? voteMovementsRecord : undefined,
         decisionConditions: arrayToRecord(values.decisionConditions),
         timeoutDuration: values.timeoutDuration,
       } satisfies ApprovalProperties,
@@ -64,19 +123,28 @@ export function ApprovalForm({ nodeId }: Props) {
     <form onChange={handleSubmit(onSubmit)} className="flex flex-col gap-4">
       <div className="badge badge-success gap-1 text-xs">Approval Activity</div>
 
+      {/* Name */}
       <div className="form-control">
         <label className="label"><span className="label-text text-xs font-medium">Name</span></label>
         <input {...register('name')} className="input input-bordered input-sm w-full" />
         {errors.name && <label className="label"><span className="label-text-alt text-error">{errors.name.message}</span></label>}
       </div>
 
+      {/* Description */}
       <div className="form-control">
         <label className="label"><span className="label-text text-xs font-medium">Description</span></label>
         <textarea {...register('description')} className="textarea textarea-bordered textarea-sm w-full" rows={2} />
       </div>
 
+      {/* Activity Name */}
+      <div className="form-control">
+        <label className="label"><span className="label-text text-xs font-medium">Activity Name</span></label>
+        <input {...register('activityName')} className="input input-bordered input-sm w-full" placeholder="e.g. PendingApproval" />
+      </div>
+
       <div className="divider text-xs">Member Source</div>
 
+      {/* Source Type */}
       <div className="form-control">
         <label className="label"><span className="label-text text-xs font-medium">Source Type</span></label>
         <select {...register('memberSourceType')} className="select select-bordered select-sm w-full">
@@ -85,6 +153,54 @@ export function ApprovalForm({ nodeId }: Props) {
           <option value="threshold">Threshold</option>
         </select>
       </div>
+
+      {/* Threshold-specific fields */}
+      {memberSourceType === 'threshold' && (
+        <>
+          <div className="form-control">
+            <label className="label"><span className="label-text text-xs font-medium">Value Expression</span></label>
+            <input
+              {...register('valueExpression')}
+              className="input input-bordered input-sm w-full"
+              placeholder="e.g. facilityLimit"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium">Thresholds</span>
+            {thresholdFields.map((field, index) => (
+              <div key={field.id} className="flex gap-2 items-center">
+                <input
+                  {...register(`thresholds.${index}.committeeCode`)}
+                  className="input input-bordered input-xs flex-[2]"
+                  placeholder="Committee code"
+                  onBlur={handleSubmit(onSubmit)}
+                />
+                <input
+                  {...register(`thresholds.${index}.maxValue`)}
+                  className="input input-bordered input-xs flex-1"
+                  placeholder="Max value (blank = null)"
+                  type="number"
+                />
+                <button
+                  type="button"
+                  onClick={() => { removeThreshold(index); handleSubmit(onSubmit)(); }}
+                  className="btn btn-ghost btn-xs text-error"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => { appendThreshold({ committeeCode: '', maxValue: '' }); setTimeout(() => handleSubmit(onSubmit)(), 0); }}
+              className="btn btn-ghost btn-xs text-primary"
+            >
+              + Add Threshold
+            </button>
+          </div>
+        </>
+      )}
 
       <div className="divider text-xs">Quorum &amp; Majority</div>
 
@@ -119,6 +235,40 @@ export function ApprovalForm({ nodeId }: Props) {
       <div className="form-control">
         <label className="label"><span className="label-text text-xs font-medium">Timeout Duration (ISO 8601)</span></label>
         <input {...register('timeoutDuration')} className="input input-bordered input-sm w-full" placeholder="PT72H" />
+      </div>
+
+      <div className="divider text-xs">Vote Movements</div>
+
+      <div className="flex flex-col gap-2">
+        {voteMovementFields.map((field, index) => (
+          <div key={field.id} className="flex gap-2">
+            <input
+              {...register(`voteMovements.${index}.key`)}
+              className="input input-bordered input-xs flex-1"
+              placeholder="Vote option (e.g. route_back)"
+              onBlur={handleSubmit(onSubmit)}
+            />
+            <input
+              {...register(`voteMovements.${index}.value`)}
+              className="input input-bordered input-xs w-16"
+              placeholder="F/B/C"
+            />
+            <button
+              type="button"
+              onClick={() => { removeVoteMovement(index); handleSubmit(onSubmit)(); }}
+              className="btn btn-ghost btn-xs text-error"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => { appendVoteMovement({ key: '', value: '' }); setTimeout(() => handleSubmit(onSubmit)(), 0); }}
+          className="btn btn-ghost btn-xs text-primary"
+        >
+          + Add Vote Movement
+        </button>
       </div>
 
       <div className="divider text-xs">Decision Conditions</div>
@@ -156,22 +306,4 @@ export function ApprovalForm({ nodeId }: Props) {
       </div>
     </form>
   );
-}
-
-function buildDefaults(
-  data: ActivityNodeData | undefined,
-  props: ApprovalProperties | undefined,
-): ApprovalFormValues {
-  return {
-    name: data?.name ?? '',
-    description: data?.description ?? '',
-    memberSourceType: props?.memberSource?.type ?? 'inline',
-    quorumType: props?.quorum?.type ?? 'count',
-    quorumValue: props?.quorum?.value ?? 1,
-    majorityType: props?.majority?.type ?? 'count',
-    majorityValue: props?.majority?.value ?? 1,
-    voteOptions: props?.voteOptions ?? ['approve', 'reject', 'route_back'],
-    decisionConditions: recordToArray(props?.decisionConditions ?? {}),
-    timeoutDuration: props?.timeoutDuration ?? 'PT72H',
-  };
 }

--- a/src/features/workflowBuilder/components/panels/TaskForm.tsx
+++ b/src/features/workflowBuilder/components/panels/TaskForm.tsx
@@ -15,6 +15,14 @@ const STRATEGY_OPTIONS = [
   { value: AssignmentStrategy.STARTED_BY, label: 'Started By' },
   { value: AssignmentStrategy.ROUND_ROBIN, label: 'Round Robin' },
   { value: AssignmentStrategy.PREVIOUS_OWNER, label: 'Previous Owner' },
+  { value: 'pool', label: 'Pool' },
+  { value: 'variable_assignee', label: 'Variable Assignee' },
+];
+
+const MOVEMENT_OPTIONS = [
+  { value: 'F', label: 'Forward (F)' },
+  { value: 'B', label: 'Backward (B)' },
+  { value: 'C', label: 'Complete (C)' },
 ];
 
 function recordToArray(record: Record<string, string>): { key: string; value: string }[] {
@@ -46,6 +54,12 @@ export function TaskForm({ nodeId }: TaskFormProps) {
   const { fields: decisionFields, append: appendDecision, remove: removeDecision } =
     useFieldArray({ control, name: 'decisionConditions' });
 
+  const { fields: actionFields, append: appendAction, remove: removeAction } =
+    useFieldArray({ control, name: 'actions' });
+
+  const { fields: mappingFields, append: appendMapping, remove: removeMapping } =
+    useFieldArray({ control, name: 'inputMappings' });
+
   useEffect(() => {
     if (data && props) {
       reset(buildDefaults(data, props));
@@ -58,14 +72,22 @@ export function TaskForm({ nodeId }: TaskFormProps) {
       description: values.description,
       requiredRoles: values.requiredRoles,
       properties: {
+        ...(props ?? {}),
         activityName: values.activityName,
-        assigneeRole: values.assigneeRole,
+        assigneeRole: values.assigneeRole || undefined,
         assigneeGroup: values.assigneeGroup,
         assignmentStrategies: values.initialAssignmentStrategies[0] ?? 'round_robin',
         initialAssignmentStrategies: values.initialAssignmentStrategies,
         revisitAssignmentStrategies: values.revisitAssignmentStrategies,
         timeoutDuration: values.timeoutDuration,
         decisionConditions: arrayToRecord(values.decisionConditions),
+        actions: values.actions.length > 0 ? values.actions : undefined,
+        canRaiseFollowup: values.canRaiseFollowup || undefined,
+        canRaiseQuotation: values.canRaiseQuotation || undefined,
+        teamIdVariable: values.teamIdVariable || undefined,
+        assignmentRules: values.teamConstrained ? { teamConstrained: true } : undefined,
+        assigneeVariable: values.assigneeVariable || undefined,
+        inputMappings: values.inputMappings.length > 0 ? arrayToRecord(values.inputMappings) : undefined,
       },
     });
   };
@@ -239,12 +261,198 @@ export function TaskForm({ nodeId }: TaskFormProps) {
           type="button"
           onClick={() => {
             appendDecision({ key: '', value: '' });
-            // Trigger store update so node re-renders with new handle
             setTimeout(() => handleSubmit(onSubmit)(), 0);
           }}
           className="btn btn-ghost btn-xs text-primary"
         >
           + Add Decision
+        </button>
+      </div>
+
+      {/* Actions */}
+      <div className="divider text-xs">Actions</div>
+
+      <div className="flex flex-col gap-3">
+        {actionFields.map((field, index) => (
+          <div key={field.id} className="border border-base-300 rounded-lg p-2 flex flex-col gap-2">
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <label className="label py-0">
+                  <span className="label-text text-xs">Value</span>
+                </label>
+                <input
+                  {...register(`actions.${index}.value`)}
+                  className="input input-bordered input-xs w-full"
+                  placeholder="e.g. approve"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="label py-0">
+                  <span className="label-text text-xs">Label</span>
+                </label>
+                <input
+                  {...register(`actions.${index}.label`)}
+                  className="input input-bordered input-xs w-full"
+                  placeholder="e.g. Approve"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  removeAction(index);
+                  handleSubmit(onSubmit)();
+                }}
+                className="btn btn-ghost btn-xs text-error self-end"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <label className="label py-0">
+                  <span className="label-text text-xs">Assignment Mode</span>
+                </label>
+                <select
+                  {...register(`actions.${index}.assignmentMode`)}
+                  className="select select-bordered select-xs w-full"
+                >
+                  <option value="system">System</option>
+                  <option value="user">User</option>
+                </select>
+              </div>
+              <div className="flex-1">
+                <label className="label py-0">
+                  <span className="label-text text-xs">Movement</span>
+                </label>
+                <select
+                  {...register(`actions.${index}.movement`)}
+                  className="select select-bordered select-xs w-full"
+                >
+                  {MOVEMENT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="label py-0">
+                <span className="label-text text-xs">Condition (optional)</span>
+              </label>
+              <input
+                {...register(`actions.${index}.condition`)}
+                className="input input-bordered input-xs w-full"
+                placeholder="e.g. status == 'pending'"
+              />
+            </div>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            appendAction({ value: '', label: '', assignmentMode: 'system', movement: 'F', condition: '' });
+            setTimeout(() => handleSubmit(onSubmit)(), 0);
+          }}
+          className="btn btn-ghost btn-xs text-primary"
+        >
+          + Add Action
+        </button>
+      </div>
+
+      {/* Additional Options */}
+      <div className="divider text-xs">Additional Options</div>
+
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            {...register('canRaiseFollowup')}
+            className="checkbox checkbox-primary checkbox-xs"
+          />
+          <span className="text-xs">Can Raise Followup</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            {...register('canRaiseQuotation')}
+            className="checkbox checkbox-primary checkbox-xs"
+          />
+          <span className="text-xs">Can Raise Quotation</span>
+        </label>
+      </div>
+
+      {/* Variable Assignee */}
+      <div className="form-control">
+        <label className="label">
+          <span className="label-text text-xs font-medium">Assignee Variable</span>
+        </label>
+        <input
+          {...register('assigneeVariable')}
+          className="input input-bordered input-sm w-full"
+          placeholder="e.g. internalFollowupStaffId"
+        />
+      </div>
+
+      {/* Team Assignment */}
+      <div className="divider text-xs">Team Assignment</div>
+
+      <div className="form-control">
+        <label className="label">
+          <span className="label-text text-xs font-medium">Team ID Variable</span>
+        </label>
+        <input
+          {...register('teamIdVariable')}
+          className="input input-bordered input-sm w-full"
+          placeholder="e.g. assignedCompanyId"
+        />
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          {...register('teamConstrained')}
+          className="checkbox checkbox-primary checkbox-xs"
+        />
+        <span className="text-xs">Team Constrained</span>
+      </label>
+
+      {/* Input Mappings */}
+      <div className="divider text-xs">Input Mappings</div>
+
+      <div className="flex flex-col gap-2">
+        {mappingFields.map((field, index) => (
+          <div key={field.id} className="flex gap-2">
+            <input
+              {...register(`inputMappings.${index}.key`)}
+              className="input input-bordered input-xs flex-1"
+              placeholder="Key"
+              onBlur={handleSubmit(onSubmit)}
+            />
+            <input
+              {...register(`inputMappings.${index}.value`)}
+              className="input input-bordered input-xs flex-[2]"
+              placeholder="Value / variable"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                removeMapping(index);
+                handleSubmit(onSubmit)();
+              }}
+              className="btn btn-ghost btn-xs text-error"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            appendMapping({ key: '', value: '' });
+            setTimeout(() => handleSubmit(onSubmit)(), 0);
+          }}
+          className="btn btn-ghost btn-xs text-primary"
+        >
+          + Add Mapping
         </button>
       </div>
     </form>
@@ -266,5 +474,18 @@ function buildDefaults(
     timeoutDuration: props?.timeoutDuration ?? 'PT72H',
     decisionConditions: recordToArray(props?.decisionConditions ?? {}),
     requiredRoles: data?.requiredRoles ?? [],
+    actions: (props?.actions ?? []).map((a) => ({
+      value: a.value ?? '',
+      label: a.label ?? '',
+      assignmentMode: a.assignmentMode ?? 'system',
+      movement: a.movement ?? 'F',
+      condition: a.condition ?? '',
+    })),
+    canRaiseFollowup: props?.canRaiseFollowup ?? false,
+    canRaiseQuotation: props?.canRaiseQuotation ?? false,
+    teamIdVariable: props?.teamIdVariable ?? '',
+    teamConstrained: props?.assignmentRules?.teamConstrained ?? false,
+    assigneeVariable: props?.assigneeVariable ?? '',
+    inputMappings: recordToArray(props?.inputMappings ?? {}),
   };
 }

--- a/src/features/workflowBuilder/hooks/useWorkflowStore.ts
+++ b/src/features/workflowBuilder/hooks/useWorkflowStore.ts
@@ -190,7 +190,7 @@ export const useWorkflowStore = create<WorkflowBuilderState>((set, get) => ({
       target: connection.target,
       sourceHandle: connection.sourceHandle,
       targetHandle: connection.targetHandle,
-      type: 'smoothstep',
+      type: 'draggable',
       animated: true,
       style: { stroke: '#94a3b8', strokeWidth: 2 },
       markerEnd: { type: 'arrowclosed' as const },

--- a/src/features/workflowBuilder/schemas/index.ts
+++ b/src/features/workflowBuilder/schemas/index.ts
@@ -97,7 +97,7 @@ export const taskFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string(),
   activityName: z.string().min(1, 'Activity name is required'),
-  assigneeRole: z.string().min(1, 'Assignee role is required'),
+  assigneeRole: z.string().optional(),
   assigneeGroup: z.string().min(1, 'Assignee group is required'),
   initialAssignmentStrategies: z.array(z.string()).min(1),
   revisitAssignmentStrategies: z.array(z.string()).min(1),
@@ -109,6 +109,21 @@ export const taskFormSchema = z.object({
     }),
   ),
   requiredRoles: z.array(z.string()),
+  actions: z.array(
+    z.object({
+      value: z.string(),
+      label: z.string(),
+      assignmentMode: z.enum(['system', 'user']),
+      movement: z.enum(['F', 'B', 'C']),
+      condition: z.string().optional(),
+    }),
+  ),
+  canRaiseFollowup: z.boolean().optional(),
+  canRaiseQuotation: z.boolean().optional(),
+  teamIdVariable: z.string().optional(),
+  teamConstrained: z.boolean().optional(),
+  assigneeVariable: z.string().optional(),
+  inputMappings: z.array(z.object({ key: z.string(), value: z.string() })),
 });
 
 export const routingFormSchema = z.object({
@@ -182,12 +197,19 @@ export const transitionFormSchema = z.object({
 export const approvalFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string(),
+  activityName: z.string().optional(),
   memberSourceType: z.string().min(1, 'Member source type is required'),
+  valueExpression: z.string().optional(),
+  thresholds: z.array(z.object({
+    committeeCode: z.string(),
+    maxValue: z.string(), // string in form; convert to number|null on submit
+  })),
   quorumType: z.enum(['count', 'percent']),
   quorumValue: z.coerce.number().min(1),
   majorityType: z.enum(['count', 'percent']),
   majorityValue: z.coerce.number().min(1),
   voteOptions: z.array(z.string().min(1)),
+  voteMovements: z.array(z.object({ key: z.string(), value: z.string() })),
   decisionConditions: z.array(z.object({ key: z.string(), value: z.string() })),
   timeoutDuration: z.string().min(1, 'Timeout is required'),
 });

--- a/src/features/workflowBuilder/types/index.ts
+++ b/src/features/workflowBuilder/types/index.ts
@@ -63,6 +63,14 @@ export interface StartProperties {
   [key: string]: unknown;
 }
 
+export interface TaskAction {
+  value: string;
+  label: string;
+  assignmentMode: 'system' | 'user';
+  movement: 'F' | 'B' | 'C';
+  condition?: string;
+}
+
 export interface TaskProperties {
   activityName: string;
   assigneeRole?: string;
@@ -72,6 +80,13 @@ export interface TaskProperties {
   revisitAssignmentStrategies: string[];
   timeoutDuration: string;
   decisionConditions: Record<string, string>;
+  actions?: TaskAction[];
+  canRaiseFollowup?: boolean;
+  canRaiseQuotation?: boolean;
+  teamIdVariable?: string;
+  assignmentRules?: { teamConstrained: boolean };
+  assigneeVariable?: string;
+  inputMappings?: Record<string, string>;
 }
 
 export interface RoutingProperties {
@@ -118,10 +133,17 @@ export interface GenericProperties {
 // Phase 2 — new activity property interfaces
 
 export interface ApprovalProperties {
-  memberSource: { type: string; parameters: Record<string, unknown> };
-  quorum: { type: 'count' | 'percent'; value: number };
-  majority: { type: 'count' | 'percent'; value: number };
+  activityName?: string;
+  memberSource: {
+    type: string;
+    valueExpression?: string;
+    thresholds?: Array<{ maxValue: number | null; committeeCode: string }>;
+    parameters?: Record<string, unknown>;
+  };
+  quorum?: { type: 'count' | 'percent'; value: number };
+  majority?: { type: 'count' | 'percent'; value: number };
   voteOptions: string[];
+  voteMovements?: Record<string, string>;
   decisionConditions: Record<string, string>;
   timeoutDuration: string;
 }
@@ -419,6 +441,7 @@ export function createDefaultApprovalProperties(): ApprovalProperties {
     quorum: { type: 'count', value: 1 },
     majority: { type: 'count', value: 1 },
     voteOptions: ['approve', 'reject', 'route_back'],
+    voteMovements: {},
     decisionConditions: {},
     timeoutDuration: 'PT72H',
   };

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -1473,6 +1473,13 @@ const SaveComparativeAnalysisRequest = z
     calculations: z.array(CalculationInput),
     comparativeAnalysisTemplateId: z.string().uuid().nullish().default(null),
     appraisalValue: z.number().nullish().default(null),
+    finalValueAdjusted: z.number().nullish().default(null),
+    hasBuildingCost: z.boolean().nullish().default(null),
+    buildingCost: z.number().nullish().default(null),
+    appraisalPrice: z.number().nullish().default(null),
+    includeLandArea: z.boolean().nullish().default(null),
+    landArea: z.number().nullish().default(null),
+    landValue: z.number().nullish().default(null),
   })
   .passthrough();
 const SaveComparativeAnalysisResponse = z
@@ -1615,6 +1622,7 @@ const GetComparativeFactorsResponse = z
     methodType: z.string(),
     comparativeAnalysisTemplateId: z.string().uuid().nullable(),
     methodValue: z.number().nullable(),
+    finalValueAdjusted: z.number().nullable().optional(),
     linkedComparables: z.array(LinkedComparableDto),
     comparativeFactors: z.array(ComparativeFactorDto),
     factorScores: z.array(FactorScoreDto),
@@ -2002,7 +2010,8 @@ const AppraisalFeeDto = z
     totalPaidAmount: z.number(),
     outstandingAmount: z.number(),
     paymentStatus: z.string(),
-    inspectionFeeAmount: z.number().nullable(),
+    constructionInspectionFeeAmount: z.number().nullable(),
+    hasBuildingUnderConstruction: z.boolean(),
     createdAt: z.string().datetime({ offset: true }).nullable(),
     items: z.array(AppraisalFeeItemDto),
     paymentHistory: z.array(PaymentHistoryDto),


### PR DESCRIPTION
## Summary

Three independent feature clusters bundled into one PR.

### Appraisal — construction inspection fee & summary
- New `PATCH /appraisals/{id}/fees/{feeId}/construction-inspection-fee` endpoint and inline fee editor with commit-on-blur + rollback.
- New `ConstructionSummaryTable` (per-phase progress / total / land / building values) added to all DecisionSummary flows.
- Weighted previous/current progress metrics added to construction inspection totals.

### Pricing analysis (WQS) — fix override persistence + simplify model
- **Bug fix**: user overrides (`landValue`, `appraisalPrice`, `finalValueAdjusted`) were being clobbered on re-render. Ref-guards on seed rules now prevent re-fire on rule-array re-creation.
- **Model simplification**: drop 6 computed-only fields, add 3 user-editable overrides; types, schema, adapters, and submit mapper updated together.
- **UX**: auto-derive "Include Area" from comparable price unit (01/02 per-unit vs 03 total); dynamic Sq.Wa/Sq.m label; redesigned cost-approach layout.

### Workflow builder — draggable edges + enriched forms
- New `DraggableEdge` component: drag waypoints, double-click reset, delete on hover, persisted for Save Draft.
- `TaskForm` gains custom Actions, Raise Followup/Quotation toggles, team constraints, variable bindings, input mappings; `assigneeRole` now optional.
- `ApprovalForm` gains Activity Name, threshold member source (committee + max-value rows), and Vote Movements.

## Test plan
- [ ] Appraisal: open an appraisal with `hasBuildingUnderConstruction=true`, edit construction inspection fee, blur — confirm PATCH fires; confirm rollback if API fails.
- [ ] Decision summary: confirm `ConstructionSummaryTable` renders for ext/int execution, check, and verification when `constructionSummary` present; confirm "Current" row bold.
- [ ] Construction inspection tab: confirm weighted progress columns appear in category and grand-total rows.
- [ ] WQS: edit land/appraisal/final-value-adjusted overrides, save, reload — confirm values persist (regression test for the clobber bug).
- [ ] WQS: switch comparable price unit between 01/02 and 03 — confirm "Include Area" auto-derives and Sq.Wa vs Sq.m label updates.
- [ ] Workflow: drag an edge waypoint, save draft, reload — confirm waypoint position persists; double-click resets; hover-delete works.
- [ ] Workflow: configure TaskForm Actions and ApprovalForm thresholds/Vote Movements; confirm validation and auto-save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)