### PR TITLE
feat(task): resizable columns and activity table improvements

### DIFF
--- a/src/features/task/components/ActivityTaskTable.tsx
+++ b/src/features/task/components/ActivityTaskTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { FavoritesRow } from '@features/menuFavorites';
@@ -10,12 +10,14 @@ import PoolTaskListPage from '../pages/PoolTaskListPage';
 import { useGetTaskCounts, useGetTasks, useGetTasksForKanban } from '../api';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import type { GroupByField, Task, TaskFilterParams, TaskListResponse } from '../types';
-import { columnDefs, getActivityColumnConfig } from '../config/columnDefs';
+import { columnDefs, getActivityColumnConfig, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
 import Icon from '@/shared/components/Icon';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { useColumnVisibility } from '../hooks/useColumnVisibility';
+import { useColumnWidths } from '../hooks/useColumnWidths';
 import { ColumnVisibilityDropdown } from './ColumnVisibilityDropdown';
+import { ColumnResizeHandle } from './ColumnResizeHandle';
 import { TaskFilterDialog } from './TaskFilterDialog';
 import { TaskKanbanBoard } from './TaskKanbanBoard';
 
@@ -93,6 +95,37 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
     reorderColumns,
     resetToDefault,
   } = useColumnVisibility('task-columns-' + activityId, columnConfig);
+
+  const { widths: colWidths, setWidth: setColWidth, resetWidths } = useColumnWidths(
+    'task-columns-' + activityId,
+    columnConfig,
+  );
+
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  const ACTIONS_COL_WIDTH = 32; // w-8 = 2rem = 32px
+
+  const totalTableWidth = useMemo(
+    () => visibleColumns.reduce((sum, k) => sum + colWidths[k], 0) + ACTIONS_COL_WIDTH,
+    [visibleColumns, colWidths],
+  );
+
+  const getAutoFitWidth = useCallback(
+    (_key: string, colIndex: number): (() => number | null) =>
+      () => {
+        const tbl = tableRef.current;
+        if (!tbl) return null;
+        const rows = tbl.querySelectorAll('tr');
+        let max = 0;
+        rows.forEach(row => {
+          const cell = row.children[colIndex] as HTMLElement | undefined;
+          if (cell) max = Math.max(max, cell.scrollWidth);
+        });
+        if (max === 0) return null;
+        return Math.min(Math.max(max + 24, MIN_COLUMN_WIDTH), MAX_AUTOFIT_WIDTH);
+      },
+    [],
+  );
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [groupBy, setGroupBy] = useState<GroupByField>('status');
@@ -399,7 +432,7 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
                   alwaysVisible={alwaysVisible}
                   onToggle={toggleColumn}
                   onReorder={reorderColumns}
-                  onReset={resetToDefault}
+                  onReset={() => { resetToDefault(); resetWidths(); }}
                 />
               </div>
             )}
