### PR TITLE
fix: remove estimatedDays from quotation submission and related logic

### DIFF
--- a/src/features/quotation/api/quotation.ts
+++ b/src/features/quotation/api/quotation.ts
@@ -453,7 +453,6 @@ export const useSubmitQuotation = (quotationId: string) => {
   return useMutation({
     mutationFn: async (payload: {
       quotationNumber: string;
-      estimatedDays: number;
       items: Array<{
         quotationRequestItemId: string;
         appraisalId: string;

--- a/src/features/quotation/pages/ExtCompanySubmitQuotationPage.tsx
+++ b/src/features/quotation/pages/ExtCompanySubmitQuotationPage.tsx
@@ -320,7 +320,6 @@ const ExtCompanySubmitQuotationPage = () => {
       quotationRequestId: id ?? '',
       companyId,
       quotationNumber: values.quotationNumber,
-      estimatedDays: Math.max(...values.items.map(i => i.estimatedDays ?? 1), 1),
       items: values.items.map((item, idx) => ({
         quotationRequestItemId: '00000000-0000-0000-0000-000000000000',
         appraisalId: item.appraisalId,
@@ -527,7 +526,6 @@ const ExtCompanySubmitQuotationPage = () => {
     submitQuotation(
       {
         quotationNumber: values.quotationNumber,
-        estimatedDays: Math.max(...values.items.map(i => i.estimatedDays), 1),
         items: values.items.map((item, idx) => ({
           quotationRequestItemId: '00000000-0000-0000-0000-000000000000',
           appraisalId: item.appraisalId,

--- a/src/features/quotation/schemas/quotation.ts
+++ b/src/features/quotation/schemas/quotation.ts
@@ -355,7 +355,6 @@ export const SaveDraftQuotationSchema = z.object({
   quotationRequestId: z.string().uuid(),
   companyId: z.string().uuid(),
   quotationNumber: z.string(),
-  estimatedDays: z.number().int(),
   items: z.array(SaveDraftQuotationItemSchema),
   validUntil: z.string().nullable().optional(),
   proposedStartDate: z.string().nullable().optional(),


### PR DESCRIPTION
This pull request removes the `estimatedDays` field from the quotation submission flow, simplifying the data model and related logic. The most important changes are:

**Schema and API changes:**

* Removed the `estimatedDays` field from the `SaveDraftQuotationSchema` in `quotation.ts`, so this value is no longer required or validated for draft quotations.
* Updated the `useSubmitQuotation` mutation to no longer accept or send the `estimatedDays` field in its payload.

**Page and form logic updates:**

* Removed all logic related to calculating and passing `estimatedDays` when submitting a quotation on the `ExtCompanySubmitQuotationPage` component, including the removal of code that aggregated this value from quotation items. [[1]](diffhunk://#diff-be442af356c3e091f096306d3107901c834fda7374cf585c523ac924555daf09L323) [[2]](diffhunk://#diff-be442af356c3e091f096306d3107901c834fda7374cf585c523ac924555daf09L530)