### PR TITLE
feat(quotation): quotation listing, selection, and task page updates

### DIFF
--- a/src/features/quotation/components/AppraisalPicker.tsx
+++ b/src/features/quotation/components/AppraisalPicker.tsx
@@ -813,7 +813,7 @@ export function AppraisalPicker({
                 <ProvinceAutocomplete
                   value={filters.province}
                   onChange={v => handleFilterChange('province', v)}
-                  placeholder="All provinces"
+                  placeholder={t('picker.provincePlaceholder')}
                 />
               </div>
               <div className="flex items-end">

--- a/src/features/quotation/pages/AdminCompanyQuotationDetailPage.tsx
+++ b/src/features/quotation/pages/AdminCompanyQuotationDetailPage.tsx
@@ -389,7 +389,7 @@ export const AdminCompanyQuotationDetailContent = ({
                 {selectedAppraisal ? (
                   <div className="p-5 space-y-6">
                     {/* Section 1 — Appraisal Information */}
-                    <section aria-label="Appraisal Information">
+                    <section aria-label={t('aria.sectionAppraisalInfo')}>
                       <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                         {t('sections.appraisalInformation')}
                       </h2>
@@ -415,7 +415,7 @@ export const AdminCompanyQuotationDetailContent = ({
 
                     {/* Section 2 — Attached Documents (grouped by section, mirrors ext-company submit page) */}
                     {appraisalDocs.length > 0 && (
-                      <section aria-label="Attached Documents">
+                      <section aria-label={t('aria.sectionAttachedDocs')}>
                         <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                           {t('sections.attachDocument')}
                         </h2>
@@ -487,7 +487,7 @@ export const AdminCompanyQuotationDetailContent = ({
 
                     {/* Section 3 — Quotation Information — Appraisal Fee */}
                     {selectedItem && (
-                      <section aria-label="Quotation Information">
+                      <section aria-label={t('aria.sectionQuotationInfo')}>
                         <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                           {t('sections.quotationInformationFee')}
                         </h2>
@@ -497,7 +497,7 @@ export const AdminCompanyQuotationDetailContent = ({
 
                     {/* Section 4 — Duration */}
                     {selectedItem && (
-                      <section aria-label="Duration and Mandays">
+                      <section aria-label={t('aria.sectionDuration')}>
                         <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                           {t('sections.duration')}
                         </h2>
@@ -524,7 +524,7 @@ export const AdminCompanyQuotationDetailContent = ({
 
                     {/* Section 5 — Remark for this Appraisal */}
                     {selectedItem && (
-                      <section aria-label="Appraisal Remark">
+                      <section aria-label={t('aria.sectionAppraisalRemark')}>
                         <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                           {t('sections.appraisalRemark')}
                         </h2>

--- a/src/features/quotation/pages/AdminQuotationTaskPage.tsx
+++ b/src/features/quotation/pages/AdminQuotationTaskPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import DataErrorState from '@/shared/components/DataErrorState';
 import Icon from '@/shared/components/Icon';
 import QuotationSection from '@/features/appraisal/components/QuotationSection';
@@ -17,6 +18,7 @@ import { useGetTaskById } from '@features/appraisal/api/workflow';
  * No AppraisalLayout wrapper — the page lives inside TaskLayout.
  */
 const AdminQuotationTaskPage = () => {
+  const { t } = useTranslation('quotation');
   const { taskId } = useParams<{ taskId: string }>();
   const { data: taskData, isLoading, isError, refetch } = useGetTaskById(taskId);
 
@@ -33,7 +35,7 @@ const AdminQuotationTaskPage = () => {
   }
 
   if (isError) {
-    return <DataErrorState title="Failed to load task" onRetry={() => refetch()} />;
+    return <DataErrorState title={t('errors.failedToLoadTask')} onRetry={() => refetch()} />;
   }
 
   if (!appraisalId) {
@@ -41,7 +43,7 @@ const AdminQuotationTaskPage = () => {
       <div className="flex flex-col items-center justify-center h-64 gap-3">
         <Icon name="triangle-exclamation" style="solid" className="w-12 h-12 text-red-400" />
         <p className="text-sm text-gray-600">
-          No appraisal linked to this task. Cannot display quotation section.
+          {t('errors.noAppraisalLinked')}
         </p>
       </div>
     );

--- a/src/features/quotation/pages/ExtCompanySubmitQuotationPage.tsx
+++ b/src/features/quotation/pages/ExtCompanySubmitQuotationPage.tsx
@@ -812,7 +812,7 @@ const ExtCompanySubmitQuotationPage = () => {
                 {selectedAppraisal && selectedItem ? (
                   <div key={selectedIndex} className="p-5 space-y-6">
                     {/* Section 1: Appraisal Information (read-only) */}
-                    <section aria-label="Appraisal Information">
+                    <section aria-label={t('aria.sectionAppraisalInfo')}>
                       <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                         {t('sections.appraisalInformation')}
                       </h2>
@@ -838,7 +838,7 @@ const ExtCompanySubmitQuotationPage = () => {
 
                     {/* Section 2: Attached Documents — grouped by section, mirroring DocumentChecklist. */}
                     {selectedDocs.length > 0 && (
-                      <section aria-label="Attached Documents">
+                      <section aria-label={t('aria.sectionAttachedDocs')}>
                         <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                           {t('sections.attachDocument')}
                         </h2>
@@ -931,7 +931,7 @@ const ExtCompanySubmitQuotationPage = () => {
                     )}
 
                     {/* Section 3: Quotation Information — Fee Breakdown */}
-                    <section aria-label="Quotation Information">
+                    <section aria-label={t('aria.sectionQuotationInfo')}>
                       <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                         {t('sections.quotationInformationFee')}
                       </h2>
@@ -948,7 +948,7 @@ const ExtCompanySubmitQuotationPage = () => {
                     </section>
 
                     {/* Section 4: Duration / Mandays */}
-                    <section aria-label="Duration and Mandays">
+                    <section aria-label={t('aria.sectionDuration')}>
                       <h2 className="text-sm font-semibold text-gray-700 mb-3 pb-1.5 border-b border-gray-100">
                         {t('sections.duration')}
                       </h2>

--- a/src/features/quotation/pages/QuotationListingPage.tsx
+++ b/src/features/quotation/pages/QuotationListingPage.tsx
@@ -11,13 +11,16 @@ import { DateInput } from '@/shared/components/inputs';
 import { formatLocaleDate, formatLocaleDateTime } from '@/shared/utils/dateUtils';
 import QuotationStatusBadge from '../components/QuotationStatusBadge';
 import { useCancelQuotation, useGetQuotations, type QuotationListItem } from '../api/quotation';
+import { z } from 'zod';
 import { QuotationStatusSchema } from '../schemas/quotation';
+
+type QuotationStatus = z.infer<typeof QuotationStatusSchema>;
 
 /** Slice a DatePickerInput ISO value (`2026-04-28T00:00:00+07:00`) down to the
     `yyyy-MM-dd` slug the backend's `DateOnly?` query binder expects. */
 const toDateOnly = (iso: string | null | undefined) => (iso ? iso.slice(0, 10) : undefined);
 
-const QUOTATION_STATUS_OPTIONS = QuotationStatusSchema.options;
+const QUOTATION_STATUS_OPTIONS: QuotationStatus[] = QuotationStatusSchema.options;
 
 const TERMINAL_STATUSES = new Set(['Finalized', 'Cancelled', 'Closed']);
 
@@ -196,7 +199,7 @@ function QuotationListingPage() {
           <option value="">{t('filters.allStatuses')}</option>
           {QUOTATION_STATUS_OPTIONS.map(s => (
             <option key={s} value={s}>
-              {t(`status.${s}` as `status.${string}`)}
+              {t(`status.${s}`)}
             </option>
           ))}
         </select>

--- a/src/features/quotation/pages/QuotationSelectionPage.tsx
+++ b/src/features/quotation/pages/QuotationSelectionPage.tsx
@@ -1017,12 +1017,12 @@ const QuotationSelectionPage = () => {
       <EmailCompositionModal
         isOpen={isSendConfirmOpen}
         onClose={() => setIsSendConfirmOpen(false)}
-        title="Drafting email to send to external appraisal company"
+        title={t('email.draftingTitle')}
         defaultValues={defaultEmailValues}
         showCc={true}
         showBcc={true}
         showAttachments={false}
-        subjectLabel="Subject"
+        subjectLabel={t('email.subjectLabel')}
         isPending={isSendPending}
         onSubmit={handleSendConfirm}
       />

--- a/src/i18n/locales/en/quotation.json
+++ b/src/i18n/locales/en/quotation.json
@@ -178,7 +178,12 @@
     "collapseAppraisal": "Collapse {{number}}",
     "selectAllVisibleCompanies": "Select all visible companies",
     "selectAllPage": "Select all on this page",
-    "maxDaysFor": "Max appraisal days for {{number}}"
+    "maxDaysFor": "Max appraisal days for {{number}}",
+    "sectionAppraisalInfo": "Appraisal Information",
+    "sectionAttachedDocs": "Attached Documents",
+    "sectionQuotationInfo": "Quotation Information",
+    "sectionDuration": "Duration and Mandays",
+    "sectionAppraisalRemark": "Appraisal Remark"
   },
   "empty": {
     "noQuotations": "No quotations found",
@@ -213,7 +218,8 @@
     "failedToLoadQuotation": "Failed to load quotation.",
     "companyNotFound": "Company quotation not found.",
     "noAppraisalLinked": "No appraisal linked to this task. Cannot display quotation section.",
-    "noAccessDocument": "You no longer have access to this document — the quotation may have been awarded or cancelled."
+    "noAccessDocument": "You no longer have access to this document — the quotation may have been awarded or cancelled.",
+    "failedToLoadTask": "Failed to load task"
   },
   "toasts": {
     "saved": "Quotation saved successfully",
@@ -403,6 +409,10 @@
     "totalLabel": "{{count}} total",
     "pending": "Pending"
   },
+  "email": {
+    "draftingTitle": "Drafting email to send to external appraisal company",
+    "subjectLabel": "Subject"
+  },
   "picker": {
     "customerName": "Customer Name",
     "customerNamePlaceholder": "Search customer...",
@@ -425,6 +435,7 @@
     "district": "District",
     "districtPlaceholder": "District...",
     "province": "Province",
+    "provincePlaceholder": "All provinces",
     "clearFilters": "Clear all filters",
     "clear": "Clear",
     "selectAll": "Select all",

--- a/src/i18n/locales/th/quotation.json
+++ b/src/i18n/locales/th/quotation.json
@@ -178,7 +178,12 @@
     "collapseAppraisal": "ยุบ {{number}}",
     "selectAllVisibleCompanies": "เลือกบริษัทที่มองเห็นทั้งหมด",
     "selectAllPage": "เลือกทั้งหมดในหน้านี้",
-    "maxDaysFor": "จำนวนวันสูงสุดสำหรับ {{number}}"
+    "maxDaysFor": "จำนวนวันสูงสุดสำหรับ {{number}}",
+    "sectionAppraisalInfo": "ข้อมูลการประเมิน",
+    "sectionAttachedDocs": "เอกสารแนบ",
+    "sectionQuotationInfo": "ข้อมูลใบเสนอราคา",
+    "sectionDuration": "ระยะเวลาและจำนวนวัน",
+    "sectionAppraisalRemark": "หมายเหตุการประเมิน"
   },
   "empty": {
     "noQuotations": "ไม่พบใบเสนอราคา",
@@ -213,7 +218,8 @@
     "failedToLoadQuotation": "ไม่สามารถโหลดใบเสนอราคาได้",
     "companyNotFound": "ไม่พบใบเสนอราคาของบริษัท",
     "noAppraisalLinked": "ไม่มีการประเมินที่เชื่อมโยงกับงานนี้ ไม่สามารถแสดงส่วนใบเสนอราคาได้",
-    "noAccessDocument": "คุณไม่มีสิทธิ์เข้าถึงเอกสารนี้อีกต่อไป — ใบเสนอราคาอาจถูกมอบหรือยกเลิกแล้ว"
+    "noAccessDocument": "คุณไม่มีสิทธิ์เข้าถึงเอกสารนี้อีกต่อไป — ใบเสนอราคาอาจถูกมอบหรือยกเลิกแล้ว",
+    "failedToLoadTask": "โหลดงานไม่สำเร็จ"
   },
   "toasts": {
     "saved": "บันทึกใบเสนอราคาเรียบร้อย",
@@ -403,6 +409,10 @@
     "totalLabel": "{{count}} รายการ",
     "pending": "รอดำเนินการ"
   },
+  "email": {
+    "draftingTitle": "ร่างอีเมลเพื่อส่งถึงบริษัทประเมินราคาภายนอก",
+    "subjectLabel": "หัวข้อ"
+  },
   "picker": {
     "customerName": "ชื่อลูกค้า",
     "customerNamePlaceholder": "ค้นหาลูกค้า...",
@@ -425,6 +435,7 @@
     "district": "อำเภอ",
     "districtPlaceholder": "อำเภอ...",
     "province": "จังหวัด",
+    "provincePlaceholder": "ทุกจังหวัด",
     "clearFilters": "ล้างตัวกรองทั้งหมด",
     "clear": "ล้าง",
     "selectAll": "เลือกทั้งหมด",

--- a/src/i18n/locales/zh/quotation.json
+++ b/src/i18n/locales/zh/quotation.json
@@ -178,7 +178,12 @@
     "collapseAppraisal": "Collapse {{number}}",
     "selectAllVisibleCompanies": "Select all visible companies",
     "selectAllPage": "Select all on this page",
-    "maxDaysFor": "Max appraisal days for {{number}}"
+    "maxDaysFor": "Max appraisal days for {{number}}",
+    "sectionAppraisalInfo": "评估信息",
+    "sectionAttachedDocs": "附件文件",
+    "sectionQuotationInfo": "报价信息",
+    "sectionDuration": "工期与工作日",
+    "sectionAppraisalRemark": "评估备注"
   },
   "empty": {
     "noQuotations": "No quotations found",
@@ -213,7 +218,8 @@
     "failedToLoadQuotation": "Failed to load quotation.",
     "companyNotFound": "Company quotation not found.",
     "noAppraisalLinked": "No appraisal linked to this task. Cannot display quotation section.",
-    "noAccessDocument": "You no longer have access to this document — the quotation may have been awarded or cancelled."
+    "noAccessDocument": "You no longer have access to this document — the quotation may have been awarded or cancelled.",
+    "failedToLoadTask": "Failed to load task"
   },
   "toasts": {
     "saved": "Quotation saved successfully",
@@ -403,6 +409,10 @@
     "totalLabel": "{{count}} total",
     "pending": "Pending"
   },
+  "email": {
+    "draftingTitle": "Drafting email to send to external appraisal company",
+    "subjectLabel": "Subject"
+  },
   "picker": {
     "customerName": "Customer Name",
     "customerNamePlaceholder": "Search customer...",
@@ -425,6 +435,7 @@
     "district": "District",
     "districtPlaceholder": "District...",
     "province": "Province",
+    "provincePlaceholder": "All provinces",
     "clearFilters": "Clear all filters",
     "clear": "Clear",
     "selectAll": "Select all",


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR isolates the **quotation** feature changes.

## Changes
- Updates to admin company quotation detail, admin quotation task, external company submit, listing, and selection pages
- `AppraisalPicker` component update
- en/th/zh `quotation.json` i18n strings

## Scope / coupling
Self-contained — only quotation files + its own i18n namespace. Independent off `main`.

## Verification
- `tsc -b` → no new type errors vs `main` baseline (one pre-existing error incidentally resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)