### PR TITLE
feat(signalr): force WebSockets-only transport on both hubs

### DIFF
--- a/src/features/notification/hooks/useNotificationHub.tsx
+++ b/src/features/notification/hooks/useNotificationHub.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnectionState, HttpTransportType } from '@microsoft/signalr';
 import { signalrLogger } from '@shared/utils/signalrLogger';
 import { useQueryClient } from '@tanstack/react-query';
 import { getAccessToken } from '@shared/api/axiosInstance';
@@ -32,6 +32,9 @@ export function useNotificationHub() {
     const connection = new HubConnectionBuilder()
       .withUrl(getHubUrl(), {
         accessTokenFactory: () => getAccessToken() ?? '',
+        skipNegotiation: true,
+        transport: HttpTransportType.WebSockets,
+        withCredentials: true,
       })
       .withAutomaticReconnect()
       .configureLogging(signalrLogger)

--- a/src/features/task/hooks/useWorkflowHub.ts
+++ b/src/features/task/hooks/useWorkflowHub.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnectionState, HttpTransportType } from '@microsoft/signalr';
 import { signalrLogger } from '@shared/utils/signalrLogger';
 import { getAccessToken } from '@shared/api/axiosInstance';
 
@@ -43,6 +43,9 @@ export function useWorkflowHub({ poolGroups, onPoolTaskUpdate }: UseWorkflowHubO
     const connection = new HubConnectionBuilder()
       .withUrl(getHubUrl(), {
         accessTokenFactory: () => getAccessToken() ?? '',
+        skipNegotiation: true,
+        transport: HttpTransportType.WebSockets,
+        withCredentials: true,
       })
       .withAutomaticReconnect()
       .configureLogging(signalrLogger)


### PR DESCRIPTION
## Summary
Forward-port of the WS-only hub-client change already pushed directly to `release/uat/v3.0.0-2026-05-11` (commit `64b4c5d`) for the UAT deploy. Verbatim cherry-pick to keep main in sync per-change.

Companion to backend PR https://github.com/immortalgky/collateral-appraisal-system-api/pull/206 / commit `cbbdbee2` (Redis backplane). With both landed, SignalR fan-out across the two UAT IIS replicas works without requiring F5 sticky sessions.

## Files (2)
- `src/features/notification/hooks/useNotificationHub.tsx` — add `HttpTransportType` import + `skipNegotiation: true`, `transport: HttpTransportType.WebSockets`, `withCredentials: true` to `.withUrl(...)` options.
- `src/features/task/hooks/useWorkflowHub.ts` — same.

## Why each option
- **`skipNegotiation: true` + `transport: WebSockets`** — the load-bearing change. Forces SignalR to skip the `/negotiate` POST and go straight to a WebSocket. The TCP socket pins one client to one IIS box, so cross-replica HTTP balancing can't break the connection.
- **`withCredentials: true`** — no-op for the WS-only path (browser handles WS-handshake cookies natively), kept for defense in depth: if anyone later flips `skipNegotiation` back to `false` to debug or allow fallback transports, the XHR-based transports need this to satisfy the backend's `.AllowCredentials()` CORS policy.

## Risk
- **Low.** Same code as already running on UAT.
- Users on networks/browsers that block WebSockets (rare on internal banking LAN) will see a clear connection failure instead of silently degrading to broken long-polling. Considered a feature, not a regression.
- No change to auth — bearer still rides the WS handshake via `accessTokenFactory` query-string.

## Test plan
- [x] `vite build` clean on `main` cherry-pick (pre-existing `tsc -b` test-file errors are unrelated and present on `origin/main` without this change).
- [ ] DevTools Network on the SPA: `/notificationHub` and `/workflowHub` show `101 Switching Protocols` with `Connection: Upgrade` + `Upgrade: websocket` headers (no polling fallback).
- [ ] Cross-replica fan-out verified on UAT alongside backend backplane (open SPA in two browsers same user → both receive notifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)