### PR TITLE
feat: invoice payment UX refactor and task-monitor people drill-down

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,5 +1,5 @@
-import { Outlet } from 'react-router-dom';
-import { useRef } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import { useEffect, useMemo, useRef } from 'react';
 import Navbar from '@shared/components/Navbar';
 import Sidebar, { MobileSidebar } from '@shared/components/Sidebar';
 import Breadcrumb from '@shared/components/Breadcrumb';
@@ -10,6 +10,7 @@ import { useParametersQuery } from '@shared/api/parameters';
 import { useAddressesQuery } from '@shared/api/addresses';
 import { useCompaniesQuery } from '@shared/api/companies';
 import { useBreadcrumb } from '@shared/hooks/useBreadcrumb';
+import { useBreadcrumbExtrasStore } from '@shared/store';
 import { useNavigation } from '@shared/hooks/useNavigation';
 import LoadingOverlay from '@shared/components/LoadingOverlay';
 import {
@@ -98,6 +99,7 @@ function CompanyLoader() {
 }
 
 function Layout() {
+  const location = useLocation();
   const { items: breadcrumbItems } = useBreadcrumb();
   const { isOpen: isRightMenuOpen, onToggle: toggleRightMenu } = useDisclosure({
     defaultIsOpen: true,
@@ -107,6 +109,19 @@ function Layout() {
 
   // Get role-based navigation
   const navigation = useNavigation();
+
+  // Page-level dynamic crumbs (fetched record names) appended after the layout-built
+  // crumbs. Same pattern as AppraisalLayout / TaskLayout: clear extras whenever the
+  // pathname changes so stale crumbs don't leak across pages.
+  const breadcrumbExtras = useBreadcrumbExtrasStore(s => s.extras);
+  const setExtras = useBreadcrumbExtrasStore(s => s.setExtras);
+  useEffect(() => {
+    setExtras([]);
+  }, [location.pathname, setExtras]);
+  const breadcrumbItemsWithExtras = useMemo(() => {
+    const merged = [...breadcrumbItems, ...breadcrumbExtras];
+    return merged.filter((item, idx) => idx === 0 || item.label !== merged[idx - 1].label);
+  }, [breadcrumbItems, breadcrumbExtras]);
 
   return (
     <RightMenuPortalProvider
@@ -128,7 +143,7 @@ function Layout() {
             {/* Main Content */}
             <main className="py-4 flex-1 flex flex-col min-h-0 min-w-0 pr-4">
               <div className="px-4 sm:px-6 lg:px-6 flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-                <Breadcrumb items={breadcrumbItems} className="mb-4 shrink-0" />
+                <Breadcrumb items={breadcrumbItemsWithExtras} className="mb-4 shrink-0" />
                 <div className="flex-1 min-h-0 min-w-0 overflow-y-auto">
                   <ErrorBoundary>
                     <Outlet />

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -43,7 +43,10 @@ import CreateLeaseAgreementCondoPage from '@/features/appraisal/pages/CreateLeas
 import AppraisalSearchPage from '@/features/appraisal/pages/AppraisalSearchPage';
 import AppraisalListPage from '@/features/appraisal/pages/AppraisalListPage';
 import Appraisal360Page from '@/features/appraisal/pages/Appraisal360Page';
-import { AppraisalReadOnlyWrapper, ReadOnlyPageWrapper, } from '@shared/contexts/PageReadOnlyContext';
+import {
+  AppraisalReadOnlyWrapper,
+  ReadOnlyPageWrapper,
+} from '@shared/contexts/PageReadOnlyContext';
 import WorkflowBuilderPage from '@features/workflowBuilder/pages/WorkflowBuilderPage';
 import ProvideDocumentsTaskPage from '@/features/document-followup/pages/ProvideDocumentsTaskPage';
 import WorkflowListPage from '@features/workflowBuilder/pages/WorkflowListPage';
@@ -83,6 +86,8 @@ import IntInvoiceListPage from '@/features/invoice/pages/IntInvoiceListPage';
 import IntInvoiceDetailPage from '@/features/invoice/pages/IntInvoiceDetailPage';
 import IntBulkPaymentPage from '@/features/invoice/pages/IntBulkPaymentPage';
 import WebhookDeliveryListPage from '@features/webhookAdmin/pages/WebhookDeliveryListPage';
+import TaskMonitorPage from '@/features/taskMonitor/routes/TaskMonitorPage';
+import PersonTasksPage from '@/features/taskMonitor/routes/PersonTasksPage';
 
 /**
  * Thin wrappers that bind PricingAnalysisPage to a project-model subject.
@@ -191,6 +196,15 @@ export const router = createBrowserRouter([
       {
         path: 'tasks',
         children: [{ index: true, element: <TaskPageDispatcher /> }],
+      },
+      // Task Monitor — supervisor view for reassigning tasks across monitored groups
+      {
+        path: 'task-monitor',
+        element: <TaskMonitorPage />,
+      },
+      {
+        path: 'task-monitor/:username',
+        element: <PersonTasksPage />,
       },
       // Meeting Routes (tier-3 approval gate)
       {

--- a/src/features/invoice/api/invoice.ts
+++ b/src/features/invoice/api/invoice.ts
@@ -33,6 +33,8 @@ export interface GetInvoicesParams {
   pageSize?: number;
   /** Single status value (Pending | Sent | Paid). Omit when listing all statuses. */
   status?: string;
+  /** Status to exclude (e.g. "Paid" on the Ext Unpaid tab so drafts + sent show but paid don't). */
+  excludeStatus?: string;
   companySearch?: string;
   /** Filter by a specific company id. Internal admins only — ext users are auto-scoped. */
   companyId?: string;
@@ -44,6 +46,10 @@ export interface GetInvoicesParams {
   search?: string;
   /** Group-by criterion. Supported: "company". Null/omit = newest-first. */
   groupBy?: string;
+  /** Whitelisted sort column. Server falls back to default ordering when null/unknown. */
+  sortBy?: string;
+  /** "asc" | "desc". Defaults to descending server-side. */
+  sortDir?: 'asc' | 'desc';
 }
 
 export interface GetEligibleAssignmentsParams {
@@ -64,9 +70,12 @@ export const useGetInvoices = (params: GetInvoicesParams = {}) => {
     pageNumber: params.pageNumber ?? 0,
     pageSize: params.pageSize ?? 10,
     ...(params.status && { status: params.status }),
+    ...(params.excludeStatus && { excludeStatus: params.excludeStatus }),
     ...(params.companySearch && { companySearch: params.companySearch }),
     ...(params.companyId && { companyId: params.companyId }),
     ...(params.groupBy && { groupBy: params.groupBy }),
+    ...(params.sortBy && { sortBy: params.sortBy }),
+    ...(params.sortDir && { sortDir: params.sortDir }),
     ...(params.sentDateFrom && { sentDateFrom: params.sentDateFrom }),
     ...(params.sentDateTo && { sentDateTo: params.sentDateTo }),
     ...(params.paidDateFrom && { paidDateFrom: params.paidDateFrom }),

--- a/src/features/invoice/components/InvoiceItemsTable.tsx
+++ b/src/features/invoice/components/InvoiceItemsTable.tsx
@@ -1,16 +1,141 @@
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatLocaleDate } from '@/shared/utils/dateUtils';
+import Icon from '@/shared/components/Icon';
 import type { InvoiceItem } from '../types/invoice';
 
 interface InvoiceItemsTableProps {
   items: InvoiceItem[];
+  /**
+   * Hide payment-state columns (Paid / Remaining). Used by the Mark-as-Paid flow
+   * where the focus is on the bank-absorb amount being paid, not the customer's
+   * outstanding balance.
+   */
+  hidePaymentColumns?: boolean;
+  /**
+   * Show the Cost Center column. Only internal-admin surfaces care about cost-center
+   * routing — external company users don't need it.
+   */
+  showCostCenter?: boolean;
+  /**
+   * Hide the Last Payment column. The internal admin processes the bank-absorb
+   * portion; the customer-side last-payment date is not relevant.
+   */
+  hideLastPayment?: boolean;
 }
+
+type SortField =
+  | 'appraisalNumber'
+  | 'customerName'
+  | 'feeBeforeVAT'
+  | 'totalFeeAfterVAT'
+  | 'payPartialAmount'
+  | 'bankAbsorbAmount'
+  | 'remainingFee'
+  | 'lastPaymentDate'
+  | 'submittedDate';
+
+type SortDir = 'asc' | 'desc';
 
 const formatCurrency = (amount: number) =>
   `฿${amount.toLocaleString('th-TH', { minimumFractionDigits: 2 })}`;
 
-const InvoiceItemsTable = ({ items }: InvoiceItemsTableProps) => {
+const compare = (a: InvoiceItem, b: InvoiceItem, field: SortField, dir: SortDir): number => {
+  const av = a[field];
+  const bv = b[field];
+  const aNull = av == null;
+  const bNull = bv == null;
+  // Nulls always sort last regardless of direction (so empty rows don't drift to the top).
+  if (aNull && bNull) return 0;
+  if (aNull) return 1;
+  if (bNull) return -1;
+
+  let cmp = 0;
+  if (typeof av === 'number' && typeof bv === 'number') {
+    cmp = av - bv;
+  } else {
+    cmp = String(av).localeCompare(String(bv));
+  }
+  return dir === 'asc' ? cmp : -cmp;
+};
+
+interface SortableHeaderProps {
+  label: string;
+  field: SortField;
+  active: SortField | null;
+  dir: SortDir;
+  align?: 'left' | 'right';
+  onSort: (field: SortField) => void;
+}
+
+// Matches the project-standard sort affordance from the task list (ActivityTaskTable):
+// click the entire <th>, primary-colored text + single-chevron icon when active,
+// dual-arrow ghost icon when inactive.
+const SortableHeader = ({ label, field, active, dir, align = 'left', onSort }: SortableHeaderProps) => {
+  const isActive = active === field;
+  const iconName = isActive ? (dir === 'asc' ? 'sort-up' : 'sort-down') : 'sort';
+  return (
+    <th
+      onClick={() => onSort(field)}
+      className={`font-semibold px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap select-none cursor-pointer hover:text-gray-900 ${
+        align === 'right' ? 'text-right' : 'text-left'
+      } ${isActive ? 'text-primary' : 'text-gray-600'}`}
+    >
+      <div className={`inline-flex items-center gap-1 ${align === 'right' ? 'flex-row-reverse' : ''}`}>
+        <span>{label}</span>
+        <Icon
+          style="solid"
+          name={iconName}
+          className={`size-2.5 ${isActive ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </div>
+    </th>
+  );
+};
+
+const InvoiceItemsTable = ({
+  items,
+  hidePaymentColumns = false,
+  showCostCenter = false,
+  hideLastPayment = false,
+}: InvoiceItemsTableProps) => {
   const { i18n, t } = useTranslation('invoice');
+
+  const [sortField, setSortField] = useState<SortField | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  // Three-stage cycle: unsorted → asc → desc → unsorted. Clicking a different
+  // column restarts the cycle at asc on that column.
+  const handleSort = (field: SortField) => {
+    if (sortField !== field) {
+      setSortField(field);
+      setSortDir('asc');
+      return;
+    }
+    if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      // currently desc → clear
+      setSortField(null);
+      setSortDir('asc');
+    }
+  };
+
+  const sortedItems = useMemo(() => {
+    if (!sortField) return items;
+    return [...items].sort((a, b) => compare(a, b, sortField, sortDir));
+  }, [items, sortField, sortDir]);
+
+  const sumFee = items.reduce((s, i) => s + i.feeBeforeVAT, 0);
+  const sumTotal = items.reduce((s, i) => s + i.totalFeeAfterVAT, 0);
+  const sumPaid = items.reduce((s, i) => s + i.payPartialAmount, 0);
+  const sumBankAbsorb = items.reduce((s, i) => s + i.bankAbsorbAmount, 0);
+  const sumRemaining = items.reduce((s, i) => s + i.remainingFee, 0);
+
+  const headColCount =
+    (hidePaymentColumns ? 9 : 11) +
+    (showCostCenter ? 1 : 0) -
+    (hideLastPayment ? 1 : 0);
 
   return (
     <div className="overflow-auto rounded-lg border border-gray-200">
@@ -18,35 +143,99 @@ const InvoiceItemsTable = ({ items }: InvoiceItemsTableProps) => {
         <thead className="bg-gray-100 sticky top-0">
           <tr className="border-b-2 border-gray-300">
             <th className="text-center font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide w-10">#</th>
-            <th className="text-left font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap">
-              {t('book.col.appraisalReportNo')}
-            </th>
-            <th className="text-left font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide">
-              {t('book.col.customerName')}
-            </th>
-            <th className="text-right font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap">
-              {t('book.col.feeAmount')}
-            </th>
+            <SortableHeader
+              label={t('book.col.appraisalReportNo')}
+              field="appraisalNumber"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
+            <SortableHeader
+              label={t('book.col.customerName')}
+              field="customerName"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
+            {showCostCenter && (
+              <th className="text-left font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap">
+                {t('book.col.costCenter')}
+              </th>
+            )}
+            <SortableHeader
+              label={t('book.col.feeAmount')}
+              field="feeBeforeVAT"
+              align="right"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
             <th className="text-right font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide">
               {t('book.col.vat')}
             </th>
-            <th className="text-right font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap">
-              {t('book.col.totalAmount')}
-            </th>
-            <th className="text-left font-semibold text-gray-600 px-4 py-2.5 text-xs uppercase tracking-wide whitespace-nowrap">
-              {t('book.col.submittedDate')}
-            </th>
+            <SortableHeader
+              label={t('book.col.totalAmount')}
+              field="totalFeeAfterVAT"
+              align="right"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
+            {!hidePaymentColumns && (
+              <SortableHeader
+                label={t('book.col.payPartialAmount')}
+                field="payPartialAmount"
+                align="right"
+                active={sortField}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+            )}
+            <SortableHeader
+              label={t('book.col.bankAbsorbAmount')}
+              field="bankAbsorbAmount"
+              align="right"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
+            {!hidePaymentColumns && (
+              <SortableHeader
+                label={t('book.col.remainingFee')}
+                field="remainingFee"
+                align="right"
+                active={sortField}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+            )}
+            {!hideLastPayment && (
+              <SortableHeader
+                label={t('book.col.lastPaymentDate')}
+                field="lastPaymentDate"
+                active={sortField}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+            )}
+            <SortableHeader
+              label={t('book.col.submittedDate')}
+              field="submittedDate"
+              active={sortField}
+              dir={sortDir}
+              onSort={handleSort}
+            />
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {items.length === 0 ? (
+          {sortedItems.length === 0 ? (
             <tr>
-              <td colSpan={7} className="text-center py-10 text-gray-400 text-xs">
+              <td colSpan={headColCount} className="text-center py-10 text-gray-400 text-xs">
                 {t('draft.noItems')}
               </td>
             </tr>
           ) : (
-            items.map((item, index) => (
+            sortedItems.map((item, index) => (
               <tr key={item.id} className="even:bg-gray-50/50">
                 <td className="px-4 py-2.5 text-center text-gray-400 tabular-nums">
                   {index + 1}
@@ -55,6 +244,11 @@ const InvoiceItemsTable = ({ items }: InvoiceItemsTableProps) => {
                   {item.appraisalNumber ?? '—'}
                 </td>
                 <td className="px-4 py-2.5 text-gray-700">{item.customerName ?? '—'}</td>
+                {showCostCenter && (
+                  <td className="px-4 py-2.5 text-gray-400 whitespace-nowrap italic">
+                    {t('book.col.notAvailable')}
+                  </td>
+                )}
                 <td className="px-4 py-2.5 text-right text-gray-700 tabular-nums whitespace-nowrap">
                   {formatCurrency(item.feeBeforeVAT)}
                 </td>
@@ -65,6 +259,26 @@ const InvoiceItemsTable = ({ items }: InvoiceItemsTableProps) => {
                 <td className="px-4 py-2.5 text-right font-medium text-gray-900 tabular-nums whitespace-nowrap">
                   {formatCurrency(item.totalFeeAfterVAT)}
                 </td>
+                {!hidePaymentColumns && (
+                  <td className="px-4 py-2.5 text-right text-gray-700 tabular-nums whitespace-nowrap">
+                    {formatCurrency(item.payPartialAmount)}
+                  </td>
+                )}
+                <td className="px-4 py-2.5 text-right text-gray-700 tabular-nums whitespace-nowrap">
+                  {formatCurrency(item.bankAbsorbAmount)}
+                </td>
+                {!hidePaymentColumns && (
+                  <td className="px-4 py-2.5 text-right text-gray-700 tabular-nums whitespace-nowrap">
+                    {formatCurrency(item.remainingFee)}
+                  </td>
+                )}
+                {!hideLastPayment && (
+                  <td className="px-4 py-2.5 text-gray-600 whitespace-nowrap">
+                    {item.lastPaymentDate
+                      ? formatLocaleDate(item.lastPaymentDate, i18n.language)
+                      : '—'}
+                  </td>
+                )}
                 <td className="px-4 py-2.5 text-gray-600 whitespace-nowrap">
                   {item.submittedDate
                     ? formatLocaleDate(item.submittedDate, i18n.language)
@@ -77,17 +291,33 @@ const InvoiceItemsTable = ({ items }: InvoiceItemsTableProps) => {
         {items.length > 0 && (
           <tfoot>
             <tr className="bg-gray-50 border-t-2 border-gray-300">
-              <td colSpan={3} className="px-4 py-2.5 text-xs font-semibold text-gray-600 uppercase tracking-wide">
+              <td
+                colSpan={3 + (showCostCenter ? 1 : 0)}
+                className="px-4 py-2.5 text-xs font-semibold text-gray-600 uppercase tracking-wide"
+              >
                 {t('list.grandTotal')}
               </td>
               <td className="px-4 py-2.5 text-right font-semibold text-gray-900 tabular-nums whitespace-nowrap text-sm">
-                {formatCurrency(items.reduce((s, i) => s + i.feeBeforeVAT, 0))}
+                {formatCurrency(sumFee)}
               </td>
               <td />
+              <td className="px-4 py-2.5 text-right font-semibold text-gray-900 tabular-nums whitespace-nowrap text-sm">
+                {formatCurrency(sumTotal)}
+              </td>
+              {!hidePaymentColumns && (
+                <td className="px-4 py-2.5 text-right font-semibold text-gray-700 tabular-nums whitespace-nowrap text-sm">
+                  {formatCurrency(sumPaid)}
+                </td>
+              )}
               <td className="px-4 py-2.5 text-right font-bold text-primary tabular-nums whitespace-nowrap text-sm">
-                {formatCurrency(items.reduce((s, i) => s + i.bankAbsorbAmount, 0))}
+                {formatCurrency(sumBankAbsorb)}
               </td>
-              <td />
+              {!hidePaymentColumns && (
+                <td className="px-4 py-2.5 text-right font-semibold text-gray-700 tabular-nums whitespace-nowrap text-sm">
+                  {formatCurrency(sumRemaining)}
+                </td>
+              )}
+              <td colSpan={hideLastPayment ? 1 : 2} />
             </tr>
           </tfoot>
         )}

--- a/src/features/invoice/components/MarkPaidLayout.tsx
+++ b/src/features/invoice/components/MarkPaidLayout.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '@/shared/components/Icon';
+import Button from '@/shared/components/Button';
+import Input from '@/shared/components/Input';
+import { DateInput } from '@/shared/components/inputs';
+import InvoiceItemsTable from './InvoiceItemsTable';
+import type { InvoiceDetail } from '../types/invoice';
+
+interface MarkPaidLayoutProps {
+  invoices: InvoiceDetail[];
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onSubmit: (values: { paymentOrderNo: string; paidDate: string }) => void;
+}
+
+const formatCurrency = (amount: number) =>
+  `฿${amount.toLocaleString('th-TH', { minimumFractionDigits: 2 })}`;
+
+/**
+ * Shared payment layout used by both single-invoice and bulk Mark-as-Paid flows.
+ * Top strip: Total + inline Account/PO/Paid-Date fields.
+ * Body: collapsible per-invoice sections with line items.
+ * Footer: sticky Cancel / Update bar.
+ */
+const MarkPaidLayout = ({ invoices, isSubmitting, onCancel, onSubmit }: MarkPaidLayoutProps) => {
+  const { t } = useTranslation('invoice');
+
+  const [paymentOrderNo, setPaymentOrderNo] = useState('');
+  const [paidDate, setPaidDate] = useState<string | null>(null);
+
+  // Track collapsed state per invoice id. Default expanded.
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const toggle = (id: string) => setCollapsed(c => ({ ...c, [id]: !c[id] }));
+
+  const firstInvoice = invoices[0];
+  const bankAccountNo = firstInvoice?.bankAccountNo ?? '';
+  const bankAccountName = firstInvoice?.bankAccountName ?? '';
+
+  const grandTotal = useMemo(
+    () => invoices.reduce((s, inv) => s + inv.totalAmount, 0),
+    [invoices],
+  );
+
+  const isValid =
+    invoices.length > 0 &&
+    paymentOrderNo.trim().length > 0 &&
+    paymentOrderNo.trim().length <= 10 &&
+    paidDate != null;
+
+  const handleSubmit = () => {
+    if (!isValid || !paidDate) return;
+    onSubmit({ paymentOrderNo: paymentOrderNo.trim(), paidDate: paidDate.slice(0, 10) });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 pb-20">
+      {/* Top strip: Total + inline account/PO/paid-date */}
+      <div className="bg-white rounded-lg border border-gray-200 p-5">
+        <p className="text-xs text-gray-500 font-medium uppercase tracking-wide mb-3">
+          {t('internal.markPaidTitle')}
+        </p>
+        <div className="flex flex-wrap items-end gap-6">
+          <div className="shrink-0">
+            <p className="text-xs text-gray-500 mb-1">{t('detail.totalAmount')}</p>
+            <p className="text-3xl font-bold text-primary tabular-nums whitespace-nowrap">
+              {formatCurrency(grandTotal)}
+            </p>
+          </div>
+          <div className="flex-1 min-w-0 grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <Input
+              label={t('internal.accountNo')}
+              value={bankAccountNo}
+              disabled
+              readOnly
+            />
+            <Input
+              label={t('internal.accountName')}
+              value={bankAccountName}
+              disabled
+              readOnly
+            />
+            <Input
+              label={t('internal.paymentOrderNo')}
+              required
+              value={paymentOrderNo}
+              onChange={e => setPaymentOrderNo(e.target.value)}
+              maxLength={10}
+              placeholder="e.g. PO-000001"
+            />
+            <DateInput
+              label={t('internal.paidDate')}
+              required
+              value={paidDate}
+              onChange={setPaidDate}
+              placeholder="dd/mm/yyyy"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Per-invoice collapsible sections */}
+      {invoices.map(inv => {
+        const isCollapsed = collapsed[inv.id] ?? false;
+        return (
+          <div
+            key={inv.id}
+            className="bg-white rounded-lg border border-gray-200 overflow-hidden"
+          >
+            <button
+              type="button"
+              onClick={() => toggle(inv.id)}
+              className="w-full px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors flex items-center justify-between gap-3 border-b border-gray-100"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="font-semibold text-primary truncate">
+                  {inv.invoiceNumber ?? '—'}
+                </span>
+                <span className="text-xs text-gray-500">
+                  ({inv.items.length} {t('list.col.totalItems')})
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-semibold text-gray-900 tabular-nums whitespace-nowrap">
+                  {formatCurrency(inv.totalAmount)}
+                </span>
+                <Icon
+                  style="solid"
+                  name={isCollapsed ? 'chevron-down' : 'chevron-up'}
+                  className="size-3.5 text-gray-400"
+                />
+              </div>
+            </button>
+            {!isCollapsed && (
+              <div className="p-4">
+                <InvoiceItemsTable
+                  items={inv.items}
+                  hidePaymentColumns
+                  hideLastPayment
+                  showCostCenter
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Sticky bottom action bar */}
+      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-6 py-3 flex items-center justify-between gap-3 z-10">
+        <span className="text-xs text-gray-500">
+          {invoices.length} {t('internal.selected')} · {formatCurrency(grandTotal)}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={isSubmitting}>
+            {t('maintenance.cancel')}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            isLoading={isSubmitting}
+            disabled={isSubmitting || !isValid}
+          >
+            <Icon style="solid" name="circle-check" className="size-3.5 mr-1.5" />
+            {t('internal.update')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MarkPaidLayout;

--- a/src/features/invoice/pages/ExtInvoiceListPage.tsx
+++ b/src/features/invoice/pages/ExtInvoiceListPage.tsx
@@ -46,6 +46,50 @@ const countActiveFilters = (f: InvoiceFilterValues): number =>
     Boolean,
   ).length;
 
+/**
+ * Sortable column header — matches the project-standard sort affordance from the
+ * task list (ActivityTaskTable). Click the whole <th>, primary-colored text + single
+ * chevron when active, dual-arrow ghost icon when inactive.
+ */
+const SortableTh = ({
+  field,
+  sortBy,
+  sortDir,
+  onSort,
+  align = 'left',
+  children,
+}: {
+  field: string;
+  sortBy: string | null;
+  sortDir: 'asc' | 'desc';
+  onSort: (f: string) => void;
+  align?: 'left' | 'center' | 'right';
+  children: React.ReactNode;
+}) => {
+  const isActive = sortBy === field;
+  const alignCls = align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+  const flexAlign =
+    align === 'right' ? 'flex-row-reverse' : align === 'center' ? 'justify-center' : '';
+  const iconName = isActive ? (sortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort';
+  return (
+    <th
+      onClick={() => onSort(field)}
+      className={`font-medium px-4 py-2.5 whitespace-nowrap select-none cursor-pointer hover:text-gray-900 ${alignCls} ${
+        isActive ? 'text-primary' : 'text-gray-600'
+      }`}
+    >
+      <div className={`inline-flex items-center gap-1 ${flexAlign}`}>
+        <span>{children}</span>
+        <Icon
+          style="solid"
+          name={iconName}
+          className={`size-2.5 ${isActive ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </div>
+    </th>
+  );
+};
+
 const ExtInvoiceListPage = () => {
   const navigate = useNavigate();
   const { i18n, t } = useTranslation('invoice');
@@ -64,6 +108,23 @@ const ExtInvoiceListPage = () => {
   const [pageSize, setPageSize] = useState(10);
   const [filters, setFilters] = useState<InvoiceFilterValues>({});
 
+  /** Server-side sort. Whitelisted: invoiceNumber, sentDate, paidDate, totalAmount,
+   *  totalItems, status. Three-stage cycle: unsorted → asc → desc → unsorted. */
+  const [sortBy, setSortBy] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const toggleSort = (field: string) => {
+    if (sortBy !== field) {
+      setSortBy(field);
+      setSortDir('asc');
+    } else if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      setSortBy(null);
+      setSortDir('asc');
+    }
+    setPageNumber(0);
+  };
+
   // Delete confirm state
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
@@ -76,10 +137,15 @@ const ExtInvoiceListPage = () => {
   // Debounce the single search bar to avoid a request per keystroke
   const debouncedSearch = useDebounce(filters.search, 300);
 
-  // Tab drives status: Paid tab → status=Paid; Unpaid tab → no status filter
-  // (any non-Paid). The dropdown's explicit value overrides when set.
+  // Tab drives status: Paid tab → include status=Paid. Unpaid tab → exclude Paid (so
+  // Pending drafts AND Sent invoices both show up). The dropdown's explicit value overrides
+  // when set on the Unpaid tab.
   const tabStatus = tab === 'paid' ? 'Paid' : undefined;
   const statusParam = filters.status ?? tabStatus;
+  // Only apply the exclude when no explicit status is selected on the Unpaid tab — otherwise
+  // an explicit status filter could conflict with the exclude.
+  const excludeStatusParam =
+    tab === 'unpaid' && !filters.status ? 'Paid' : undefined;
 
   // Map filter date fields to API params (DateOnly = yyyy-MM-dd).
   // Invoice Date applies on both tabs; Paid Date is History-only.
@@ -92,11 +158,14 @@ const ExtInvoiceListPage = () => {
     pageNumber,
     pageSize,
     status: statusParam,
+    excludeStatus: excludeStatusParam,
     sentDateFrom,
     sentDateTo,
     paidDateFrom,
     paidDateTo,
     search: debouncedSearch || undefined,
+    sortBy: sortBy ?? undefined,
+    sortDir: sortBy ? sortDir : undefined,
   });
 
   const items = data?.items ?? [];
@@ -107,11 +176,15 @@ const ExtInvoiceListPage = () => {
 
   // Sidecar count query for the OPPOSITE tab. Respects search + date filters
   // so the badge reflects what the user would see if they switched tabs.
+  // - On Unpaid → count opposite (Paid) via status=Paid.
+  // - On Paid → count opposite (Unpaid) via excludeStatus=Paid (Pending + Sent).
   const otherTabStatus = tab === 'unpaid' ? 'Paid' : undefined;
+  const otherTabExcludeStatus = tab === 'paid' ? 'Paid' : undefined;
   const { data: otherTabData } = useGetInvoices({
     pageNumber: 0,
     pageSize: 1,
     status: otherTabStatus,
+    excludeStatus: otherTabExcludeStatus,
     sentDateFrom: toDateOnly(filters.invoiceDateFrom),
     sentDateTo: toDateOnly(filters.invoiceDateTo),
     paidDateFrom: tab === 'unpaid' ? toDateOnly(filters.paidDateFrom) : undefined,
@@ -260,26 +333,26 @@ const ExtInvoiceListPage = () => {
             </colgroup>
             <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
               <tr className="border-b border-gray-200">
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                <SortableTh field="invoiceNumber" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.invoiceNumber')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh field="sentDate" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.sentDate')}
-                </th>
+                </SortableTh>
                 {tab === 'paid' && (
-                  <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                  <SortableTh field="paidDate" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                     {t('list.col.paidDate')}
-                  </th>
+                  </SortableTh>
                 )}
-                <th className="text-center font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                <SortableTh field="totalItems" align="center" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.totalItems')}
-                </th>
-                <th className="text-right font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh field="totalAmount" align="right" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.totalAmount')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
+                </SortableTh>
+                <SortableTh field="status" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.status')}
-                </th>
+                </SortableTh>
                 <th className="px-4 py-2.5" />
               </tr>
             </thead>

--- a/src/features/invoice/pages/IntBulkPaymentPage.tsx
+++ b/src/features/invoice/pages/IntBulkPaymentPage.tsx
@@ -1,18 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import axios from '@/shared/api/axiosInstance';
 import Icon from '@/shared/components/Icon';
-import Button from '@/shared/components/Button';
-import { DateInput } from '@/shared/components/inputs';
-import InvoiceItemsTable from '../components/InvoiceItemsTable';
+import MarkPaidLayout from '../components/MarkPaidLayout';
 import { invoiceKeys, useBulkMarkInvoicesPaid } from '../api/invoice';
+import { useBreadcrumb } from '@shared/hooks/useBreadcrumb';
 import type { InvoiceDetail, InvoiceListItem } from '../types/invoice';
 import toast from 'react-hot-toast';
-
-const formatCurrency = (amount: number) =>
-  `฿${amount.toLocaleString('th-TH', { minimumFractionDigits: 2 })}`;
 
 interface LocationState {
   invoices?: InvoiceListItem[];
@@ -23,16 +19,18 @@ const IntBulkPaymentPage = () => {
   const location = useLocation();
   const { t } = useTranslation('invoice');
   const state = (location.state ?? {}) as LocationState;
-  const invoices = state.invoices ?? [];
+  const selected = state.invoices ?? [];
+
+  useBreadcrumb(t('internal.markPaidTitle'));
 
   // Page reached via direct URL (no state) — bounce back to the list.
   useEffect(() => {
-    if (invoices.length === 0) navigate('/admin/invoices', { replace: true });
-  }, [invoices.length, navigate]);
+    if (selected.length === 0) navigate('/admin/invoices', { replace: true });
+  }, [selected.length, navigate]);
 
-  // Fetch each invoice's detail (including line items) in parallel.
+  // Fetch each invoice's detail (including line items + bank info) in parallel.
   const detailQueries = useQueries({
-    queries: invoices.map(inv => ({
+    queries: selected.map(inv => ({
       queryKey: invoiceKeys.detail(inv.id),
       queryFn: async (): Promise<InvoiceDetail> => {
         const { data } = await axios.get<InvoiceDetail>(`/invoices/${inv.id}`);
@@ -42,204 +40,50 @@ const IntBulkPaymentPage = () => {
     })),
   });
 
-  // Bank info: all selected invoices share a company, so use the first available.
-  const firstDetail = detailQueries.find(q => q.data)?.data ?? null;
-  const bankAccountNo = firstDetail?.bankAccountNo ?? null;
-  const bankAccountName = firstDetail?.bankAccountName ?? null;
+  const invoices = detailQueries
+    .map(q => q.data)
+    .filter((d): d is InvoiceDetail => !!d);
   const isLoadingAny = detailQueries.some(q => q.isLoading);
-
-  const [paymentOrderNo, setPaymentOrderNo] = useState('');
-  const [paidDate, setPaidDate] = useState<string | null>(null);
 
   const { mutate: bulkMarkPaid, isPending } = useBulkMarkInvoicesPaid();
 
-  const isValid =
-    invoices.length > 0 &&
-    paymentOrderNo.trim().length > 0 &&
-    paymentOrderNo.trim().length <= 10 &&
-    paidDate != null;
-
-  const grandTotal = invoices.reduce((s, inv) => s + inv.totalAmount, 0);
-  const grandItemCount = invoices.reduce((s, inv) => s + inv.itemCount, 0);
-  const companyName = invoices[0]?.companyName ?? '—';
-
-  const handleSubmit = () => {
-    if (!isValid || !paidDate) return;
+  const handleSubmit = ({
+    paymentOrderNo,
+    paidDate,
+  }: {
+    paymentOrderNo: string;
+    paidDate: string;
+  }) => {
     bulkMarkPaid(
-      {
-        invoiceIds: invoices.map(i => i.id),
-        paymentOrderNo: paymentOrderNo.trim(),
-        paidDate: paidDate.slice(0, 10),
-      },
+      { invoiceIds: selected.map(i => i.id), paymentOrderNo, paidDate },
       {
         onSuccess: () => {
           toast.success(t('internal.bulkSuccess'));
           navigate('/admin/invoices');
         },
-        onError: () => {
-          toast.error(t('errors.bulkFailed'));
-        },
+        onError: () => toast.error(t('errors.bulkFailed')),
       },
     );
   };
 
-  if (invoices.length === 0) return null;
+  if (selected.length === 0) return null;
+
+  if (isLoadingAny && invoices.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-gray-400">
+        <Icon style="solid" name="spinner" className="size-5 animate-spin mr-2" />
+        {t('common.loading')}
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => navigate('/admin/invoices')}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
-          >
-            <Icon style="solid" name="chevron-left" className="size-4" />
-          </button>
-          <div>
-            <h3 className="text-sm font-semibold text-gray-900">
-              {t('internal.markPaidTitle')}
-            </h3>
-            <p className="text-xs text-gray-500 mt-0.5">
-              {invoices.length} {t('internal.selected')} · {companyName}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Mark Paid form — pinned at the top so it's the first interaction */}
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h4 className="text-sm font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <Icon style="solid" name="circle-check" className="size-4 text-emerald-500" />
-          {t('internal.markPaidTitle')}
-        </h4>
-
-        {/* Bank account info */}
-        <div className="bg-gray-50 rounded-lg p-3 mb-4 grid grid-cols-2 gap-3 text-sm">
-          <div>
-            <p className="text-xs text-gray-500">{t('internal.accountNo')}</p>
-            <p className="font-medium text-gray-900">{bankAccountNo ?? '—'}</p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-500">{t('internal.accountName')}</p>
-            <p className="font-medium text-gray-900">{bankAccountName ?? '—'}</p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              {t('internal.paymentOrderNo')}
-              <span className="text-red-500 ml-0.5">*</span>
-            </label>
-            <input
-              type="text"
-              value={paymentOrderNo}
-              onChange={e => setPaymentOrderNo(e.target.value)}
-              maxLength={10}
-              placeholder="e.g. PO-000001"
-              className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none hover:border-gray-300"
-            />
-          </div>
-          <div>
-            <DateInput
-              label={t('internal.paidDate')}
-              required
-              value={paidDate}
-              onChange={setPaidDate}
-              placeholder="dd/mm/yyyy"
-            />
-          </div>
-        </div>
-        <div className="mt-4 flex items-center justify-end gap-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/admin/invoices')}
-            disabled={isPending}
-          >
-            {t('maintenance.cancel')}
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            isLoading={isPending}
-            disabled={isPending || !isValid}
-          >
-            <Icon style="solid" name="circle-check" className="size-3.5 mr-1.5" />
-            {t('internal.update')}
-          </Button>
-        </div>
-      </div>
-
-      {/* Grand total summary */}
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <div className="flex items-baseline justify-between">
-          <div>
-            <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">
-              {t('list.grandTotal')}
-            </p>
-            <p className="text-xs text-gray-400 mt-0.5">
-              {invoices.length} {t('internal.selected')} · {grandItemCount}{' '}
-              {t('list.col.totalItems')}
-            </p>
-          </div>
-          <p className="text-2xl font-bold text-primary tabular-nums">
-            {formatCurrency(grandTotal)}
-          </p>
-        </div>
-      </div>
-
-      {/* Per-invoice cards with full line items */}
-      {isLoadingAny && (
-        <div className="flex items-center justify-center py-6 text-gray-400 text-sm">
-          <Icon style="solid" name="spinner" className="size-4 animate-spin mr-2" />
-          {t('common.loading')}
-        </div>
-      )}
-
-      {detailQueries.map((q, idx) => {
-        const inv = invoices[idx];
-        const detail = q.data;
-        return (
-          <div
-            key={inv.id}
-            className="bg-white rounded-lg border border-gray-200 overflow-hidden"
-          >
-            {/* Per-invoice header */}
-            <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between gap-3 bg-gray-50/50">
-              <div className="flex items-center gap-3 min-w-0">
-                <span className="font-semibold text-primary truncate">
-                  {inv.invoiceNumber ?? '—'}
-                </span>
-                <span className="text-xs text-gray-400">
-                  {inv.itemCount} {t('list.col.totalItems')}
-                </span>
-              </div>
-              <span className="text-sm font-semibold text-gray-900 tabular-nums whitespace-nowrap">
-                {formatCurrency(inv.totalAmount)}
-              </span>
-            </div>
-
-            {/* Line items */}
-            <div className="p-4">
-              {q.isLoading ? (
-                <div className="flex items-center justify-center py-6 text-gray-400 text-sm">
-                  <Icon style="solid" name="spinner" className="size-4 animate-spin mr-2" />
-                </div>
-              ) : detail ? (
-                <InvoiceItemsTable items={detail.items} />
-              ) : (
-                <p className="text-sm text-gray-400 text-center py-4">
-                  {t('errors.loadFailed')}
-                </p>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
+    <MarkPaidLayout
+      invoices={invoices}
+      isSubmitting={isPending}
+      onCancel={() => navigate('/admin/invoices')}
+      onSubmit={handleSubmit}
+    />
   );
 };
 

--- a/src/features/invoice/pages/IntInvoiceDetailPage.tsx
+++ b/src/features/invoice/pages/IntInvoiceDetailPage.tsx
@@ -1,14 +1,12 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import Icon from '@/shared/components/Icon';
-import Button from '@/shared/components/Button';
-import { DateInput } from '@/shared/components/inputs';
 import { formatLocaleDate, formatLocaleDateTime } from '@/shared/utils/dateUtils';
+import { useBreadcrumb } from '@shared/hooks/useBreadcrumb';
 import InvoiceStatusBadge from '../components/InvoiceStatusBadge';
 import InvoiceItemsTable from '../components/InvoiceItemsTable';
+import MarkPaidLayout from '../components/MarkPaidLayout';
 import { useGetInvoiceById, useMarkInvoicePaid } from '../api/invoice';
-import type { MarkPaidPayload } from '../types/invoice';
 import toast from 'react-hot-toast';
 
 const formatCurrency = (amount: number) =>
@@ -19,36 +17,10 @@ const IntInvoiceDetailPage = () => {
   const navigate = useNavigate();
   const { i18n, t } = useTranslation('invoice');
 
-  const [paymentOrderNo, setPaymentOrderNo] = useState('');
-  const [paidDate, setPaidDate] = useState<string | null>(null);
-
   const { data: invoice, isLoading, isError, error } = useGetInvoiceById(id);
   const { mutate: markPaid, isPending: isMarking } = useMarkInvoicePaid();
 
-  const isFormValid =
-    paymentOrderNo.trim().length > 0 &&
-    paymentOrderNo.trim().length <= 10 &&
-    paidDate != null;
-
-  const handleMarkPaid = () => {
-    if (!id || !isFormValid || !paidDate) return;
-    const payload: MarkPaidPayload = {
-      paymentOrderNo: paymentOrderNo.trim(),
-      paidDate: paidDate.slice(0, 10),
-    };
-    markPaid(
-      { id, payload },
-      {
-        onSuccess: () => {
-          toast.success(t('internal.paidSuccess'));
-          navigate('/admin/invoices');
-        },
-        onError: () => {
-          toast.error(t('errors.markPaidFailed'));
-        },
-      },
-    );
-  };
+  useBreadcrumb(invoice?.invoiceNumber ?? t('detail.invoice'));
 
   if (isLoading) {
     return (
@@ -68,129 +40,80 @@ const IntInvoiceDetailPage = () => {
     );
   }
 
+  // Sent invoices use the shared Mark-Paid layout (top strip + collapsible body
+  // + sticky action bar), the same layout the bulk-payment screen uses. Single-invoice
+  // is just a 1-element array.
+  if (invoice.status === 'Sent') {
+    return (
+      <MarkPaidLayout
+        invoices={[invoice]}
+        isSubmitting={isMarking}
+        onCancel={() => navigate('/admin/invoices')}
+        onSubmit={({ paymentOrderNo, paidDate }) =>
+          markPaid(
+            { id: invoice.id, payload: { paymentOrderNo, paidDate } },
+            {
+              onSuccess: () => {
+                toast.success(t('internal.paidSuccess'));
+                navigate('/admin/invoices');
+              },
+              onError: () => toast.error(t('errors.markPaidFailed')),
+            },
+          )
+        }
+      />
+    );
+  }
+
+  // Pending / Paid: read-only view.
   return (
     <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => navigate('/admin/invoices')}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
-          >
-            <Icon style="solid" name="chevron-left" className="size-4" />
-          </button>
+      <div className="bg-white rounded-lg border border-gray-200 p-5">
+        <div className="flex items-start justify-between gap-4">
           <div>
-            <div className="flex items-center gap-2.5">
-              <h3 className="text-sm font-semibold text-gray-900">
-                {invoice.invoiceNumber ?? t('detail.invoice')}
-              </h3>
-              <InvoiceStatusBadge status={invoice.status} viewContext="internal" />
-            </div>
+            <p className="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">
+              {t('detail.totalAmount')}
+            </p>
+            <p className="text-3xl font-bold text-gray-900 tabular-nums">
+              {formatCurrency(invoice.totalAmount)}
+            </p>
+            {invoice.submittedAt && (
+              <p className="text-xs text-gray-400 mt-1">
+                {t('detail.submittedAt')}:{' '}
+                {formatLocaleDateTime(invoice.submittedAt, i18n.language)}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col items-end gap-1.5">
+            <InvoiceStatusBadge status={invoice.status} viewContext="internal" />
             {invoice.companyName && (
-              <p className="text-xs text-gray-500 mt-0.5">{invoice.companyName}</p>
+              <p className="text-xs text-gray-500">{invoice.companyName}</p>
             )}
           </div>
         </div>
       </div>
 
-      {/* Mark Paid form — Sent only. Pinned at top + bank info inside the card. */}
-      {invoice.status === 'Sent' && (
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h4 className="text-sm font-semibold text-gray-900 mb-4 flex items-center gap-2">
-            <Icon style="solid" name="circle-check" className="size-4 text-emerald-500" />
-            {t('internal.markPaidTitle')}
-          </h4>
-
-          {/* Bank account info */}
-          <div className="bg-gray-50 rounded-lg p-3 mb-4 grid grid-cols-2 gap-3 text-sm">
-            <div>
-              <p className="text-xs text-gray-500">{t('internal.accountNo')}</p>
-              <p className="font-medium text-gray-900">{invoice.bankAccountNo ?? '—'}</p>
-            </div>
-            <div>
-              <p className="text-xs text-gray-500">{t('internal.accountName')}</p>
-              <p className="font-medium text-gray-900">{invoice.bankAccountName ?? '—'}</p>
-            </div>
+      {/* Bank account info */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h4 className="text-sm font-semibold text-gray-900 mb-3">{t('internal.bankInfo')}</h4>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-xs text-gray-500">{t('internal.accountNo')}</p>
+            <p className="font-medium text-gray-900">{invoice.bankAccountNo ?? '—'}</p>
           </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                {t('internal.paymentOrderNo')}
-                <span className="text-red-500 ml-0.5">*</span>
-              </label>
-              <input
-                type="text"
-                value={paymentOrderNo}
-                onChange={e => setPaymentOrderNo(e.target.value)}
-                maxLength={10}
-                placeholder="e.g. PO-000001"
-                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none hover:border-gray-300"
-              />
-            </div>
-            <div>
-              <DateInput
-                label={t('internal.paidDate')}
-                required
-                value={paidDate}
-                onChange={setPaidDate}
-                placeholder="dd/mm/yyyy"
-              />
-            </div>
-          </div>
-          <div className="mt-4 flex items-center justify-end gap-3">
-            <Button
-              size="sm"
-              onClick={handleMarkPaid}
-              isLoading={isMarking}
-              disabled={isMarking || !isFormValid}
-            >
-              <Icon style="solid" name="circle-check" className="size-3.5 mr-1.5" />
-              {t('internal.update')}
-            </Button>
+          <div>
+            <p className="text-xs text-gray-500">{t('internal.accountName')}</p>
+            <p className="font-medium text-gray-900">{invoice.bankAccountName ?? '—'}</p>
           </div>
         </div>
-      )}
-
-      {/* Total Amount */}
-      <div className="bg-white rounded-lg border border-gray-200 p-5">
-        <p className="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">
-          {t('detail.totalAmount')}
-        </p>
-        <p className="text-3xl font-bold text-gray-900 tabular-nums">
-          {formatCurrency(invoice.totalAmount)}
-        </p>
-        {invoice.submittedAt && (
-          <p className="text-xs text-gray-400 mt-1">
-            {t('detail.submittedAt')}: {formatLocaleDateTime(invoice.submittedAt, i18n.language)}
-          </p>
-        )}
       </div>
-
-      {/* Bank account info — shown for non-Sent statuses (Sent already has it inline above) */}
-      {invoice.status !== 'Sent' && (
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h4 className="text-sm font-semibold text-gray-900 mb-3">{t('internal.bankInfo')}</h4>
-          <div className="grid grid-cols-2 gap-3 text-sm">
-            <div>
-              <p className="text-xs text-gray-500">{t('internal.accountNo')}</p>
-              <p className="font-medium text-gray-900">{invoice.bankAccountNo ?? '—'}</p>
-            </div>
-            <div>
-              <p className="text-xs text-gray-500">{t('internal.accountName')}</p>
-              <p className="font-medium text-gray-900">{invoice.bankAccountName ?? '—'}</p>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Line Items */}
       <div className="bg-white rounded-lg border border-gray-200 p-4">
         <h4 className="text-sm font-semibold text-gray-900 mb-3">
           {t('detail.lineItems')} ({invoice.items.length})
         </h4>
-        <InvoiceItemsTable items={invoice.items} />
+        <InvoiceItemsTable items={invoice.items} showCostCenter hideLastPayment />
       </div>
 
       {/* Notes */}

--- a/src/features/invoice/pages/IntInvoiceListPage.tsx
+++ b/src/features/invoice/pages/IntInvoiceListPage.tsx
@@ -42,6 +42,50 @@ const toDateOnly = (iso: string | null | undefined) => (iso ? iso.slice(0, 10) :
 
 type Tab = 'unpaid' | 'paid';
 
+/**
+ * Sortable column header — matches the project-standard sort affordance from the
+ * task list (ActivityTaskTable). Click the whole <th>, primary-colored text + single
+ * chevron when active, dual-arrow ghost icon when inactive.
+ */
+const SortableTh = ({
+  field,
+  sortBy,
+  sortDir,
+  onSort,
+  align = 'left',
+  children,
+}: {
+  field: string;
+  sortBy: string | null;
+  sortDir: 'asc' | 'desc';
+  onSort: (f: string) => void;
+  align?: 'left' | 'center' | 'right';
+  children: React.ReactNode;
+}) => {
+  const isActive = sortBy === field;
+  const alignCls = align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+  const flexAlign =
+    align === 'right' ? 'flex-row-reverse' : align === 'center' ? 'justify-center' : '';
+  const iconName = isActive ? (sortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort';
+  return (
+    <th
+      onClick={() => onSort(field)}
+      className={`font-medium px-4 py-2.5 whitespace-nowrap select-none cursor-pointer hover:text-gray-900 ${alignCls} ${
+        isActive ? 'text-primary' : 'text-gray-600'
+      }`}
+    >
+      <div className={`inline-flex items-center gap-1 ${flexAlign}`}>
+        <span>{children}</span>
+        <Icon
+          style="solid"
+          name={iconName}
+          className={`size-2.5 ${isActive ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </div>
+    </th>
+  );
+};
+
 /** Count non-empty filter values */
 const countActiveFilters = (f: InvoiceFilterValues): number =>
   [
@@ -75,6 +119,24 @@ const IntInvoiceListPage = () => {
   /** Group-by criterion. Add new keys here as new criteria are supported. */
   const [groupBy, setGroupBy] = useState<string | null>(null);
   const groupByCompany = groupBy === 'company';
+
+  /** Server-side sort. Whitelisted backend columns: invoiceNumber, companyName,
+   *  sentDate, paidDate, totalAmount, totalItems, status. Three-stage cycle:
+   *  unsorted → asc → desc → unsorted. */
+  const [sortBy, setSortBy] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const toggleSort = (field: string) => {
+    if (sortBy !== field) {
+      setSortBy(field);
+      setSortDir('asc');
+    } else if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      setSortBy(null);
+      setSortDir('asc');
+    }
+    setPageNumber(0);
+  };
 
   // Bulk selection state. PO + paid date inputs live on the bulk-payment screen.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -111,6 +173,8 @@ const IntInvoiceListPage = () => {
     paidDateTo,
     search: debouncedSearch || undefined,
     groupBy: groupBy ?? undefined,
+    sortBy: sortBy ?? undefined,
+    sortDir: sortBy ? sortDir : undefined,
   });
 
   const items = data?.items ?? [];
@@ -277,9 +341,11 @@ const IntInvoiceListPage = () => {
         </div>
       </div>
 
-      {/* Filter bar + tabs on the right */}
-      <div className="shrink-0 flex flex-wrap items-end justify-between gap-3">
-        <div className="flex flex-wrap items-end gap-2">
+      {/* Filter bar + tabs on the right.
+          Right pane (Group by + Tabs) is pinned top-right and never wraps below;
+          filters wrap to additional rows on the left when they can't fit on a single line. */}
+      <div className="shrink-0 flex items-start gap-4">
+        <div className="flex-1 min-w-0 flex flex-wrap items-end gap-2">
           <div className="w-72">
             <Input
               placeholder={t('filter.searchPlaceholder')}
@@ -352,7 +418,7 @@ const IntInvoiceListPage = () => {
             </Button>
           )}
         </div>
-        <div className="flex items-end gap-2">
+        <div className="shrink-0 flex items-end gap-2">
           <div className="w-40">
             <Dropdown
               label={t('list.groupBy')}
@@ -401,31 +467,31 @@ const IntInvoiceListPage = () => {
                     />
                   </th>
                 )}
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                <SortableTh field="invoiceNumber" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.invoiceNumber')}
-                </th>
+                </SortableTh>
                 {!groupByCompany && (
-                  <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                  <SortableTh field="companyName" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                     {t('list.col.companyName')}
-                  </th>
+                  </SortableTh>
                 )}
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                <SortableTh field="sentDate" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.sentDate')}
-                </th>
+                </SortableTh>
                 {tab === 'paid' && (
-                  <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                  <SortableTh field="paidDate" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                     {t('list.col.paidDate')}
-                  </th>
+                  </SortableTh>
                 )}
-                <th className="text-center font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                <SortableTh field="totalItems" align="center" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.totalItems')}
-                </th>
-                <th className="text-right font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh field="totalAmount" align="right" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.totalAmount')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
+                </SortableTh>
+                <SortableTh field="status" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('list.col.status')}
-                </th>
+                </SortableTh>
                 <th className="px-4 py-2.5" />
               </tr>
             </thead>

--- a/src/features/invoice/types/invoice.ts
+++ b/src/features/invoice/types/invoice.ts
@@ -40,6 +40,9 @@ export interface InvoiceItem {
   vatAmount: number;
   totalFeeAfterVAT: number;
   bankAbsorbAmount: number;
+  payPartialAmount: number;
+  remainingFee: number;
+  lastPaymentDate: string | null;
   submittedDate: string | null;
 }
 

--- a/src/features/taskMonitor/api/taskMonitor.ts
+++ b/src/features/taskMonitor/api/taskMonitor.ts
@@ -1,0 +1,177 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import { z } from 'zod';
+import type {
+  EligibleAssigneesResponse,
+  GetMonitoredPeopleParams,
+  GetMonitoredTasksParams,
+  MonitoredPersonListResponse,
+  MonitoredTaskListResponse,
+  MonitorFilterOptions,
+  ReassignTaskRequest,
+  ReassignTaskResponse,
+} from '../types';
+
+// ─── Zod schemas ────────────────────────────────────────────────────────────
+
+export const reassignTaskSchema = z.object({
+  newAssignedTo: z.string().min(1, 'Please select an assignee'),
+});
+
+export type ReassignTaskFormValues = z.infer<typeof reassignTaskSchema>;
+
+// ─── Query key factory ───────────────────────────────────────────────────────
+
+export const taskMonitorKeys = {
+  all: ['task-monitor'] as const,
+  list: (params: GetMonitoredTasksParams) => ['task-monitor', 'list', params] as const,
+  people: (params: GetMonitoredPeopleParams) => ['task-monitor', 'people', params] as const,
+  filterOptions: () => ['task-monitor', 'filter-options'] as const,
+  eligibleAssignees: (workflowInstanceId: string, activityId: string) =>
+    ['task-monitor', 'eligible-assignees', workflowInstanceId, activityId] as const,
+};
+
+/**
+ * Distinct task-type descriptions (supervisor scope) + appraisal status enum
+ * for the drill-down filter card dropdowns.
+ * GET /tasks/monitor/filter-options
+ */
+export const useMonitorFilterOptions = () =>
+  useQuery({
+    queryKey: taskMonitorKeys.filterOptions(),
+    queryFn: async (): Promise<MonitorFilterOptions> => {
+      const { data } = await axios.get('/tasks/monitor/filter-options');
+      return data.result ?? data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+/**
+ * Fetches the supervisor-scoped people list (one row per monitored user with task counts).
+ * GET /tasks/monitor/people
+ */
+export const useMonitoredPeople = (params: GetMonitoredPeopleParams = {}) => {
+  const { search, sortBy, sortDir, page = 0, pageSize = 25 } = params;
+
+  return useQuery({
+    queryKey: taskMonitorKeys.people(params),
+    queryFn: async (): Promise<MonitoredPersonListResponse> => {
+      const { data } = await axios.get('/tasks/monitor/people', {
+        params: {
+          PageNumber: page,
+          PageSize: pageSize,
+          ...(search && { Search: search }),
+          ...(sortBy && { SortBy: sortBy }),
+          ...(sortDir && { SortDir: sortDir }),
+        },
+      });
+      return data.result ?? data;
+    },
+    staleTime: 0,
+  });
+};
+
+// ─── Hooks ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the supervisor-scoped monitored task list.
+ * GET /tasks/monitor
+ *
+ * staleTime: 0 so post-reassign invalidations always trigger a fresh fetch.
+ */
+export const useMonitoredTasks = (params: GetMonitoredTasksParams = {}) => {
+  const {
+    groupId,
+    assigneeUsername,
+    sla,
+    activityId,
+    search,
+    appraisalNumber,
+    customerName,
+    appraisalStatus,
+    taskType,
+    sortBy,
+    sortDir,
+    page = 0,
+    pageSize = 25,
+  } = params;
+
+  return useQuery({
+    queryKey: taskMonitorKeys.list(params),
+    queryFn: async (): Promise<MonitoredTaskListResponse> => {
+      const { data } = await axios.get('/tasks/monitor', {
+        params: {
+          PageNumber: page,
+          PageSize: pageSize,
+          ...(groupId && { GroupId: groupId }),
+          ...(assigneeUsername && { AssigneeUsername: assigneeUsername }),
+          ...(sla && { Sla: sla }),
+          ...(activityId && { ActivityId: activityId }),
+          ...(search && { Search: search }),
+          ...(appraisalNumber && { AppraisalNumber: appraisalNumber }),
+          ...(customerName && { CustomerName: customerName }),
+          ...(appraisalStatus && { AppraisalStatus: appraisalStatus }),
+          ...(taskType && { TaskType: taskType }),
+          ...(sortBy && { SortBy: sortBy }),
+          ...(sortDir && { SortDir: sortDir }),
+        },
+      });
+      return data.result ?? data;
+    },
+    staleTime: 0,
+  });
+};
+
+/**
+ * Fetches eligible assignees for a workflow activity.
+ * GET /api/workflows/instances/{workflowInstanceId}/activities/{activityId}/eligible-assignees
+ *
+ * Only fires when both IDs are provided (modal is open and a task is selected).
+ */
+export const useEligibleAssignees = (
+  workflowInstanceId: string | null,
+  activityId: string | null,
+) => {
+  return useQuery({
+    queryKey: taskMonitorKeys.eligibleAssignees(workflowInstanceId ?? '', activityId ?? ''),
+    queryFn: async (): Promise<EligibleAssigneesResponse> => {
+      const { data } = await axios.get(
+        `/api/workflows/instances/${workflowInstanceId}/activities/${activityId}/eligible-assignees`,
+      );
+      return data.result ?? data;
+    },
+    enabled: !!workflowInstanceId && !!activityId,
+    staleTime: 30 * 1000,
+  });
+};
+
+/**
+ * Reassigns a pending task to a new user.
+ * POST /tasks/{taskId}/reassign
+ */
+export const useReassignTask = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      taskId,
+      body,
+    }: {
+      taskId: string;
+      body: ReassignTaskRequest;
+    }): Promise<ReassignTaskResponse> => {
+      const { data } = await axios.post(`/tasks/${taskId}/reassign`, body);
+      return data.result ?? data;
+    },
+    onSuccess: result => {
+      if (result.isSuccess) {
+        // Invalidate the monitor list so it refetches with the new assignment
+        queryClient.invalidateQueries({ queryKey: taskMonitorKeys.all });
+      }
+    },
+    onError: () => {
+      // On concurrency error: silently refetch the list in the background
+      queryClient.invalidateQueries({ queryKey: taskMonitorKeys.all });
+    },
+  });
+};

--- a/src/features/taskMonitor/components/PeopleMonitorTable.tsx
+++ b/src/features/taskMonitor/components/PeopleMonitorTable.tsx
@@ -1,0 +1,113 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Icon from '@shared/components/Icon';
+import Avatar from '@shared/components/Avatar';
+import SortableTh from './SortableTh';
+import type { MonitoredPerson, SortDir } from '../types';
+
+interface PeopleMonitorTableProps {
+  people: MonitoredPerson[];
+  isLoading: boolean;
+  sortBy?: string;
+  sortDir?: SortDir;
+  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+}
+
+const COLUMNS: { key: string; label: string; sortKey?: string; numeric?: boolean }[] = [
+  { key: 'userName', label: 'User code', sortKey: 'UserName' },
+  { key: 'displayName', label: 'User name', sortKey: 'DisplayName' },
+  { key: 'openTasks', label: 'Open Tasks', sortKey: 'OpenTasks', numeric: true },
+  { key: 'availableTasks', label: 'Available Tasks', sortKey: 'AvailableTasks', numeric: true },
+  { key: 'totalTasks', label: 'Total Tasks', sortKey: 'TotalTasks', numeric: true },
+];
+
+function PeopleMonitorTable({
+  people,
+  isLoading,
+  sortBy,
+  sortDir,
+  onSortChange,
+}: PeopleMonitorTableProps) {
+  const navigate = useNavigate();
+
+  if (!isLoading && people.length === 0) {
+    return (
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-center py-24 gap-4">
+        <div className="size-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center">
+          <Icon style="regular" name="users" className="size-7 text-gray-300" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-semibold text-gray-700">No people to monitor</p>
+          <p className="text-xs text-gray-400 mt-1">
+            Nobody in the groups you monitor has any active tasks right now.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 min-h-0 overflow-auto">
+      <table className="w-full min-w-max text-sm">
+        <thead className="sticky top-0 z-20">
+          <tr className="bg-gray-50 border-b border-gray-200">
+            {COLUMNS.map(col => (
+              <SortableTh
+                key={col.key}
+                label={col.label}
+                sortKey={col.sortKey}
+                activeSortKey={sortBy}
+                activeSortDir={sortDir}
+                onSortChange={onSortChange}
+                className={col.numeric ? 'text-right' : 'text-left'}
+              />
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
+            <TableRowSkeleton columns={COLUMNS.map(() => ({ width: 'w-24' }))} rows={8} />
+          ) : (
+            people.map(person => {
+              const to = `/task-monitor/${encodeURIComponent(person.userName)}`;
+              const linkState = { displayName: person.displayName ?? person.userName };
+              return (
+                <tr
+                  key={person.userName}
+                  onClick={() => navigate(to, { state: linkState })}
+                  className="group hover:bg-gray-50 transition-colors cursor-pointer"
+                >
+                  <td className="px-4 py-3 text-xs text-gray-500 font-mono">{person.userName}</td>
+                  <td className="px-4 py-3">
+                    <Link
+                      to={to}
+                      state={linkState}
+                      onClick={e => e.stopPropagation()}
+                      className="flex items-center gap-2 group-hover:text-primary"
+                    >
+                      <Avatar name={person.displayName || person.userName} size="sm" />
+                      <span className="text-sm font-medium text-gray-900 truncate max-w-[220px]">
+                        {person.displayName || person.userName}
+                      </span>
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-sm text-gray-700">
+                    {person.openTasks}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-sm text-gray-700">
+                    {person.availableTasks}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-sm text-gray-900 font-semibold">
+                    {person.totalTasks}
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default PeopleMonitorTable;

--- a/src/features/taskMonitor/components/PersonTasksFilter.tsx
+++ b/src/features/taskMonitor/components/PersonTasksFilter.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from 'react';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import Dropdown from '@shared/components/inputs/Dropdown';
+import { useDebounce } from '@shared/hooks/useDebounce';
+import { useMonitorFilterOptions } from '../api/taskMonitor';
+
+export interface PersonTasksFilterValues {
+  search?: string;
+  appraisalStatus?: string;
+  taskType?: string;
+}
+
+interface PersonTasksFilterProps {
+  value: PersonTasksFilterValues;
+  onChange: (next: PersonTasksFilterValues) => void;
+}
+
+const EMPTY: PersonTasksFilterValues = {};
+
+function hasAnyFilter(v: PersonTasksFilterValues): boolean {
+  return Boolean(v.search || v.appraisalStatus || v.taskType);
+}
+
+function PersonTasksFilter({ value, onChange }: PersonTasksFilterProps) {
+  // Local state for the text input — debounced so we don't refetch every keystroke
+  const [search, setSearch] = useState(value.search ?? '');
+  const debouncedSearch = useDebounce(search, 400);
+
+  // Keep local state in sync if parent resets externally (Clear)
+  useEffect(() => {
+    setSearch(value.search ?? '');
+  }, [value.search]);
+
+  // Propagate debounced search up
+  useEffect(() => {
+    const trimmed = debouncedSearch.trim();
+    if (trimmed !== (value.search ?? '')) {
+      onChange({ ...value, search: trimmed || undefined });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
+
+  const { data: options } = useMonitorFilterOptions();
+  const statusOptions = useMemo(
+    () =>
+      (options?.appraisalStatuses ?? []).map(s => ({
+        value: s,
+        label: s.replace(/([a-z])([A-Z])/g, '$1 $2'),
+      })),
+    [options?.appraisalStatuses],
+  );
+  const taskTypeOptions = useMemo(
+    () => (options?.taskTypes ?? []).map(t => ({ value: t, label: t })),
+    [options?.taskTypes],
+  );
+
+  const handleClear = () => {
+    setSearch('');
+    onChange(EMPTY);
+  };
+
+  const inputClass =
+    'w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/40';
+
+  const isFiltered = hasAnyFilter(value);
+
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      {/* Combined search: Appraisal Number / Customer Name (server-side LIKE on both) */}
+      <div className="flex-1 min-w-[220px]">
+        <label htmlFor="filter-search" className="block text-[11px] font-medium text-gray-500 mb-1">
+          Search
+        </label>
+        <div className="relative">
+          <Icon
+            style="solid"
+            name="magnifying-glass"
+            className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-gray-400"
+          />
+          <input
+            id="filter-search"
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Appraisal number or customer name..."
+            className={`${inputClass} pl-9`}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 min-w-[180px]">
+        <Dropdown
+          label="Status"
+          value={value.appraisalStatus ?? ''}
+          onChange={(v: string | null) => onChange({ ...value, appraisalStatus: v ?? undefined })}
+          options={statusOptions}
+          placeholder="Please Select"
+          showValuePrefix={false}
+        />
+      </div>
+
+      <div className="flex-1 min-w-[180px]">
+        <Dropdown
+          label="Task Type"
+          value={value.taskType ?? ''}
+          onChange={(v: string | null) => onChange({ ...value, taskType: v ?? undefined })}
+          options={taskTypeOptions}
+          placeholder="Please Select"
+          showValuePrefix={false}
+        />
+      </div>
+
+      {isFiltered && (
+        <div className="shrink-0">
+          <Button type="button" variant="outline" size="sm" onClick={handleClear}>
+            Clear
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PersonTasksFilter;

--- a/src/features/taskMonitor/components/ReassignTaskModal.tsx
+++ b/src/features/taskMonitor/components/ReassignTaskModal.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { format, parseISO } from 'date-fns';
+
+import Modal from '@shared/components/Modal';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import Avatar from '@shared/components/Avatar';
+
+import { useEligibleAssignees, useReassignTask } from '../api/taskMonitor';
+import type { EligibleAssignee, MonitoredTask } from '../types';
+
+interface ReassignTaskModalProps {
+  task: MonitoredTask | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function formatDueAt(dueAt: string | null): string {
+  if (!dueAt) return '—';
+  try {
+    return format(parseISO(dueAt), 'dd MMM yyyy HH:mm');
+  } catch {
+    return dueAt;
+  }
+}
+
+const PAGE_SIZE = 10;
+
+function ReassignTaskModal({ task, isOpen, onClose }: ReassignTaskModalProps) {
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  // Reset on open / task change
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedUserId(null);
+      setPage(0);
+      setServerError(null);
+    }
+  }, [isOpen, task]);
+
+  const { data: eligibleData, isLoading: isLoadingAssignees } = useEligibleAssignees(
+    task?.workflowInstanceId ?? null,
+    task?.activityId ?? null,
+  );
+
+  const reassign = useReassignTask();
+
+  // Filter out the current assignee + paginate client-side
+  const allCandidates: EligibleAssignee[] = useMemo(
+    () => (eligibleData?.eligibleAssignees ?? []).filter(a => a.userId !== task?.assignedTo),
+    [eligibleData?.eligibleAssignees, task?.assignedTo],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(allCandidates.length / PAGE_SIZE));
+  const pagedCandidates = allCandidates.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  const onSave = async () => {
+    if (!task || !selectedUserId) return;
+    setServerError(null);
+
+    try {
+      const result = await reassign.mutateAsync({
+        taskId: task.taskId,
+        body: { newAssignedTo: selectedUserId },
+      });
+
+      if (!result.isSuccess) {
+        setServerError(result.errorMessage ?? 'Reassignment failed.');
+        return;
+      }
+
+      if (result.changed) {
+        const picked = allCandidates.find(a => a.userId === selectedUserId);
+        toast.success(`Reassigned to ${picked?.displayName ?? selectedUserId}. DueAt unchanged.`);
+      }
+      onClose();
+    } catch {
+      setServerError('An unexpected error occurred. Please try again.');
+    }
+  };
+
+  const handleClose = () => {
+    if (!reassign.isPending) onClose();
+  };
+
+  if (!task) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Reassign Task" size="lg">
+      <div className="space-y-4">
+        {/* ── Current assignment summary ── */}
+        <div className="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 space-y-2">
+          <div className="flex items-start gap-3">
+            <Avatar
+              name={task.assignedToDisplayName || task.assignedTo}
+              size="md"
+              className="mt-0.5"
+            />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-500 mb-0.5">Currently assigned to</p>
+              <p className="text-sm font-semibold text-gray-900 truncate">
+                {task.assignedToDisplayName || task.assignedTo}
+              </p>
+              <p className="text-xs text-gray-500 truncate">{task.activityName}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-1">
+            <Icon style="solid" name="clock" className="size-3.5 text-gray-400 shrink-0" />
+            <span className="text-xs text-gray-600">
+              Due: <span className="font-medium text-gray-800">{formatDueAt(task.dueAt)}</span>
+            </span>
+            <span className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold rounded-full bg-blue-50 border border-blue-200 text-blue-700">
+              <Icon style="solid" name="lock" className="size-2.5" />
+              preserved
+            </span>
+          </div>
+        </div>
+
+        {/* ── Eligible list ── */}
+        <div>
+          <p className="block text-sm font-medium text-gray-700 mb-2">
+            New assignee <span className="text-red-500">*</span>
+          </p>
+
+          {isLoadingAssignees ? (
+            <div className="flex items-center justify-center py-12 text-xs text-gray-400">
+              <Icon style="solid" name="spinner" className="size-4 animate-spin mr-2" />
+              Loading eligible users…
+            </div>
+          ) : allCandidates.length === 0 ? (
+            <p className="text-xs text-gray-500 py-6 text-center">
+              No eligible users found for this activity.
+            </p>
+          ) : (
+            <>
+              <ul className="rounded-lg border border-gray-200 divide-y divide-gray-100 max-h-[360px] overflow-auto">
+                {pagedCandidates.map(candidate => {
+                  const isSelected = selectedUserId === candidate.userId;
+                  return (
+                    <li key={candidate.userId}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedUserId(candidate.userId)}
+                        className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors ${
+                          isSelected
+                            ? 'bg-primary/5 ring-1 ring-inset ring-primary/30'
+                            : 'hover:bg-gray-50'
+                        }`}
+                      >
+                        <Avatar name={candidate.displayName || candidate.userName} size="md" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-gray-900">
+                            <span className="font-mono text-xs text-gray-500">
+                              {candidate.userName}
+                            </span>
+                            <span className="mx-1.5 text-gray-300">-</span>
+                            <span className="font-medium">{candidate.displayName}</span>
+                          </p>
+                        </div>
+                        <div className="text-xs text-gray-500 shrink-0 max-w-[180px] truncate text-right">
+                          {candidate.roles.length > 0 ? candidate.roles.join(', ') : '—'}
+                        </div>
+                        {isSelected && (
+                          <Icon
+                            style="solid"
+                            name="circle-check"
+                            className="size-4 text-primary shrink-0"
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {/* Pagination (client-side; eligible pools are typically small) */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-3 text-xs text-gray-500">
+                  <span>
+                    {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, allCandidates.length)}{' '}
+                    of {allCandidates.length}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setPage(p => Math.max(0, p - 1))}
+                      disabled={page === 0}
+                      className="px-2 py-1 rounded border border-gray-200 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <Icon style="solid" name="chevron-left" className="size-3" />
+                    </button>
+                    {Array.from({ length: totalPages }).map((_, i) => (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => setPage(i)}
+                        className={`min-w-[28px] px-2 py-1 rounded border ${
+                          i === page
+                            ? 'border-primary bg-primary/10 text-primary font-semibold'
+                            : 'border-gray-200 hover:bg-gray-50'
+                        }`}
+                      >
+                        {i + 1}
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                      disabled={page >= totalPages - 1}
+                      className="px-2 py-1 rounded border border-gray-200 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <Icon style="solid" name="chevron-right" className="size-3" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* ── Server error ── */}
+        {serverError && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2.5">
+            <Icon
+              style="solid"
+              name="triangle-exclamation"
+              className="size-4 text-red-500 shrink-0 mt-0.5"
+            />
+            <p className="text-sm text-red-700">{serverError}</p>
+          </div>
+        )}
+
+        {/* ── Actions ── */}
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleClose}
+            disabled={reassign.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            isLoading={reassign.isPending}
+            disabled={!selectedUserId}
+            onClick={onSave}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default ReassignTaskModal;

--- a/src/features/taskMonitor/components/SortableTh.tsx
+++ b/src/features/taskMonitor/components/SortableTh.tsx
@@ -1,0 +1,71 @@
+import Icon from '@shared/components/Icon';
+import type { SortDir } from '../types';
+
+interface SortableThProps {
+  label: string;
+  /** When undefined, the header is non-sortable (plain text). */
+  sortKey?: string;
+  activeSortKey?: string;
+  activeSortDir?: SortDir;
+  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+  className?: string;
+}
+
+/**
+ * Table header cell with a click-to-sort affordance. Cycles between asc → desc.
+ * Non-sortable when `sortKey` is omitted (renders plain label).
+ */
+function SortableTh({
+  label,
+  sortKey,
+  activeSortKey,
+  activeSortDir,
+  onSortChange,
+  className,
+}: SortableThProps) {
+  const isSortable = Boolean(sortKey && onSortChange);
+  const isActive = isSortable && sortKey === activeSortKey;
+
+  const handleClick = () => {
+    if (!isSortable || !sortKey || !onSortChange) return;
+    const nextDir: SortDir = isActive && activeSortDir === 'asc' ? 'desc' : 'asc';
+    onSortChange(sortKey, nextDir);
+  };
+
+  const baseCls =
+    'px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
+
+  if (!isSortable) {
+    return <th className={`${baseCls} ${className ?? ''}`.trim()}>{label}</th>;
+  }
+
+  return (
+    <th
+      className={`${baseCls} ${className ?? ''}`.trim()}
+      aria-sort={isActive ? (activeSortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className="inline-flex items-center gap-1 hover:text-gray-700 transition-colors group"
+      >
+        <span>{label}</span>
+        {isActive ? (
+          <Icon
+            style="solid"
+            name={activeSortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
+            className="size-3 text-primary"
+          />
+        ) : (
+          <Icon
+            style="solid"
+            name="sort"
+            className="size-3 text-gray-300 group-hover:text-gray-500"
+          />
+        )}
+      </button>
+    </th>
+  );
+}
+
+export default SortableTh;

--- a/src/features/taskMonitor/components/TaskMonitorFilters.tsx
+++ b/src/features/taskMonitor/components/TaskMonitorFilters.tsx
@@ -1,0 +1,122 @@
+import Icon from '@shared/components/Icon';
+import type { GetMonitoredTasksParams, SlaStatus } from '../types';
+
+interface TaskMonitorFiltersProps {
+  filters: GetMonitoredTasksParams;
+  search: string;
+  onSearchChange: (value: string) => void;
+  onFilterChange: (patch: Partial<GetMonitoredTasksParams>) => void;
+  onClearAll: () => void;
+}
+
+const SLA_OPTIONS: { value: SlaStatus; label: string }[] = [
+  { value: 'OnTrack', label: 'On Track' },
+  { value: 'AtRisk', label: 'At Risk' },
+  { value: 'Breached', label: 'Breached' },
+];
+
+function TaskMonitorFilters({
+  filters,
+  search,
+  onSearchChange,
+  onFilterChange,
+  onClearAll,
+}: TaskMonitorFiltersProps) {
+  const activeCount = Object.values(filters).filter(Boolean).length;
+  const hasAny = !!search || activeCount > 0;
+
+  return (
+    <div className="shrink-0 flex flex-wrap items-center gap-2 mb-3">
+      {/* Search */}
+      <div className="relative w-56">
+        <Icon
+          style="solid"
+          name="magnifying-glass"
+          className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-gray-400 pointer-events-none"
+        />
+        <input
+          type="text"
+          placeholder="Search tasks..."
+          value={search}
+          onChange={e => onSearchChange(e.target.value)}
+          className="w-full pl-9 pr-8 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all placeholder:text-gray-400"
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => onSearchChange('')}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          >
+            <Icon style="solid" name="xmark" className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {/* SLA filter */}
+      <select
+        value={filters.sla ?? ''}
+        onChange={e => onFilterChange({ sla: (e.target.value as SlaStatus) || undefined })}
+        className="px-3 py-2 text-sm border border-gray-200 rounded-lg bg-gray-50 focus:bg-white focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all text-gray-600"
+      >
+        <option value="">All SLA</option>
+        {SLA_OPTIONS.map(o => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Group ID filter */}
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="Group..."
+          value={filters.groupId ?? ''}
+          onChange={e => onFilterChange({ groupId: e.target.value || undefined })}
+          className="w-32 px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all placeholder:text-gray-400"
+        />
+      </div>
+
+      {/* Assignee filter */}
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="Assignee..."
+          value={filters.assigneeUsername ?? ''}
+          onChange={e => onFilterChange({ assigneeUsername: e.target.value || undefined })}
+          className="w-36 px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all placeholder:text-gray-400"
+        />
+      </div>
+
+      {/* Activity ID filter */}
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="Activity..."
+          value={filters.activityId ?? ''}
+          onChange={e => onFilterChange({ activityId: e.target.value || undefined })}
+          className="w-36 px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg focus:bg-white focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none transition-all placeholder:text-gray-400"
+        />
+      </div>
+
+      {/* Clear all */}
+      {hasAny && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="flex items-center gap-1.5 px-3 py-2 text-sm text-gray-500 border border-gray-200 rounded-lg hover:border-gray-300 hover:text-gray-700 transition-all"
+        >
+          <Icon style="solid" name="xmark" className="size-3.5" />
+          Clear
+          {activeCount > 0 && (
+            <span className="inline-flex items-center justify-center size-4 rounded-full bg-gray-200 text-gray-600 text-[10px] font-semibold">
+              {activeCount}
+            </span>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default TaskMonitorFilters;

--- a/src/features/taskMonitor/components/TaskMonitorTable.tsx
+++ b/src/features/taskMonitor/components/TaskMonitorTable.tsx
@@ -1,0 +1,208 @@
+import { format, parseISO } from 'date-fns';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Icon from '@shared/components/Icon';
+import SortableTh from './SortableTh';
+import type { MonitoredTask, SlaStatus, SortDir } from '../types';
+
+// ─── SLA badge ───────────────────────────────────────────────────────────────
+
+const SLA_BADGE: Record<SlaStatus, { label: string; className: string }> = {
+  OnTrack: { label: 'On Track', className: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  AtRisk: { label: 'At Risk', className: 'bg-amber-50 text-amber-700 border-amber-200' },
+  Breached: { label: 'Breached', className: 'bg-red-50 text-red-700 border-red-200' },
+};
+
+function SlaBadge({ sla }: { sla: SlaStatus | null }) {
+  if (!sla) return <span className="text-gray-400 text-xs">—</span>;
+  const cfg = SLA_BADGE[sla];
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full border ${cfg.className}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+// ─── Appraisal status badge ──────────────────────────────────────────────────
+
+const APPRAISAL_STATUS_STYLES: Record<string, string> = {
+  InProgress: 'bg-blue-50 text-blue-700 border-blue-200',
+  PendingApproval: 'bg-amber-50 text-amber-700 border-amber-200',
+  Completed: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  Cancelled: 'bg-red-50 text-red-700 border-red-200',
+  Rejected: 'bg-red-50 text-red-700 border-red-200',
+};
+
+function AppraisalStatusBadge({ status }: { status: string | null }) {
+  if (!status) return <span className="text-gray-400 text-xs">—</span>;
+  const cls = APPRAISAL_STATUS_STYLES[status] ?? 'bg-gray-50 text-gray-700 border-gray-200';
+  // Split PascalCase into spaced words for display: "PendingApproval" -> "Pending Approval"
+  const label = status.replace(/([a-z])([A-Z])/g, '$1 $2');
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full border ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ─── Date cell ────────────────────────────────────────────────────────────────
+
+function DateCell({ value }: { value: string | null }) {
+  if (!value) return <span className="text-gray-400 text-xs">—</span>;
+  try {
+    return (
+      <span className="text-xs text-gray-600 tabular-nums">
+        {format(parseISO(value), 'dd MMM yyyy HH:mm')}
+      </span>
+    );
+  } catch {
+    return <span className="text-gray-400 text-xs">—</span>;
+  }
+}
+
+// ─── Amount formatter ────────────────────────────────────────────────────────
+
+function formatAmount(amount: number | null): string {
+  if (amount == null) return '';
+  return amount.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+// ─── Table ────────────────────────────────────────────────────────────────────
+
+interface TaskMonitorTableProps {
+  tasks: MonitoredTask[];
+  isLoading: boolean;
+  onReassign: (task: MonitoredTask) => void;
+  sortBy?: string;
+  sortDir?: SortDir;
+  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+}
+
+const COLUMNS: { key: string; label: string; sortKey?: string }[] = [
+  { key: 'appraisalNumber', label: 'Appraisal Number', sortKey: 'AppraisalNumber' },
+  { key: 'customerName', label: 'Customer Name', sortKey: 'CustomerName' },
+  { key: 'taskType', label: 'Task Type', sortKey: 'TaskName' },
+  { key: 'purpose', label: 'Purpose', sortKey: 'Purpose' },
+  { key: 'appraisalStatus', label: 'Status', sortKey: 'AppraisalStatus' },
+  { key: 'slaStatus', label: 'SLA', sortKey: 'SlaStatus' },
+  { key: 'assignedAt', label: 'Assigned', sortKey: 'AssignedAt' },
+  { key: 'dueAt', label: 'Due At', sortKey: 'DueAt' },
+  { key: 'actions', label: '' },
+];
+
+function TaskMonitorTable({
+  tasks,
+  isLoading,
+  onReassign,
+  sortBy,
+  sortDir,
+  onSortChange,
+}: TaskMonitorTableProps) {
+  if (!isLoading && tasks.length === 0) {
+    return (
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-center py-24 gap-4">
+        <div className="size-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center">
+          <Icon style="regular" name="inbox" className="size-7 text-gray-300" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-semibold text-gray-700">No monitored tasks</p>
+          <p className="text-xs text-gray-400 mt-1">
+            No tasks found in the groups you monitor, or all tasks are in a non-reassignable state.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 min-h-0 overflow-auto">
+      <table className="w-full min-w-max text-sm">
+        <thead className="sticky top-0 z-20">
+          <tr className="bg-gray-50 border-b border-gray-200">
+            {COLUMNS.map(col => (
+              <SortableTh
+                key={col.key}
+                label={col.label}
+                sortKey={col.sortKey}
+                activeSortKey={sortBy}
+                activeSortDir={sortDir}
+                onSortChange={onSortChange}
+              />
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {isLoading ? (
+            <TableRowSkeleton columns={COLUMNS.map(() => ({ width: 'w-24' }))} rows={8} />
+          ) : (
+            tasks.map(task => (
+              <tr key={task.taskId} className="group hover:bg-gray-50 transition-colors">
+                {/* Appraisal Number (with optional Ref sub-line) */}
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <span className="text-xs text-gray-900 font-mono">
+                    {task.appraisalNumber ?? '—'}
+                  </span>
+                  {task.prevAppraisalNumber && (
+                    <span className="block text-[11px] text-gray-400 font-mono">
+                      (Ref. {task.prevAppraisalNumber})
+                    </span>
+                  )}
+                </td>
+                {/* Customer Name */}
+                <td className="px-4 py-3 text-xs text-gray-700 max-w-[180px] truncate">
+                  {task.customerName ?? '—'}
+                </td>
+                {/* Task Type — prefer human-readable description, fall back to TaskName */}
+                <td className="px-4 py-3 text-gray-900 text-sm font-medium max-w-[220px] truncate">
+                  {task.taskDescription || task.taskName || '—'}
+                </td>
+                {/* Purpose (with optional amount sub-line) */}
+                <td className="px-4 py-3 max-w-[200px]">
+                  <span className="text-xs text-gray-700 block truncate">
+                    {task.purpose ?? '—'}
+                  </span>
+                  {task.facilityLimit != null && (
+                    <span className="block text-[11px] text-gray-400 tabular-nums">
+                      {formatAmount(task.facilityLimit)}
+                    </span>
+                  )}
+                </td>
+                {/* Status = Appraisal status (authoritative on Appraisals.Status) */}
+                <td className="px-4 py-3">
+                  <AppraisalStatusBadge status={task.appraisalStatus} />
+                </td>
+                <td className="px-4 py-3">
+                  <SlaBadge sla={task.slaStatus} />
+                </td>
+                <td className="px-4 py-3">
+                  <DateCell value={task.assignedAt} />
+                </td>
+                <td className="px-4 py-3">
+                  <DateCell value={task.dueAt} />
+                </td>
+                <td className="px-4 py-3 w-24">
+                  <button
+                    type="button"
+                    onClick={() => onReassign(task)}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-primary border border-primary/30 rounded-lg bg-primary/5 hover:bg-primary/10 transition-colors"
+                  >
+                    <Icon style="solid" name="arrow-right-arrow-left" className="size-3" />
+                    Reassign
+                  </button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default TaskMonitorTable;

--- a/src/features/taskMonitor/routes/PersonTasksPage.tsx
+++ b/src/features/taskMonitor/routes/PersonTasksPage.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+
+import Pagination from '@shared/components/Pagination';
+import Icon from '@shared/components/Icon';
+import Avatar from '@shared/components/Avatar';
+import useBreadcrumbExtras from '@shared/hooks/useBreadcrumbExtras';
+
+import { useMonitoredTasks } from '../api/taskMonitor';
+import TaskMonitorTable from '../components/TaskMonitorTable';
+import ReassignTaskModal from '../components/ReassignTaskModal';
+import PersonTasksFilter from '../components/PersonTasksFilter';
+import type { PersonTasksFilterValues } from '../components/PersonTasksFilter';
+import type { GetMonitoredTasksParams, MonitoredTask, SortDir } from '../types';
+
+function PersonTasksPage() {
+  const { username = '' } = useParams<{ username: string }>();
+  const location = useLocation();
+
+  // Initial display name preference: location.state (set by PeopleMonitorTable link),
+  // falling back to the username from the URL. We then upgrade this when task rows
+  // arrive — but never downgrade it back to the bare username, so an active filter
+  // returning 0 rows can't flip the header/breadcrumb to the user code.
+  const initialDisplayName =
+    (location.state as { displayName?: string } | null)?.displayName ?? username;
+  const [stableDisplayName, setStableDisplayName] = useState<string>(initialDisplayName);
+
+  const [filters, setFilters] = useState<PersonTasksFilterValues>({});
+  const [pageNumber, setPageNumber] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortDir, setSortDir] = useState<SortDir | undefined>(undefined);
+  const [selectedTask, setSelectedTask] = useState<MonitoredTask | null>(null);
+  const [isReassignOpen, setIsReassignOpen] = useState(false);
+
+  const handleSortChange = (key: string, dir: SortDir) => {
+    setSortBy(key);
+    setSortDir(dir);
+    setPageNumber(0);
+  };
+
+  const queryParams: GetMonitoredTasksParams = {
+    assigneeUsername: username,
+    ...filters,
+    sortBy,
+    sortDir,
+    page: pageNumber,
+    pageSize,
+  };
+
+  const { data, isLoading, isError, error } = useMonitoredTasks(queryParams);
+
+  const tasks = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  // Upgrade the stable display name once a real one arrives from the task rows.
+  // Never downgrade back to the username — keeps the header/breadcrumb stable
+  // when filters return zero rows.
+  const fromRowDisplayName = tasks[0]?.assignedToDisplayName;
+  useEffect(() => {
+    if (fromRowDisplayName && fromRowDisplayName !== stableDisplayName) {
+      setStableDisplayName(fromRowDisplayName);
+    }
+  }, [fromRowDisplayName, stableDisplayName]);
+
+  const displayName = stableDisplayName;
+
+  // Append the person's name as the leaf breadcrumb crumb. "Task Monitor" already comes
+  // from the layout breadcrumb and links back to /task-monitor.
+  useBreadcrumbExtras(
+    [{ label: displayName, href: location.pathname, icon: 'user' }],
+    [displayName, location.pathname],
+  );
+
+  const handleFiltersChange = (next: PersonTasksFilterValues) => {
+    setFilters(next);
+    setPageNumber(0);
+  };
+
+  const handleReassign = (task: MonitoredTask) => {
+    setSelectedTask(task);
+    setIsReassignOpen(true);
+  };
+
+  const handleReassignClose = () => {
+    setIsReassignOpen(false);
+    setSelectedTask(null);
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 min-w-0">
+      {/* ── Header ── */}
+      <div className="shrink-0 mb-3 flex items-center gap-3">
+        <Avatar name={displayName} size="md" />
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">{displayName}</h2>
+          <p className="text-xs text-gray-500 font-mono">{username}</p>
+        </div>
+        {!isLoading && totalCount > 0 && (
+          <span className="ml-2 px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded-full tabular-nums">
+            {totalCount}
+          </span>
+        )}
+      </div>
+
+      {/* ── Filter ── */}
+      <div className="shrink-0 mb-3">
+        <PersonTasksFilter value={filters} onChange={handleFiltersChange} />
+      </div>
+
+      {/* ── Error state ── */}
+      {isError && (
+        <div className="flex flex-col items-center justify-center h-64 gap-3">
+          <div className="size-12 rounded-full bg-red-50 flex items-center justify-center">
+            <Icon style="solid" name="triangle-exclamation" className="size-5 text-red-500" />
+          </div>
+          <div className="text-center">
+            <p className="text-sm font-medium text-gray-800">Failed to load tasks</p>
+            <p className="text-xs text-gray-400 mt-0.5">{(error as Error)?.message}</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Table ── */}
+      {!isError && (
+        <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
+          <TaskMonitorTable
+            tasks={tasks}
+            isLoading={isLoading}
+            onReassign={handleReassign}
+            sortBy={sortBy}
+            sortDir={sortDir}
+            onSortChange={handleSortChange}
+          />
+
+          <Pagination
+            currentPage={pageNumber}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            pageSize={pageSize}
+            onPageChange={setPageNumber}
+            onPageSizeChange={size => {
+              setPageSize(size);
+              setPageNumber(0);
+            }}
+          />
+        </div>
+      )}
+
+      {/* ── Reassign modal ── */}
+      <ReassignTaskModal
+        task={selectedTask}
+        isOpen={isReassignOpen}
+        onClose={handleReassignClose}
+      />
+    </div>
+  );
+}
+
+export default PersonTasksPage;

--- a/src/features/taskMonitor/routes/TaskMonitorPage.tsx
+++ b/src/features/taskMonitor/routes/TaskMonitorPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import Pagination from '@shared/components/Pagination';
+import Icon from '@shared/components/Icon';
+import { useDebounce } from '@shared/hooks/useDebounce';
+
+import { useMonitoredPeople } from '../api/taskMonitor';
+import PeopleMonitorTable from '../components/PeopleMonitorTable';
+import type { GetMonitoredPeopleParams, SortDir } from '../types';
+
+function TaskMonitorPage() {
+  const { t } = useTranslation('nav');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [search, setSearch] = useState(searchParams.get('search') ?? '');
+  const debouncedSearch = useDebounce(search, 400);
+  const [pageNumber, setPageNumber] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortDir, setSortDir] = useState<SortDir | undefined>(undefined);
+
+  const handleSortChange = (key: string, dir: SortDir) => {
+    setSortBy(key);
+    setSortDir(dir);
+    setPageNumber(0);
+  };
+
+  // Sync search to URL
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (debouncedSearch) next.set('search', debouncedSearch);
+    if (next.toString() !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [debouncedSearch, searchParams, setSearchParams]);
+
+  // Reset to page 0 when search changes
+  useEffect(() => {
+    setPageNumber(0);
+  }, [debouncedSearch]);
+
+  const queryParams: GetMonitoredPeopleParams = {
+    search: debouncedSearch || undefined,
+    sortBy,
+    sortDir,
+    page: pageNumber,
+    pageSize,
+  };
+
+  const { data, isLoading, isError, error } = useMonitoredPeople(queryParams);
+
+  const people = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 min-w-0">
+      {/* ── Page header ── */}
+      <div className="shrink-0 mb-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold text-gray-900">{t('taskMonitor.title')}</h2>
+          {!isLoading && totalCount > 0 && (
+            <span className="px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded-full tabular-nums">
+              {totalCount}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-gray-500 mt-0.5">{t('taskMonitor.description')}</p>
+      </div>
+
+      {/* ── Search bar ── */}
+      <div className="shrink-0 mb-3 flex items-center gap-2">
+        <div className="relative flex-1 max-w-sm">
+          <Icon
+            style="solid"
+            name="magnifying-glass"
+            className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-gray-400"
+          />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search user code or name..."
+            className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/40"
+          />
+        </div>
+      </div>
+
+      {/* ── Error state ── */}
+      {isError && (
+        <div className="flex flex-col items-center justify-center h-64 gap-3">
+          <div className="size-12 rounded-full bg-red-50 flex items-center justify-center">
+            <Icon style="solid" name="triangle-exclamation" className="size-5 text-red-500" />
+          </div>
+          <div className="text-center">
+            <p className="text-sm font-medium text-gray-800">Failed to load monitored people</p>
+            <p className="text-xs text-gray-400 mt-0.5">{(error as Error)?.message}</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Table ── */}
+      {!isError && (
+        <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
+          <PeopleMonitorTable
+            people={people}
+            isLoading={isLoading}
+            sortBy={sortBy}
+            sortDir={sortDir}
+            onSortChange={handleSortChange}
+          />
+
+          <Pagination
+            currentPage={pageNumber}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            pageSize={pageSize}
+            onPageChange={setPageNumber}
+            onPageSizeChange={size => {
+              setPageSize(size);
+              setPageNumber(0);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TaskMonitorPage;

--- a/src/features/taskMonitor/types.ts
+++ b/src/features/taskMonitor/types.ts
@@ -1,0 +1,115 @@
+// SLA status values that may come from the backend
+export type SlaStatus = 'OnTrack' | 'AtRisk' | 'Breached';
+
+// Task status values that the monitor endpoint filters on
+export type MonitorTaskStatus = 'Assigned' | 'InProgress';
+
+// A single row returned by GET /tasks/monitor
+export interface MonitoredTask {
+  taskId: string;
+  taskName: string;
+  taskDescription: string | null;
+  activityId: string;
+  activityName: string;
+  assignedTo: string;
+  assignedToDisplayName: string;
+  groupId: string;
+  groupName: string;
+  dueAt: string | null;
+  slaStatus: SlaStatus | null;
+  taskStatus: MonitorTaskStatus;
+  appraisalStatus: string | null;
+  workflowInstanceId: string;
+  assignedAt: string | null;
+  appraisalNumber: string | null;
+  prevAppraisalNumber: string | null;
+  customerName: string | null;
+  purpose: string | null;
+  facilityLimit: number | null;
+}
+
+// Paginated response wrapper that matches the project's existing pattern
+export interface MonitoredTaskListResponse {
+  items: MonitoredTask[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export type SortDir = 'asc' | 'desc';
+
+// Query params for GET /tasks/monitor
+export interface GetMonitoredTasksParams {
+  groupId?: string;
+  assigneeUsername?: string;
+  sla?: SlaStatus;
+  activityId?: string;
+  search?: string;
+  appraisalNumber?: string;
+  customerName?: string;
+  appraisalStatus?: string;
+  taskType?: string;
+  sortBy?: string;
+  sortDir?: SortDir;
+  page?: number;
+  pageSize?: number;
+}
+
+// Response from GET /tasks/monitor/filter-options
+export interface MonitorFilterOptions {
+  taskTypes: string[];
+  appraisalStatuses: string[];
+}
+
+// One row in the supervisor "people I monitor" list (GET /tasks/monitor/people)
+export interface MonitoredPerson {
+  userName: string;
+  displayName: string | null;
+  openTasks: number;
+  availableTasks: number;
+  totalTasks: number;
+}
+
+export interface MonitoredPersonListResponse {
+  items: MonitoredPerson[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetMonitoredPeopleParams {
+  search?: string;
+  sortBy?: string;
+  sortDir?: SortDir;
+  page?: number;
+  pageSize?: number;
+}
+
+// Eligible assignee item returned by the existing eligible-assignees endpoint
+export interface EligibleAssignee {
+  userId: string;
+  userName: string;
+  displayName: string;
+  roles: string[];
+}
+
+// Response from GET /api/workflows/instances/{id}/activities/{activityId}/eligible-assignees
+export interface EligibleAssigneesResponse {
+  activityId: string;
+  teamId?: string;
+  teamName?: string;
+  eligibleAssignees: EligibleAssignee[];
+}
+
+// POST /tasks/{taskId}/reassign request body
+export interface ReassignTaskRequest {
+  newAssignedTo: string;
+}
+
+// POST /tasks/{taskId}/reassign response
+export interface ReassignTaskResponse {
+  isSuccess: boolean;
+  changed: boolean;
+  assignedTo?: string;
+  errorMessage?: string;
+}

--- a/src/i18n/locales/en/invoice.json
+++ b/src/i18n/locales/en/invoice.json
@@ -107,6 +107,8 @@
     "col": {
       "appraisalReportNo": "Appraisal Number",
       "customerName": "Customer",
+      "costCenter": "Cost Center",
+      "notAvailable": "Not Available",
       "feePaymentMethod": "Fee Payment Method",
       "feeAmount": "Fee (excl. VAT)",
       "vat": "VAT",

--- a/src/i18n/locales/en/nav.json
+++ b/src/i18n/locales/en/nav.json
@@ -28,5 +28,9 @@
       "documents": "Documents"
     }
   },
-  "notifications": "Notifications"
+  "notifications": "Notifications",
+  "taskMonitor": {
+    "title": "Task Monitor",
+    "description": "Reassign tasks held by users in your monitored groups"
+  }
 }

--- a/src/i18n/locales/th/invoice.json
+++ b/src/i18n/locales/th/invoice.json
@@ -107,6 +107,8 @@
     "col": {
       "appraisalReportNo": "เลขที่รายงาน",
       "customerName": "ชื่อลูกค้า",
+      "costCenter": "ศูนย์ต้นทุน",
+      "notAvailable": "ไม่มีข้อมูล",
       "feePaymentMethod": "วิธีการชำระค่าธรรมเนียม",
       "feeAmount": "ค่าธรรมเนียม (ก่อน VAT)",
       "vat": "VAT",

--- a/src/i18n/locales/th/nav.json
+++ b/src/i18n/locales/th/nav.json
@@ -28,5 +28,9 @@
       "documents": "เอกสาร"
     }
   },
-  "notifications": "การแจ้งเตือน"
+  "notifications": "การแจ้งเตือน",
+  "taskMonitor": {
+    "title": "ตรวจสอบงาน",
+    "description": "มอบหมายงานใหม่ให้กับผู้ใช้ในกลุ่มที่คุณดูแล"
+  }
 }

--- a/src/i18n/locales/zh/invoice.json
+++ b/src/i18n/locales/zh/invoice.json
@@ -107,6 +107,8 @@
     "col": {
       "appraisalReportNo": "评估编号",
       "customerName": "客户名称",
+      "costCenter": "成本中心",
+      "notAvailable": "暂无",
       "feePaymentMethod": "费用支付方式",
       "feeAmount": "费用（不含增值税）",
       "vat": "增值税",

--- a/src/i18n/locales/zh/nav.json
+++ b/src/i18n/locales/zh/nav.json
@@ -28,5 +28,9 @@
       "documents": "文档"
     }
   },
-  "notifications": "通知"
+  "notifications": "通知",
+  "taskMonitor": {
+    "title": "任务监控",
+    "description": "重新分配您监管组中的任务"
+  }
 }


### PR DESCRIPTION
## Summary
- **Invoice** — server-side sort across Int/Ext lists, shared `MarkPaidLayout` used by both single-invoice (Sent state) and bulk Mark-as-Paid pages, new payment-state columns + variant props on `InvoiceItemsTable`, `excludeStatus=Paid` on the Ext Unpaid tab (so Pending drafts + Sent both appear), and matching `costCenter` / `notAvailable` i18n.
- **Task Monitor** — `TaskMonitorPage` is now the supervisor "people I monitor" list; new `/task-monitor/:username` `PersonTasksPage` drill-down owns the per-user task view (filter + sortable table + reassign). New `MonitoredPerson` types + `useMonitoredPeople` / `useMonitorFilterOptions` hooks. `ReassignTaskModal` reworked to a paged list picker with `Avatar`.
- **Cross-cutting** — root `Layout` now consumes `useBreadcrumbExtrasStore` (matching `TaskLayout` / `AppraisalLayout`) so pages outside those sublayouts can append a dynamic leaf crumb. Routes wired; nav i18n in en/th/zh.

## Test plan
- [ ] \`pnpm tsc --noEmit\` passes (or at least introduces no new errors beyond the pre-existing ones noted in project memory).
- [ ] \`pnpm lint\` passes.
- [ ] **Invoice list (Int):** sort by Invoice #, Sent Date, Total Items, Total Amount, Status — three-stage cycle (unsorted → asc → desc → unsorted), and resets page to 0.
- [ ] **Invoice list (Ext) Unpaid tab:** shows both Pending and Sent rows; opposite-tab count reflects Paid only.
- [ ] **Invoice detail (Sent):** renders \`MarkPaidLayout\` with bank account, PO #, paid date; submit calls \`markPaid\` and toasts on success; cancel returns to list.
- [ ] **Invoice detail (Pending/Paid):** renders read-only summary (Total + status + company).
- [ ] **Bulk payment:** select multiple invoices on the Int list, navigate to bulk page; collapsible per-invoice sections render; submit calls \`bulkMarkPaid\`.
- [ ] **Task Monitor people list:** search, sort, paginate; clicking a row navigates to \`/task-monitor/:username\` with \`location.state.displayName\` preserved.
- [ ] **PersonTasksPage:** breadcrumb leaf shows the person's display name; applying a filter that returns 0 rows does not flip the header to the user code.
- [ ] **Reassign modal:** paged list picker shows eligible assignees minus the current one; selecting + saving toasts "Reassigned to …. DueAt unchanged"; "changed: false" silently closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)