@@ -538,18 +571,28 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
           {viewMode === 'list' ? (
             <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
               <div className="flex-1 min-h-0 overflow-auto">
-                <table className="w-full min-w-max text-sm">
+                <table
+                  ref={tableRef}
+                  className="table-fixed text-sm"
+                  style={{ width: totalTableWidth }}
+                >
+                  <colgroup>
+                    {visibleColumns.map(key => (
+                      <col key={key} style={{ width: colWidths[key] }} />
+                    ))}
+                    <col style={{ width: ACTIONS_COL_WIDTH }} />
+                  </colgroup>
                   <thead className="sticky top-0 z-20">
                     <tr className="bg-gray-50 border-b border-gray-200">
-                      {visibleColumns.map(key => {
+                      {visibleColumns.map((key, colIndex) => {
                         const col = columnDefs[key];
                         const isActive = sortField === col.sortField;
                         const isSticky = key === columnConfig.stickyColumn;
                         const thClass = isSticky
-                          ? stickyThBase
+                          ? `relative ${stickyThBase}`
                           : col.sortField
-                            ? `${sortableThBase} ${isActive ? 'text-primary' : ''}`
-                            : plainThBase;
+                            ? `relative ${sortableThBase} ${isActive ? 'text-primary' : ''}`
+                            : `relative ${plainThBase}`;
                         return (
                           <th
                             key={key}
@@ -564,6 +607,11 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
                             ) : (
                               col.label
                             )}
+                            <ColumnResizeHandle
+                              width={colWidths[key]}
+                              onResize={px => setColWidth(key, px)}
+                              getAutoFitWidth={getAutoFitWidth(key, colIndex)}
+                            />
                           </th>
                         );
                       })}
@@ -630,7 +678,9 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
                               <td
                                 key={key}
                                 className={
-                                  isSticky ? stickyTdClass : (col.tdClassName ?? defaultTdClass)
+                                  isSticky
+                                    ? `${stickyTdClass} overflow-hidden whitespace-nowrap`
+                                    : (col.tdClassName ?? `${defaultTdClass} overflow-hidden whitespace-nowrap`)
                                 }
                                 onClick={isSticky ? e => e.stopPropagation() : undefined}
                               >

--- a/src/features/task/components/ColumnResizeHandle.tsx
+++ b/src/features/task/components/ColumnResizeHandle.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
+
+// Manual drag may go much wider than auto-fit so a user can always pull a column
+// open far enough to read very long values; double-click auto-fit stays capped at
+// MAX_AUTOFIT_WIDTH so it never snaps to an absurd width on its own.
+const MAX_DRAG_WIDTH = 960;
+
+interface ColumnResizeHandleProps {
+  width: number;
+  minWidth?: number;
+  maxWidth?: number;
+  onResize: (px: number) => void;
+  getAutoFitWidth: () => number | null;
+}
+
+export function ColumnResizeHandle({
+  width,
+  minWidth = MIN_COLUMN_WIDTH,
+  maxWidth = MAX_AUTOFIT_WIDTH,
+  onResize,
+  getAutoFitWidth,
+}: ColumnResizeHandleProps) {
+  const startXRef = useRef<number>(0);
+  const startWidthRef = useRef<number>(0);
+  // True while a drag is in progress. Drives userSelect restoration on unmount.
+  const draggingRef = useRef(false);
+
+  // Always clear the body selection lock if we unmount mid-drag (the table is
+  // unmounted by tab / activity / view switches while the pointer is held down).
+  useEffect(() => {
+    return () => {
+      if (draggingRef.current) document.body.style.userSelect = '';
+    };
+  }, []);
+
+  const clampTo = useCallback(
+    (px: number, max: number) => Math.max(minWidth, Math.min(max, Math.round(px))),
+    [minWidth],
+  );
+
+  // Pointer events are captured on the element itself, so they keep firing
+  // outside the handle and auto-detach if the element unmounts — no window
+  // listeners to leak.
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLSpanElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      startXRef.current = e.clientX;
+      startWidthRef.current = width;
+      draggingRef.current = true;
+      document.body.style.userSelect = 'none';
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [width],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLSpanElement>) => {
+      if (!draggingRef.current) return;
+      onResize(clampTo(startWidthRef.current + (e.clientX - startXRef.current), MAX_DRAG_WIDTH));
+    },
+    [onResize, clampTo],
+  );
+
+  const endDrag = useCallback(() => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    document.body.style.userSelect = '';
+  }, []);
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLSpanElement>) => {
+      e.stopPropagation();
+      const autoFit = getAutoFitWidth();
+      if (autoFit !== null) {
+        onResize(clampTo(autoFit, maxWidth));
+      }
+    },
+    [getAutoFitWidth, onResize, clampTo, maxWidth],
+  );
+
+  return (
+    <span
+      className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize select-none touch-none z-10 border-r border-gray-100 hover:border-r-2 hover:border-primary hover:bg-primary/10"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onLostPointerCapture={endDrag}
+      onDoubleClick={handleDoubleClick}
+      onClick={e => e.stopPropagation()}
+    />
+  );
+}

--- a/src/features/task/config/activityConfig.ts
+++ b/src/features/task/config/activityConfig.ts
@@ -28,6 +28,13 @@ const ACTIVITY_CONFIG_MAP: Record<string, ActivityConfig> = {
     icon: 'building',
     allowedRoles: ['Admin', 'IntAdmin'],
   },
