### PR TITLE
feat(request): title information table and form updates

### DIFF
--- a/src/features/request/components/RequestRightMenu.tsx
+++ b/src/features/request/components/RequestRightMenu.tsx
@@ -478,7 +478,7 @@ const RequestRightMenu = ({
                                     type="button"
                                     onClick={() => handleEditClick(index, comment)}
                                     className="w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-primary hover:bg-primary-50 transition-all"
-                                    title="Edit"
+                                    title={t('common:actions.edit')}
                                   >
                                     <Icon style="regular" name="pen" className="size-2.5" />
                                   </button>
@@ -486,7 +486,7 @@ const RequestRightMenu = ({
                                     type="button"
                                     onClick={() => setDeleteConfirmIndex(index)}
                                     className="w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-danger-500 hover:bg-danger-50 transition-all"
-                                    title="Delete"
+                                    title={t('common:actions.delete')}
                                   >
                                     <Icon style="solid" name="xmark" className="size-3" />
                                   </button>

--- a/src/features/request/components/tables/TitleInformationTable.tsx
+++ b/src/features/request/components/tables/TitleInformationTable.tsx
@@ -2,6 +2,7 @@ import Table from '@/shared/components/tables/Table';
 import type { RequestTitleDtoType } from '@/shared/forms/v1';
 import { useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
 type TableData = {
   itemNo: string;
@@ -11,9 +12,17 @@ type TableData = {
 };
 
 const TitleInformationTable = () => {
+  const { t } = useTranslation('request');
   const { control } = useFormContext();
   const titles: RequestTitleDtoType[] = useWatch({ name: 'titles', control });
   const [tableData, setTableData] = useState<TableData[]>([]);
+
+  const headers: { name: keyof TableData; label: string }[] = [
+    { name: 'itemNo', label: t('titleTable.itemNo') },
+    { name: 'propertyType', label: t('titleTable.propertyType') },
+    { name: 'buildingType', label: t('titleTable.buildingType') },
+    { name: 'area', label: t('titleTable.area') },
+  ];
 
   useEffect(() => {
     setTableData(titles.map(title => mapTitleToTableData(title)));
@@ -50,24 +59,5 @@ function checkCandidates(candidates: unknown[]): string {
 function checkValidText(text: unknown): text is string {
   return typeof text === 'string' && text.trim() !== '';
 }
-
-const headers: { name: keyof TableData; label: string }[] = [
-  {
-    name: 'itemNo',
-    label: 'Title No / Room No',
-  },
-  {
-    name: 'propertyType',
-    label: 'Property Type',
-  },
-  {
-    name: 'buildingType',
-    label: 'Building Type',
-  },
-  {
-    name: 'area',
-    label: 'Area',
-  },
-];
 
 export default TitleInformationTable;

--- a/src/features/request/forms/TitleInformationForm.tsx
+++ b/src/features/request/forms/TitleInformationForm.tsx
@@ -319,7 +319,7 @@ const TitleInformationForm = () => {
                                 handleDeleteTitle(index);
                               }}
                               className="opacity-0 group-hover:opacity-100 w-5 h-5 flex items-center justify-center rounded bg-danger/10 text-danger hover:bg-danger/20 transition-all shrink-0"
-                              title="Delete"
+                              title={t('common:actions.delete')}
                             >
                               <Icon style="solid" name="xmark" className="size-2.5" />
                             </button>

--- a/src/i18n/locales/en/request.json
+++ b/src/i18n/locales/en/request.json
@@ -29,6 +29,12 @@
     "createdAt": "Created At",
     "actions": "Actions"
   },
+  "titleTable": {
+    "itemNo": "Title No / Room No",
+    "propertyType": "Property Type",
+    "buildingType": "Building Type",
+    "area": "Area"
+  },
   "filters": {
     "searchPlaceholder": "Search requests...",
     "allStatus": "All Status",

--- a/src/i18n/locales/th/request.json
+++ b/src/i18n/locales/th/request.json
@@ -29,6 +29,12 @@
     "createdAt": "วันที่สร้าง",
     "actions": "การดำเนินการ"
   },
+  "titleTable": {
+    "itemNo": "เลขที่โฉนด / เลขห้อง",
+    "propertyType": "ประเภททรัพย์สิน",
+    "buildingType": "ประเภทอาคาร",
+    "area": "พื้นที่"
+  },
   "filters": {
     "searchPlaceholder": "ค้นหาคำขอ...",
     "allStatus": "ทุกสถานะ",

--- a/src/i18n/locales/zh/request.json
+++ b/src/i18n/locales/zh/request.json
@@ -29,6 +29,12 @@
     "createdAt": "创建时间",
     "actions": "操作"
   },
+  "titleTable": {
+    "itemNo": "产权编号 / 房号",
+    "propertyType": "房产类型",
+    "buildingType": "建筑类型",
+    "area": "面积"
+  },
   "filters": {
     "searchPlaceholder": "搜索申请...",
     "allStatus": "所有状态",


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR isolates the **request** feature changes.

## Changes
- `TitleInformationTable` and `TitleInformationForm` updates
- `RequestRightMenu` update
- en/th/zh `request.json` i18n strings

## Scope / coupling
Self-contained. Independent off `main`.

## ⚠️ Known pre-existing issue
`TitleInformationTable.tsx:34` references `title.titleNo`, but the title schema exposes `titleNumber` → `error TS2339`. This error is **present in the original source changeset** (not introduced by the split) and was preserved as-is to keep this PR a faithful extraction. Should be fixed before merge.

## Verification
- `tsc -b` → one new error vs baseline, confirmed pre-existing in the source working tree (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)