### PR TITLE
fix: invalidate property detail cache for lease agreement condo prope…

### DIFF
--- a/src/features/appraisal/pages/CreateLeaseAgreementCondoPage.tsx
+++ b/src/features/appraisal/pages/CreateLeaseAgreementCondoPage.tsx
@@ -4,6 +4,7 @@ import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAppraisalId, useBasePath } from '../context/AppraisalContext';
 import type { PropertyPhotoSectionRef } from '../components/PropertyPhotoSection';
+import PropertyPhotoSection from '../components/PropertyPhotoSection';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { mapCondoPropertyResponseToForm } from '../utils/mappers';
 import {
@@ -20,7 +21,6 @@ import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import { FormProvider } from '@/shared/components/form/FormProvider';
 import Section from '@/shared/components/sections/Section';
 import ResizableSidebar from '@/shared/components/ResizableSidebar';
-import PropertyPhotoSection from '../components/PropertyPhotoSection';
 import CondoDetailForm from '../forms/CondoDetailForm';
 import LeaseAgreementForm from '../forms/LeaseAgreementForm';
 import RentalInfoForm from '../forms/RentalInfoForm';
@@ -29,7 +29,7 @@ import CancelButton from '@/shared/components/buttons/CancelButton';
 import UnsavedChangesDialog from '@/shared/components/UnsavedChangesDialog';
 import { Button } from '@/shared/components';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useForm, type SubmitHandler } from 'react-hook-form';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 
 // ─── Inline create/update mutations ──────────────────────────────
 
@@ -69,6 +69,14 @@ const useUpdateLeaseAgreementCondoProperty = () => {
       queryClient.invalidateQueries({ queryKey: propertyGroupKeys.all(variables.appraisalId) });
       queryClient.invalidateQueries({
         queryKey: propertyGroupKeys.propertyDetail(variables.appraisalId, variables.propertyId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          'appraisals',
+          variables.appraisalId,
+          'lease-agreement-condo-properties',
+          variables.propertyId,
+        ],
       });
     },
   });


### PR DESCRIPTION
This pull request introduces a minor fix and a small enhancement to the `CreateLeaseAgreementCondoPage.tsx` file. The main changes include correcting the import order, improving code consistency, and ensuring that the relevant query is invalidated after a mutation.

Enhancements to query invalidation:

* Added an extra `invalidateQueries` call in the `useUpdateLeaseAgreementCondoProperty` hook to ensure that the lease agreement condo properties cache is properly refreshed after updates.

Code cleanup and consistency:

* Fixed the order of imports for `PropertyPhotoSection` to align with project conventions and avoid duplicate imports. [[1]](diffhunk://#diff-ef4f643e533e21bf7010e455f0036d36157093bb948f23fe81eb7d86e4a26f7dR7) [[2]](diffhunk://#diff-ef4f643e533e21bf7010e455f0036d36157093bb948f23fe81eb7d86e4a26f7dL23)
* Updated the import statement for `useForm` and `SubmitHandler` from `react-hook-form` to group type imports first, improving code readability.