### PR TITLE
feat: service quality evaluation overhaul + shared inputs/constants, taskmonitor sort, signalr unpin, breadcrumb fix

### DIFF
--- a/src/features/appraisal/components/search/SearchFilterBar.tsx
+++ b/src/features/appraisal/components/search/SearchFilterBar.tsx
@@ -1,7 +1,7 @@
 import type { FilterField } from './tabConfigs';
 import Icon from '@/shared/components/Icon';
 import ProvinceAutocomplete from '@/shared/components/inputs/ProvinceAutocomplete';
-import CompanyAutocomplete from './CompanyAutocomplete';
+import CompanyAutocomplete from '@/shared/components/inputs/CompanyAutocomplete';
 
 interface SearchFilterBarProps {
   filters: FilterField[];

--- a/src/features/invoice/pages/IntInvoiceListPage.tsx
+++ b/src/features/invoice/pages/IntInvoiceListPage.tsx
@@ -11,7 +11,7 @@ import { formatLocaleDate } from '@/shared/utils/dateUtils';
 import InvoiceStatusBadge from '../components/InvoiceStatusBadge';
 import InvoiceRowActionsMenu from '../components/InvoiceRowActionsMenu';
 import InvoiceListTabs from '../components/InvoiceListTabs';
-import CompanyAutocomplete from '@features/appraisal/components/search/CompanyAutocomplete';
+import CompanyAutocomplete from '@/shared/components/inputs/CompanyAutocomplete';
 import { useGetInvoices } from '../api/invoice';
 
 interface InvoiceFilterValues {

--- a/src/features/notification/hooks/useNotificationHub.tsx
+++ b/src/features/notification/hooks/useNotificationHub.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnectionState, HttpTransportType } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
 import { signalrLogger } from '@shared/utils/signalrLogger';
 import { useQueryClient } from '@tanstack/react-query';
 import { getAccessToken } from '@shared/api/axiosInstance';
@@ -21,7 +21,9 @@ const getHubUrl = () => {
 };
 
 export function useNotificationHub() {
-  const connectionRef = useRef<ReturnType<typeof HubConnectionBuilder.prototype.build> | null>(null);
+  const connectionRef = useRef<ReturnType<typeof HubConnectionBuilder.prototype.build> | null>(
+    null,
+  );
   const addNotification = useNotificationStore(s => s.addNotification);
   const queryClient = useQueryClient();
 
@@ -32,8 +34,8 @@ export function useNotificationHub() {
     const connection = new HubConnectionBuilder()
       .withUrl(getHubUrl(), {
         accessTokenFactory: () => getAccessToken() ?? '',
-        skipNegotiation: true,
-        transport: HttpTransportType.WebSockets,
+        // skipNegotiation: true,
+        // transport: HttpTransportType.WebSockets,
         withCredentials: true,
       })
       .withAutomaticReconnect()
@@ -80,7 +82,8 @@ export function useNotificationHub() {
 
     let cancelled = false;
 
-    connection.start()
+    connection
+      .start()
       .then(() => {
         if (!cancelled) console.log('[NotificationHub] SignalR connected');
       })

--- a/src/features/quotation/components/AppraisalPicker.tsx
+++ b/src/features/quotation/components/AppraisalPicker.tsx
@@ -13,6 +13,7 @@ import {
 import { useGetRequestDocuments } from '@/features/request/api/documents';
 import type { SharedDocumentSelectionDto } from '../schemas/quotation';
 import { useParameterOptions } from '@/shared/utils/parameterUtils';
+import { APPRAISAL_STATUS_OPTIONS } from '@/shared/constants/appraisalStatus';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -26,17 +27,6 @@ export interface SelectedAppraisal {
 
 /** Outer key = appraisalId, inner key = documentId, value = level */
 export type DocSelections = Record<string, Record<string, SharedDocumentSelectionDto['level']>>;
-
-// ─── Hardcoded status options (mirrors vw_AppraisalList status values) ────────
-
-const APPRAISAL_STATUS_OPTIONS = [
-  { value: 'Pending', label: 'Pending' },
-  { value: 'Assigned', label: 'Assigned' },
-  { value: 'InProgress', label: 'In Progress' },
-  { value: 'UnderReview', label: 'Under Review' },
-  { value: 'Completed', label: 'Completed' },
-  { value: 'Cancelled', label: 'Cancelled' },
-];
 
 // ─── Filter state type ────────────────────────────────────────────────────────
 

--- a/src/features/serviceQualityEvaluation/api/index.ts
+++ b/src/features/serviceQualityEvaluation/api/index.ts
@@ -2,6 +2,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 import axios from '@shared/api/axiosInstance';
 import type {
   AppraisalEvaluationDetail,
+  AppraisalEvaluationHeader,
   CreateEvaluationBody,
   EvaluationListParams,
   PaginatedEvaluationList,
@@ -17,6 +18,8 @@ export const evaluationKeys = {
   list: (params: Record<string, unknown>) => [...evaluationKeys.lists(), params] as const,
   details: () => [...evaluationKeys.all, 'detail'] as const,
   detail: (appraisalId: string) => [...evaluationKeys.details(), appraisalId] as const,
+  detectDelivery: (appraisalId: string) =>
+    [...evaluationKeys.all, 'detect-delivery', appraisalId] as const,
 };
 
 // ─── GET /appraisal-evaluations (paginated list) ──────────────────────────────
@@ -26,22 +29,22 @@ export const useGetEvaluationList = (params: EvaluationListParams) => {
     queryKey: evaluationKeys.list({
       pageNumber: params.pageNumber,
       pageSize: params.pageSize,
-      ...(params.appraisalNumber && { appraisalNumber: params.appraisalNumber }),
-      ...(params.customerName && { customerName: params.customerName }),
+      ...(params.search && { search: params.search }),
       ...(params.appraisalStatus && { appraisalStatus: params.appraisalStatus }),
-      ...(params.appraiserName && { appraiserName: params.appraiserName }),
+      ...(params.appraiserCompanyId && { appraiserCompanyId: params.appraiserCompanyId }),
       ...(params.evaluationStatus && { evaluationStatus: params.evaluationStatus }),
+      ...(params.sortBy && { sortBy: params.sortBy, sortDir: params.sortDir }),
     }),
     queryFn: async (): Promise<PaginatedEvaluationList> => {
       const { data } = await axios.get('/appraisal-evaluations', {
         params: {
           PageNumber: params.pageNumber,
           PageSize: params.pageSize,
-          ...(params.appraisalNumber && { AppraisalNumber: params.appraisalNumber }),
-          ...(params.customerName && { CustomerName: params.customerName }),
+          ...(params.search && { Search: params.search }),
           ...(params.appraisalStatus && { AppraisalStatus: params.appraisalStatus }),
-          ...(params.appraiserName && { AppraiserName: params.appraiserName }),
+          ...(params.appraiserCompanyId && { AppraiserCompanyId: params.appraiserCompanyId }),
           ...(params.evaluationStatus && { EvaluationStatus: params.evaluationStatus }),
+          ...(params.sortBy && { SortBy: params.sortBy, SortDir: params.sortDir ?? 'asc' }),
         },
       });
       const result = data.evaluations ?? data;
@@ -57,14 +60,14 @@ export const useGetEvaluationList = (params: EvaluationListParams) => {
   });
 };
 
-// ─── GET /appraisal-evaluations/by-appraisal/{appraisalId} ───────────────────
+// ─── GET /appraisal-evaluations/header/{appraisalId} ─────────────────────────
 
-export const useGetEvaluationByAppraisal = (appraisalId: string) => {
+export const useGetEvaluationHeader = (appraisalId: string) => {
   return useQuery({
-    queryKey: evaluationKeys.detail(appraisalId),
-    queryFn: async (): Promise<AppraisalEvaluationDetail | null> => {
+    queryKey: [...evaluationKeys.all, 'header', appraisalId] as const,
+    queryFn: async (): Promise<AppraisalEvaluationHeader | null> => {
       try {
-        const { data } = await axios.get(`/appraisal-evaluations/by-appraisal/${appraisalId}`);
+        const { data } = await axios.get(`/appraisal-evaluations/header/${appraisalId}`);
         return data;
       } catch (err: unknown) {
         const axiosErr = err as { response?: { status?: number } };
@@ -73,20 +76,48 @@ export const useGetEvaluationByAppraisal = (appraisalId: string) => {
       }
     },
     enabled: !!appraisalId,
+    staleTime: 30_000,
+  });
+};
+
+// ─── GET /appraisal-evaluations/by-appraisal/{appraisalId} ───────────────────
+
+export const useGetEvaluationByAppraisal = (appraisalId: string) => {
+  return useQuery({
+    queryKey: evaluationKeys.detail(appraisalId),
+    queryFn: async (): Promise<AppraisalEvaluationDetail | null> => {
+      const { data } = await axios.get<AppraisalEvaluationDetail | null>(
+        `/appraisal-evaluations/by-appraisal/${appraisalId}`,
+      );
+      return data ?? null;
+    },
+    enabled: !!appraisalId,
     staleTime: 10_000,
   });
 };
 
 // ─── GET /appraisal-evaluations/detect-delivery-time/{appraisalId} ───────────
 
-export const useDetectDeliveryTime = () => {
-  return useMutation({
-    mutationFn: async (appraisalId: string): Promise<DetectDeliveryTimeResponse> => {
-      const { data } = await axios.get(
-        `/appraisal-evaluations/detect-delivery-time/${appraisalId}`,
-      );
-      return data;
+export const useDetectDeliveryTime = (appraisalId: string, enabled: boolean) => {
+  return useQuery({
+    queryKey: evaluationKeys.detectDelivery(appraisalId),
+    queryFn: async (): Promise<DetectDeliveryTimeResponse | null> => {
+      try {
+        const { data } = await axios.get(
+          `/appraisal-evaluations/detect-delivery-time/${appraisalId}`,
+        );
+        return data;
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } }).response?.status;
+        if (status === 404) return null;
+        throw err;
+      }
     },
+    enabled: enabled && !!appraisalId,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: (count, err) =>
+      (err as { response?: { status?: number } }).response?.status !== 404 && count < 2,
   });
 };
 
@@ -103,6 +134,7 @@ export const useCreateEvaluation = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: evaluationKeys.lists() });
       queryClient.invalidateQueries({ queryKey: evaluationKeys.detail(variables.appraisalId) });
+      queryClient.invalidateQueries({ queryKey: evaluationKeys.detectDelivery(variables.appraisalId) });
     },
   });
 };
@@ -126,6 +158,7 @@ export const useUpdateEvaluation = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: evaluationKeys.lists() });
       queryClient.invalidateQueries({ queryKey: evaluationKeys.detail(variables.appraisalId) });
+      queryClient.invalidateQueries({ queryKey: evaluationKeys.detectDelivery(variables.appraisalId) });
     },
   });
 };

