### PR TITLE
fix(task): keep pinned first column from jumping to last in task list

### DIFF
--- a/src/features/menuFavorites/preferenceKeys.ts
+++ b/src/features/menuFavorites/preferenceKeys.ts
@@ -1,4 +1,3 @@
 export const PREFERENCE_KEYS = {
   menuFavorites: 'menu.favorites',
-  taskColumns: 'task.columns.all',
 } as const;

--- a/src/features/task/hooks/useColumnVisibility.ts
+++ b/src/features/task/hooks/useColumnVisibility.ts
@@ -1,8 +1,6 @@
-import { useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
 import { z } from 'zod';
-import { usePreferences } from '@shared/hooks/usePreferences';
-import { PREFERENCE_KEYS } from '@features/menuFavorites/preferenceKeys';
 import type { ActivityColumnConfig, ColumnKey } from '../config/columnDefs';
 
 // ── Zod schema ────────────────────────────────────────────────────────────────
@@ -33,31 +31,63 @@ function normalizeState(
       (config.columns as string[]).includes(k) && !alwaysVisible.has(k as ColumnKey),
   );
 
-  // Restore order: saved order filtered to valid keys, then append new columns
-  const savedOrder = raw.order.filter((k): k is ColumnKey =>
-    (config.columns as string[]).includes(k),
-  );
+  // Restore order: saved order filtered to valid, unique keys, then append new columns.
+  // Deduping guards against a corrupt/hand-edited stored value producing duplicate cells.
+  const savedOrder = [
+    ...new Set(
+      raw.order.filter((k): k is ColumnKey => (config.columns as string[]).includes(k)),
+    ),
+  ];
   const missing = config.columns.filter(k => !savedOrder.includes(k));
   const order = [...savedOrder, ...missing];
 
-  return { hidden: new Set(validHidden), order };
+  // The sticky column must always render first — force it to index 0 so a stale
+  // saved order (or a user dragging another column ahead of it) can't unpin it.
+  const sticky = config.stickyColumn;
+  const ordered = [sticky, ...order.filter(k => k !== sticky)];
+
+  return { hidden: new Set(validHidden), order: ordered };
 }
 
 function defaultPersistedState(config: ActivityColumnConfig): PersistedState {
   return { hidden: [], order: config.columns };
 }
 
+function readStored(storageKey: string, config: ActivityColumnConfig): PersistedState {
+  try {
+    const item = localStorage.getItem(storageKey);
+    if (!item) return defaultPersistedState(config);
+    const parsed = taskColumnsSchema.safeParse(JSON.parse(item));
+    return parsed.success ? parsed.data : defaultPersistedState(config);
+  } catch {
+    return defaultPersistedState(config);
+  }
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
-export function useColumnVisibility(_storageKey: string, config: ActivityColumnConfig) {
-  // _storageKey is kept in the signature for API compatibility but unused —
-  // storage has moved to the backend under PREFERENCE_KEYS.taskColumns.
-  const defaultValue = useMemo(() => defaultPersistedState(config), [config]);
+export function useColumnVisibility(storageKey: string, config: ActivityColumnConfig) {
+  // Column layout is persisted per-screen in localStorage under the caller's storageKey.
+  // Each screen (All Tasks, each activity view) owns its own key, so the views no longer
+  // clobber each other — and the layout survives a page refresh.
+  const [raw, setRawState] = useState<PersistedState>(() => readStored(storageKey, config));
 
-  const { value: raw, setValue: setRaw } = usePreferences(
-    PREFERENCE_KEYS.taskColumns,
-    defaultValue,
-    taskColumnsSchema,
+  // Re-read when the screen changes: the activity table swaps activityId via the URL query
+  // without remounting, so storageKey/config can change while the hook stays mounted.
+  useEffect(() => {
+    setRawState(readStored(storageKey, config));
+  }, [storageKey, config]);
+
+  const setRaw = useCallback(
+    (next: PersistedState) => {
+      setRawState(next);
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(next));
+      } catch {
+        // ignore quota / unavailable-storage errors — in-memory state still updates
+      }
+    },
+    [storageKey],
   );
 
   const { hidden, order } = useMemo(() => normalizeState(raw, config), [raw, config]);


### PR DESCRIPTION
## Problem

On the task list page, the left-pinned first column jumps to the **last** column position after visiting a different task view (e.g. Appraisal Initiation Check) and returning to **All Tasks** / refreshing. It should be `Appraisal Number` pinned first on All Tasks, and `Request Number` pinned first on the Initiation views.

## Root cause

Every task screen persisted its column layout to **one shared** key (`task.columns.all`). `useColumnVisibility` accepted a per-screen `storageKey` but ignored it. The All Tasks view (`stickyColumn = appraisalNumber`) and the Initiation views (`stickyColumn = requestNumber`, no `appraisalNumber` column at all) therefore clobbered each other. On reload `normalizeState` dropped the foreign sticky column and appended the missing one to the **end** of the order; the table applies `sticky left-0` to whichever cell equals `stickyColumn` wherever it sits — so the pin ended up last.

The backend strictly allowlists preference keys and 400-rejects anything but `task.columns.all`, so per-view **backend** keys aren't viable without a cross-repo allowlist change.

## Fix

Persist column layout **per-screen in localStorage**, keyed by the `storageKey` each caller already passes (`task-columns-all`, `task-columns-<activityId>`):

- Use the `storageKey` param (was ignored); read/write `localStorage`, validated with the existing `taskColumnsSchema` (zod), falling back to config defaults on missing/corrupt data.
- Re-read on `storageKey`/`config` change — the activity table swaps `activityId` via the URL query **without remounting**, so the key changes mid-mount.
- Force the sticky column to index 0 in `normalizeState` so a stale/corrupt order can never unpin it; dedupe the order array defensively.
- Remove the now-orphaned `PREFERENCE_KEYS.taskColumns`.

Layout now survives refresh and views stay independent. No backend changes.

## Files

- `src/features/task/hooks/useColumnVisibility.ts`
- `src/features/menuFavorites/preferenceKeys.ts`

## Testing

- [ ] All Tasks: `Appraisal Number` is first/left-pinned; set a column order → refresh → holds.
- [ ] Initiation Check: `Request Number` is first/pinned; reorder/hide columns → refresh → holds.
- [ ] Return to All Tasks → pin still correct, Initiation changes did not leak in.
- [ ] Drag another column before the pinned one → it snaps back to first.
- [ ] No `400 Unknown preference key` in the network tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)