+  'fee-appointment-approval': {
+    activityId: 'fee-appointment-approval',
+    title: 'Fee & Appointment Approval',
+    description: 'Tasks for approving external-company appointment-postpone and added-fee changes',
+    icon: 'check-to-slot',
+    allowedRoles: ['Admin', 'IntAdmin'],
+  },
   'ext-appraisal-assignment': {
     activityId: 'ext-appraisal-assignment',
     title: 'External Appraisal Assignment',

--- a/src/features/task/config/columnDefs.tsx
+++ b/src/features/task/config/columnDefs.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { differenceInDays, format, isPast } from 'date-fns';
+import { format } from 'date-fns';
 import type { Task } from '../types';
 import Badge from '@/shared/components/Badge';
 import ParameterDisplay from '@/shared/components/ParameterDisplay';
 import Icon from '@/shared/components/Icon';
-import { SlaStatusBadge } from '@features/common/monitoring/components/SlaCells';
+import { SlaStatusBadge, bucketForSlaStatus } from '@features/common/monitoring/components/SlaCells';
 import { MovementBadgeFromTaskDto } from '@features/common/monitoring/components/MovementBadge';
 import { DateCell } from '@features/common/monitoring/components/DateCell';
 
@@ -61,21 +61,28 @@ function PersonCell({ name }: { name: string | null | undefined }) {
 }
 
 
-function DueDateCell({ dateString }: { dateString: string | null | undefined }) {
+function DueDateCell({
+  dateString,
+  slaStatus,
+}: {
+  dateString: string | null | undefined;
+  slaStatus: string | null;
+}) {
   if (!dateString) return <>-</>;
   try {
-    const date = new Date(dateString);
-    const days = differenceInDays(date, new Date());
-    const overdue = isPast(date);
-    const formatted = format(date, 'dd/MM/yyyy');
-    if (overdue)
+    const formatted = format(new Date(dateString), 'dd/MM/yyyy');
+    // Drive icon/color from the backend slaStatus so this cell agrees with the
+    // SLA Status badge and the row tint (proportional 75%-of-window rule), rather
+    // than a fixed client-side day threshold.
+    const bucket = bucketForSlaStatus(slaStatus);
+    if (bucket === 'breached')
       return (
         <span className="inline-flex items-center gap-1 text-red-600 font-medium text-sm">
           <Icon style="solid" name="circle-exclamation" className="size-3 flex-shrink-0" />
           {formatted}
         </span>
       );
-    if (days <= 3)
+    if (bucket === 'atRisk')
       return (
         <span className="inline-flex items-center gap-1 text-amber-600 font-medium text-sm">
           <Icon style="solid" name="clock" className="size-3 flex-shrink-0" />
@@ -158,13 +165,20 @@ export type ColumnDef = {
   sortField?: string;
   /** td className override. Defaults to 'px-3 py-1.5 text-gray-600 text-xs' when not set. */
   tdClassName?: string;
+  /** Default column width in px. Falls back to DEFAULT_COLUMN_WIDTH when not set. */
+  width?: number;
   render: (task: Task) => ReactNode;
 };
+
+export const DEFAULT_COLUMN_WIDTH = 150;
+export const MIN_COLUMN_WIDTH = 60;
+export const MAX_AUTOFIT_WIDTH = 480;
 
 export const columnDefs: Record<ColumnKey, ColumnDef> = {
   appraisalNumber: {
     label: 'Appraisal Number',
     sortField: 'appraisalNumber',
+    width: 130,
     render: task => {
       const display = task.appraisalNumber ?? task.requestNumber;
       const isReq = !task.appraisalNumber && !!task.requestNumber;
@@ -187,6 +201,7 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
   requestNumber: {
     label: 'Request Number',
     sortField: 'requestNumber',
+    width: 130,
     render: task => (
       <Link
         to={`/tasks/${task.id}/opening`}
@@ -200,58 +215,70 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
   customerName: {
     label: 'Customer Name',
     sortField: 'customerName',
+    width: 170,
     render: task => task.customerName ?? '-',
   },
   taskType: {
     label: 'Task Type',
     sortField: 'taskType',
+    width: 150,
     render: task => task.taskDescription || task.taskType || '-',
   },
   purpose: {
     label: 'Purpose',
     sortField: 'purpose',
+    width: 200,
     render: task => <ParameterDisplay group="AppraisalPurpose" code={task.purpose} />,
   },
   propertyType: {
     label: 'Property Type',
     sortField: 'propertyType',
+    width: 150,
     render: task => <ParameterDisplay group="PropertyType" code={task.propertyType} />,
   },
   status: {
     label: 'Status',
     tdClassName: 'px-3 py-1.5',
+    width: 120,
     render: task => <Badge type="status" value={task.status} size="sm" />,
   },
   appointmentDateTime: {
     label: 'Appointment Date',
     sortField: 'appointmentDateTime',
+    width: 150,
     render: task => <AppointmentCell dateString={task.appointmentDateTime} />,
   },
   requestedAt: {
     label: 'Requested At',
     sortField: 'RequestedAt',
+    width: 140,
     render: task => formatDate(task.requestedAt),
   },
   requestedBy: {
     label: 'Requested By',
+    width: 150,
     render: task => <PersonCell name={task.requestedByName ?? task.requestedBy} />,
   },
   reportReceivedAt: {
     label: 'Report Received At',
     sortField: 'ReportReceivedAt',
+    width: 150,
     render: task => formatDate(task.reportReceivedAt),
   },
   requestReceivedDate: {
     label: 'Request Received Date',
     sortField: 'requestReceivedDate',
+    width: 150,
     render: task => <AppointmentCell dateString={task.requestReceivedDate} />,
   },
   internalFollowupStaff: {
     label: 'Internal Followup Staff',
+    width: 160,
     render: task => <PersonCell name={task.internalFollowupStaff} />,
   },
   appraiser: {
     label: 'Appraiser',
+    width: 160,
     render: task =>
       task.appraiser ? (
         <div className="flex items-center gap-2 min-w-0">
@@ -265,38 +292,45 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
   assignedDate: {
     label: 'Assigned Date',
     sortField: 'assignedDate',
+    width: 150,
     render: task => <DateCell value={task.assignedDate} withTime withAgo />,
   },
   movement: {
     label: 'Movement',
     sortField: 'movement',
+    width: 120,
     render: task => <MovementBadgeFromTaskDto value={task.movement} />,
   },
   dueAt: {
     label: 'SLA Due',
     sortField: 'dueAt',
-    render: task => <DueDateCell dateString={task.dueAt} />,
+    width: 140,
+    render: task => <DueDateCell dateString={task.dueAt} slaStatus={task.slaStatus} />,
   },
   elapsedHours: {
     label: 'Elapsed (hrs)',
     sortField: 'elapsedHours',
+    width: 110,
     render: task => <HoursCell hours={task.elapsedHours} type="elapsed" />,
   },
   remainingHours: {
     label: 'Remaining (hrs)',
     sortField: 'remainingHours',
+    width: 120,
     render: task => <HoursCell hours={task.remainingHours} type="remaining" />,
   },
   slaStatus: {
     label: 'SLA Status',
     sortField: 'slaStatus',
     tdClassName: 'px-3 py-1.5',
+    width: 120,
     render: task => <SlaStatusBadge sla={task.slaStatus} />,
   },
   priority: {
     label: 'Priority',
     sortField: 'priority',
     tdClassName: 'px-3 py-1.5',
+    width: 110,
     render: task => <Badge type="priority" value={task.priority} size="sm" />,
   },
 };

--- a/src/features/task/hooks/useColumnWidths.ts
+++ b/src/features/task/hooks/useColumnWidths.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+import { z } from 'zod';
+import {
+  columnDefs,
+  DEFAULT_COLUMN_WIDTH,
+  MIN_COLUMN_WIDTH,
+} from '../config/columnDefs';
+import type { ColumnKey } from '../config/columnDefs';
+
+// ── Zod schema ─────────────────────────────────────────────────────────────────
+
+const columnWidthsSchema = z.record(z.string(), z.number());
+
+type StoredWidths = z.infer<typeof columnWidthsSchema>;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function readStored(storageKey: string): StoredWidths {
+  try {
+    const item = localStorage.getItem(storageKey);
+    if (!item) return {};
+    const parsed = columnWidthsSchema.safeParse(JSON.parse(item));
+    return parsed.success ? parsed.data : {};
+  } catch {
+    return {};
+  }
+}
+
+// ── Hook ───────────────────────────────────────────────────────────────────────
+
+type ColumnWidthsConfig = { columns: string[] };
+
+export function useColumnWidths(storageKey: string, config: ColumnWidthsConfig) {
+  const widthsKey = `${storageKey}-widths`;
+
+  const [stored, setStoredState] = useState<StoredWidths>(() => readStored(widthsKey));
+
+  // Re-read when storageKey changes (ActivityTaskTable swaps activityId without remounting)
+  useEffect(() => {
+    setStoredState(readStored(widthsKey));
+  }, [widthsKey]);
+
+  const persist = useCallback(
+    (next: StoredWidths) => {
+      setStoredState(next);
+      try {
+        localStorage.setItem(widthsKey, JSON.stringify(next));
+      } catch {
+        // ignore quota / unavailable-storage errors — in-memory state still updates
+      }
+    },
+    [widthsKey],
+  );
+
+  /** Resolved widths: stored value → column def default → global default */
+  const widths: Record<string, number> = {};
+  for (const key of config.columns) {
+    widths[key] =
+      stored[key] ??
+      (columnDefs[key as ColumnKey]?.width ?? DEFAULT_COLUMN_WIDTH);
+  }
+
+  const setWidth = useCallback(
+    (key: string, px: number) => {
+      const clamped = Math.max(MIN_COLUMN_WIDTH, Math.round(px));
+      persist({ ...stored, [key]: clamped });
+    },
+    [stored, persist],
+  );
+
+  const resetWidths = useCallback(() => {
+    persist({});
+  }, [persist]);
+
+  return { widths, setWidth, resetWidths };
+}

--- a/src/features/task/pages/PoolTaskListPage.tsx
+++ b/src/features/task/pages/PoolTaskListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
@@ -14,7 +14,10 @@ import { useWorkflowHub } from '../hooks/useWorkflowHub';
 import Icon from '@/shared/components/Icon';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
-import { columnDefs } from '../config/columnDefs';
+import { columnDefs, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
+import type { ColumnKey } from '../config/columnDefs';
+import { useColumnWidths } from '../hooks/useColumnWidths';
+import { ColumnResizeHandle } from '../components/ColumnResizeHandle';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import { TaskFilterDialog } from '../components/TaskFilterDialog';
 
@@ -158,6 +161,38 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters }: PoolT
   const { mutate: claimTask, isPending: isClaiming } = useClaimTask();
   const pendingTaskIdRef = useRef<string | null>(null);
   const [openMenuTaskId, setOpenMenuTaskId] = useState<string | null>(null);
+
+  // Column widths
+  const poolColumnConfig = useMemo(
+    () => ({ columns: [...POOL_COLUMNS] as ColumnKey[], stickyColumn: 'appraisalNumber' as const }),
+    [],
+  );
+  const { widths: colWidths, setWidth: setColWidth } = useColumnWidths(
+    'task-columns-pool',
+    poolColumnConfig,
+  );
+  const tableRef = useRef<HTMLTableElement>(null);
+  const ACTIONS_COL_WIDTH = 40; // w-10 = 2.5rem = 40px
+  const totalTableWidth = useMemo(
+    () => POOL_COLUMNS.reduce((sum, k) => sum + colWidths[k], 0) + ACTIONS_COL_WIDTH,
+    [colWidths],
+  );
+  const getAutoFitWidth = useCallback(
+    (_key: string, colIndex: number): (() => number | null) =>
+      () => {
+        const tbl = tableRef.current;
+        if (!tbl) return null;
+        const rows = tbl.querySelectorAll('tr');
+        let max = 0;
+        rows.forEach(row => {
+          const cell = row.children[colIndex] as HTMLElement | undefined;
+          if (cell) max = Math.max(max, cell.scrollWidth);
+        });
+        if (max === 0) return null;
+        return Math.min(Math.max(max + 24, MIN_COLUMN_WIDTH), MAX_AUTOFIT_WIDTH);
+      },
+    [],
+  );
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -396,14 +431,24 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters }: PoolT
       {/* Table */}
       <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
         <div className="flex-1 min-h-0 overflow-auto">
-          <table className="w-full min-w-max text-sm">
+          <table
+            ref={tableRef}
+            className="table-fixed text-sm"
+            style={{ width: totalTableWidth }}
+          >
+            <colgroup>
+              {POOL_COLUMNS.map(key => (
+                <col key={key} style={{ width: colWidths[key] }} />
+              ))}
+              <col style={{ width: ACTIONS_COL_WIDTH }} />
+            </colgroup>
             <thead className="sticky top-0 z-20">
               <tr className="bg-gray-50 border-b border-gray-200">
-                {POOL_COLUMNS.map(key => {
+                {POOL_COLUMNS.map((key, colIndex) => {
                   const col = columnDefs[key];
                   const isActive = sortField === col.sortField;
                   const base =
-                    'px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
+                    'relative px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
                   const isSticky = key === 'appraisalNumber';
                   const thClass = isSticky
                     ? `${base} sticky left-0 z-30 cursor-pointer hover:text-gray-600 after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
@@ -424,6 +469,11 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters }: PoolT
                       ) : (
                         col.label
                       )}
+                      <ColumnResizeHandle
+                        width={colWidths[key]}
+                        onResize={px => setColWidth(key, px)}
+                        getAutoFitWidth={getAutoFitWidth(key, colIndex)}
+                      />
                     </th>
                   );
                 })}
@@ -486,8 +536,8 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters }: PoolT
                         const col = columnDefs[key];
                         const isSticky = key === 'appraisalNumber';
                         const tdClass = isSticky
-                          ? `${isLockedBySelf ? 'bg-blue-50' : isLockedByOther ? 'bg-amber-50' : 'bg-white group-hover:bg-gray-50'} transition-colors sticky left-0 z-10 px-3 py-1.5 after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
-                          : (col.tdClassName ?? 'px-3 py-1.5 text-gray-600 text-xs');
+                          ? `${isLockedBySelf ? 'bg-blue-50' : isLockedByOther ? 'bg-amber-50' : 'bg-white group-hover:bg-gray-50'} transition-colors sticky left-0 z-10 px-3 py-1.5 overflow-hidden whitespace-nowrap after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
+                          : (col.tdClassName ?? 'px-3 py-1.5 text-gray-600 text-xs overflow-hidden whitespace-nowrap');
                         return (
                           <td key={key} className={tdClass}>
                             {key === 'appraisalNumber' ? (

--- a/src/features/task/pages/TaskListingPage.tsx
+++ b/src/features/task/pages/TaskListingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useGetPoolTasks, useGetTasks, useGetTasksForKanban } from '../api';
@@ -19,9 +19,11 @@ import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { TaskKanbanBoard } from '../components/TaskKanbanBoard';
 import { TaskFilterDialog } from '../components/TaskFilterDialog';
-import { columnDefs, DEFAULT_CONFIG } from '../config/columnDefs';
+import { columnDefs, DEFAULT_CONFIG, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
 import { useColumnVisibility } from '../hooks/useColumnVisibility';
+import { useColumnWidths } from '../hooks/useColumnWidths';
 import { ColumnVisibilityDropdown } from '../components/ColumnVisibilityDropdown';
+import { ColumnResizeHandle } from '../components/ColumnResizeHandle';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import { FavoritesRow } from '@features/menuFavorites';
 
@@ -106,6 +108,35 @@ function TaskListingPage() {
     reorderColumns,
     resetToDefault,
   } = useColumnVisibility('task-columns-all', DEFAULT_CONFIG);
+
+  const { widths: colWidths, setWidth: setColWidth, resetWidths } = useColumnWidths(
+    'task-columns-all',
+    DEFAULT_CONFIG,
+  );
+
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  const ACTIONS_COL_WIDTH = 32; // w-8 = 2rem = 32px
+
+  const totalTableWidth =
+    visibleColumns.reduce((sum, k) => sum + colWidths[k], 0) + ACTIONS_COL_WIDTH;
+
+  const getAutoFitWidth = useCallback(
+    (_key: string, colIndex: number): (() => number | null) =>
+      () => {
+        const tbl = tableRef.current;
+        if (!tbl) return null;
+        const rows = tbl.querySelectorAll('tr');
+        let max = 0;
+        rows.forEach(row => {
+          const cell = row.children[colIndex] as HTMLElement | undefined;
+          if (cell) max = Math.max(max, cell.scrollWidth);
+        });
+        if (max === 0) return null;
+        return Math.min(Math.max(max + 24, MIN_COLUMN_WIDTH), MAX_AUTOFIT_WIDTH);
+      },
+    [],
+  );
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('personal');
   const [poolSearch, setPoolSearch] = useState('');
@@ -469,7 +500,7 @@ function TaskListingPage() {
                   alwaysVisible={alwaysVisible}
                   onToggle={toggleColumn}
                   onReorder={reorderColumns}
-                  onReset={resetToDefault}
+                  onReset={() => { resetToDefault(); resetWidths(); }}
                 />
               </div>
             )}
@@ -608,15 +639,25 @@ function TaskListingPage() {
           {viewMode === 'list' ? (
             <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
               <div className="flex-1 min-h-0 overflow-auto">
-                <table className="w-full min-w-max text-sm">
+                <table
+                  ref={tableRef}
+                  className="table-fixed text-sm"
+                  style={{ width: totalTableWidth }}
+                >
+                  <colgroup>
+                    {visibleColumns.map(key => (
+                      <col key={key} style={{ width: colWidths[key] }} />
+                    ))}
+                    <col style={{ width: ACTIONS_COL_WIDTH }} />
+                  </colgroup>
                   <thead className="sticky top-0 z-20">
                     <tr className="bg-gray-50 border-b border-gray-200">
-                      {visibleColumns.map(key => {
+                      {visibleColumns.map((key, colIndex) => {
                         const col = columnDefs[key];
                         const isActive = sortField === col.sortField;
                         const isSticky = key === DEFAULT_CONFIG.stickyColumn;
                         const base =
-                          'px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
+                          'relative px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
                         const thClass = isSticky
                           ? `${base} sticky left-0 z-30 cursor-pointer hover:text-gray-600 after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
                           : col.sortField
@@ -636,6 +677,11 @@ function TaskListingPage() {
                             ) : (
                               col.label
                             )}
+                            <ColumnResizeHandle
+                              width={colWidths[key]}
+                              onResize={px => setColWidth(key, px)}
+                              getAutoFitWidth={getAutoFitWidth(key, colIndex)}
+                            />
                           </th>
                         );
                       })}
@@ -703,8 +749,8 @@ function TaskListingPage() {
                                 key={key}
                                 className={
                                   isSticky
-                                    ? 'bg-white group-hover:bg-gray-50 transition-colors sticky left-0 z-10 px-3 py-1.5 after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-100'
-                                    : (col.tdClassName ?? 'px-3 py-1.5 text-gray-600 text-xs')
+                                    ? 'bg-white group-hover:bg-gray-50 transition-colors sticky left-0 z-10 px-3 py-1.5 overflow-hidden whitespace-nowrap after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-100'
+                                    : (col.tdClassName ?? 'px-3 py-1.5 text-gray-600 text-xs overflow-hidden whitespace-nowrap')
                                 }
                                 onClick={isSticky ? e => e.stopPropagation() : undefined}
                               >


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated working-tree changeset into independent, reviewable PRs (one per feature domain). This PR isolates the **task** feature changes.

## Changes
- New `ColumnResizeHandle` component + `useColumnWidths` hook for resizable table columns
- Updates to `ActivityTaskTable`, `columnDefs`, and `activityConfig`
- `PoolTaskListPage` and `TaskListingPage` wired to the new column-resize behavior

## Scope / coupling
Self-contained — no shared files, no i18n, no cross-feature dependencies. Independent off `main`, mergeable in any order.

## Verification
- `tsc -b` → no new type errors vs `main` baseline (519 pre-existing, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)