### PR TITLE
fix: make area id optional

### DIFF
--- a/src/features/appraisal/schemas/form.ts
+++ b/src/features/appraisal/schemas/form.ts
@@ -132,7 +132,7 @@ export const createBuildingForm = buildFormSchema(
 
 const AreaDetailDto = z
   .object({
-    id: z.string().uuid().nullable(),
+    id: z.string().uuid().nullable().optional(),
     areaDescription: z.string().nullable(),
     areaSize: z.coerce.number().nullable(),
   })


### PR DESCRIPTION
This pull request makes a minor adjustment to the `AreaDetailDto` schema in `form.ts`, allowing the `id` field to be either omitted or set to null. This increases flexibility when handling area details in forms.