### PR TITLE
feat: add lease condo support in CreateLeaseAgreement flow and update…

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -75,12 +75,6 @@ import ExtCompanySubmitQuotationPage from '@/features/quotation/pages/ExtCompany
 import AdminQuotationTaskPage from '@/features/quotation/pages/AdminQuotationTaskPage';
 import AdminCompanyQuotationDetailPage from '@/features/quotation/pages/AdminCompanyQuotationDetailPage';
 
-function TaskPageDispatcher() {
-  const [searchParams] = useSearchParams();
-  const activityId = searchParams.get('activityId');
-  return activityId ? <ActivityTaskListPage /> : <TaskListingPage />;
-}
-
 /**
  * Thin wrappers that bind PricingAnalysisPage to a project-model subject.
  * modelId and pricingAnalysisId are read from route params inside PricingAnalysisPage.

--- a/src/features/pricingAnalysis/domain/dcf/createEmptyMethodDetail.ts
+++ b/src/features/pricingAnalysis/domain/dcf/createEmptyMethodDetail.ts
@@ -59,30 +59,6 @@ export function createDefaultMethod(methodType: MethodType): DCFMethod {
           startIn: 1,
         },
       };
-    case '02':
-      return {
-        id,
-        methodType: '02',
-        totalMethodValues: [],
-        detail: {
-          seasonCount: 1,
-          seasonDetails: [],
-          roomDetails: [],
-          avgRoomRate: 0,
-          totalSaleableArea: 0,
-          increaseRatePct: 0,
-          increaseRateYrs: 0,
-          occupancyRateFirstYearPct: 0,
-          occupancyRatePct: 0,
-          occupancyRateYrs: 0,
-          saleableArea: [],
-          occupancyRate: [],
-          totalSaleableAreaDeductByOccRate: [],
-          roomRateIncrease: [],
-          avgDailyRate: [],
-          roomIncome: [],
-        },
-      };
     case '03':
       return {
         id,
@@ -275,13 +251,6 @@ export function createDefaultMethod(methodType: MethodType): DCFMethod {
           increaseRateYrs: 0,
           startIn: 1,
         },
-      };
-    case '15':
-      return {
-        id,
-        methodType: '15',
-        totalMethodValues: [],
-        detail: { startIn: 1 },
       };
     default: {
       const _exhaustive: never = methodType;


### PR DESCRIPTION
This pull request primarily removes support for two DCF method types ('02' and '15') from the `createDefaultMethod` function, and also deletes an unused component from the router. These changes help streamline the codebase by removing unused or deprecated functionality.

**Removal of DCF Method Types:**

* Removed the case for method type `'02'` in the `createDefaultMethod` function, eliminating its default value structure and associated fields.
* Removed the case for method type `'15'` in the `createDefaultMethod` function, cleaning up unnecessary code paths.

**Router Cleanup:**

* Deleted the unused `TaskPageDispatcher` component from `src/app/router.tsx`, reducing dead code.