--- a/src/features/serviceQualityEvaluation/api/types.ts
+++ b/src/features/serviceQualityEvaluation/api/types.ts
@@ -6,10 +6,24 @@ export interface AppraisalEvaluationListItem {
   appraisalStatus: string;
   externalAppraiserName: string;
   assigneeCompanyId: string;
+  appraiserCompanyName: string | null;
   appraisalValue: number | null;
   evaluationId: string | null;
-  evaluationStatus: string; // "Pending" | "Draft" | "Completed"
+  evaluationStatus: string; // "Pending" | "Completed"
   totalScore: number | null;
+}
+
+export interface AppraisalEvaluationHeader {
+  appraisalId: string;
+  appraisalNumber: string | null;
+  appraisalStatus: string | null;
+  customerName: string | null;
+  reportReceivedDate: string | null;
+  appraiserCompanyName: string | null;
+  assigneeCompanyId: string | null;
+  collateralTypes: string | null;
+  inspectionDates: string | null;
+  departmentOfAppraisal: string | null;
 }
 
 export interface AppraisalEvaluationDetail {
@@ -19,18 +33,13 @@ export interface AppraisalEvaluationDetail {
   evaluationStatus: string;
   evaluatedBy: string | null;
   evaluatedAt: string | null;
-  criteria1Rating: number;
-  criteria1Description: string | null;
-  criteria2Rating: number;
+  criteria1Rating: number | null;
+  criteria2Rating: number | null;
   criteria2IsAutoDetected: boolean;
   criteria2DetectedDays: number | null;
-  criteria2Description: string | null;
-  criteria3Rating: number;
-  criteria3Description: string | null;
-  criteria4Rating: number;
-  criteria4Description: string | null;
-  criteria5Rating: number;
-  criteria5Description: string | null;
+  criteria3Rating: number | null;
+  criteria4Rating: number | null;
+  criteria5Rating: number | null;
   additionalComments: string | null;
   note: string | null;
 }
@@ -41,11 +50,12 @@ export interface DetectDeliveryTimeResponse {
 }
 
 export interface EvaluationListParams {
-  appraisalNumber?: string;
-  customerName?: string;
+  search?: string;
   appraisalStatus?: string;
-  appraiserName?: string;
+  appraiserCompanyId?: string;
   evaluationStatus?: string;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
   pageNumber: number;
   pageSize: number;
 }
@@ -60,36 +70,26 @@ export interface PaginatedEvaluationList {
 export interface CreateEvaluationBody {
   appraisalId: string;
   evaluationStatus: string;
-  criteria1Rating: number;
-  criteria1Description: string | null;
-  criteria2Rating: number;
+  criteria1Rating: number | null;
+  criteria2Rating: number | null;
   criteria2IsAutoDetected: boolean;
   criteria2DetectedDays: number | null;
-  criteria2Description: string | null;
-  criteria3Rating: number;
-  criteria3Description: string | null;
-  criteria4Rating: number;
-  criteria4Description: string | null;
-  criteria5Rating: number;
-  criteria5Description: string | null;
+  criteria3Rating: number | null;
+  criteria4Rating: number | null;
+  criteria5Rating: number | null;
   additionalComments: string | null;
   note: string | null;
 }
 
 export interface UpdateEvaluationBody {
   evaluationStatus: string;
-  criteria1Rating: number;
-  criteria1Description: string | null;
-  criteria2Rating: number;
+  criteria1Rating: number | null;
+  criteria2Rating: number | null;
   criteria2IsAutoDetected: boolean;
   criteria2DetectedDays: number | null;
-  criteria2Description: string | null;
-  criteria3Rating: number;
-  criteria3Description: string | null;
-  criteria4Rating: number;
-  criteria4Description: string | null;
-  criteria5Rating: number;
-  criteria5Description: string | null;
+  criteria3Rating: number | null;
+  criteria4Rating: number | null;
+  criteria5Rating: number | null;
   additionalComments: string | null;
   note: string | null;
 }

--- a/src/features/serviceQualityEvaluation/components/EvaluationCriteriaRow.tsx
+++ b/src/features/serviceQualityEvaluation/components/EvaluationCriteriaRow.tsx
@@ -1,17 +1,45 @@
-import { useController, useFormContext, useWatch } from 'react-hook-form';
-import type { EvaluationFormValues } from '../schemas/evaluation';
-import { CRITERIA_WEIGHTS } from '../schemas/evaluation';
-import Button from '@shared/components/Button';
+import { useController, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import type { EvaluationFormValues } from '../schemas/form';
+import { CRITERIA_WEIGHTS } from '../schemas/form';
+import { GUIDELINE_DESCRIPTIONS, RATING_VALUES } from '../constants/guidelines';
 import Icon from '@shared/components/Icon';
-import { useDetectDeliveryTime } from '../api';
 
 export type CriteriaIndex = 0 | 1 | 2 | 3 | 4;
+
+// Red (1, worst) → Green (5, best). Static class names so Tailwind keeps them.
+const RATING_PILL: Record<number, { selected: string; unselected: string }> = {
+  1: {
+    selected: 'bg-red-500 text-white ring-1 ring-red-600',
+    unselected: 'bg-red-50 text-red-700 hover:bg-red-100',
+  },
+  2: {
+    selected: 'bg-orange-500 text-white ring-1 ring-orange-600',
+    unselected: 'bg-orange-50 text-orange-700 hover:bg-orange-100',
+  },
+  3: {
+    selected: 'bg-amber-500 text-white ring-1 ring-amber-600',
+    unselected: 'bg-amber-50 text-amber-700 hover:bg-amber-100',
+  },
+  4: {
+    selected: 'bg-lime-500 text-white ring-1 ring-lime-600',
+    unselected: 'bg-lime-50 text-lime-700 hover:bg-lime-100',
+  },
+  5: {
+    selected: 'bg-green-500 text-white ring-1 ring-green-600',
+    unselected: 'bg-green-50 text-green-700 hover:bg-green-100',
+  },
+};
 
 interface EvaluationCriteriaRowProps {
   index: CriteriaIndex;
   criteriaLabel: string;
-  appraisalId: string;
   disabled?: boolean;
+  forceDisabled?: boolean;
+  /** True when the parent's form state says criterion #2 was auto-detected. */
+  deliveryAutoDetected?: boolean;
+  /** Detected business-days value (only meaningful when deliveryAutoDetected). */
+  deliveryDetectedDays?: number | null;
 }
 
 const RATING_KEYS: readonly [
@@ -28,114 +56,106 @@ const RATING_KEYS: readonly [
   'criteria5Rating',
 ];
 
-const DESC_KEYS: readonly [
-  'criteria1Description',
-  'criteria2Description',
-  'criteria3Description',
-  'criteria4Description',
-  'criteria5Description',
-] = [
-  'criteria1Description',
-  'criteria2Description',
-  'criteria3Description',
-  'criteria4Description',
-  'criteria5Description',
-];
-
-function EvaluationCriteriaRow({ index, criteriaLabel, appraisalId, disabled = false }: EvaluationCriteriaRowProps) {
-  const { control, setValue } = useFormContext<EvaluationFormValues>();
+function EvaluationCriteriaRow({
+  index,
+  criteriaLabel,
+  disabled = false,
+  forceDisabled = false,
+  deliveryAutoDetected = false,
+  deliveryDetectedDays = null,
+}: EvaluationCriteriaRowProps) {
+  const { t } = useTranslation('serviceQualityEvaluation');
+  const { control } = useFormContext<EvaluationFormValues>();
   const weight = CRITERIA_WEIGHTS[index];
 
   const ratingName = RATING_KEYS[index];
-  const descName = DESC_KEYS[index];
 
   const { field: ratingField } = useController({ name: ratingName, control });
-  const { field: descField } = useController({ name: descName, control });
 
-  const rating = (ratingField.value as number) ?? 1;
-  const score = weight * rating;
+  const rating = ratingField.value as number | null | undefined;
+  const hasRating = rating != null && rating >= 1 && rating <= 5;
+  const clampedRating = hasRating ? (rating as 1 | 2 | 3 | 4 | 5) : null;
+  const score = hasRating ? weight * (rating as number) : null;
+  const description = clampedRating ? GUIDELINE_DESCRIPTIONS[index][clampedRating] : '—';
 
+  const isSelectDisabled = disabled || forceDisabled;
+
+  // Badge is driven by props — the parent owns the whole-form useWatch and the
+  // single hydration reset, so we don't subscribe a second time here.
   const isDeliveryRow = index === 1;
-  const { mutate: detectDelivery, isPending: isDetecting } = useDetectDeliveryTime();
-
-  const detectedDays = useWatch({ control, name: 'criteria2DetectedDays' });
-  const isAutoDetected = useWatch({ control, name: 'criteria2IsAutoDetected' });
-
-  const handleAutoDetect = () => {
-    detectDelivery(appraisalId, {
-      onSuccess: response => {
-        if (response.suggestedRating != null) {
-          ratingField.onChange(response.suggestedRating);
-        }
-        if (response.detectedDays != null) {
-          setValue('criteria2IsAutoDetected', true);
-          setValue('criteria2DetectedDays', response.detectedDays);
-        }
-      },
-    });
-  };
+  const showDetectedBadge =
+    isDeliveryRow && deliveryAutoDetected === true && deliveryDetectedDays != null;
 
   return (
-    <tr className="border-b border-gray-100 last:border-0">
+    <tr
+      className={`border-b border-gray-100 last:border-0 ${
+        forceDisabled ? 'bg-blue-50/40' : ''
+      }`}
+    >
       <td className="px-3 py-2.5 text-sm text-gray-500 text-center w-8">{index + 1}</td>
-      <td className="px-3 py-2.5 text-sm text-gray-700">{criteriaLabel}</td>
+      <td className="px-3 py-2.5 text-sm text-gray-700">
+        <span className="inline-flex items-center gap-1.5">
+          {forceDisabled && (
+            <Icon name="lock" style="solid" className="size-3 text-blue-500" />
+          )}
+          {criteriaLabel}
+          {showDetectedBadge && (
+            <span className="relative group inline-flex">
+              <Icon
+                name="circle-info"
+                style="solid"
+                className="size-4 text-blue-500 cursor-help"
+              />
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 z-20 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal text-white shadow-lg opacity-0 group-hover:opacity-100 transition-opacity whitespace-normal text-left"
+              >
+                {t('deliveryTime.tooltip')}
+              </span>
+            </span>
+          )}
+        </span>
+      </td>
       <td className="px-3 py-2.5 text-sm text-gray-600 text-center tabular-nums w-16">
         {weight.toFixed(2)}
       </td>
-      <td className="px-3 py-2.5 w-44">
-        <div className="flex items-center gap-2">
-          <select
-            value={rating}
-            onChange={e => {
-              ratingField.onChange(Number(e.target.value));
-              if (isDeliveryRow) {
-                setValue('criteria2IsAutoDetected', false);
-              }
-            }}
-            onBlur={ratingField.onBlur}
-            disabled={disabled}
-            className="px-2 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white w-20 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
-          >
-            <option value={1}>1</option>
-            <option value={2}>2</option>
-            <option value={3}>3</option>
-            <option value={4}>4</option>
-          </select>
-
-          {isDeliveryRow && (
-            <div className="flex items-center gap-1.5">
-              <Button
-                size="xs"
-                variant="outline"
-                onClick={handleAutoDetect}
-                isLoading={isDetecting}
-                disabled={disabled || isDetecting}
+      <td className="px-3 py-2.5 w-48">
+        <div
+          role="radiogroup"
+          aria-label={`${criteriaLabel} rating`}
+          className={`inline-flex gap-1 ${forceDisabled ? 'opacity-40 saturate-50' : isSelectDisabled ? 'opacity-60' : ''}`}
+        >
+          {RATING_VALUES.map(value => {
+            const isSelected = value === clampedRating;
+            const palette = RATING_PILL[value];
+            const classes = isSelected ? palette.selected : palette.unselected;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={isSelected}
+                disabled={isSelectDisabled}
+                onClick={() => ratingField.onChange(value)}
+                onBlur={ratingField.onBlur}
+                className={`w-7 h-7 rounded-md text-sm font-semibold tabular-nums transition focus:outline-none focus:ring-2 focus:ring-primary-500/30 disabled:cursor-not-allowed ${classes}`}
               >
-                <Icon name="bolt" style="solid" className="size-3 mr-1" />
-                Auto
-              </Button>
-              {isAutoDetected && detectedDays != null && (
-                <span className="text-xs bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded-md whitespace-nowrap">
-                  {(detectedDays as number).toFixed(2)} days
-                </span>
-              )}
-            </div>
-          )}
+                {value}
+              </button>
+            );
+          })}
         </div>
       </td>
       <td className="px-3 py-2.5 text-sm text-gray-700 text-center tabular-nums w-16">
-        {score.toFixed(2)}
+        {score == null ? '—' : score.toFixed(2)}
       </td>
-      <td className="px-3 py-2.5">
-        <input
-          type="text"
-          value={(descField.value as string | null | undefined) ?? ''}
-          onChange={e => descField.onChange(e.target.value || null)}
-          onBlur={descField.onBlur}
-          disabled={disabled}
-          placeholder="Optional note..."
-          className="w-full px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white placeholder:text-gray-400 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
-        />
+      <td className={`px-3 py-2.5 text-sm ${description === '—' ? 'text-gray-400' : 'text-gray-600'}`}>
+        {description}
+        {showDetectedBadge && (
+          <span className="ml-1 text-gray-500 whitespace-nowrap">
+            {t('deliveryTime.detectedDays', { days: (deliveryDetectedDays as number).toFixed(2) })}
+          </span>
+        )}
       </td>
     </tr>
   );

--- a/src/features/serviceQualityEvaluation/components/EvaluationStatusBadge.tsx
+++ b/src/features/serviceQualityEvaluation/components/EvaluationStatusBadge.tsx
@@ -1,27 +1,33 @@
+import { useTranslation } from 'react-i18next';
+
 interface EvaluationStatusBadgeProps {
   status: string;
 }
 
-const STATUS_COLOR_MAP: Record<string, 'amber' | 'blue' | 'emerald' | 'gray'> = {
+const STATUS_COLOR_MAP: Record<string, 'amber' | 'emerald' | 'gray'> = {
   Pending: 'amber',
-  Draft: 'blue',
   Completed: 'emerald',
 };
 
 function EvaluationStatusBadge({ status }: EvaluationStatusBadgeProps) {
-  const color = STATUS_COLOR_MAP[status] ?? 'gray';
+  const { t } = useTranslation('serviceQualityEvaluation');
+  // Historical 'Draft' rows surface as Pending — same colour, same label.
+  const normalized = status === 'Draft' ? 'Pending' : status;
+  const color = STATUS_COLOR_MAP[normalized] ?? 'gray';
+  const labelKey = `evaluationStatus.${normalized}` as
+    | 'evaluationStatus.Pending'
+    | 'evaluationStatus.Completed';
+  const label = normalized === 'Pending' || normalized === 'Completed' ? t(labelKey) : status;
 
   // Map to badge variant via the typeColorMap approach — use className override
   const colorClasses: Record<string, string> = {
     amber: 'bg-amber-50 text-amber-700',
-    blue: 'bg-blue-50 text-blue-700',
     emerald: 'bg-emerald-50 text-emerald-700',
     gray: 'bg-gray-100 text-gray-600',
   };
 
   const dotClasses: Record<string, string> = {
     amber: 'bg-amber-500',
-    blue: 'bg-blue-500',
     emerald: 'bg-emerald-500',
     gray: 'bg-gray-400',
   };
@@ -31,7 +37,7 @@ function EvaluationStatusBadge({ status }: EvaluationStatusBadgeProps) {
       className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${colorClasses[color]}`}
     >
       <span className={`size-1.5 rounded-full shrink-0 ${dotClasses[color]}`} />
-      {status}
+      {label}
     </span>
   );
 }

--- a/src/features/serviceQualityEvaluation/components/RatingGuidelinesTable.tsx
+++ b/src/features/serviceQualityEvaluation/components/RatingGuidelinesTable.tsx
@@ -1,51 +1,22 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Icon from '@shared/components/Icon';
+import { GUIDELINE_DESCRIPTIONS, RATING_VALUES } from '../constants/guidelines';
 
-const GUIDELINES = [
-  {
-    no: 1,
-    criteria: 'Report book quality',
-    rating1: '>5 corrections',
-    rating2: '3–4 corrections',
-    rating3: '1–2 corrections',
-    rating4: 'No revision',
-  },
-  {
-    no: 2,
-    criteria: 'Delivery time',
-    rating1: '>3.5 days',
-    rating2: '2.5–3.5 days',
-    rating3: '2–2.5 days',
-    rating4: '<2 days',
-  },
-  {
-    no: 3,
-    criteria: 'Preparing company personnel',
-    rating1: 'Should be improved',
-    rating2: 'Fairly prepared',
-    rating3: 'Well prepared',
-    rating4: 'Very well prepared',
-  },
-  {
-    no: 4,
-    criteria: 'Response time to problem',
-    rating1: 'Fix >90 min',
-    rating2: 'Fix within 60 min',
-    rating3: 'Fix within 30 min',
-    rating4: 'Fix within 30 min',
-  },
-  {
-    no: 5,
-    criteria: 'Coordination & responsibility',
-    rating1: 'Fairly good level',
-    rating2: 'Moderate level',
-    rating3: 'Good level',
-    rating4: 'Very good level',
-  },
-];
+const CRITERIA_COUNT = 5;
+
+// Red (1, worst) → Green (5, best). Static class names so Tailwind keeps them.
+const RATING_COLOR: Record<number, { header: string; cell: string }> = {
+  1: { header: 'bg-red-100 text-red-800',       cell: 'bg-red-50 text-red-900' },
+  2: { header: 'bg-orange-100 text-orange-800', cell: 'bg-orange-50 text-orange-900' },
+  3: { header: 'bg-amber-100 text-amber-800',   cell: 'bg-amber-50 text-amber-900' },
+  4: { header: 'bg-lime-100 text-lime-800',     cell: 'bg-lime-50 text-lime-900' },
+  5: { header: 'bg-green-100 text-green-800',   cell: 'bg-green-50 text-green-900' },
+};
 
 function RatingGuidelinesTable() {
   const [open, setOpen] = useState(false);
+  const { t } = useTranslation('serviceQualityEvaluation');
 
   return (
     <div className="border border-gray-200 rounded-lg overflow-hidden">
@@ -56,7 +27,7 @@ function RatingGuidelinesTable() {
       >
         <span className="flex items-center gap-2">
           <Icon name="circle-info" style="solid" className="size-4 text-blue-500" />
-          Rating Guidelines
+          {t('ratingGuidelines.title')}
         </span>
         <Icon
           name={open ? 'chevron-up' : 'chevron-down'}
@@ -69,34 +40,29 @@ function RatingGuidelinesTable() {
         <div className="overflow-x-auto">
           <table className="w-full text-xs">
             <thead>
-              <tr className="bg-gray-50 border-t border-gray-200">
-                <th className="text-left font-medium text-gray-600 px-3 py-2 whitespace-nowrap w-8">
-                  No
+              <tr className="bg-gray-50 border-t border-b border-gray-200">
+                <th className="text-center font-medium text-gray-600 px-3 py-2 whitespace-nowrap w-8">
+                  {t('ratingGuidelines.no')}
                 </th>
-                <th className="text-left font-medium text-gray-600 px-3 py-2">Criteria</th>
-                <th className="text-left font-medium text-gray-600 px-3 py-2 whitespace-nowrap">
-                  Rating 1
-                </th>
-                <th className="text-left font-medium text-gray-600 px-3 py-2 whitespace-nowrap">
-                  Rating 2
-                </th>
-                <th className="text-left font-medium text-gray-600 px-3 py-2 whitespace-nowrap">
-                  Rating 3
-                </th>
-                <th className="text-left font-medium text-gray-600 px-3 py-2 whitespace-nowrap">
-                  Rating 4
-                </th>
+                {RATING_VALUES.map(rating => (
+                  <th
+                    key={rating}
+                    className={`text-center font-medium px-3 py-2 whitespace-nowrap ${RATING_COLOR[rating].header}`}
+                  >
+                    {t('ratingGuidelines.rating', { value: rating })}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {GUIDELINES.map(row => (
-                <tr key={row.no} className="even:bg-gray-50/50">
-                  <td className="px-3 py-2 text-gray-500">{row.no}</td>
-                  <td className="px-3 py-2 font-medium text-gray-700">{row.criteria}</td>
-                  <td className="px-3 py-2 text-gray-600">{row.rating1}</td>
-                  <td className="px-3 py-2 text-gray-600">{row.rating2}</td>
-                  <td className="px-3 py-2 text-gray-600">{row.rating3}</td>
-                  <td className="px-3 py-2 text-gray-600">{row.rating4}</td>
+              {Array.from({ length: CRITERIA_COUNT }, (_, i) => (
+                <tr key={i}>
+                  <td className="px-3 py-2 text-center text-gray-500">{i + 1}</td>
+                  {RATING_VALUES.map(rating => (
+                    <td key={rating} className={`px-3 py-2 ${RATING_COLOR[rating].cell}`}>
+                      {GUIDELINE_DESCRIPTIONS[i][rating]}
+                    </td>
+                  ))}
                 </tr>
               ))}
             </tbody>

--- a/src/features/serviceQualityEvaluation/components/StarRating.tsx
+++ b/src/features/serviceQualityEvaluation/components/StarRating.tsx
@@ -1,0 +1,41 @@
+import Icon from '@shared/components/Icon';
+
+interface StarRatingProps {
+  /** 0–5 numeric score. Half-star kicks in at fractional ≥ 0.5. */
+  score: number;
+  /** Tailwind size class for each star. Default: `size-3.5`. */
+  size?: string;
+}
+
+/**
+ * 5-star visualisation of a 0–5 score.
+ * - Full star: amber-400 solid
+ * - Half star: amber-400 solid (star-half-stroke)
+ * - Empty star: gray-300 regular
+ */
+function StarRating({ score, size = 'size-3.5' }: StarRatingProps) {
+  const full = Math.floor(score);
+  const hasHalf = score - full >= 0.5;
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map(i => {
+        if (i <= full) {
+          return <Icon key={i} name="star" style="solid" className={`${size} text-amber-400`} />;
+        }
+        if (i === full + 1 && hasHalf) {
+          return (
+            <Icon
+              key={i}
+              name="star-half-stroke"
+              style="solid"
+              className={`${size} text-amber-400`}
+            />
+          );
+        }
+        return <Icon key={i} name="star" style="regular" className={`${size} text-gray-300`} />;
+      })}
+    </span>
+  );
+}
+
+export default StarRating;

--- a/src/features/serviceQualityEvaluation/constants/guidelines.ts
+++ b/src/features/serviceQualityEvaluation/constants/guidelines.ts
@@ -1,0 +1,39 @@
+export const GUIDELINE_DESCRIPTIONS: Readonly<Record<number, Readonly<Record<number, string>>>> = {
+  0: {
+    1: 'Create a new evaluation book',
+    2: 'There are more than 5 points of correction in the report',
+    3: 'There were 3-4 corrections to the report',
+    4: 'There are 1-2 corrections to the report',
+    5: 'There has been no revision of the report',
+  },
+  1: {
+    1: 'Can deliver the report book > 3.5 days',
+    2: 'Report book can be delivered within ≤ 3-3.5 days',
+    3: 'Report book can be delivered within ≤ 2.5-3 days',
+    4: 'Report book can be delivered within ≤ 2-2.5 days',
+    5: 'The report book can be delivered within 2 days',
+  },
+  2: {
+    1: 'Should be improved',
+    2: 'Fairly prepared',
+    3: 'Moderately prepared',
+    4: 'Well prepared',
+    5: 'Very well prepared',
+  },
+  3: {
+    1: 'Fix issues in reports in more than 60 minutes',
+    2: 'Fix the problem in the report within 60 minutes',
+    3: 'Fix the problem in the report within 50 minutes',
+    4: 'Fix the problem in the report within 40 minutes',
+    5: 'Fix the problem in the report within 30 minutes',
+  },
+  4: {
+    1: 'It is at a level that should be improved.',
+    2: 'It is at a fairly good level',
+    3: 'It is at a moderate level',
+    4: 'At a good level',
+    5: 'It is at a very good level',
+  },
+};
+
+export const RATING_VALUES = [1, 2, 3, 4, 5] as const;

--- a/src/features/serviceQualityEvaluation/pages/ServiceQualityEvaluationDetailPage.tsx
+++ b/src/features/serviceQualityEvaluation/pages/ServiceQualityEvaluationDetailPage.tsx
@@ -1,29 +1,34 @@
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useForm, FormProvider, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
-import Breadcrumb from '@shared/components/Breadcrumb';
 import Button from '@shared/components/Button';
+import { CancelButton } from '@shared/components/buttons';
 import ActionBar from '@shared/components/ActionBar';
 import Icon from '@shared/components/Icon';
 import { Textarea } from '@shared/components/inputs';
+import toast from 'react-hot-toast';
 import { formatLocaleDate } from '@shared/utils/dateUtils';
+import { useBreadcrumbExtrasStore } from '@shared/store';
 import { useGetAppraisalById } from '@/features/appraisal/api/appraisal';
 import {
   useGetEvaluationByAppraisal,
+  useGetEvaluationHeader,
   useCreateEvaluation,
   useUpdateEvaluation,
+  useDetectDeliveryTime,
 } from '../api';
 import {
   evaluationSchema,
   defaultEvaluationValues,
   CRITERIA_LABELS,
   CRITERIA_WEIGHTS,
-} from '../schemas/evaluation';
-import type { EvaluationFormValues } from '../schemas/evaluation';
+} from '../schemas/form';
+import type { EvaluationFormValues } from '../schemas/form';
 import RatingGuidelinesTable from '../components/RatingGuidelinesTable';
 import EvaluationCriteriaRow from '../components/EvaluationCriteriaRow';
+import StarRating from '../components/StarRating';
 
 // ─── Info Grid ────────────────────────────────────────────────────────────────
 
@@ -38,21 +43,22 @@ function InfoRow({ label, value }: { label: string; value: string }) {
 
 // ─── Total Row ────────────────────────────────────────────────────────────────
 
-function EvaluationTotalRow({ values }: { values: EvaluationFormValues }) {
+function EvaluationTotalRow({ values, totalLabel }: { values: EvaluationFormValues; totalLabel: string }) {
+  // Null ratings contribute 0 — partial scores stay visible while the user is still filling in.
   const totalScore =
-    CRITERIA_WEIGHTS[0] * (values.criteria1Rating ?? 1) +
-    CRITERIA_WEIGHTS[1] * (values.criteria2Rating ?? 1) +
-    CRITERIA_WEIGHTS[2] * (values.criteria3Rating ?? 1) +
-    CRITERIA_WEIGHTS[3] * (values.criteria4Rating ?? 1) +
-    CRITERIA_WEIGHTS[4] * (values.criteria5Rating ?? 1);
+    CRITERIA_WEIGHTS[0] * (values.criteria1Rating ?? 0) +
+    CRITERIA_WEIGHTS[1] * (values.criteria2Rating ?? 0) +
+    CRITERIA_WEIGHTS[2] * (values.criteria3Rating ?? 0) +
+    CRITERIA_WEIGHTS[3] * (values.criteria4Rating ?? 0) +
+    CRITERIA_WEIGHTS[4] * (values.criteria5Rating ?? 0);
 
   const totalWeight = CRITERIA_WEIGHTS.reduce((a, b) => a + b, 0);
-  const pct = ((totalScore / 4) * 100).toFixed(0);
+  const pct = ((totalScore / 5) * 100).toFixed(0);
 
   return (
     <tr className="bg-gray-50 font-medium">
       <td className="px-3 py-2.5 text-sm text-gray-500 text-center" />
-      <td className="px-3 py-2.5 text-sm text-gray-700">Total</td>
+      <td className="px-3 py-2.5 text-sm text-gray-700">{totalLabel}</td>
       <td className="px-3 py-2.5 text-sm text-gray-700 text-center tabular-nums">
         {totalWeight.toFixed(2)}
       </td>
@@ -61,9 +67,12 @@ function EvaluationTotalRow({ values }: { values: EvaluationFormValues }) {
         {totalScore.toFixed(2)}
       </td>
       <td className="px-3 py-2.5 text-sm text-gray-700">
-        <span className="inline-flex items-center gap-1 bg-primary/10 text-primary px-2 py-0.5 rounded-md font-semibold">
-          {pct}%
-        </span>
+        <div className="inline-flex items-center gap-2">
+          <span className="inline-flex items-center gap-1 bg-primary/10 text-primary px-2 py-0.5 rounded-md font-semibold">
+            {pct}%
+          </span>
+          <StarRating score={totalScore} />
+        </div>
       </td>
     </tr>
   );
@@ -73,10 +82,10 @@ function EvaluationTotalRow({ values }: { values: EvaluationFormValues }) {
 
 function ServiceQualityEvaluationDetailPage() {
   const { appraisalId } = useParams<{ appraisalId: string }>();
-  const navigate = useNavigate();
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation('serviceQualityEvaluation');
 
   const { data: appraisal, isLoading: appraisalLoading } = useGetAppraisalById(appraisalId);
+  const { data: header, isLoading: headerLoading } = useGetEvaluationHeader(appraisalId ?? '');
   const { data: evaluation, isLoading: evalLoading } = useGetEvaluationByAppraisal(
     appraisalId ?? '',
   );
@@ -86,6 +95,12 @@ function ServiceQualityEvaluationDetailPage() {
 
   const isSaving = isCreating || isUpdating;
 
+  // Tracks which button was clicked so only that button shows the spinner.
+  const [savingStatus, setSavingStatus] = useState<'Pending' | 'Completed' | null>(null);
+  useEffect(() => {
+    if (!isSaving) setSavingStatus(null);
+  }, [isSaving]);
+
   const methods = useForm<EvaluationFormValues>({
     resolver: zodResolver(evaluationSchema),
     defaultValues: defaultEvaluationValues,
@@ -93,67 +108,137 @@ function ServiceQualityEvaluationDetailPage() {
 
   const { reset, handleSubmit, register } = methods;
 
-  // Populate form when evaluation data arrives
+  // Detect runs only when we need a fresh suggestion: brand-new row, or a saved
+  // row whose criteria2Rating hasn't been filled in yet (incl. the inconsistent
+  // saved-state where autoDetected=true but rating=null — re-detect that too).
+  const detectEnabled =
+    evaluation !== undefined && (evaluation === null || evaluation.criteria2Rating == null);
+
+  const {
+    data: detect,
+    isFetching: detectFetching,
+    isError: detectError,
+  } = useDetectDeliveryTime(appraisalId ?? '', detectEnabled);
+
+  // One reset per appraisalId after BOTH evaluation and (if applicable) detect
+  // have settled. Single source of truth — no setValue race with useWatch.
+  const hydratedForRef = useRef<string | null>(null);
+
   useEffect(() => {
+    if (!appraisalId) return;
     if (evaluation === undefined) return;
-    if (evaluation === null) {
-      reset(defaultEvaluationValues);
-    } else {
-      reset({
-        criteria1Rating: evaluation.criteria1Rating,
-        criteria1Description: evaluation.criteria1Description,
-        criteria2Rating: evaluation.criteria2Rating,
-        criteria2IsAutoDetected: evaluation.criteria2IsAutoDetected,
-        criteria2DetectedDays: evaluation.criteria2DetectedDays,
-        criteria2Description: evaluation.criteria2Description,
-        criteria3Rating: evaluation.criteria3Rating,
-        criteria3Description: evaluation.criteria3Description,
-        criteria4Rating: evaluation.criteria4Rating,
-        criteria4Description: evaluation.criteria4Description,
-        criteria5Rating: evaluation.criteria5Rating,
-        criteria5Description: evaluation.criteria5Description,
-        additionalComments: evaluation.additionalComments,
-        note: evaluation.note,
-        evaluationStatus: (evaluation.evaluationStatus as 'Draft' | 'Completed') ?? 'Draft',
-      });
+    if (detectEnabled && detectFetching) return;
+    if (hydratedForRef.current === appraisalId) return;
+    hydratedForRef.current = appraisalId;
+
+    const base: EvaluationFormValues = evaluation
+      ? {
+          criteria1Rating: evaluation.criteria1Rating,
+          criteria2Rating: evaluation.criteria2Rating,
+          criteria2IsAutoDetected: evaluation.criteria2IsAutoDetected ?? false,
+          criteria2DetectedDays: evaluation.criteria2DetectedDays ?? null,
+          criteria2AutoLocked: evaluation.criteria2IsAutoDetected === true,
+          criteria3Rating: evaluation.criteria3Rating,
+          criteria4Rating: evaluation.criteria4Rating,
+          criteria5Rating: evaluation.criteria5Rating,
+          additionalComments: evaluation.additionalComments ?? null,
+          note: evaluation.note ?? null,
+          evaluationStatus: evaluation.evaluationStatus === 'Completed' ? 'Completed' : 'Pending',
+        }
+      : { ...defaultEvaluationValues };
+
+    if (detectEnabled && !detectError && detect) {
+      if (detect.suggestedRating != null) base.criteria2Rating = detect.suggestedRating;
+      if (detect.detectedDays != null) base.criteria2DetectedDays = detect.detectedDays;
+      base.criteria2IsAutoDetected = true;
+      base.criteria2AutoLocked = true;
+    } else if (detectEnabled && detectError) {
+      base.criteria2AutoLocked = false;
     }
-  }, [evaluation, reset]);
+
+    reset(base);
+  }, [appraisalId, evaluation, detect, detectEnabled, detectFetching, detectError, reset]);
 
   const watchedValues = useWatch({ control: methods.control }) as EvaluationFormValues;
 
-  const submitWithStatus = (status: 'Draft' | 'Completed') =>
-    handleSubmit(values => {
-      const body = {
-        appraisalId: appraisalId ?? '',
-        evaluationStatus: status,
-        criteria1Rating: values.criteria1Rating,
-        criteria1Description: values.criteria1Description ?? null,
-        criteria2Rating: values.criteria2Rating,
-        criteria2IsAutoDetected: values.criteria2IsAutoDetected,
-        criteria2DetectedDays: values.criteria2DetectedDays ?? null,
-        criteria2Description: values.criteria2Description ?? null,
-        criteria3Rating: values.criteria3Rating,
-        criteria3Description: values.criteria3Description ?? null,
-        criteria4Rating: values.criteria4Rating,
-        criteria4Description: values.criteria4Description ?? null,
-        criteria5Rating: values.criteria5Rating,
-        criteria5Description: values.criteria5Description ?? null,
-        additionalComments: values.additionalComments ?? null,
-        note: values.note ?? null,
-      };
+  // Complete button is only enabled when every criterion has a rating selected.
+  const canComplete =
+    watchedValues.criteria1Rating != null &&
+    watchedValues.criteria2Rating != null &&
+    watchedValues.criteria3Rating != null &&
+    watchedValues.criteria4Rating != null &&
+    watchedValues.criteria5Rating != null;
 
-      if (!evaluation?.id) {
-        createEvaluation(body);
-      } else {
-        updateEvaluation({
-          evaluationId: evaluation.id,
+  const submitWithStatus = (status: 'Pending' | 'Completed') =>
+    handleSubmit(
+      values => {
+        const body = {
           appraisalId: appraisalId ?? '',
-          body,
-        });
-      }
-    });
+          evaluationStatus: status,
+          criteria1Rating: values.criteria1Rating ?? null,
+          criteria2Rating: values.criteria2Rating ?? null,
+          criteria2IsAutoDetected: values.criteria2IsAutoDetected ?? false,
+          criteria2DetectedDays: values.criteria2DetectedDays ?? null,
+          criteria3Rating: values.criteria3Rating ?? null,
+          criteria4Rating: values.criteria4Rating ?? null,
+          criteria5Rating: values.criteria5Rating ?? null,
+          additionalComments: values.additionalComments ?? null,
+          note: values.note ?? null,
+        };
 
-  const isLoading = appraisalLoading || evalLoading;
+        const successMessage = t(
+          status === 'Completed' ? 'detail.success.completed' : 'detail.success.draftSaved',
+        );
+        const errorMessage = t(
+          status === 'Completed' ? 'detail.errors.completeFailed' : 'detail.errors.saveFailed',
+        );
+
+        setSavingStatus(status);
+        if (!evaluation?.id) {
+          createEvaluation(body, {
+            onSuccess: () => toast.success(successMessage),
+            onError: () => toast.error(errorMessage),
+          });
+        } else {
+          updateEvaluation(
+            { evaluationId: evaluation.id, appraisalId: appraisalId ?? '', body },
+            {
+              onSuccess: () => toast.success(successMessage),
+              onError: () => toast.error(errorMessage),
+            },
+          );
+        }
+      },
+      // Surface silent Zod-resolver rejections so a stray validation error never
+      // makes the button look broken.
+      errors => {
+        // eslint-disable-next-line no-console
+        console.warn('[ServiceQualityEvaluation] form validation failed', errors);
+        toast.error('Form has invalid fields — check the console for details.');
+      },
+    );
+
+  // Push the appraisal number as an extra crumb so the layout's auto-built
+  // breadcrumb gets the dynamic segment without us rendering a second bar.
+  const setBreadcrumbExtras = useBreadcrumbExtrasStore(s => s.setExtras);
+  // Resolve from any source that actually carries the appraisal number.
+  // Do NOT fall back to appraisalId (the URL UUID) — it flashes "019e36f3-..." in
+  // the breadcrumb on refresh before the real number arrives.
+  const dynamicCrumb =
+    evaluation?.appraisalNumber ?? appraisal?.appraisalNumber ?? header?.appraisalNumber;
+  useEffect(() => {
+    if (!dynamicCrumb || !appraisalId) return;
+    setBreadcrumbExtras([
+      {
+        label: dynamicCrumb,
+        href: `/standalone/service-quality-evaluation/${appraisalId}`,
+      },
+    ]);
+    return () => setBreadcrumbExtras([]);
+  }, [dynamicCrumb, appraisalId, setBreadcrumbExtras]);
+
+  const isLoading =
+    appraisalLoading || headerLoading || evalLoading || (detectEnabled && detectFetching);
 
   if (isLoading) {
     return (
@@ -169,31 +254,22 @@ function ServiceQualityEvaluationDetailPage() {
   return (
     <FormProvider {...methods}>
       <div className="flex flex-col gap-4 pb-24">
-        {/* Breadcrumb */}
-        <Breadcrumb
-          items={[
-            { label: 'Service Quality Evaluation', href: '/standalone/service-quality-evaluation' },
-            {
-              label: appraisalNumber ?? '',
-              href: `/standalone/service-quality-evaluation/${appraisalId}`,
-            },
-          ]}
-        />
-
-        {/* Appraisal Info Header */}
+        {/* Appraisal Report Information */}
         <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h3 className="text-sm font-semibold text-gray-900 mb-3">Appraisal Information</h3>
-          <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-            <InfoRow label="Appraisal Report No" value={appraisalNumber ?? '—'} />
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">{t('detail.infoTitle')}</h3>
+          <dl className="grid grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-4">
+            {/* Row 1 — identity & subject of evaluation */}
+            <InfoRow label={t('detail.info.appraisalNumber')} value={header?.appraisalNumber ?? appraisalNumber ?? '—'} />
+            <InfoRow label={t('detail.info.customerName')} value={header?.customerName ?? '—'} />
+            <InfoRow label={t('detail.info.appraiserCompany')} value={header?.appraiserCompanyName ?? '—'} />
+            <InfoRow label={t('detail.info.appraisalDepartment')} value={header?.departmentOfAppraisal ?? '—'} />
+            {/* Row 2 — what was appraised & when */}
+            <InfoRow label={t('detail.info.propertyType')} value={header?.collateralTypes ?? '—'} />
+            <InfoRow label={t('detail.info.appraisalDate')} value={header?.inspectionDates ?? '—'} />
             <InfoRow
-              label="Status"
-              value={appraisal?.status ?? evaluation?.evaluationStatus ?? '—'}
+              label={t('detail.info.reportReceivedDate')}
+              value={formatLocaleDate(header?.reportReceivedDate, i18n.language)}
             />
-            <InfoRow
-              label="Created Date"
-              value={formatLocaleDate(appraisal?.createdOn, i18n.language)}
-            />
-            <InfoRow label="Appraisal Type" value={appraisal?.appraisalType ?? '—'} />
           </dl>
         </div>
 
@@ -207,22 +283,30 @@ function ServiceQualityEvaluationDetailPage() {
           </div>
 
           <div className="overflow-x-auto">
-            <table className="w-full">
+            <table className="w-full table-fixed">
+              <colgroup>
+                <col className="w-12" />
+                <col className="w-96" />
+                <col className="w-20" />
+                <col className="w-52" />
+                <col className="w-20" />
+                <col />
+              </colgroup>
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs w-8">
+                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs">
                     No
                   </th>
                   <th className="text-left font-medium text-gray-600 px-3 py-2.5 text-xs">
                     Criteria for consideration
                   </th>
-                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs w-16">
+                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs">
                     Weight
                   </th>
-                  <th className="text-left font-medium text-gray-600 px-3 py-2.5 text-xs w-44">
+                  <th className="text-left font-medium text-gray-600 px-3 py-2.5 text-xs">
                     Rating
                   </th>
-                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs w-16">
+                  <th className="text-center font-medium text-gray-600 px-3 py-2.5 text-xs">
                     Score
                   </th>
                   <th className="text-left font-medium text-gray-600 px-3 py-2.5 text-xs">
@@ -236,29 +320,37 @@ function ServiceQualityEvaluationDetailPage() {
                     key={i}
                     index={i as 0 | 1 | 2 | 3 | 4}
                     criteriaLabel={label}
-                    appraisalId={appraisalId ?? ''}
                     disabled={isCompleted}
+                    forceDisabled={i === 1 ? (watchedValues.criteria2AutoLocked ?? false) : false}
+                    deliveryAutoDetected={i === 1 ? (watchedValues.criteria2IsAutoDetected ?? false) : false}
+                    deliveryDetectedDays={i === 1 ? (watchedValues.criteria2DetectedDays ?? null) : null}
                   />
                 ))}
-                <EvaluationTotalRow values={watchedValues} />
+                <EvaluationTotalRow values={watchedValues} totalLabel="Total" />
               </tbody>
             </table>
           </div>
 
           {/* Text areas */}
-          <div className="p-4 border-t border-gray-200 grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="p-4 border-t border-gray-200 flex flex-col gap-4">
             <Textarea
-              label="Additional Comments from the Evaluators"
-              placeholder="Enter additional comments..."
+              label={t('detail.comments.additionalLabel')}
+              placeholder={t('detail.comments.additionalPlaceholder')}
               rows={4}
+              maxLength={4000}
+              showCharCount
               disabled={isCompleted}
+              value={watchedValues.additionalComments ?? ''}
               {...register('additionalComments')}
             />
             <Textarea
-              label="Note"
-              placeholder="Enter notes..."
+              label={t('detail.comments.notesLabel')}
+              placeholder={t('detail.comments.notesPlaceholder')}
               rows={4}
+              maxLength={4000}
+              showCharCount
               disabled={isCompleted}
+              value={watchedValues.note ?? ''}
               {...register('note')}
             />
           </div>
@@ -268,35 +360,29 @@ function ServiceQualityEvaluationDetailPage() {
       {/* Action Bar */}
       <ActionBar>
         <ActionBar.Left>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => navigate('/standalone/service-quality-evaluation')}
-          >
-            Cancel
-          </Button>
+          <CancelButton fallbackPath="/standalone/service-quality-evaluation" />
         </ActionBar.Left>
         {!isCompleted && (
           <ActionBar.Right>
             <Button
-              variant="outline"
-              size="sm"
-              onClick={submitWithStatus('Draft')}
-              isLoading={isSaving}
+              variant="ghost"
+              type="button"
+              onClick={submitWithStatus('Pending')}
+              isLoading={savingStatus === 'Pending'}
               disabled={isSaving}
+              leftIcon={<Icon name="floppy-disk" style="regular" className="size-4" />}
             >
-              <Icon name="floppy-disk" style="solid" className="size-3.5 mr-1.5" />
-              Save
+              {t('detail.actions.saveDraft')}
             </Button>
             <Button
-              variant="primary"
-              size="sm"
+              type="button"
               onClick={submitWithStatus('Completed')}
-              isLoading={isSaving}
-              disabled={isSaving}
+              isLoading={savingStatus === 'Completed'}
+              disabled={isSaving || !canComplete}
+              title={!canComplete ? t('detail.errors.allRatingsRequired') : undefined}
+              leftIcon={<Icon name="check" style="solid" className="size-4" />}
             >
-              <Icon name="check" style="solid" className="size-3.5 mr-1.5" />
-              Complete
+              {t('detail.actions.complete')}
             </Button>
           </ActionBar.Right>
         )}

--- a/src/features/serviceQualityEvaluation/pages/ServiceQualityEvaluationListPage.tsx
+++ b/src/features/serviceQualityEvaluation/pages/ServiceQualityEvaluationListPage.tsx
@@ -3,70 +3,96 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '@shared/components/Icon';
 import Input from '@shared/components/Input';
+import CompanyAutocomplete from '@shared/components/inputs/CompanyAutocomplete';
+import Dropdown from '@shared/components/inputs/Dropdown';
+import { APPRAISAL_STATUS_OPTIONS } from '@shared/constants/appraisalStatus';
 import Pagination from '@shared/components/Pagination';
 import { TableRowSkeleton } from '@shared/components/Skeleton';
 import Badge from '@shared/components/Badge';
 import { formatLocaleDate } from '@shared/utils/dateUtils';
 import EvaluationStatusBadge from '../components/EvaluationStatusBadge';
+import StarRating from '../components/StarRating';
 import { useGetEvaluationList } from '../api';
 
-const EVALUATION_STATUS_OPTIONS = ['Pending', 'Draft', 'Completed'];
+type EvaluationView = 'active' | 'history';
+
+// Active tab = items still needing attention (no eval yet, or saved as Draft).
+// History tab = finalised evaluations.
+const VIEW_STATUSES: Record<EvaluationView, string> = {
+  active: 'Pending',
+  history: 'Completed',
+};
 
 function ServiceQualityEvaluationListPage() {
   const navigate = useNavigate();
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation('serviceQualityEvaluation');
 
   // Pagination
   const [pageNumber, setPageNumber] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
+  // View tab (Active = Pending + Draft, History = Completed)
+  const [view, setView] = useState<EvaluationView>('active');
+
   // Filters
-  const [appraisalNumber, setAppraisalNumber] = useState('');
-  const [customerName, setCustomerName] = useState('');
-  const [appraiserName, setAppraiserName] = useState('');
+  const [search, setSearch] = useState('');
+  const [appraiserCompanyId, setAppraiserCompanyId] = useState('');
   const [appraisalStatus, setAppraisalStatus] = useState('');
-  const [evaluationStatus, setEvaluationStatus] = useState('');
 
-  // Debounced text filters
-  const [debouncedAppraisalNumber, setDebouncedAppraisalNumber] = useState('');
-  const [debouncedCustomerName, setDebouncedCustomerName] = useState('');
-  const [debouncedAppraiserName, setDebouncedAppraiserName] = useState('');
+  // Sort
+  const [sortField, setSortField] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedAppraisalNumber(appraisalNumber), 500);
-    return () => clearTimeout(t);
-  }, [appraisalNumber]);
+  // Debounced text filter for the free-text search
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedCustomerName(customerName), 500);
+    const t = setTimeout(() => setDebouncedSearch(search), 500);
     return () => clearTimeout(t);
-  }, [customerName]);
+  }, [search]);
 
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedAppraiserName(appraiserName), 500);
-    return () => clearTimeout(t);
-  }, [appraiserName]);
-
-  // Reset to first page on filter change
+  // Reset to first page on filter, view, or sort change
   useEffect(() => {
     setPageNumber(0);
-  }, [
-    debouncedAppraisalNumber,
-    debouncedCustomerName,
-    debouncedAppraiserName,
-    appraisalStatus,
-    evaluationStatus,
-  ]);
+  }, [debouncedSearch, appraiserCompanyId, appraisalStatus, view, sortField, sortDirection]);
 
   const { data, isLoading, isFetching, isError, error } = useGetEvaluationList({
     pageNumber,
     pageSize,
-    appraisalNumber: debouncedAppraisalNumber || undefined,
-    customerName: debouncedCustomerName || undefined,
-    appraiserName: debouncedAppraiserName || undefined,
+    search: debouncedSearch || undefined,
+    appraiserCompanyId: appraiserCompanyId || undefined,
     appraisalStatus: appraisalStatus || undefined,
-    evaluationStatus: evaluationStatus || undefined,
+    evaluationStatus: VIEW_STATUSES[view],
+    sortBy: sortField ?? undefined,
+    sortDir: sortDirection,
   });
+
+  // Three-state cycle: unsorted -> asc -> desc -> unsorted
+  const handleSort = (field: string) => {
+    if (sortField === field) {
+      if (sortDirection === 'asc') {
+        setSortDirection('desc');
+      } else {
+        setSortField(null);
+        setSortDirection('asc');
+      }
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+  };
+
+  const SortIcon = ({ field }: { field: string }) => {
+    if (sortField !== field)
+      return <Icon style="solid" name="sort" className="size-2.5 text-gray-300" />;
+    return (
+      <Icon
+        style="solid"
+        name={sortDirection === 'asc' ? 'sort-up' : 'sort-down'}
+        className="size-2.5 text-primary"
+      />
+    );
+  };
 
   const items = data?.items ?? [];
   const totalCount = data?.count ?? 0;
@@ -75,22 +101,19 @@ function ServiceQualityEvaluationListPage() {
   const isFirstLoad = isLoading && items.length === 0;
   const isRefetching = isFetching && !isFirstLoad;
 
-  const hasFilters =
-    appraisalNumber || customerName || appraiserName || appraisalStatus || evaluationStatus;
+  const hasFilters = search || appraiserCompanyId || appraisalStatus;
 
   const handleClearFilters = () => {
-    setAppraisalNumber('');
-    setCustomerName('');
-    setAppraiserName('');
+    setSearch('');
+    setAppraiserCompanyId('');
     setAppraisalStatus('');
-    setEvaluationStatus('');
   };
 
   if (isError) {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-4">
         <Icon style="solid" name="triangle-exclamation" className="size-12 text-red-500" />
-        <p className="text-gray-600">Failed to load evaluations</p>
+        <p className="text-gray-600">{t('list.error.title')}</p>
         <p className="text-sm text-gray-400">{(error as Error)?.message}</p>
       </div>
     );
@@ -102,71 +125,67 @@ function ServiceQualityEvaluationListPage() {
       <div className="shrink-0 flex items-center justify-between">
         <div>
           <div className="flex items-center gap-3">
-            <h3 className="text-sm font-semibold text-gray-900">Service Quality Evaluation</h3>
+            <h3 className="text-sm font-semibold text-gray-900">{t('list.title')}</h3>
             <span className="px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded-full">
               {totalCount}
             </span>
           </div>
-          <p className="text-xs text-gray-500 mt-0.5">
-            Evaluate external appraiser service quality
-          </p>
+          <p className="text-xs text-gray-500 mt-0.5">{t('list.subtitle')}</p>
+        </div>
+      </div>
+
+      {/* View tabs */}
+      <div className="shrink-0 border-b border-gray-200">
+        <div className="flex gap-1">
+          {(['active', 'history'] as const).map(v => {
+            const isActive = view === v;
+            return (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setView(v)}
+                className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                  isActive
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {t(`list.tabs.${v}`)}
+              </button>
+            );
+          })}
         </div>
       </div>
 
       {/* Filters Bar */}
       <div className="shrink-0 flex items-end gap-3 pb-1 flex-wrap">
-        <div className="w-44">
+        <div className="w-72">
           <Input
-            label="Appraisal Report No"
-            placeholder="e.g. AP-2025-001"
-            value={appraisalNumber}
-            onChange={e => setAppraisalNumber(e.target.value)}
+            label={t('list.filters.search')}
+            placeholder={t('list.filters.searchPlaceholder')}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
           />
         </div>
-        <div className="w-44">
-          <Input
-            label="Customer Name"
-            placeholder="Customer name"
-            value={customerName}
-            onChange={e => setCustomerName(e.target.value)}
+        <div className="w-56 flex flex-col gap-1">
+          <label className="block text-xs font-medium text-gray-700">
+            {t('list.filters.appraiserCompany')}
+          </label>
+          <CompanyAutocomplete
+            value={appraiserCompanyId}
+            onChange={setAppraiserCompanyId}
+            placeholder={t('list.filters.appraiserCompanyPlaceholder')}
           />
         </div>
-        <div className="w-44">
-          <Input
-            label="Appraiser Name"
-            placeholder="Appraiser name"
-            value={appraiserName}
-            onChange={e => setAppraiserName(e.target.value)}
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className="block text-xs font-medium text-gray-700">Status</label>
-          <select
+        <div className="w-40">
+          <Dropdown
+            label={t('list.filters.status')}
+            placeholder={t('list.filters.statusAll')}
+            options={APPRAISAL_STATUS_OPTIONS}
             value={appraisalStatus}
-            onChange={e => setAppraisalStatus(e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white min-w-32 hover:border-gray-300"
-          >
-            <option value="">All statuses</option>
-            <option value="Pending">Pending</option>
-            <option value="InProgress">In Progress</option>
-            <option value="Completed">Completed</option>
-            <option value="Cancelled">Cancelled</option>
-          </select>
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className="block text-xs font-medium text-gray-700">Evaluation Status</label>
-          <select
-            value={evaluationStatus}
-            onChange={e => setEvaluationStatus(e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white min-w-36 hover:border-gray-300"
-          >
-            <option value="">All</option>
-            {EVALUATION_STATUS_OPTIONS.map(s => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
+            onChange={v => setAppraisalStatus(v ?? '')}
+            showValuePrefix={false}
+          />
         </div>
         {hasFilters && (
           <button
@@ -175,7 +194,7 @@ function ServiceQualityEvaluationListPage() {
             className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors"
           >
             <Icon style="solid" name="xmark" className="size-3" />
-            Clear all
+            {t('list.filters.clearAll')}
           </button>
         )}
       </div>
@@ -186,21 +205,33 @@ function ServiceQualityEvaluationListPage() {
           <table className="w-full text-sm">
             <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
               <tr className="border-b border-gray-200">
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  Appraisal Report No
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Appraiser</th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Customer Name</th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  Report Received Date
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">Status</th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  Evaluation Status
-                </th>
-                <th className="text-right font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  Appraisal Value
-                </th>
+                {[
+                  { key: 'AppraisalNumber', label: t('list.columns.appraisalNumber'), align: 'left' as const, nowrap: true },
+                  { key: 'AppraiserCompanyName', label: t('list.columns.appraiser'), align: 'left' as const, nowrap: false },
+                  { key: 'CustomerName', label: t('list.columns.customerName'), align: 'left' as const, nowrap: false },
+                  { key: 'ReportReceivedDate', label: t('list.columns.reportReceivedDate'), align: 'left' as const, nowrap: true },
+                  { key: 'AppraisalStatus', label: t('list.columns.status'), align: 'left' as const, nowrap: false },
+                  { key: 'EvaluationStatus', label: t('list.columns.evaluationStatus'), align: 'left' as const, nowrap: true },
+                  { key: 'TotalScore', label: t('list.columns.rating'), align: 'left' as const, nowrap: true },
+                  { key: 'AppraisalValue', label: t('list.columns.appraisalValue'), align: 'right' as const, nowrap: true },
+                ].map(col => {
+                  const isActive = sortField === col.key;
+                  const alignClass = col.align === 'right' ? 'text-right' : 'text-left';
+                  return (
+                    <th
+                      key={col.key}
+                      onClick={() => handleSort(col.key)}
+                      className={`${alignClass} font-medium px-4 py-2.5 select-none cursor-pointer hover:text-gray-700 transition-colors ${
+                        col.nowrap ? 'whitespace-nowrap' : ''
+                      } ${isActive ? 'text-primary' : 'text-gray-600'}`}
+                    >
+                      <div className={`inline-flex items-center gap-1 ${col.align === 'right' ? 'justify-end' : ''}`}>
+                        {col.label}
+                        <SortIcon field={col.key} />
+                      </div>
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody
@@ -221,12 +252,12 @@ function ServiceQualityEvaluationListPage() {
                 />
               ) : items.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="text-center py-16">
+                  <td colSpan={8} className="text-center py-16">
                     <div className="flex flex-col items-center gap-2">
                       <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
-                      <p className="text-gray-500 font-medium">No evaluations found</p>
+                      <p className="text-gray-500 font-medium">{t('list.empty.title')}</p>
                       <p className="text-xs text-gray-400">
-                        {hasFilters ? 'Try different filters' : 'No appraisals to evaluate yet'}
+                        {hasFilters ? t('list.empty.withFilters') : t('list.empty.noData')}
                       </p>
                     </div>
                   </td>
@@ -245,7 +276,7 @@ function ServiceQualityEvaluationListPage() {
                     <td className="px-4 py-2.5">
                       <span className="font-medium text-primary">{item.appraisalNumber}</span>
                     </td>
-                    <td className="px-4 py-2.5 text-gray-700">{item.externalAppraiserName || '—'}</td>
+                    <td className="px-4 py-2.5 text-gray-700">{item.appraiserCompanyName || '—'}</td>
                     <td className="px-4 py-2.5 text-gray-700">{item.customerName || '—'}</td>
                     <td className="px-4 py-2.5 text-gray-600 whitespace-nowrap">
                       {formatLocaleDate(item.reportReceivedDate, i18n.language)}
@@ -262,9 +293,19 @@ function ServiceQualityEvaluationListPage() {
                     <td className="px-4 py-2.5">
                       <EvaluationStatusBadge status={item.evaluationStatus} />
                     </td>
+                    <td className="px-4 py-2.5">
+                      {item.totalScore != null ? (
+                        <StarRating score={item.totalScore} />
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </td>
                     <td className="px-4 py-2.5 text-right text-gray-700 tabular-nums whitespace-nowrap">
                       {item.appraisalValue != null
-                        ? item.appraisalValue.toLocaleString()
+                        ? item.appraisalValue.toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })
                         : '—'}
                     </td>
                   </tr>

--- a/src/features/serviceQualityEvaluation/schemas/form.ts
+++ b/src/features/serviceQualityEvaluation/schemas/form.ts
@@ -1,43 +1,37 @@
 import { z } from 'zod';
 
-const ratingSchema = z.number().int().min(1).max(4);
+const ratingSchema = z.number().int().min(1).max(5).nullable().optional();
 
 export const evaluationSchema = z.object({
   criteria1Rating: ratingSchema,
-  criteria1Description: z.string().nullable().optional(),
   criteria2Rating: ratingSchema,
-  criteria2IsAutoDetected: z.boolean(),
+  // Internal display flags — populated by the auto-detect effect, never user-edited.
+  // Marked .optional() so RHF can hold them as undefined without tripping Zod.
+  criteria2IsAutoDetected: z.boolean().optional(),
   criteria2DetectedDays: z.number().nullable().optional(),
-  criteria2Description: z.string().nullable().optional(),
+  criteria2AutoLocked: z.boolean().optional(),
   criteria3Rating: ratingSchema,
-  criteria3Description: z.string().nullable().optional(),
   criteria4Rating: ratingSchema,
-  criteria4Description: z.string().nullable().optional(),
   criteria5Rating: ratingSchema,
-  criteria5Description: z.string().nullable().optional(),
   additionalComments: z.string().nullable().optional(),
   note: z.string().nullable().optional(),
-  evaluationStatus: z.enum(['Draft', 'Completed']),
+  evaluationStatus: z.enum(['Pending', 'Completed']).optional(),
 });
 
 export type EvaluationFormValues = z.infer<typeof evaluationSchema>;
 
 export const defaultEvaluationValues: EvaluationFormValues = {
-  criteria1Rating: 1,
-  criteria1Description: null,
-  criteria2Rating: 1,
+  criteria1Rating: null,
+  criteria2Rating: null,
   criteria2IsAutoDetected: false,
   criteria2DetectedDays: null,
-  criteria2Description: null,
-  criteria3Rating: 1,
-  criteria3Description: null,
-  criteria4Rating: 1,
-  criteria4Description: null,
-  criteria5Rating: 1,
-  criteria5Description: null,
+  criteria2AutoLocked: false,
+  criteria3Rating: null,
+  criteria4Rating: null,
+  criteria5Rating: null,
   additionalComments: null,
   note: null,
-  evaluationStatus: 'Draft',
+  evaluationStatus: 'Pending',
 };
 
 /** Criteria weights — fixed per spec */

--- a/src/features/task/hooks/useWorkflowHub.ts
+++ b/src/features/task/hooks/useWorkflowHub.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnectionState, HttpTransportType } from '@microsoft/signalr';
+import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
 import { signalrLogger } from '@shared/utils/signalrLogger';
 import { getAccessToken } from '@shared/api/axiosInstance';
 
@@ -43,8 +43,8 @@ export function useWorkflowHub({ poolGroups, onPoolTaskUpdate }: UseWorkflowHubO
     const connection = new HubConnectionBuilder()
       .withUrl(getHubUrl(), {
         accessTokenFactory: () => getAccessToken() ?? '',
-        skipNegotiation: true,
-        transport: HttpTransportType.WebSockets,
+        // skipNegotiation: true,
+        // transport: HttpTransportType.WebSockets,
         withCredentials: true,
       })
       .withAutomaticReconnect()

--- a/src/features/taskMonitor/components/PeopleMonitorTable.tsx
+++ b/src/features/taskMonitor/components/PeopleMonitorTable.tsx
@@ -10,7 +10,7 @@ interface PeopleMonitorTableProps {
   isLoading: boolean;
   sortBy?: string;
   sortDir?: SortDir;
-  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+  onSortChange?: (sortKey: string | undefined, sortDir: SortDir | undefined) => void;
 }
 
 const COLUMNS: { key: string; label: string; sortKey?: string; numeric?: boolean }[] = [

--- a/src/features/taskMonitor/components/ReassignTaskModal.tsx
+++ b/src/features/taskMonitor/components/ReassignTaskModal.tsx
@@ -115,7 +115,7 @@ function ReassignTaskModal({ task, isOpen, onClose }: ReassignTaskModalProps) {
             </span>
             <span className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold rounded-full bg-blue-50 border border-blue-200 text-blue-700">
               <Icon style="solid" name="lock" className="size-2.5" />
-              preserved
+              SLA preserved
             </span>
           </div>
         </div>

--- a/src/features/taskMonitor/components/SortableTh.tsx
+++ b/src/features/taskMonitor/components/SortableTh.tsx
@@ -7,12 +7,13 @@ interface SortableThProps {
   sortKey?: string;
   activeSortKey?: string;
   activeSortDir?: SortDir;
-  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+  /** Called with `(undefined, undefined)` when the sort is cleared. */
+  onSortChange?: (sortKey: string | undefined, sortDir: SortDir | undefined) => void;
   className?: string;
 }
 
 /**
- * Table header cell with a click-to-sort affordance. Cycles between asc → desc.
+ * Table header cell with a click-to-sort affordance. Cycles asc → desc → none.
  * Non-sortable when `sortKey` is omitted (renders plain label).
  */
 function SortableTh({
@@ -28,8 +29,17 @@ function SortableTh({
 
   const handleClick = () => {
     if (!isSortable || !sortKey || !onSortChange) return;
-    const nextDir: SortDir = isActive && activeSortDir === 'asc' ? 'desc' : 'asc';
-    onSortChange(sortKey, nextDir);
+    // Three-stage cycle: unsorted → asc → desc → unsorted
+    if (!isActive) {
+      onSortChange(sortKey, 'asc');
+      return;
+    }
+    if (activeSortDir === 'asc') {
+      onSortChange(sortKey, 'desc');
+      return;
+    }
+    // currently 'desc' → clear
+    onSortChange(undefined, undefined);
   };
 
   const baseCls =
@@ -47,22 +57,18 @@ function SortableTh({
       <button
         type="button"
         onClick={handleClick}
-        className="inline-flex items-center gap-1 hover:text-gray-700 transition-colors group"
+        className={`inline-flex items-center gap-1 hover:text-gray-700 transition-colors group ${
+          isActive ? 'text-primary' : ''
+        }`}
       >
         <span>{label}</span>
-        {isActive ? (
-          <Icon
-            style="solid"
-            name={activeSortDir === 'asc' ? 'arrow-up' : 'arrow-down'}
-            className="size-3 text-primary"
-          />
-        ) : (
-          <Icon
-            style="solid"
-            name="sort"
-            className="size-3 text-gray-300 group-hover:text-gray-500"
-          />
-        )}
+        <Icon
+          style="solid"
+          name={isActive ? (activeSortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort'}
+          className={`size-2.5 ${
+            isActive ? 'text-primary' : 'text-gray-300 group-hover:text-gray-500'
+          }`}
+        />
       </button>
     </th>
   );

--- a/src/features/taskMonitor/components/TaskMonitorTable.tsx
+++ b/src/features/taskMonitor/components/TaskMonitorTable.tsx
@@ -81,7 +81,7 @@ interface TaskMonitorTableProps {
   onReassign: (task: MonitoredTask) => void;
   sortBy?: string;
   sortDir?: SortDir;
-  onSortChange?: (sortKey: string, sortDir: SortDir) => void;
+  onSortChange?: (sortKey: string | undefined, sortDir: SortDir | undefined) => void;
 }
 
 const COLUMNS: { key: string; label: string; sortKey?: string }[] = [

--- a/src/features/taskMonitor/routes/PersonTasksPage.tsx
+++ b/src/features/taskMonitor/routes/PersonTasksPage.tsx
@@ -33,7 +33,7 @@ function PersonTasksPage() {
   const [selectedTask, setSelectedTask] = useState<MonitoredTask | null>(null);
   const [isReassignOpen, setIsReassignOpen] = useState(false);
 
-  const handleSortChange = (key: string, dir: SortDir) => {
+  const handleSortChange = (key: string | undefined, dir: SortDir | undefined) => {
     setSortBy(key);
     setSortDir(dir);
     setPageNumber(0);

--- a/src/features/taskMonitor/routes/TaskMonitorPage.tsx
+++ b/src/features/taskMonitor/routes/TaskMonitorPage.tsx
@@ -21,7 +21,7 @@ function TaskMonitorPage() {
   const [sortBy, setSortBy] = useState<string | undefined>(undefined);
   const [sortDir, setSortDir] = useState<SortDir | undefined>(undefined);
 
-  const handleSortChange = (key: string, dir: SortDir) => {
+  const handleSortChange = (key: string | undefined, dir: SortDir | undefined) => {
     setSortBy(key);
     setSortDir(dir);
     setPageNumber(0);

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -7,14 +7,17 @@ import enCommon from './locales/en/common.json';
 import enNav from './locales/en/nav.json';
 import enWebhookAdmin from './locales/en/webhookAdmin.json';
 import enInvoice from './locales/en/invoice.json';
+import enServiceQualityEvaluation from './locales/en/serviceQualityEvaluation.json';
 import thCommon from './locales/th/common.json';
 import thNav from './locales/th/nav.json';
 import thWebhookAdmin from './locales/th/webhookAdmin.json';
 import thInvoice from './locales/th/invoice.json';
+import thServiceQualityEvaluation from './locales/th/serviceQualityEvaluation.json';
 import zhCommon from './locales/zh/common.json';
 import zhNav from './locales/zh/nav.json';
 import zhWebhookAdmin from './locales/zh/webhookAdmin.json';
 import zhInvoice from './locales/zh/invoice.json';
+import zhServiceQualityEvaluation from './locales/zh/serviceQualityEvaluation.json';
 
 export const defaultNS = 'common' as const;
 
@@ -24,18 +27,21 @@ export const resources = {
     nav: enNav,
     webhookAdmin: enWebhookAdmin,
     invoice: enInvoice,
+    serviceQualityEvaluation: enServiceQualityEvaluation,
   },
   th: {
     common: thCommon,
     nav: thNav,
     webhookAdmin: thWebhookAdmin,
     invoice: thInvoice,
+    serviceQualityEvaluation: thServiceQualityEvaluation,
   },
   zh: {
     common: zhCommon,
     nav: zhNav,
     webhookAdmin: zhWebhookAdmin,
     invoice: zhInvoice,
+    serviceQualityEvaluation: zhServiceQualityEvaluation,
   },
 } as const;
 

--- a/src/i18n/locales/en/serviceQualityEvaluation.json
+++ b/src/i18n/locales/en/serviceQualityEvaluation.json
@@ -1,0 +1,85 @@
+{
+  "list": {
+    "title": "Service Quality Evaluation",
+    "subtitle": "Evaluate external appraiser service quality",
+    "tabs": {
+      "active": "To Evaluate",
+      "history": "Evaluated"
+    },
+    "filters": {
+      "search": "Search",
+      "searchPlaceholder": "Appraisal number or customer name",
+      "appraiserCompany": "Appraiser Company",
+      "appraiserCompanyPlaceholder": "Search company...",
+      "status": "Status",
+      "statusAll": "All statuses",
+      "evaluationStatus": "Evaluation Status",
+      "evaluationStatusAll": "All",
+      "clearAll": "Clear all"
+    },
+    "columns": {
+      "appraisalNumber": "Appraisal Number",
+      "appraiser": "Appraiser",
+      "customerName": "Customer Name",
+      "reportReceivedDate": "Report Received Date",
+      "status": "Status",
+      "evaluationStatus": "Evaluation Status",
+      "rating": "Rating",
+      "appraisalValue": "Appraisal Value"
+    },
+    "empty": {
+      "title": "No evaluations found",
+      "withFilters": "Try different filters",
+      "noData": "No appraisals to evaluate yet"
+    },
+    "error": {
+      "title": "Failed to load evaluations"
+    }
+  },
+  "detail": {
+    "infoTitle": "Appraisal Information",
+    "info": {
+      "appraisalNumber": "Appraisal Number",
+      "customerName": "Customer Name",
+      "appraiserCompany": "Appraiser Company",
+      "appraisalDepartment": "Appraisal Department",
+      "propertyType": "Property Type",
+      "appraisalDate": "Appraisal Date",
+      "reportReceivedDate": "Report Received Date"
+    },
+    "comments": {
+      "additionalLabel": "Additional Comments from the Evaluators",
+      "additionalPlaceholder": "Enter additional comments...",
+      "notesLabel": "Notes",
+      "notesPlaceholder": "Enter notes..."
+    },
+    "actions": {
+      "saveDraft": "Save draft",
+      "complete": "Complete"
+    },
+    "errors": {
+      "allRatingsRequired": "Please select a rating for every criterion before completing the evaluation.",
+      "saveFailed": "Failed to save the evaluation. Please try again.",
+      "completeFailed": "Failed to complete the evaluation. Please try again."
+    },
+    "success": {
+      "draftSaved": "Draft saved.",
+      "completed": "Evaluation completed."
+    }
+  },
+  "evaluationStatus": {
+    "Pending": "Pending",
+    "Draft": "Draft",
+    "Completed": "Completed"
+  },
+  "deliveryTime": {
+    "tooltip": "Auto-calculated by the system from the appraiser's assigned → submitted timestamps (business hours, excluding weekends and holidays).",
+    "detectedDays": "({{days}} days)"
+  },
+  "ratingGuidelines": {
+    "title": "Rating Guidelines",
+    "no": "No",
+    "rating": "Rating {{value}}",
+    "detectedDays": "({{days}} days)"
+  }
+}

--- a/src/i18n/locales/th/serviceQualityEvaluation.json
+++ b/src/i18n/locales/th/serviceQualityEvaluation.json
@@ -1,0 +1,85 @@
+{
+  "list": {
+    "title": "การประเมินคุณภาพบริการ",
+    "subtitle": "ประเมินคุณภาพบริการของผู้ประเมินภายนอก",
+    "tabs": {
+      "active": "รอประเมิน",
+      "history": "ประเมินแล้ว"
+    },
+    "filters": {
+      "search": "ค้นหา",
+      "searchPlaceholder": "เลขที่รายงานประเมิน หรือ ชื่อลูกค้า",
+      "appraiserCompany": "บริษัทผู้ประเมิน",
+      "appraiserCompanyPlaceholder": "ค้นหาบริษัท...",
+      "status": "สถานะ",
+      "statusAll": "ทุกสถานะ",
+      "evaluationStatus": "สถานะการประเมิน",
+      "evaluationStatusAll": "ทั้งหมด",
+      "clearAll": "ล้างทั้งหมด"
+    },
+    "columns": {
+      "appraisalNumber": "เลขที่รายงานประเมิน",
+      "appraiser": "ผู้ประเมิน",
+      "customerName": "ชื่อลูกค้า",
+      "reportReceivedDate": "วันที่ได้รับรายงาน",
+      "status": "สถานะ",
+      "evaluationStatus": "สถานะการประเมิน",
+      "rating": "คะแนน",
+      "appraisalValue": "มูลค่าประเมิน"
+    },
+    "empty": {
+      "title": "ไม่พบรายการประเมิน",
+      "withFilters": "ลองเปลี่ยนตัวกรอง",
+      "noData": "ยังไม่มีรายงานที่ต้องประเมินคุณภาพ"
+    },
+    "error": {
+      "title": "ไม่สามารถโหลดข้อมูลการประเมินได้"
+    }
+  },
+  "detail": {
+    "infoTitle": "ข้อมูลรายงานประเมิน",
+    "info": {
+      "appraisalNumber": "เลขที่รายงานประเมิน",
+      "customerName": "ชื่อลูกค้า",
+      "appraiserCompany": "บริษัทผู้ประเมิน",
+      "appraisalDepartment": "ฝ่ายประเมิน",
+      "propertyType": "ประเภทหลักประกัน",
+      "appraisalDate": "วันที่ประเมิน",
+      "reportReceivedDate": "วันที่ได้รับรายงาน"
+    },
+    "comments": {
+      "additionalLabel": "ความคิดเห็นเพิ่มเติมจากผู้ประเมิน",
+      "additionalPlaceholder": "กรอกความคิดเห็นเพิ่มเติม...",
+      "notesLabel": "บันทึก",
+      "notesPlaceholder": "กรอกบันทึก..."
+    },
+    "actions": {
+      "saveDraft": "บันทึกฉบับร่าง",
+      "complete": "ดำเนินการเสร็จสิ้น"
+    },
+    "errors": {
+      "allRatingsRequired": "โปรดเลือกคะแนนสำหรับทุกเกณฑ์ก่อนยืนยันการประเมิน",
+      "saveFailed": "บันทึกการประเมินไม่สำเร็จ โปรดลองอีกครั้ง",
+      "completeFailed": "ยืนยันการประเมินไม่สำเร็จ โปรดลองอีกครั้ง"
+    },
+    "success": {
+      "draftSaved": "บันทึกฉบับร่างเรียบร้อย",
+      "completed": "ยืนยันการประเมินเรียบร้อย"
+    }
+  },
+  "evaluationStatus": {
+    "Pending": "รอดำเนินการ",
+    "Draft": "ฉบับร่าง",
+    "Completed": "เสร็จสิ้น"
+  },
+  "deliveryTime": {
+    "tooltip": "ระบบคำนวณอัตโนมัติจากเวลาที่ผู้ประเมินได้รับมอบหมาย → เวลาที่ส่งงาน (เฉพาะเวลาทำการ ไม่นับวันหยุดสุดสัปดาห์และวันหยุดนักขัตฤกษ์)",
+    "detectedDays": "({{days}} วัน)"
+  },
+  "ratingGuidelines": {
+    "title": "เกณฑ์การให้คะแนน",
+    "no": "ลำดับ",
+    "rating": "คะแนน {{value}}",
+    "detectedDays": "({{days}} วัน)"
+  }
+}

--- a/src/i18n/locales/zh/serviceQualityEvaluation.json
+++ b/src/i18n/locales/zh/serviceQualityEvaluation.json
@@ -1,0 +1,85 @@
+{
+  "list": {
+    "title": "服务质量评估",
+    "subtitle": "评估外部估价人员的服务质量",
+    "tabs": {
+      "active": "待评估",
+      "history": "已评估"
+    },
+    "filters": {
+      "search": "搜索",
+      "searchPlaceholder": "评估报告编号或客户名称",
+      "appraiserCompany": "估价公司",
+      "appraiserCompanyPlaceholder": "搜索公司...",
+      "status": "状态",
+      "statusAll": "所有状态",
+      "evaluationStatus": "评估状态",
+      "evaluationStatusAll": "全部",
+      "clearAll": "清除全部"
+    },
+    "columns": {
+      "appraisalNumber": "评估报告编号",
+      "appraiser": "估价人员",
+      "customerName": "客户名称",
+      "reportReceivedDate": "报告接收日期",
+      "status": "状态",
+      "evaluationStatus": "评估状态",
+      "rating": "评分",
+      "appraisalValue": "评估价值"
+    },
+    "empty": {
+      "title": "未找到评估记录",
+      "withFilters": "请尝试其他筛选条件",
+      "noData": "暂无待评估的报告"
+    },
+    "error": {
+      "title": "加载评估记录失败"
+    }
+  },
+  "detail": {
+    "infoTitle": "评估报告信息",
+    "info": {
+      "appraisalNumber": "评估报告编号",
+      "customerName": "客户名称",
+      "appraiserCompany": "估价公司",
+      "appraisalDepartment": "评估部门",
+      "propertyType": "抵押物类型",
+      "appraisalDate": "评估日期",
+      "reportReceivedDate": "报告接收日期"
+    },
+    "comments": {
+      "additionalLabel": "评估员补充意见",
+      "additionalPlaceholder": "请输入补充意见...",
+      "notesLabel": "备注",
+      "notesPlaceholder": "请输入备注..."
+    },
+    "actions": {
+      "saveDraft": "保存草稿",
+      "complete": "完成"
+    },
+    "errors": {
+      "allRatingsRequired": "请先为每个评估项选择评分，然后再完成评估。",
+      "saveFailed": "保存评估失败，请重试。",
+      "completeFailed": "完成评估失败，请重试。"
+    },
+    "success": {
+      "draftSaved": "草稿已保存。",
+      "completed": "评估已完成。"
+    }
+  },
+  "evaluationStatus": {
+    "Pending": "待处理",
+    "Draft": "草稿",
+    "Completed": "已完成"
+  },
+  "deliveryTime": {
+    "tooltip": "系统根据估价人员的分配时间 → 提交时间自动计算（仅计算工作时间，不含周末和节假日）。",
+    "detectedDays": "({{days}} 天)"
+  },
+  "ratingGuidelines": {
+    "title": "评分指南",
+    "no": "序号",
+    "rating": "评分 {{value}}",
+    "detectedDays": "({{days}} 天)"
+  }
+}

--- a/src/shared/api/companies.ts
+++ b/src/shared/api/companies.ts
@@ -2,6 +2,30 @@ import { useQuery } from '@tanstack/react-query';
 import axios from './axiosInstance';
 import { useCompanyStore } from '../store';
 
+export interface CompanyOption {
+  id: string;
+  companyName: string;
+}
+
+/**
+ * Fallback single-company fetch for autocomplete hydration when the global
+ * company store has not yet loaded. Returns only the fields needed to render
+ * a selected chip ({id, companyName}). For full company details (rating,
+ * contact, etc.) use the feature-level useGetCompanyById in features/appraisal.
+ */
+export const useGetCompanyByIdMinimal = (companyId: string | null) => {
+  return useQuery({
+    queryKey: ['companies', 'minimal', companyId],
+    queryFn: async (): Promise<CompanyOption> => {
+      const { data } = await axios.get(`/companies/${companyId}`);
+      const company = data.company ?? data;
+      return { id: company.id, companyName: company.name };
+    },
+    enabled: !!companyId,
+    staleTime: 30_000,
+  });
+};
+
 export const useCompaniesQuery = () => {
   return useQuery({
     queryKey: ['companies', 'all'],

--- a/src/shared/components/inputs/CompanyAutocomplete.tsx
+++ b/src/shared/components/inputs/CompanyAutocomplete.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useCompanyStore } from '@/shared/store';
-import { useGetCompanyById } from '../../api/administration';
+import { useGetCompanyByIdMinimal } from '@/shared/api/companies';
 import Autocomplete from '@/shared/components/inputs/Autocomplete';
 
 interface CompanyAutocompleteProps {
@@ -19,8 +19,8 @@ function CompanyAutocomplete({
   const isLoaded = useCompanyStore(s => s.isLoaded);
 
   // Fallback: if the store hasn't loaded yet and we have an external value,
-  // hydrate the display name from the API so the chip and input show a name.
-  const { data: hydratedCompany } = useGetCompanyById(!isLoaded && value ? value : null);
+  // hydrate the display name from the API so the input shows a name.
+  const { data: hydratedCompany } = useGetCompanyByIdMinimal(!isLoaded && value ? value : null);
 
   const items = useMemo(
     () => companies.map(c => ({ value: c.id, label: c.companyName })),
@@ -29,7 +29,6 @@ function CompanyAutocomplete({
 
   const displayText = useMemo(() => {
     if (!value) return undefined;
-    // Prefer store lookup once loaded
     const fromStore = companies.find(c => c.id === value)?.companyName;
     return fromStore ?? hydratedCompany?.companyName;
   }, [value, companies, hydratedCompany]);
@@ -43,9 +42,7 @@ function CompanyAutocomplete({
       placeholder={placeholder}
       ariaLabel={placeholder}
       showAllOnFocus
-      filterItems={(item, text) =>
-        item.label.toLowerCase().includes(text.toLowerCase())
-      }
+      filterItems={(item, text) => item.label.toLowerCase().includes(text.toLowerCase())}
     />
   );
 }

--- a/src/shared/constants/appraisalStatus.ts
+++ b/src/shared/constants/appraisalStatus.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical appraisal status codes — mirrors the backend value object at
+ * Modules/Appraisal/Appraisal/Domain/Appraisals/AppraisalStatus.cs.
+ * Keep in sync when statuses are added or removed on the backend.
+ */
+export const APPRAISAL_STATUS_CODES = [
+  'Submitted',
+  'Pending',
+  'Assigned',
+  'InProgress',
+  'UnderReview',
+  'Completed',
+  'Cancelled',
+] as const;
+
+export type AppraisalStatusCode = (typeof APPRAISAL_STATUS_CODES)[number];
+
+/** Display label for each status code. CamelCase → spaced for the UI. */
+export const APPRAISAL_STATUS_LABELS: Record<AppraisalStatusCode, string> = {
+  Submitted: 'Submitted',
+  Pending: 'Pending',
+  Assigned: 'Assigned',
+  InProgress: 'In Progress',
+  UnderReview: 'Under Review',
+  Completed: 'Completed',
+  Cancelled: 'Cancelled',
+};
+
+/**
+ * Default dropdown options covering every filterable appraisal status.
+ * Screens that need a subset should `.filter()` this list rather than maintain
+ * their own copy.
+ */
+export const APPRAISAL_STATUS_OPTIONS: { value: AppraisalStatusCode; label: string }[] =
+  APPRAISAL_STATUS_CODES.map(code => ({ value: code, label: APPRAISAL_STATUS_LABELS[code] }));

--- a/src/shared/hooks/useBreadcrumb.ts
+++ b/src/shared/hooks/useBreadcrumb.ts
@@ -68,13 +68,29 @@ export function useBreadcrumb(customLabel?: string, customIcon?: string) {
     }
 
     // For pages not in navigation (detail pages, etc.):
+    // On a fresh load (e.g. browser refresh of a deep link) the breadcrumb store
+    // is empty and the nav-history-based push below would render just the leaf
+    // with no parent. Walk up the URL to seed the nearest menu ancestor.
+    const currentItems = useBreadcrumbStore.getState().items;
+    if (currentItems.length === 0) {
+      const segments = path.split('/').filter(Boolean);
+      for (let i = segments.length - 1; i >= 1; i--) {
+        const ancestorPath = '/' + segments.slice(0, i).join('/');
+        const ancestor = routeMap.get(ancestorPath);
+        if (ancestor) {
+          setItems([{ label: ancestor.name, href: ancestor.href, icon: ancestor.icon }]);
+          break;
+        }
+      }
+    }
+
     if (customLabel) {
-      const currentItems = useBreadcrumbStore.getState().items;
-      const existingIndex = currentItems.findIndex(i => i.href === path);
+      const itemsAfterSeed = useBreadcrumbStore.getState().items;
+      const existingIndex = itemsAfterSeed.findIndex(i => i.href === path);
 
       if (existingIndex !== -1) {
-        if (currentItems[existingIndex].label !== customLabel) {
-          const updatedItems = [...currentItems];
+        if (itemsAfterSeed[existingIndex].label !== customLabel) {
+          const updatedItems = [...itemsAfterSeed];
           updatedItems[existingIndex] = { label: customLabel, href: path, icon };
           setItems(updatedItems);
         }


### PR DESCRIPTION
## Summary

Six logically-independent concerns bundled into a single PR with **one atomic commit each** (in dependency order):

1. **`refactor(shared)`** — promote `CompanyAutocomplete` to `src/shared/components/inputs/` + add `useGetCompanyByIdMinimal` hook for chip hydration. Updates consumers in invoice and appraisal search.
2. **`refactor(shared)`** — extract `APPRAISAL_STATUS_OPTIONS` from `AppraisalPicker` into `src/shared/constants/appraisalStatus.ts` (`CODES`, `LABELS`, `OPTIONS`). Adds back `Submitted` to match backend.
3. **`feat(serviceQualityEvaluation)`** — major overhaul:
   - New `GET /appraisal-evaluations/header/{id}` for the detail-page info card
   - `useDetectDeliveryTime` becomes a `useQuery` (was a mutation), wired into a single-reset hydration effect on the detail page (no more setValue/useWatch race)
   - All criteria ratings now nullable; description fields removed (derived from `GUIDELINE_DESCRIPTIONS` matrix)
   - New auto-detect badge + tooltip + lock UI for delivery-time row (criterion #2)
   - New `StarRating` component on the totals row
   - List page: Active vs History tabs, three-stage sortable columns, debounced search, company filter via shared `CompanyAutocomplete`, status filter via shared `APPRAISAL_STATUS_OPTIONS`
   - i18n: new `serviceQualityEvaluation` namespace registered in `src/i18n/index.ts` for `en`, `th`, `zh`
   - Schema rename: `schemas/evaluation.ts → schemas/form.ts`
4. **`feat(taskMonitor)`** — column sort cycles **asc → desc → unsorted** (was asc ↔ desc only). Callback signature widened to `(key?, dir?)`. Also fixes `ReassignTaskModal` SLA badge copy ("preserved" → "SLA preserved").
5. **`revert(signalr)`** — reverts `c7d5ea5` (WS-only transport pin) so both hubs negotiate transports again. The pin lines are commented (not deleted) so flipping back is one-line.
6. **`fix(breadcrumb)`** — seeds the nearest ancestor crumb on fresh deep-link loads (e.g. browser refresh of a deep route). Previously the breadcrumb showed only the leaf.

> **Please rebase-merge or merge-commit; do not squash.** The atomic commit structure is the point — squashing would defeat surgical `git revert` of any single concern post-merge.

## Test plan

- [ ] `pnpm tsc --noEmit` shows no **new** type errors versus `main` (verified locally — pre-existing errors are unchanged)
- [ ] **Commit 1** — `/invoice` list + `/appraisal` search: company autocomplete renders and selects; refresh with a company already selected → chip shows company name (`useGetCompanyByIdMinimal` hydration path)
- [ ] **Commit 2** — `/quotation` AppraisalPicker: status dropdown lists all 7 codes (incl. `Submitted`), labels match (`InProgress` → "In Progress", `UnderReview` → "Under Review")
- [ ] **Commit 3** — `/standalone/service-quality-evaluation`:
  - [ ] Active vs History tab filtering works (Pending vs Completed)
  - [ ] Debounced search + company filter + status filter + three-stage sort
  - [ ] Row click opens detail page; locale switcher (EN/TH/ZH) updates all labels
  - [ ] Header card shows `appraiserCompanyName`, `departmentOfAppraisal`, `collateralTypes`, `inspectionDates`, `reportReceivedDate`
  - [ ] Auto-detect badge + tooltip appears on row #2 when `criteria2IsAutoDetected`
  - [ ] Row #2 is locked when `criteria2AutoLocked` is true
  - [ ] **Save (Pending)** and **Complete** buttons each show their own spinner; **Complete** disabled until all 5 ratings are set
- [ ] **Commit 4** — TaskMonitor + PersonTasks: clicking a sortable header three times cycles asc → desc → unsorted (no arrow, neutral colour). `ReassignTaskModal` SLA badge reads "SLA preserved".
- [ ] **Commit 5** — DevTools → Network on app load: both `/notificationhub/negotiate` and `/workflowhub/negotiate` requests fire (negotiation re-enabled) and SignalR still connects.
- [ ] **Commit 6** — Hard-refresh a deep route (e.g. `/standalone/service-quality-evaluation/<id>`); breadcrumb shows `ParentMenu › Leaf`, not just `Leaf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)