### PR TITLE
feat(pricingAnalysis): DCF, leasehold, profit-rent & market reference enhancements

### DIFF
--- a/src/features/pricingAnalysis/api/index.ts
+++ b/src/features/pricingAnalysis/api/index.ts
@@ -224,6 +224,14 @@ export function useSaveComparativeAnalysis() {
       queryClient.invalidateQueries({
         queryKey: pricingAnalysisKeys.detail(variables.id),
       });
+      // When the saved method is a market REFERENCE (the panel hosted inside
+      // MarketReferenceModal saves through this same mutation), the reference
+      // list/apply value (valuePerUnit = FinalValueAdjusted) must refresh too —
+      // otherwise the list keeps showing the pre-edit (copied source) value.
+      // The save mutation is generic and doesn't know the anchor, so invalidate
+      // both reference query prefixes (only mounted lists refetch — cheap).
+      queryClient.invalidateQueries({ queryKey: ['price-analysis-references'] });
+      queryClient.invalidateQueries({ queryKey: ['price-analysis-group-references'] });
     },
   });
 }

--- a/src/features/pricingAnalysis/api/references.ts
+++ b/src/features/pricingAnalysis/api/references.ts
@@ -16,6 +16,39 @@ export const PricingAnalysisSubjectType = {
 export type PricingAnalysisSubjectType =
   (typeof PricingAnalysisSubjectType)[keyof typeof PricingAnalysisSubjectType];
 
+// The API serializes enums as their STRING name (global JsonStringEnumConverter),
+// so `subjectType` arrives as e.g. "IncomeLandRef" — but the rest of the FE
+// compares it against the numeric enum. Normalize string → number on read so
+// label derivation and manualSubject detection work.
+const SUBJECT_TYPE_NAME_TO_VALUE: Record<string, PricingAnalysisSubjectType> = {
+  PropertyGroup: 0,
+  ProjectModel: 1,
+  MachineryCostRef: 2,
+  IncomeLandRef: 3,
+  LeaseholdLandRef: 4,
+  RoomIncomeRef: 5,
+  ProfitRentRef: 6,
+};
+
+function normalizeSubjectType(raw: unknown): PricingAnalysisSubjectType {
+  if (typeof raw === 'number') return raw as PricingAnalysisSubjectType;
+  if (typeof raw === 'string') {
+    if (raw in SUBJECT_TYPE_NAME_TO_VALUE) return SUBJECT_TYPE_NAME_TO_VALUE[raw];
+    const asNum = Number(raw);
+    if (!Number.isNaN(asNum)) return asNum as PricingAnalysisSubjectType;
+  }
+  return 0 as PricingAnalysisSubjectType;
+}
+
+function normalizeReferencesResponse(data: GetReferencesResponse): GetReferencesResponse {
+  return {
+    references: (data.references ?? []).map(r => ({
+      ...r,
+      subjectType: normalizeSubjectType(r.subjectType),
+    })),
+  };
+}
+
 // ── DTOs ──────────────────────────────────────────────────────────────────────
 
 export interface CreateOrGetReferenceRequest {
@@ -74,7 +107,7 @@ export function useGetReferences(
         params.anchorRefKey = anchorRefKey;
       }
       const { data } = await axios.get('/pricing-analysis/references', { params });
-      return data as GetReferencesResponse;
+      return normalizeReferencesResponse(data as GetReferencesResponse);
     },
     enabled: subjectType != null && !!anchorId,
     refetchOnWindowFocus: false,
@@ -110,6 +143,43 @@ export function useCreateOrGetReference() {
   });
 }
 
+// ── CreateReferenceFromMethod ─────────────────────────────────────────────────
+
+export interface CreateReferenceFromMethodRequest {
+  subjectType: PricingAnalysisSubjectType;
+  anchorId: string;
+  hostMethodId: string;
+  sourcePricingAnalysisId: string;
+  sourceMethodId: string;
+  landAreaOverride?: number | null;
+}
+
+/**
+ * POST /pricing-analysis/references/from-method
+ * Clones a Cost-approach method into a new IncomeLandRef reference (idempotent).
+ */
+export function useCreateReferenceFromMethod() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (
+      request: CreateReferenceFromMethodRequest,
+    ): Promise<CreateOrGetReferenceResponse> => {
+      const { data } = await axios.post('/pricing-analysis/references/from-method', request);
+      return data as CreateOrGetReferenceResponse;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: pricingAnalysisKeys.references(
+          variables.subjectType,
+          variables.anchorId,
+          null,
+        ),
+      });
+    },
+  });
+}
+
 /**
  * GET /pricing-analysis/{pricingAnalysisId}/references
  * Returns all reference analyses whose HostMethodId belongs to the group's pricing analysis.
@@ -119,7 +189,7 @@ export function useGetGroupReferences(pricingAnalysisId: string | undefined) {
     queryKey: pricingAnalysisKeys.groupReferences(pricingAnalysisId ?? ''),
     queryFn: async (): Promise<GetReferencesResponse> => {
       const { data } = await axios.get(`/pricing-analysis/${pricingAnalysisId}/references`);
-      return data as GetReferencesResponse;
+      return normalizeReferencesResponse(data as GetReferencesResponse);
     },
     enabled: !!pricingAnalysisId,
     refetchOnWindowFocus: false,

--- a/src/features/pricingAnalysis/components/CostMachineSection.tsx
+++ b/src/features/pricingAnalysis/components/CostMachineSection.tsx
@@ -192,29 +192,32 @@ function MachineryRow({
 
       {/* RCN */}
       <td className="border-b border-r border-gray-300">
-        <div className="flex items-center gap-1 px-1">
-          <div className="flex-1">
-            <RHFInputCell
-              fieldName={costMachinePath.rcn(rowIndex)}
-              inputType="number"
-              disabled={inputDisabled}
-              number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
-            />
-          </div>
-          {appraisalPropertyId && !isReadOnly && (
-            <MarketReferenceButton
-              subjectType={PricingAnalysisSubjectType.MachineryCostRef}
-              anchorId={appraisalPropertyId}
-              hostMethodId={methodId}
-              marketSurveys={marketSurveys ?? []}
-              templateList={templateList}
-              subjectProperty={machineryDetail}
-              onApplyValue={v =>
-                setValue(costMachinePath.rcn(rowIndex), v, { shouldDirty: true })
-              }
-              className="shrink-0 !px-1.5 !py-0.5 text-[10px]"
-            />
-          )}
+        <div className="px-1">
+          <RHFInputCell
+            fieldName={costMachinePath.rcn(rowIndex)}
+            inputType="number"
+            disabled={inputDisabled}
+            number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
+            inputClassName={appraisalPropertyId && !isReadOnly ? '!pr-14' : undefined}
+            rightIcon={
+              appraisalPropertyId && !isReadOnly ? (
+                <MarketReferenceButton
+                  subjectType={PricingAnalysisSubjectType.MachineryCostRef}
+                  anchorId={appraisalPropertyId}
+                  hostMethodId={methodId}
+                  marketSurveys={marketSurveys ?? []}
+                  templateList={templateList}
+                  subjectProperty={machineryDetail}
+                  onApplyValue={v =>
+                    setValue(costMachinePath.rcn(rowIndex), v, { shouldDirty: true })
+                  }
+                  compact
+                  label="WQS"
+                  className="pointer-events-auto shrink-0"
+                />
+              ) : undefined
+            }
+          />
         </div>
       </td>
 

--- a/src/features/pricingAnalysis/components/DirectComparisonPanel.tsx
+++ b/src/features/pricingAnalysis/components/DirectComparisonPanel.tsx
@@ -1,7 +1,7 @@
 import { useForm, type SubmitErrorHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
-import { DirectComparisonDto, type DirectComparisonType } from '../schemas/directComparisonForm';
+import { makeDirectComparisonDto, DirectComparisonDto, type DirectComparisonType } from '../schemas/directComparisonForm';
 import { useEffect, useState } from 'react';
 import type {
   CalculationType,
@@ -96,7 +96,7 @@ export function DirectComparisonPanel({
 
   const methods = useForm<DirectComparisonType>({
     mode: 'onSubmit',
-    resolver: zodResolver(DirectComparisonDto),
+    resolver: zodResolver(makeDirectComparisonDto(t)),
   });
 
   const {
@@ -244,7 +244,10 @@ export function DirectComparisonPanel({
   // Auto-show table when linked comparables already exist from the API
   useEffect(() => {
     if (isGenerated || comparativeSurveys.length === 0) return;
-    if (!methodId || !methodType || (!manualSubject && !property)) return;
+    // A saved reference (e.g. opened from the group References section) has no live
+    // subject `property` but does have saved data to restore — never block a restore.
+    const hasSavedData = !!(savedComparativeFactors && savedComparativeFactors.length > 0);
+    if (!methodId || !methodType || (!manualSubject && !property && !hasSavedData)) return;
 
     // Restore from saved data if available
     if (savedComparativeFactors && savedComparativeFactors.length > 0) {

--- a/src/features/pricingAnalysis/components/GroupReferencesSection.tsx
+++ b/src/features/pricingAnalysis/components/GroupReferencesSection.tsx
@@ -163,7 +163,7 @@ function ReferenceRow({
                   <span
                     className={clsx(
                       'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider',
-                      'bg-blue-50 text-blue-700 border border-blue-100',
+                      'bg-primary/10 text-primary border border-primary/20',
                     )}
                   >
                     {methodTypeBadge(m.methodType)}

--- a/src/features/pricingAnalysis/components/LeaseholdPanel.tsx
+++ b/src/features/pricingAnalysis/components/LeaseholdPanel.tsx
@@ -404,6 +404,10 @@ export function LeaseholdPanel({
     [appointment, rentalScheduleData, propertyData, isPartialUsage],
   );
 
+  // Local state: caches the analysis id obtained by an auto-save on button open,
+  // so the WQS button is available even before the user has saved the form.
+  const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
+
   const handleOnSubmit = async () => {
     if (readOnly || !pricingAnalysisId || !methodId) return;
 
@@ -452,6 +456,14 @@ export function LeaseholdPanel({
     } catch {
       toast.error(t('toasts.saveFailed'));
     }
+  };
+
+  const ensureAnalysisId = async (): Promise<string | undefined> => {
+    if (savedData?.analysis?.id) return savedData.analysis.id;
+    if (readOnly || !pricingAnalysisId || !methodId) return undefined;
+    await handleOnSubmit();
+    const res = await refetchSavedData();
+    return res.data?.analysis?.id;
   };
 
   const handleOnReset = () => setIsShowResetDialog(true);
@@ -771,26 +783,13 @@ export function LeaseholdPanel({
                 'rounded-md bg-gray-50 px-4 py-3',
               )}
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="mb-1">
                 <label className="text-[11px] text-gray-400 uppercase tracking-wide block">
                   {t('leasehold.landValue')} <span className="text-red-400">*</span>
                 </label>
-                {savedData?.analysis?.id && (
-                  <MarketReferenceButton
-                    subjectType={PricingAnalysisSubjectType.LeaseholdLandRef}
-                    anchorId={savedData.analysis.id}
-                    hostMethodId={methodId}
-                    marketSurveys={marketSurveys ?? []}
-                    templateList={templateList}
-                    subjectProperty={propertyDetail as Record<string, unknown> | undefined}
-                    onApplyValue={v =>
-                      landValueField.onChange(v)
-                    }
-                  />
-                )}
               </div>
               <div className="flex items-baseline gap-1.5">
-                <div className="w-28">
+                <div className="w-44">
                   <NumberInput
                     name={landValueField.name}
                     ref={landValueField.ref}
@@ -799,6 +798,34 @@ export function LeaseholdPanel({
                     onBlur={landValueField.onBlur}
                     decimalPlaces={2}
                     disabled={readOnly}
+                    className={!readOnly ? '!pr-14' : undefined}
+                    rightIcon={(() => {
+                      if (readOnly) return undefined;
+                      const effectiveId = savedData?.analysis?.id ?? ensuredId;
+                      return (
+                        <MarketReferenceButton
+                          compact
+                          label="WQS"
+                          subjectType={PricingAnalysisSubjectType.LeaseholdLandRef}
+                          anchorId={effectiveId ?? ''}
+                          hostMethodId={methodId}
+                          marketSurveys={marketSurveys ?? []}
+                          templateList={templateList}
+                          subjectProperty={propertyDetail as Record<string, unknown> | undefined}
+                          onApplyValue={v => landValueField.onChange(v)}
+                          onBeforeOpen={
+                            effectiveId
+                              ? undefined
+                              : async () => {
+                                  const id = await ensureAnalysisId();
+                                  if (id) setEnsuredId(id);
+                                  if (!id) throw new Error('no-id');
+                                }
+                          }
+                          className="pointer-events-auto shrink-0"
+                        />
+                      );
+                    })()}
                   />
                 </div>
                 <span className="text-xs text-gray-500">{t('leasehold.units.bahtPerSqWa')}</span>

--- a/src/features/pricingAnalysis/components/MarketReferenceButton.tsx
+++ b/src/features/pricingAnalysis/components/MarketReferenceButton.tsx
@@ -34,6 +34,16 @@ export type MarketReferenceButtonProps = Omit<
   readOnly?: boolean;
   /** Additional class names for the button */
   className?: string;
+  /** Icon-only compact mode (hides the text label; full label shown as tooltip). */
+  compact?: boolean;
+  /** Override the button label/tooltip (defaults to the generic "Market References"). */
+  label?: string;
+  /**
+   * Called async before the modal opens. Use this to ensure prerequisite state
+   * (e.g. auto-saving to obtain an incomeAnalysisId) before rendering the list.
+   * If it throws or returns a rejected promise, the modal does NOT open.
+   */
+  onBeforeOpen?: () => Promise<void> | void;
 };
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -50,11 +60,16 @@ export function MarketReferenceButton({
   currentAnchorLabel,
   readOnly: readOnlyProp,
   className,
+  compact = false,
+  label,
+  onBeforeOpen,
 }: MarketReferenceButtonProps) {
   const { t } = useTranslation('pricingAnalysis');
+  const buttonLabel = label ?? t('marketRef.buttonLabel');
   const isPageReadOnly = usePageReadOnly();
   const isReadOnly = readOnlyProp ?? isPageReadOnly;
   const [isOpen, setIsOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
 
   // Badge: count saved references so user sees there is existing work
   const { data } = useGetReferences(
@@ -68,19 +83,47 @@ export function MarketReferenceButton({
     <>
       <button
         type="button"
-        onClick={() => setIsOpen(true)}
+        disabled={isPending}
+        onClick={async () => {
+          if (onBeforeOpen) {
+            setIsPending(true);
+            try {
+              await onBeforeOpen();
+            } catch {
+              // onBeforeOpen is responsible for showing its own toast
+              setIsPending(false);
+              return;
+            }
+            setIsPending(false);
+          }
+          setIsOpen(true);
+        }}
         className={clsx(
-          'relative inline-flex items-center gap-1 px-2 py-1 text-xs font-medium',
-          'text-primary border border-primary/20 rounded-lg',
+          'relative inline-flex items-center text-primary border border-primary/20 rounded-lg',
           'hover:bg-primary/5 hover:border-primary/40 transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          compact
+            ? 'gap-0 px-1.5 py-0.5 text-[10px] font-semibold'
+            : 'gap-1 px-2 py-1 text-xs font-medium',
+          isPending && 'opacity-60 cursor-wait',
           className,
         )}
-        title={t('marketRef.buttonLabel')}
-        aria-label={t('marketRef.buttonLabel')}
+        title={buttonLabel}
+        aria-label={buttonLabel}
       >
-        <Icon name="chart-bar" className="size-3" />
-        <span>{t('marketRef.buttonLabel')}</span>
+        {isPending ? (
+          <span className="inline-flex items-center gap-1">
+            <span className="animate-spin size-3 rounded-full border-2 border-primary/30 border-t-primary" />
+            {!compact && <span>{buttonLabel}</span>}
+          </span>
+        ) : compact ? (
+          <span>{buttonLabel}</span>
+        ) : (
+          <>
+            <Icon name="chart-bar" className="size-3" />
+            <span>{buttonLabel}</span>
+          </>
+        )}
         {count > 0 && (
           <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center size-4 text-[9px] font-bold text-white bg-primary rounded-full">
             {count}

--- a/src/features/pricingAnalysis/components/MarketReferenceList.tsx
+++ b/src/features/pricingAnalysis/components/MarketReferenceList.tsx
@@ -200,14 +200,6 @@ export function MarketReferenceList({
                               : t('marketRef.noValue')}
                           </span>
                         </div>
-                        {method.finalValue != null && (
-                          <div className="flex flex-col">
-                            <span className="text-xs text-gray-500">{t('marketRef.finalValue')}</span>
-                            <span className="text-sm font-medium text-gray-700 tabular-nums">
-                              {formatNumber(method.finalValue)}
-                            </span>
-                          </div>
-                        )}
                       </div>
                       {/* Apply button — only shown when onApplyValue is provided */}
                       {!readOnly && onApplyValue && method.valuePerUnit != null && (

--- a/src/features/pricingAnalysis/components/MarketReferenceModal.tsx
+++ b/src/features/pricingAnalysis/components/MarketReferenceModal.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
 import { Icon } from '@/shared/components';
 import { MarketReferenceList } from './MarketReferenceList';
 import { MarketReferenceMethodPanel } from './MarketReferenceMethodPanel';
+import { useGetComparativeAnalysisTemplates } from '@features/templateManagement/api/comparativeTemplate';
 import type { ReferenceDto } from '../api/references';
 import type { PricingAnalysisSubjectType } from '../api/references';
 import type { MarketComparableDetailType } from '../schemas';
@@ -58,6 +59,14 @@ export function MarketReferenceModal({
 }: MarketReferenceModalProps) {
   const { t } = useTranslation('pricingAnalysis');
   const [openedRef, setOpenedRef] = useState<ReferenceDto | null>(null);
+
+  // Some entry points (notably the DCF / room-income reference flow) don't thread the WQS/SAG/DC
+  // comparative template list down to here and pass `undefined`, leaving the in-panel Template
+  // dropdown permanently empty. Fall back to fetching it directly — same cached query, so callers
+  // that already provide it pay nothing extra.
+  const { data: fetchedTemplateList = [] } = useGetComparativeAnalysisTemplates();
+  const resolvedTemplateList =
+    templateList && templateList.length > 0 ? templateList : fetchedTemplateList;
 
   const handleClose = () => {
     setOpenedRef(null);
@@ -111,7 +120,7 @@ export function MarketReferenceModal({
                   pricingAnalysisId={openedRef.pricingAnalysisId}
                   subjectType={openedRef.subjectType}
                   marketSurveys={marketSurveys}
-                  templateList={templateList}
+                  templateList={resolvedTemplateList}
                   subjectProperty={subjectProperty}
                   onBack={() => setOpenedRef(null)}
                 />

--- a/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/MethodSectionRenderer.tsx
@@ -12,6 +12,7 @@ import { LeaseholdPanel } from './LeaseholdPanel';
 import { ProfitRentPanel } from './ProfitRentPanel';
 import { HypothesisPanel } from './hypothesis/HypothesisPanel';
 import { CostBuildingPanel } from './CostBuildingPanel';
+import { findRentalSourceProperty } from '../utils/leaseProperty';
 
 interface MethodSectionRendererProps {
   state: SelectionState;
@@ -190,28 +191,35 @@ export function MethodSectionRenderer({
           }
         />
       );
-    case 'LH':
+    case 'LH': {
+      // Source rental data from the rental-bearing property (a lease-agreement
+      // property, or plain land rented out to others) rather than assuming
+      // properties[0]. A mixed group only needs at least one such property.
+      const leaseProperty = findRentalSourceProperty(serverData.groupDetail?.properties);
       return (
         <LeaseholdPanel
           {...panelProps}
           propertiesMap={serverData.propertiesMap}
-          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId ?? undefined}
-          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType ?? undefined}
+          firstPropertyId={leaseProperty?.propertyId ?? undefined}
+          firstPropertyType={leaseProperty?.propertyType ?? undefined}
           marketSurveys={filteredMarketSurveys}
           templateList={calculationMethodData.templateList}
         />
       );
-    case 'PR':
+    }
+    case 'PR': {
+      const leaseProperty = findRentalSourceProperty(serverData.groupDetail?.properties);
       return (
         <ProfitRentPanel
           {...panelProps}
           propertiesMap={serverData.propertiesMap}
-          firstPropertyId={serverData.groupDetail?.properties?.[0]?.propertyId ?? undefined}
-          firstPropertyType={serverData.groupDetail?.properties?.[0]?.propertyType ?? undefined}
+          firstPropertyId={leaseProperty?.propertyId ?? undefined}
+          firstPropertyType={leaseProperty?.propertyType ?? undefined}
           marketSurveys={filteredMarketSurveys}
           templateList={calculationMethodData.templateList}
         />
       );
+    }
     case 'Hypothesis':
       return (
         <HypothesisPanel

--- a/src/features/pricingAnalysis/components/ProfitRentChart.tsx
+++ b/src/features/pricingAnalysis/components/ProfitRentChart.tsx
@@ -10,6 +10,7 @@ import {
   Legend,
 } from 'recharts';
 import type { ProfitRentTableResult } from '../domain/calculateProfitRent';
+import { useTranslation } from 'react-i18next';
 
 interface ProfitRentChartProps {
   result: ProfitRentTableResult;
@@ -25,6 +26,7 @@ const fmtTooltip = (n: number): string =>
   n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
 export function ProfitRentChart({ result }: ProfitRentChartProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const data = result.rows.map(r => ({
     year: r.year,
     marketRental: r.marketRentalFeePerYear,
@@ -36,7 +38,7 @@ export function ProfitRentChart({ result }: ProfitRentChartProps) {
   return (
     <div className="rounded-lg border border-gray-200 p-4">
       <div className="text-xs font-medium text-gray-500 mb-2">
-        Market vs Contract Rental & Present Value
+        {t('viz.profitRentChart.title')}
       </div>
       <ResponsiveContainer width="100%" height={240}>
         <ComposedChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
@@ -63,13 +65,13 @@ export function ProfitRentChart({ result }: ProfitRentChartProps) {
             contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid #e5e7eb' }}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formatter={((value: number, name: string) => [fmtTooltip(value), name]) as any}
-            labelFormatter={label => `Year ${Number(label).toFixed(1)}`}
+            labelFormatter={label => t('viz.profitRentChart.year', { n: Number(label).toFixed(1) })}
           />
           <Legend wrapperStyle={{ fontSize: 10, paddingTop: 4 }} />
           <Bar
             yAxisId="left"
             dataKey="marketRental"
-            name="Market Rental (Year)"
+            name={t('viz.profitRentChart.marketRental')}
             fill="#93c5fd"
             fillOpacity={0.7}
             radius={[2, 2, 0, 0]}
@@ -77,7 +79,7 @@ export function ProfitRentChart({ result }: ProfitRentChartProps) {
           <Bar
             yAxisId="left"
             dataKey="contractRental"
-            name="Contract Rental (Year)"
+            name={t('viz.profitRentChart.contractRental')}
             fill="#d1d5db"
             fillOpacity={0.7}
             radius={[2, 2, 0, 0]}
@@ -86,7 +88,7 @@ export function ProfitRentChart({ result }: ProfitRentChartProps) {
             yAxisId="right"
             type="monotone"
             dataKey="presentValue"
-            name="Present Value"
+            name={t('viz.profitRentChart.presentValue')}
             stroke="#22c55e"
             strokeWidth={2}
             dot={false}

--- a/src/features/pricingAnalysis/components/ProfitRentPanel.tsx
+++ b/src/features/pricingAnalysis/components/ProfitRentPanel.tsx
@@ -89,6 +89,9 @@ export function ProfitRentPanel({
   const [isRentalInfoModalOpen, setIsRentalInfoModalOpen] = useState(false);
   const [tableResult, setTableResult] = useState<ProfitRentTableResult | null>(null);
   const [hoveredCol, setHoveredCol] = useState<number | null>(null);
+  // Local state: caches the analysis id obtained by an auto-save on button open,
+  // so the WQS button is available even before the user has saved the form.
+  const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
 
   const resetMutation = useResetMethod();
   const saveMutation = useSaveProfitRentAnalysis();
@@ -392,6 +395,14 @@ export function ProfitRentPanel({
     }
   };
 
+  const ensureAnalysisId = async (): Promise<string | undefined> => {
+    if (savedData?.analysis?.id) return savedData.analysis.id;
+    if (readOnly || !pricingAnalysisId || !methodId) return undefined;
+    await handleOnSubmit();
+    const res = await refetchSavedData();
+    return res.data?.analysis?.id;
+  };
+
   const handleOnReset = () => setIsShowResetDialog(true);
   const handleOnConfirmReset = async () => {
     setIsShowResetDialog(false);
@@ -500,7 +511,7 @@ export function ProfitRentPanel({
 
   if (isSavedDataError) {
     return (
-      <DataErrorState title="Failed to load profit rent analysis" onRetry={refetchSavedData} />
+      <DataErrorState title={t('profitRent.loadError')} onRetry={refetchSavedData} />
     );
   }
 
@@ -518,7 +529,7 @@ export function ProfitRentPanel({
           <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
             <Icon name="file-signature" className="size-4" />
           </div>
-          <h2 className="text-lg font-semibold text-gray-900">Profit Rent</h2>
+          <h2 className="text-lg font-semibold text-gray-900">{t('profitRent.headerTitle')}</h2>
         </div>
 
         {/* Lease Info Cards — matches Leasehold layout */}
@@ -528,7 +539,7 @@ export function ProfitRentPanel({
               <Icon name="calendar" className="size-4 text-gray-400 shrink-0" />
               <div>
                 <div className="text-[11px] text-gray-400 uppercase tracking-wide">
-                  Appraisal Date
+                  {t('profitRent.appraisalDate')}
                 </div>
                 <div className="text-sm font-medium text-gray-900">
                   {appointment?.appointmentDateTime
@@ -540,7 +551,7 @@ export function ProfitRentPanel({
             <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
               <Icon name="calendar" className="size-4 text-green-500 shrink-0" />
               <div>
-                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease Start</div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">{t('profitRent.leaseStart')}</div>
                 <div className="text-sm font-medium text-gray-900">
                   {leaseAgreement?.leaseStartDate
                     ? formatDateOnly(leaseAgreement.leaseStartDate)
@@ -551,7 +562,7 @@ export function ProfitRentPanel({
             <div className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2.5">
               <Icon name="calendar" className="size-4 text-red-400 shrink-0" />
               <div>
-                <div className="text-[11px] text-gray-400 uppercase tracking-wide">Lease End</div>
+                <div className="text-[11px] text-gray-400 uppercase tracking-wide">{t('profitRent.leaseEnd')}</div>
                 <div className="text-sm font-medium text-gray-900">
                   {leaseAgreement?.leaseEndDate ? formatDateOnly(leaseAgreement.leaseEndDate) : '-'}
                 </div>
@@ -564,8 +575,8 @@ export function ProfitRentPanel({
             >
               <Icon name="receipt" className="size-4 text-primary shrink-0" />
               <div className="text-left">
-                <div className="text-[11px] text-primary/60 uppercase tracking-wide">View</div>
-                <div className="text-sm font-medium text-primary">Rental Information</div>
+                <div className="text-[11px] text-primary/60 uppercase tracking-wide">{t('profitRent.viewRentalInfoShort')}</div>
+                <div className="text-sm font-medium text-primary">{t('profitRent.viewRentalInfo')}</div>
               </div>
             </button>
           </div>
@@ -583,7 +594,7 @@ export function ProfitRentPanel({
             {/* Land Area — read-only */}
             <div className="rounded-md bg-gray-50 px-3 py-2">
               <div className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">
-                Land Area
+                {t('profitRent.landArea')}
               </div>
               <div className="flex items-baseline gap-1">
                 <Icon
@@ -591,29 +602,19 @@ export function ProfitRentPanel({
                   className="size-3 text-gray-400 shrink-0 relative top-0.5"
                 />
                 <span className="text-sm font-semibold text-gray-900">{fmt(landAreaSqWa)}</span>
-                <span className="text-[10px] text-gray-500">Sq. Wa</span>
+                <span className="text-[10px] text-gray-500">{t('profitRent.unitSqWa')}</span>
               </div>
             </div>
 
             {/* Market Rental Fee — input */}
             <div className="rounded-md bg-gray-50 px-3 py-2">
-              <div className="flex items-center justify-between mb-0.5">
+              <div className="mb-0.5">
                 <label className="text-[10px] text-gray-400 uppercase tracking-wide block">
-                  Market Rental Fee <span className="text-red-400">*</span>
+                  {t('profitRent.marketRentalFee')} <span className="text-red-400">*</span>
                 </label>
-                {savedData?.analysis?.id && (
-                  <MarketReferenceButton
-                    subjectType={PricingAnalysisSubjectType.ProfitRentRef}
-                    anchorId={savedData.analysis.id}
-                    hostMethodId={methodId}
-                    marketSurveys={marketSurveys ?? []}
-                    templateList={templateList}
-                    onApplyValue={v => marketFeeField.onChange(v)}
-                  />
-                )}
               </div>
               <div className="flex items-baseline gap-1">
-                <div className="w-24">
+                <div className="w-44">
                   <NumberInput
                     name={marketFeeField.name}
                     ref={marketFeeField.ref}
@@ -624,29 +625,56 @@ export function ProfitRentPanel({
                     maxIntegerDigits={15}
                     required={true}
                     disabled={readOnly}
+                    className={!readOnly ? '!pr-14' : undefined}
+                    rightIcon={(() => {
+                      if (readOnly) return undefined;
+                      const effectiveId = savedData?.analysis?.id ?? ensuredId;
+                      return (
+                        <MarketReferenceButton
+                          compact
+                          label="WQS"
+                          subjectType={PricingAnalysisSubjectType.ProfitRentRef}
+                          anchorId={effectiveId ?? ''}
+                          hostMethodId={methodId}
+                          marketSurveys={marketSurveys ?? []}
+                          templateList={templateList}
+                          onApplyValue={v => marketFeeField.onChange(v)}
+                          onBeforeOpen={
+                            effectiveId
+                              ? undefined
+                              : async () => {
+                                  const id = await ensureAnalysisId();
+                                  if (id) setEnsuredId(id);
+                                  if (!id) throw new Error('no-id');
+                                }
+                          }
+                          className="pointer-events-auto shrink-0"
+                        />
+                      );
+                    })()}
                   />
                 </div>
-                <span className="text-[10px] text-gray-500">Baht/Sq.Wa/Mo</span>
+                <span className="text-[10px] text-gray-500">{t('profitRent.unitBahtPerSqWaPerMonth')}</span>
               </div>
             </div>
 
             {/* Monthly Total — computed */}
             <div className="rounded-md bg-primary/5 border border-primary/10 px-3 py-2">
               <div className="text-[10px] text-primary/60 uppercase tracking-wide mb-0.5">
-                Monthly Total
+                {t('profitRent.monthlyTotal')}
               </div>
               <div className="flex items-baseline gap-1">
                 <span className="text-sm font-semibold text-primary">
                   {fmt((marketFeeField.value ?? 0) * landAreaSqWa)}
                 </span>
-                <span className="text-[10px] text-primary/60">Baht/Mo</span>
+                <span className="text-[10px] text-primary/60">{t('profitRent.unitBahtPerMonth')}</span>
               </div>
             </div>
 
             {/* Discounted Rate — input */}
             <div className="rounded-md bg-gray-50 px-3 py-2">
               <label className="text-[10px] text-gray-400 uppercase tracking-wide mb-0.5 block">
-                Discounted Rate
+                {t('profitRent.discountedRate')}
               </label>
               <div className="w-24">
                 <NumberInput
@@ -670,7 +698,7 @@ export function ProfitRentPanel({
           {/* Market Rental Fee Increase */}
           <div className="space-y-2">
             <Toggle
-              label="Market Rental Fee Increase"
+              label={t('profitRent.marketRentalFeeIncrease')}
               options={['Frequency', 'Period']}
               checked={growthRateType === 'Period'}
               onChange={checked => {
@@ -685,7 +713,7 @@ export function ProfitRentPanel({
               <div className="flex gap-3 items-end">
                 <div className="flex-1">
                   <NumberInput
-                    label="Rate"
+                    label={t('profitRent.rate')}
                     name={growthPercentField.name}
                     ref={growthPercentField.ref}
                     value={growthPercentField.value}
@@ -697,10 +725,10 @@ export function ProfitRentPanel({
                     disabled={readOnly}
                   />
                 </div>
-                <span className="text-sm text-gray-500 pb-2">Every</span>
+                <span className="text-sm text-gray-500 pb-2">{t('profitRent.every')}</span>
                 <div className="flex-1">
                   <NumberInput
-                    label="Interval"
+                    label={t('profitRent.interval')}
                     name={intervalField.name}
                     ref={intervalField.ref}
                     value={intervalField.value}
@@ -708,7 +736,7 @@ export function ProfitRentPanel({
                     onBlur={intervalField.onBlur}
                     decimalPlaces={0}
                     maxIntegerDigits={3}
-                    rightIcon={<span className="text-xs text-gray-400">Year</span>}
+                    rightIcon={<span className="text-xs text-gray-400">{t('profitRent.unitYear')}</span>}
                     disabled={readOnly}
                   />
                 </div>
@@ -716,9 +744,9 @@ export function ProfitRentPanel({
             ) : (
               <div className="space-y-2">
                 <div className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 text-xs text-gray-500 font-medium">
-                  <span>From Year</span>
-                  <span>To Year</span>
-                  <span>Growth Rate (%)</span>
+                  <span>{t('profitRent.fromYear')}</span>
+                  <span>{t('profitRent.toYear')}</span>
+                  <span>{t('profitRent.growthRatePercent')}</span>
                   <span />
                 </div>
                 {growthPeriodFields.map((field, index) => (
@@ -778,7 +806,7 @@ export function ProfitRentPanel({
                     className="text-xs text-primary hover:underline flex items-center gap-1"
                   >
                     <Icon name="plus" className="size-3" />
-                    Add Periods
+                    {t('profitRent.addPeriods')}
                   </button>
                 )}
               </div>
@@ -792,25 +820,25 @@ export function ProfitRentPanel({
             cards={
               [
                 {
-                  label: 'Total Market Rental',
+                  label: t('profitRent.kpi.totalMarketRental'),
                   value: tableResult.totalMarketRentalFee,
                   icon: 'chart-bar',
                   color: 'blue',
                 },
                 {
-                  label: 'Total Contract Rental',
+                  label: t('profitRent.kpi.totalContractRental'),
                   value: tableResult.totalContractRentalFee,
                   icon: 'file-contract',
                   color: 'gray',
                 },
                 {
-                  label: 'Total Returns',
+                  label: t('profitRent.kpi.totalReturns'),
                   value: tableResult.totalReturnsFromLease,
                   icon: 'arrow-trend-up',
                   color: 'amber',
                 },
                 {
-                  label: 'Present Value',
+                  label: t('profitRent.kpi.presentValue'),
                   value: tableResult.totalPresentValue,
                   icon: 'circle-check',
                   color: 'green',
@@ -848,7 +876,7 @@ export function ProfitRentPanel({
         {/* Include building cost section */}
         <div className="border-t border-gray-200 pt-2 space-y-3">
           <Toggle
-            label="Include building cost"
+            label={t('profitRent.includeBuildingCost')}
             options={['No', 'Yes']}
             size="sm"
             checked={isBuildingCostIncluded}
@@ -867,7 +895,7 @@ export function ProfitRentPanel({
               {/* Formula rows */}
               <div className="text-sm divide-y divide-gray-100">
                 <div className="flex items-center justify-between py-1.5">
-                  <span className="text-xs text-gray-600">Estimate Price (from PV)</span>
+                  <span className="text-xs text-gray-600">{t('profitRent.estimatePriceFromPv')}</span>
                   <span className="text-xs font-medium text-gray-800 tabular-nums">
                     {fmt(Number(estimatePrice) || 0)}
                   </span>
@@ -875,7 +903,7 @@ export function ProfitRentPanel({
                 <div className="flex items-center justify-between py-1.5">
                   <span className="text-xs text-gray-600">
                     <span className="font-bold mr-1">+</span>
-                    Building Cost (after depre.)
+                    {t('profitRent.buildingCostAfterDepre')}
                   </span>
                   <span className="text-xs font-medium text-gray-800 tabular-nums">
                     {fmt(Number(watch('totalBuildingCost')) || 0)}
@@ -884,7 +912,7 @@ export function ProfitRentPanel({
                 <div className="flex items-center justify-between py-1.5">
                   <span className="text-xs text-gray-700 font-medium">
                     <span className="font-bold mr-1">=</span>
-                    Appraisal Price w/ Building
+                    {t('profitRent.appraisalPriceWithBuilding')}
                   </span>
                   <span className="text-xs font-semibold text-gray-900 tabular-nums">
                     {fmt(Number(watch('appraisalPriceWithBuilding')) || 0)}
@@ -892,7 +920,7 @@ export function ProfitRentPanel({
                 </div>
                 {/* Appraisal Price */}
                 <div className="flex items-center justify-between py-2">
-                  <span className="text-xs font-semibold text-gray-900">Appraisal Price</span>
+                  <span className="text-xs font-semibold text-gray-900">{t('profitRent.appraisalPrice')}</span>
                   <div className="flex items-center gap-2">
                     {(() => {
                       const rounded = Number(watch('appraisalPriceWithBuildingRounded')) || 0;
@@ -945,13 +973,13 @@ export function ProfitRentPanel({
         {!isBuildingCostIncluded && (
           <div className="text-sm divide-y divide-gray-100 border-t border-gray-200">
             <div className="flex items-center justify-between py-1.5">
-              <span className="text-xs text-gray-600">Estimate Price (from PV)</span>
+              <span className="text-xs text-gray-600">{t('profitRent.estimatePriceFromPv')}</span>
               <span className="text-xs font-medium text-gray-800 tabular-nums">
                 {fmt(tableResult?.finalValueRounded ?? 0)}
               </span>
             </div>
             <div className="flex items-center justify-between py-2">
-              <span className="text-xs font-semibold text-gray-900 shrink-0">Appraisal Price</span>
+              <span className="text-xs font-semibold text-gray-900 shrink-0">{t('profitRent.appraisalPrice')}</span>
               <div className="flex items-center gap-2">
                 {(() => {
                   const rounded = Number(estimateField.value) || 0;
@@ -1005,7 +1033,7 @@ export function ProfitRentPanel({
           isOpen={isShowResetDialog}
           onClose={() => setIsShowResetDialog(false)}
           onConfirm={handleOnConfirmReset}
-          message="Are you sure you want to reset this method? All calculation data will be cleared."
+          message={t('profitRent.resetConfirmMessage')}
         />
 
         <LeaseholdRentalInfoModal
@@ -1031,6 +1059,7 @@ function ProfitRentTable({
   hoveredCol: number | null;
   onColHover: (col: number | null) => void;
 }) {
+  const { t } = useTranslation('pricingAnalysis');
   const colHl = 'bg-blue-50/60';
 
   // Sticky columns: 0=Year, 1=Start, 2=End (pinned left)
@@ -1072,17 +1101,17 @@ function ProfitRentTable({
   });
 
   const headers = [
-    { label: 'Year', align: 'text-left' },
-    { label: 'Period Start Date', align: 'text-left' },
-    { label: 'Period End Date', align: 'text-left' },
-    { label: 'Number of Month', minW: 'min-w-[80px]' },
-    { label: 'Market Rental Fee (Baht/Sq.Wa/Month)', minW: 'min-w-[130px]' },
-    { label: 'Market Rental Fee (Baht/month)', minW: 'min-w-[120px]' },
-    { label: 'Market Rental Fee (Baht/year)', minW: 'min-w-[120px]' },
-    { label: 'Contract Rental Fee (Baht/year)', minW: 'min-w-[120px]' },
-    { label: 'Returns from Lease (Baht)', minW: 'min-w-[120px]' },
-    { label: 'Discounted Rate', minW: 'min-w-[100px]' },
-    { label: 'Present Value (Baht)', minW: 'min-w-[120px]' },
+    { label: t('profitRent.tableHeaders.year'), align: 'text-left' },
+    { label: t('profitRent.tableHeaders.periodStart'), align: 'text-left' },
+    { label: t('profitRent.tableHeaders.periodEnd'), align: 'text-left' },
+    { label: t('profitRent.tableHeaders.numberOfMonth'), minW: 'min-w-[80px]' },
+    { label: t('profitRent.tableHeaders.marketRentalFeePerSqWaMonth'), minW: 'min-w-[130px]' },
+    { label: t('profitRent.tableHeaders.marketRentalFeePerMonth'), minW: 'min-w-[120px]' },
+    { label: t('profitRent.tableHeaders.marketRentalFeePerYear'), minW: 'min-w-[120px]' },
+    { label: t('profitRent.tableHeaders.contractRentalFeePerYear'), minW: 'min-w-[120px]' },
+    { label: t('profitRent.tableHeaders.returnsFromLease'), minW: 'min-w-[120px]' },
+    { label: t('profitRent.tableHeaders.discountedRate'), minW: 'min-w-[100px]' },
+    { label: t('profitRent.tableHeaders.presentValue'), minW: 'min-w-[120px]' },
   ];
 
   return (
@@ -1141,7 +1170,7 @@ function ProfitRentTable({
       <tfoot className="sticky bottom-0 z-20">
         <tr className="bg-gray-100 font-semibold border-t-2 border-gray-300">
           <td className={`sticky left-0 z-30 ${totalBg} px-3 py-2 text-gray-800`} colSpan={3}>
-            Total
+            {t('profitRent.total')}
           </td>
           <td className={`${totalBg} ${totalTdCls(3)}`} {...cellProps(3)}></td>
           <td className={`${totalBg} ${totalTdCls(4)}`} {...cellProps(4)}></td>
@@ -1167,6 +1196,7 @@ function ProfitRentTable({
 
 /** 11b: Compact building cost summary with expand/collapse */
 function BuildingCostCollapsible({ buildingCost }: { buildingCost: Record<string, unknown>[] }) {
+  const { t } = useTranslation('pricingAnalysis');
   const [expanded, setExpanded] = useState(false);
 
   // Compute summary per building
@@ -1209,14 +1239,14 @@ function BuildingCostCollapsible({ buildingCost }: { buildingCost: Record<string
       >
         <div className="flex items-center gap-2">
           <Icon name="building" className="size-3.5 text-gray-500" />
-          <span className="text-xs font-semibold text-gray-700">Building Cost Summary</span>
+          <span className="text-xs font-semibold text-gray-700">{t('profitRent.buildingCostSummary')}</span>
           <span className="text-[10px] text-gray-400">
             ({summaries.reduce((s, b) => s + b.itemCount, 0)} items)
           </span>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-xs font-medium text-gray-600 tabular-nums">
-            After Depre.{' '}
+            {t('profitRent.afterDepre')}{' '}
             {grandAfter.toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
@@ -1234,11 +1264,11 @@ function BuildingCostCollapsible({ buildingCost }: { buildingCost: Record<string
         <div className="border-t border-gray-100">
           {/* Column headers */}
           <div className="flex items-center justify-between px-4 py-1 text-[10px] text-gray-400 uppercase tracking-wide border-b border-gray-100">
-            <span>Property</span>
+            <span>{t('profitRent.propertyCol')}</span>
             <div className="flex gap-6">
-              <span className="w-20 text-right">Area</span>
-              <span className="w-28 text-right">Before Depre.</span>
-              <span className="w-28 text-right">After Depre.</span>
+              <span className="w-20 text-right">{t('profitRent.areaCol')}</span>
+              <span className="w-28 text-right">{t('profitRent.beforeDepre')}</span>
+              <span className="w-28 text-right">{t('profitRent.afterDepre')}</span>
             </div>
           </div>
           {summaries.map((s, i) => (

--- a/src/features/pricingAnalysis/components/SaleAdjustmentGridPanel.tsx
+++ b/src/features/pricingAnalysis/components/SaleAdjustmentGridPanel.tsx
@@ -3,6 +3,7 @@ import { type SubmitErrorHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  makeSaleAdjustmentGridDto,
   SaleAdjustmentGridDto,
   type SaleAdjustmentGridType,
 } from '@features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts';
@@ -99,7 +100,7 @@ export function SaleAdjustmentGridPanel({
 
   const methods = useForm<SaleAdjustmentGridType>({
     mode: 'onSubmit',
-    resolver: zodResolver(SaleAdjustmentGridDto),
+    resolver: zodResolver(makeSaleAdjustmentGridDto(t)),
   });
 
   const {
@@ -248,7 +249,10 @@ export function SaleAdjustmentGridPanel({
   // Auto-show table when linked comparables already exist from the API
   useEffect(() => {
     if (isGenerated || comparativeSurveys.length === 0) return;
-    if (!methodId || !methodType || (!manualSubject && !property)) return;
+    // A saved reference (e.g. opened from the group References section) has no live
+    // subject `property` but does have saved data to restore — never block a restore.
+    const hasSavedData = !!(savedComparativeFactors && savedComparativeFactors.length > 0);
+    if (!methodId || !methodType || (!manualSubject && !property && !hasSavedData)) return;
 
     // Restore from saved data if available
     if (savedComparativeFactors && savedComparativeFactors.length > 0) {

--- a/src/features/pricingAnalysis/components/SensitivityStrip.tsx
+++ b/src/features/pricingAnalysis/components/SensitivityStrip.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface SensitivityStripProps {
   currentRate: number;
@@ -12,6 +13,7 @@ const fmt = (n: number): string => {
 };
 
 export function SensitivityStrip({ currentRate, calculateFinalValue }: SensitivityStripProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const scenarios = useMemo(() => {
     const offsets = [-2, -1, 0, 1, 2];
     const seen = new Set<number>();
@@ -40,7 +42,7 @@ export function SensitivityStrip({ currentRate, calculateFinalValue }: Sensitivi
     <div className="rounded-lg border border-gray-200 overflow-hidden">
       <div className="flex items-center gap-3">
         <div className="px-3 py-1.5 text-[10px] font-medium text-gray-500 uppercase tracking-wide whitespace-nowrap shrink-0">
-          Discount Rate Sensitivity
+          {t('viz.sensitivity.title')}
         </div>
         <div
           className="flex-1 grid"

--- a/src/features/pricingAnalysis/components/WQSPanel.tsx
+++ b/src/features/pricingAnalysis/components/WQSPanel.tsx
@@ -3,7 +3,7 @@ import { useForm, type SubmitErrorHandler } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { PricingAnalysisTemplateSelector } from './PricingAnalysisTemplateSelector';
 import { MethodFooterActions } from './MethodFooterActions';
-import { WQSDto, type WQSFormType } from '../schemas/wqsForm';
+import { makeWQSDto, WQSDto, type WQSFormType } from '../schemas/wqsForm';
 import { useEffect, useState } from 'react';
 import { COLLATERAL_TYPE } from '../data/constants';
 import toast from 'react-hot-toast';
@@ -95,7 +95,7 @@ export function WQSPanel({
 
   const methods = useForm<WQSFormType>({
     mode: 'onSubmit',
-    resolver: zodResolver(WQSDto),
+    resolver: zodResolver(makeWQSDto(t)),
   });
 
   const {
@@ -240,7 +240,11 @@ export function WQSPanel({
   // Auto-show table when linked comparables already exist from the API
   useEffect(() => {
     if (isGenerated || comparativeSurveys.length === 0) return;
-    if (!methodId || !methodType || (!manualSubject && !property)) return;
+    // A saved reference (e.g. IncomeLandRef opened from the group References section)
+    // has no live subject `property` — but it DOES have saved data to restore. Only
+    // require a property for a fresh, manual-less generate; never block a restore.
+    const hasSavedData = !!(savedComparativeFactors && savedComparativeFactors.length > 0);
+    if (!methodId || !methodType || (!manualSubject && !property && !hasSavedData)) return;
 
     // Restore from saved data if available
     if (savedComparativeFactors && savedComparativeFactors.length > 0) {

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategory.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategory.tsx
@@ -22,6 +22,7 @@ interface DiscountedCashFlowCategoryProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 
 export function DiscountedCashFlowCategory({
@@ -37,6 +38,7 @@ export function DiscountedCashFlowCategory({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowCategoryProps) {
   const { getValues, setValue, control } = useFormContext();
 
@@ -136,6 +138,7 @@ export function DiscountedCashFlowCategory({
               incomeAnalysisId={incomeAnalysisId}
               hostMethodId={hostMethodId}
               marketSurveys={marketSurveys}
+              ensureIncomeAnalysisId={ensureIncomeAnalysisId}
             />
           )}
 

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategoryRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowCategoryRenderer.tsx
@@ -15,6 +15,7 @@ interface DiscountedCashFlowCategoryRendererProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 export function DiscountedCashFlowCategoryRenderer({
   name,
@@ -28,6 +29,7 @@ export function DiscountedCashFlowCategoryRenderer({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowCategoryRendererProps) {
   const props = {
     name: name,
@@ -45,6 +47,7 @@ export function DiscountedCashFlowCategoryRenderer({
     incomeAnalysisId,
     hostMethodId,
     marketSurveys,
+    ensureIncomeAnalysisId,
   };
   switch (category.categoryType) {
     case 'income': {

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowHighestBestUsed.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowHighestBestUsed.tsx
@@ -1,21 +1,36 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { RHFInputCell, toNumber } from '../table/RHFInputCell';
 import { Icon } from '@/shared/components';
 import { convertLandAreaToTotalSqWa } from '../../domain/convertLandAreaToTotalSqWa';
 import { useDerivedFields, type DerivedFieldRule } from '../../adapters/useDerivedFieldArray';
 import { floorToThousands, roundToThousand } from '../../domain/calculation';
-import { MarketReferenceButton } from '../MarketReferenceButton';
-import { PricingAnalysisSubjectType } from '../../api/references';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
+import toast from 'react-hot-toast';
+import clsx from 'clsx';
+import {
+  useGetReferences,
+  useCreateReferenceFromMethod,
+  PricingAnalysisSubjectType,
+} from '../../api/references';
+import { useGetPricingAnalysis } from '../../api';
+import { MarketReferenceModal } from '../MarketReferenceModal';
 import type { MarketComparableDetailType } from '../../schemas';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface DiscountedCashFlowHighestBestUsedProps {
   isReadOnly?: boolean;
   /** Income analysis ID — used as anchorId for the IncomeLandRef market reference */
   incomeAnalysisId?: string;
   hostMethodId?: string;
+  /** Group / income PA id — needed to fetch Cost-approach methods for the picker */
+  pricingAnalysisId?: string;
   marketSurveys?: MarketComparableDetailType[];
   subjectProperty?: Record<string, unknown>;
+  /** Ensures the income analysis is saved before attempting to create/open a reference */
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 
 const fmt = (n: number | null | undefined): string => {
@@ -23,12 +38,302 @@ const fmt = (n: number | null | undefined): string => {
   return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 };
 
+// ── Cost-method picker modal ──────────────────────────────────────────────────
+
+const COST_COMPARABLE_METHODS = new Set(['WQS', 'SaleGrid', 'DirectComparison']);
+
+interface CostMethodPickerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Group PA id to load Cost-approach methods from */
+  groupPricingAnalysisId: string;
+  onPick: (methodId: string) => void;
+  isPicking: boolean;
+}
+
+function CostMethodPicker({
+  isOpen,
+  onClose,
+  groupPricingAnalysisId,
+  onPick,
+  isPicking,
+}: CostMethodPickerProps) {
+  const { t } = useTranslation('pricingAnalysis');
+
+  const { data: groupPA } = useGetPricingAnalysis(groupPricingAnalysisId);
+
+  const costMethods = (groupPA?.approaches ?? [])
+    .filter((a: any) => a.approachType === 'Cost' || a.type === 'Cost')
+    .flatMap((a: any) =>
+      (a.methods ?? []).filter((m: any) => COST_COMPARABLE_METHODS.has(m.methodType)),
+    );
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/30 backdrop-blur-sm transition-opacity duration-300 ease-linear data-closed:opacity-0"
+      />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <DialogPanel
+            transition
+            className="w-full max-w-md bg-white rounded-xl shadow-xl transition-all duration-300 ease-out data-closed:opacity-0 data-closed:scale-95"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 bg-gray-50 rounded-t-xl">
+              <div className="flex items-center gap-2">
+                <div className="flex items-center justify-center size-6 rounded-lg bg-primary/10 text-primary">
+                  <Icon name="copy" className="size-3" />
+                </div>
+                <h2 className="text-sm font-semibold text-gray-900">
+                  {t('incomeLandRef.pickerTitle')}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label="Close"
+              >
+                <Icon name="xmark" style="regular" className="size-4" />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="px-5 py-4 space-y-3">
+              <p className="text-xs text-gray-500">{t('incomeLandRef.pickerHint')}</p>
+
+              {costMethods.length === 0 ? (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">
+                  <Icon name="triangle-exclamation" className="size-3.5 shrink-0 mt-0.5 text-amber-500" />
+                  <span>{t('incomeLandRef.noCostMethods')}</span>
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  {costMethods.map((m: any) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      disabled={isPicking}
+                      onClick={() => onPick(m.id)}
+                      className={clsx(
+                        'w-full flex items-center justify-between px-3 py-2.5 rounded-lg border text-left transition-colors',
+                        'border-gray-200 hover:border-primary/40 hover:bg-primary/5',
+                        isPicking && 'opacity-60 cursor-wait',
+                      )}
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <span
+                          className={clsx(
+                            'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider',
+                            'bg-primary/10 text-primary border border-primary/20',
+                          )}
+                        >
+                          {m.methodType === 'WQS'
+                            ? 'WQS'
+                            : m.methodType === 'SaleGrid'
+                              ? 'SAG'
+                              : 'DC'}
+                        </span>
+                        <span className="text-sm font-medium text-gray-800">
+                          {m.label ?? m.methodType}
+                        </span>
+                      </div>
+                      {m.appraisalValue != null && m.appraisalValue !== 0 && (
+                        <span className="text-xs tabular-nums text-gray-500">
+                          {Number(m.appraisalValue).toLocaleString()}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </DialogPanel>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+// ── IncomeLandRefControl ──────────────────────────────────────────────────────
+
+/**
+ * Renders the WQS reference control for the HBU pricePerSqWa input.
+ *
+ * - If a reference EXISTS → compact "WQS" button → opens the reference editor.
+ * - If NONE → compact "Copy from Cost" button → picker → copy → editor.
+ */
+interface IncomeLandRefControlProps {
+  incomeAnalysisId: string;
+  hostMethodId: string;
+  pricingAnalysisId: string;
+  marketSurveys: MarketComparableDetailType[];
+  subjectProperty: Record<string, unknown> | undefined;
+  totalWaValue: number;
+  onApplyValue: (v: number) => void;
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
+}
+
+function IncomeLandRefControl({
+  incomeAnalysisId,
+  hostMethodId,
+  pricingAnalysisId,
+  marketSurveys,
+  subjectProperty,
+  totalWaValue,
+  onApplyValue,
+  ensureIncomeAnalysisId,
+}: IncomeLandRefControlProps) {
+  const { t } = useTranslation('pricingAnalysis');
+
+  const [refModalOpen, setRefModalOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+
+  const createFromMethodMutation = useCreateReferenceFromMethod();
+
+  const { data: refsData } = useGetReferences(
+    PricingAnalysisSubjectType.IncomeLandRef,
+    incomeAnalysisId,
+  );
+
+  const existingRef = refsData?.references?.[0] ?? null;
+
+  const runEnsure = async (): Promise<boolean> => {
+    if (!ensureIncomeAnalysisId) return true;
+    setIsPending(true);
+    try {
+      const id = await ensureIncomeAnalysisId();
+      setIsPending(false);
+      return !!id;
+    } catch {
+      setIsPending(false);
+      return false;
+    }
+  };
+
+  const handleOpenExisting = async () => {
+    if (!(await runEnsure())) return;
+    setRefModalOpen(true);
+  };
+
+  const handleOpenPicker = async () => {
+    if (!(await runEnsure())) return;
+    setPickerOpen(true);
+  };
+
+  const handlePick = async (sourceMethodId: string) => {
+    setPickerOpen(false);
+    setIsPending(true);
+    try {
+      await createFromMethodMutation.mutateAsync({
+        subjectType: PricingAnalysisSubjectType.IncomeLandRef,
+        anchorId: incomeAnalysisId,
+        hostMethodId,
+        sourcePricingAnalysisId: pricingAnalysisId,
+        sourceMethodId,
+        landAreaOverride: totalWaValue > 0 ? totalWaValue : null,
+      });
+      // Open the reference list/editor via the standard modal
+      setRefModalOpen(true);
+    } catch {
+      toast.error(t('incomeLandRef.copyFailed'));
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <>
+      {existingRef ? (
+        /* Reference exists — "WQS" opens the reference modal (list → panel) */
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={handleOpenExisting}
+          className={clsx(
+            'inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold',
+            'text-primary border border-primary/30 rounded-lg bg-primary/5',
+            'hover:bg-primary/10 hover:border-primary/50 transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+            'shrink-0',
+            isPending && 'opacity-60 cursor-wait',
+          )}
+          title={t('incomeLandRef.openRef')}
+          aria-label={t('incomeLandRef.openRef')}
+        >
+          {isPending ? (
+            <span className="size-3.5 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+          ) : (
+            <span>WQS</span>
+          )}
+        </button>
+      ) : (
+        /* No reference — "Copy from Cost" button */
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={handleOpenPicker}
+          className={clsx(
+            'inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold',
+            'text-amber-700 border border-amber-300 rounded-lg bg-amber-50',
+            'hover:bg-amber-100 hover:border-amber-400 transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40',
+            'shrink-0',
+            isPending && 'opacity-60 cursor-wait',
+          )}
+          title={t('incomeLandRef.copyFromCost')}
+          aria-label={t('incomeLandRef.copyFromCost')}
+        >
+          {isPending ? (
+            <span className="size-3.5 rounded-full border-2 border-amber-600 border-t-transparent animate-spin" />
+          ) : (
+            <>
+              <Icon name="copy" className="size-3" />
+              <span>{t('incomeLandRef.copyFromCost')}</span>
+            </>
+          )}
+        </button>
+      )}
+
+      {/* Cost-method picker */}
+      <CostMethodPicker
+        isOpen={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        groupPricingAnalysisId={pricingAnalysisId}
+        onPick={handlePick}
+        isPicking={createFromMethodMutation.isPending}
+      />
+
+      {/* Standard reference modal (list → panel → apply) */}
+      <MarketReferenceModal
+        isOpen={refModalOpen}
+        onClose={() => setRefModalOpen(false)}
+        subjectType={PricingAnalysisSubjectType.IncomeLandRef}
+        anchorId={incomeAnalysisId}
+        hostMethodId={hostMethodId}
+        marketSurveys={marketSurveys}
+        templateList={undefined}
+        subjectProperty={subjectProperty}
+        onApplyValue={onApplyValue}
+        readOnly={false}
+      />
+    </>
+  );
+}
+
+// ── DiscountedCashFlowHighestBestUsed ─────────────────────────────────────────
+
 export function DiscountedCashFlowHighestBestUsed({
   isReadOnly,
   incomeAnalysisId,
   hostMethodId,
+  pricingAnalysisId,
   marketSurveys,
   subjectProperty,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowHighestBestUsedProps) {
   const { control, getValues, setValue } = useFormContext();
   const isHighestBestUsed = useWatch({ control, name: 'isHighestBestUsed' });
@@ -157,6 +462,13 @@ export function DiscountedCashFlowHighestBestUsed({
   const landValueNum = toNumber(totalLandValue) ?? 0;
   const showLandRow = !isHighestBestUsed && landValueNum > 0;
 
+  // Derive the total Sq.Wa value for use as landAreaOverride when copying
+  const totalWaNum = toNumber(totalWa) ?? 0;
+
+  // Whether to show the reference control (non-HBU only, needs incomeAnalysisId + pricingAnalysisId)
+  const showRefControl =
+    !isReadOnly && !isHighestBestUsed && !!incomeAnalysisId && !!hostMethodId && !!pricingAnalysisId;
+
   return (
     <div className="flex flex-col text-sm">
       {/* ── Header row: toggle on left, compact summary stats on right ──── */}
@@ -236,18 +548,17 @@ export function DiscountedCashFlowHighestBestUsed({
               }}
             />
           </div>
-          {incomeAnalysisId && (
-            <div className="ml-2 self-end pb-1">
-              <MarketReferenceButton
-                subjectType={PricingAnalysisSubjectType.IncomeLandRef}
-                anchorId={incomeAnalysisId}
-                hostMethodId={hostMethodId}
-                marketSurveys={marketSurveys ?? []}
-                templateList={undefined}
-                subjectProperty={subjectProperty}
-                onApplyValue={v => setValue('highestBestUsed.pricePerSqWa', v, { shouldDirty: true })}
-              />
-            </div>
+          {showRefControl && (
+            <IncomeLandRefControl
+              incomeAnalysisId={incomeAnalysisId!}
+              hostMethodId={hostMethodId!}
+              pricingAnalysisId={pricingAnalysisId!}
+              marketSurveys={marketSurveys ?? []}
+              subjectProperty={subjectProperty}
+              totalWaValue={totalWaNum}
+              onApplyValue={v => setValue('highestBestUsed.pricePerSqWa', v, { shouldDirty: true })}
+              ensureIncomeAnalysisId={ensureIncomeAnalysisId}
+            />
           )}
         </div>
       )}

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
@@ -35,6 +35,7 @@ interface DiscountedCashFlowMethodModalProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 export function DiscountedCashFlowMethodModal({
   editing,
@@ -48,6 +49,7 @@ export function DiscountedCashFlowMethodModal({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowMethodModalProps) {
   const methods = useForm<AssumptionEditDraft>({
     defaultValues: initialData,
@@ -262,6 +264,7 @@ export function DiscountedCashFlowMethodModal({
                 incomeAnalysisId={incomeAnalysisId}
                 hostMethodId={hostMethodId}
                 marketSurveys={marketSurveys}
+                ensureIncomeAnalysisId={ensureIncomeAnalysisId}
               />
             )}
 

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
@@ -24,6 +24,7 @@ interface DiscountedCashFlowModalRendererProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 export function DiscountedCashFlowModalRenderer({
   name,
@@ -34,6 +35,7 @@ export function DiscountedCashFlowModalRenderer({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowModalRendererProps) {
   const props = { name, properties, getOuterFormValues, isReadOnly };
 
@@ -46,6 +48,7 @@ export function DiscountedCashFlowModalRenderer({
           incomeAnalysisId={incomeAnalysisId}
           hostMethodId={hostMethodId}
           marketSurveys={marketSurveys}
+          ensureIncomeAnalysisId={ensureIncomeAnalysisId}
         />
       );
     }

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
@@ -38,6 +38,7 @@ import { SensitivityStrip } from '../SensitivityStrip';
 import { useIncomeScenarioResults } from '../../domain/useIncomeScenarioResults';
 import toast from 'react-hot-toast';
 import { useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { findLeaseProperty, isLeasePropertyType } from '../../utils/leaseProperty';
 import DataErrorState from '@/shared/components/DataErrorState';
 
 interface DiscountedCashFlowPanelProps {
@@ -97,9 +98,8 @@ export function DiscountedCashFlowPanel({
 
   const appraisalId = useAppraisalId() ?? '';
   const propertyId =
-    ((properties ?? []).find(p => ['LS', 'LSL', 'LSB'].includes(p.propertyType))
-      ?.propertyId as string) ??
-    properties?.[0].propertyId ??
+    (findLeaseProperty(properties)?.propertyId as string) ??
+    properties?.[0]?.propertyId ??
     '';
 
   const saveMutation = useSaveIncomeAnalysis();
@@ -344,6 +344,47 @@ export function DiscountedCashFlowPanel({
     }
   });
 
+  /**
+   * Ensures the income analysis exists (saved) and returns its id.
+   * If already saved, returns immediately. Otherwise performs a silent save
+   * so the room-income reference button can use the id as anchorId.
+   * Used as `onBeforeOpen` on the room MarketReferenceButton.
+   */
+  const ensureIncomeAnalysisId = useCallback(async (): Promise<string | undefined> => {
+    if (incomeAnalysisQuery.data?.id) return incomeAnalysisQuery.data.id;
+    if (!activeMethod?.pricingAnalysisId || !activeMethod?.methodId || !appraisalId || !propertyId) {
+      toast.error(t('toasts.missingIds'));
+      return undefined;
+    }
+    try {
+      const values = methods.getValues();
+      const request = mapDCFFormToSaveRequest(values);
+      const result = await saveMutation.mutateAsync({
+        pricingAnalysisId: activeMethod.pricingAnalysisId,
+        methodId: activeMethod.methodId,
+        appraisalId,
+        propertyId,
+        request,
+      });
+      reset(mapIncomeAnalysisToDCFForm(result));
+      return result.id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('toasts.saveFailed');
+      toast.error(`${t('toasts.saveFailed')}: ${message}`);
+      return undefined;
+    }
+  }, [
+    incomeAnalysisQuery.data?.id,
+    activeMethod?.pricingAnalysisId,
+    activeMethod?.methodId,
+    appraisalId,
+    propertyId,
+    methods,
+    saveMutation,
+    reset,
+    t,
+  ]);
+
   if (isPricingTemplatesError || isTemplateDtoError) {
     const handleRetry = () => {
       if (isPricingTemplatesError) refetchPricingTemplates();
@@ -407,6 +448,7 @@ export function DiscountedCashFlowPanel({
                   incomeAnalysisId={incomeAnalysisQuery.data?.id}
                   hostMethodId={activeMethod?.methodId}
                   marketSurveys={marketSurveys}
+                  ensureIncomeAnalysisId={ensureIncomeAnalysisId}
                 />
               </div>
               {previewMutation.isPending && (
@@ -427,12 +469,13 @@ export function DiscountedCashFlowPanel({
               isReadOnly={isReadOnly}
               incomeAnalysisId={incomeAnalysisQuery.data?.id}
               hostMethodId={activeMethod?.methodId}
+              pricingAnalysisId={activeMethod?.pricingAnalysisId}
               marketSurveys={marketSurveys}
               subjectProperty={
-                (properties ?? []).find(p =>
-                  ['LS', 'LSL', 'LSB'].includes(p.propertyType as string),
-                ) ?? properties?.[0]
+                (properties ?? []).find(p => isLeasePropertyType(p.propertyType)) ??
+                properties?.[0]
               }
+              ensureIncomeAnalysisId={ensureIncomeAnalysisId}
             />
 
             {saveError && <p className="text-sm text-red-600 px-1">{saveError}</p>}

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSectionRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowSectionRenderer.tsx
@@ -17,6 +17,7 @@ interface DiscountedCashFlowSectionRendererProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 export function DiscountedCashFlowSectionRenderer({
   name,
@@ -30,6 +31,7 @@ export function DiscountedCashFlowSectionRenderer({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowSectionRendererProps) {
   switch (section.sectionType) {
     case 'income': {
@@ -46,6 +48,7 @@ export function DiscountedCashFlowSectionRenderer({
           incomeAnalysisId={incomeAnalysisId}
           hostMethodId={hostMethodId}
           marketSurveys={marketSurveys}
+          ensureIncomeAnalysisId={ensureIncomeAnalysisId}
         />
       );
     }

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
@@ -85,6 +85,7 @@ interface DiscountedCashFlowTableProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 
 export function DiscountedCashFlowTable({
@@ -95,6 +96,7 @@ export function DiscountedCashFlowTable({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: DiscountedCashFlowTableProps) {
   const { control } = useFormContext();
   const watchSections = useWatch({ control, name: 'sections' });
@@ -211,6 +213,7 @@ export function DiscountedCashFlowTable({
                   incomeAnalysisId={incomeAnalysisId}
                   hostMethodId={hostMethodId}
                   marketSurveys={marketSurveys}
+                  ensureIncomeAnalysisId={ensureIncomeAnalysisId}
                 />
               );
             })}

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@/shared/components';
 import { RHFInputCell } from '../../table/RHFInputCell';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toDecimal, toNumber } from '../../../domain/calculation';
@@ -19,6 +19,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
   hostMethodId,
   marketSurveys,
   templateList,
+  ensureIncomeAnalysisId,
 }: {
   name: string;
   isReadOnly?: boolean;
@@ -27,8 +28,12 @@ export function MethodSpecifyRoomIncomePerDayModal({
   hostMethodId?: string;
   marketSurveys?: MarketComparableDetailType[];
   templateList?: TemplateDtoType[] | undefined;
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }) {
   const { getValues, setValue } = useFormContext();
+  // Local state to cache the id obtained by ensureIncomeAnalysisId so the
+  // button can function before the first save.
+  const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
   const { fields, append, remove } = useFieldArray({ name: `${name}.roomDetails` });
 
   const handleOnAdd = () => {
@@ -157,43 +162,60 @@ export function MethodSpecifyRoomIncomePerDayModal({
                       </div>
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
-                      <div className="flex items-center gap-1">
-                        <div className="flex-1">
+                      {(() => {
+                        const roomType = getValues(`${name}.roomDetails.${index}.roomType`);
+                        const roomOther = getValues(`${name}.roomDetails.${index}.roomTypeOther`);
+                        const roomCode = String(roomType ?? '');
+                        const anchorRefKey =
+                          roomCode === '99' && roomOther
+                            ? String(roomOther)
+                            : roomCode;
+                        // The effective anchorId: already-saved id wins; fall back to locally ensured.
+                        // Read from ref for latest value without stale closure inside onBeforeOpen.
+                        const effectiveId = incomeAnalysisId ?? ensuredId;
+                        const refButton = !isReadOnly ? (
+                          <MarketReferenceButton
+                            compact
+                            label="WQS"
+                            subjectType={PricingAnalysisSubjectType.RoomIncomeRef}
+                            // Pass the live value; after onBeforeOpen resolves the state update
+                            // will have re-rendered with the new id, and the modal reads anchorId
+                            // from the prop at open time.
+                            anchorId={effectiveId ?? ''}
+                            anchorRefKey={anchorRefKey}
+                            hostMethodId={hostMethodId}
+                            marketSurveys={marketSurveys ?? []}
+                            templateList={templateList}
+                            currentAnchorLabel={anchorRefKey}
+                            onApplyValue={v =>
+                              setValue(`${name}.roomDetails.${index}.roomIncome`, v, { shouldDirty: true })
+                            }
+                            onBeforeOpen={
+                              effectiveId
+                                ? undefined
+                                : async () => {
+                                    const id = await ensureIncomeAnalysisId?.();
+                                    if (id) {
+                                      setEnsuredId(id);
+                                    }
+                                    // Throw to abort open if still no id (save failed, toast shown)
+                                    if (!id) throw new Error('no-id');
+                                  }
+                            }
+                            className="pointer-events-auto shrink-0"
+                          />
+                        ) : null;
+                        return (
                           <RHFInputCell
                             fieldName={`${name}.roomDetails.${index}.roomIncome`}
                             inputType="number"
                             disabled={isReadOnly}
                             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
+                            rightIcon={refButton}
+                            inputClassName={refButton ? '!pr-14' : undefined}
                           />
-                        </div>
-                        {incomeAnalysisId && !isReadOnly && (() => {
-                          const roomType = getValues(`${name}.roomDetails.${index}.roomType`);
-                          const roomOther = getValues(`${name}.roomDetails.${index}.roomTypeOther`);
-                          // M2 fix: use the raw room-type CODE as anchorRefKey so the backend
-                          // matches references by code, not by localized description.
-                          // For code "99" (other), use the raw roomTypeOther value as the key.
-                          const roomCode = String(roomType ?? '');
-                          const anchorRefKey =
-                            roomCode === '99' && roomOther
-                              ? String(roomOther)
-                              : roomCode;
-                          return (
-                            <MarketReferenceButton
-                              subjectType={PricingAnalysisSubjectType.RoomIncomeRef}
-                              anchorId={incomeAnalysisId}
-                              anchorRefKey={anchorRefKey}
-                              hostMethodId={hostMethodId}
-                              marketSurveys={marketSurveys ?? []}
-                              templateList={templateList}
-                              currentAnchorLabel={anchorRefKey}
-                              onApplyValue={v =>
-                                setValue(`${name}.roomDetails.${index}.roomIncome`, v, { shouldDirty: true })
-                              }
-                              className="shrink-0 !px-1 !py-0.5 text-[10px]"
-                            />
-                          );
-                        })()}
-                      </div>
+                        );
+                      })()}
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
                       <RHFInputCell

--- a/src/features/pricingAnalysis/components/dcf/dcfSections/SectionIncome.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfSections/SectionIncome.tsx
@@ -15,6 +15,7 @@ interface SectionIncomeProps {
   incomeAnalysisId?: string;
   hostMethodId?: string;
   marketSurveys?: import('@/features/pricingAnalysis/schemas').MarketComparableDetailType[];
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 
 export function SectionIncome({
@@ -29,6 +30,7 @@ export function SectionIncome({
   incomeAnalysisId,
   hostMethodId,
   marketSurveys,
+  ensureIncomeAnalysisId,
 }: SectionIncomeProps) {
   return (
     <DynamicSection
@@ -53,6 +55,7 @@ export function SectionIncome({
             incomeAnalysisId={incomeAnalysisId}
             hostMethodId={hostMethodId}
             marketSurveys={marketSurveys}
+            ensureIncomeAnalysisId={ensureIncomeAnalysisId}
           />
         );
       })}

--- a/src/features/pricingAnalysis/components/hypothesis/condominium/CondoUnitDetailsTab.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/condominium/CondoUnitDetailsTab.tsx
@@ -82,7 +82,7 @@ export function CondoUnitDetailsTab({
       { pricingAnalysisId, methodId, file },
       {
         onSuccess: result => {
-          toast.success(`Uploaded ${result.rowCount} rows`);
+          toast.success(t('toasts.uploadSuccess', { n: result.rowCount }));
         },
         onError: error => {
           const errors = extractParseErrors(error);

--- a/src/features/pricingAnalysis/components/hypothesis/landBuilding/UnitDetailsTab.tsx
+++ b/src/features/pricingAnalysis/components/hypothesis/landBuilding/UnitDetailsTab.tsx
@@ -83,7 +83,7 @@ export function UnitDetailsTab({
       { pricingAnalysisId, methodId, file },
       {
         onSuccess: result => {
-          toast.success(`Uploaded ${result.rowCount} rows`);
+          toast.success(t('toasts.uploadSuccess', { n: result.rowCount }));
         },
         onError: error => {
           const errors = extractParseErrors(error);

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
@@ -146,7 +146,7 @@ export const PricingAnalysisAccordion = ({
   }, []);
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white px-2">
+    <div className="rounded-xl border border-gray-200 bg-white px-4 py-2">
       {/* header */}
       <div className="grid grid-cols-12 justify-between items-center h-12">
         <div className="col-span-8 flex items-center gap-2">

--- a/src/features/pricingAnalysis/components/table/RHFInputCell.tsx
+++ b/src/features/pricingAnalysis/components/table/RHFInputCell.tsx
@@ -51,6 +51,10 @@ interface RHFInputCellProps {
     group?: string;
   };
   options?: ListBoxItem[];
+  /** Optional element rendered inside the input on the right (number inputs only). */
+  rightIcon?: React.ReactNode;
+  /** Extra classes for the number input element (e.g. wider right padding for a rightIcon). */
+  inputClassName?: string;
   onUserChange?: (value: number | null) => number | null;
   onSelectChange?: (value: string) => void;
   accessor?: (args: {
@@ -69,6 +73,8 @@ export const RHFInputCell = ({
   text,
   dropdown,
   options,
+  rightIcon,
+  inputClassName,
   onUserChange,
   onSelectChange,
   accessor,
@@ -124,9 +130,11 @@ export const RHFInputCell = ({
         disabled={disabled}
         error={error?.message}
         inputMode="numeric"
+        rightIcon={rightIcon}
         className={clsx(
           'w-full border border-gray-300 rounded-lg px-1.5 py-0.5 text-xs focus:scroll-smooth',
           disabled && 'opacity-50 cursor-not-allowed bg-gray-100',
+          inputClassName,
         )}
       />
     );

--- a/src/features/pricingAnalysis/components/viz/HypothesisCostDonut.tsx
+++ b/src/features/pricingAnalysis/components/viz/HypothesisCostDonut.tsx
@@ -12,6 +12,8 @@
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import { fmt } from '../../domain/formatters';
 import type { LandBuildingSummaryDto, CondominiumSummaryDto } from '../../types/hypothesis';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 const COLORS = {
   main: '#f97316', // orange-500
@@ -39,7 +41,8 @@ function scrollToTarget(targetId?: string) {
 }
 
 export function HypothesisCostDonut(props: Props) {
-  const slices = buildSlices(props);
+  const { t } = useTranslation('pricingAnalysis');
+  const slices = buildSlices(props, t);
   if (!slices) return null;
 
   const total = slices.reduce((sum, s) => sum + s.value, 0);
@@ -47,7 +50,7 @@ export function HypothesisCostDonut(props: Props) {
 
   return (
     <div className="rounded-lg border border-gray-200 p-3 h-full flex flex-col">
-      <div className="text-[11px] font-medium text-gray-500 mb-1">Cost Composition</div>
+      <div className="text-[11px] font-medium text-gray-500 mb-1">{t('viz.costDonut.title')}</div>
       <div className="flex-1 min-h-0 flex flex-col items-center gap-3 min-w-0 overflow-x-auto">
         <div className="w-[140px] h-[140px] shrink-0">
           <ResponsiveContainer width="100%" height="100%">
@@ -111,31 +114,34 @@ export function HypothesisCostDonut(props: Props) {
   );
 }
 
-function buildSlices(props: Props): Slice[] | null {
+function buildSlices(
+  props: Props,
+  t: TFunction<'pricingAnalysis'>,
+): Slice[] | null {
   if (props.variant === 'LandBuilding') {
     const s = props.summary;
     if (!s) return null;
     return [
       {
-        label: 'Project Dev Cost',
+        label: t('viz.costDonut.lb.projectDevCost'),
         value: s.totalProjectDevCost ?? 0,
         color: COLORS.main,
         targetId: 'hyp-section-dev',
       },
       {
-        label: 'Project Cost',
+        label: t('viz.costDonut.lb.projectCost'),
         value: s.totalProjectCost ?? 0,
         color: COLORS.project,
         targetId: 'hyp-section-project',
       },
       {
-        label: 'Gov Tax',
+        label: t('viz.costDonut.lb.govTax'),
         value: s.totalGovTax ?? 0,
         color: COLORS.tax,
         targetId: 'hyp-section-tax',
       },
       {
-        label: 'Risk Premium',
+        label: t('viz.costDonut.lb.riskPremium'),
         value: s.riskPremiumAmount ?? 0,
         color: COLORS.risk,
         targetId: 'hyp-section-risk',
@@ -146,20 +152,20 @@ function buildSlices(props: Props): Slice[] | null {
   if (!s) return null;
   return [
     {
-      label: 'Hard Cost',
+      label: t('viz.costDonut.condo.hardCost'),
       value: s.totalHardCost ?? 0,
       color: COLORS.main,
       targetId: 'hyp-section-hard',
     },
     {
-      label: 'Soft Cost',
+      label: t('viz.costDonut.condo.softCost'),
       value: s.totalSoftCost ?? 0,
       color: COLORS.project,
       targetId: 'hyp-section-soft',
     },
-    { label: 'Gov Tax', value: s.totalGovTax ?? 0, color: COLORS.tax, targetId: 'hyp-section-tax' },
+    { label: t('viz.costDonut.condo.govTax'), value: s.totalGovTax ?? 0, color: COLORS.tax, targetId: 'hyp-section-tax' },
     {
-      label: 'Risk & Profit',
+      label: t('viz.costDonut.condo.riskProfit'),
       value: s.riskProfitTotal ?? 0,
       color: COLORS.risk,
       targetId: 'hyp-section-risk',

--- a/src/features/pricingAnalysis/components/viz/HypothesisResidualWaterfall.tsx
+++ b/src/features/pricingAnalysis/components/viz/HypothesisResidualWaterfall.tsx
@@ -9,13 +9,16 @@
  */
 import { WaterfallChart, type WaterfallStep } from './WaterfallChart';
 import type { LandBuildingSummaryDto, CondominiumSummaryDto } from '../../types/hypothesis';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 
 type Props =
   | { variant: 'LandBuilding'; summary?: LandBuildingSummaryDto | null }
   | { variant: 'Condominium'; summary?: CondominiumSummaryDto | null };
 
 export function HypothesisResidualWaterfall(props: Props) {
-  const steps = buildSteps(props);
+  const { t } = useTranslation('pricingAnalysis');
+  const steps = buildSteps(props, t);
   if (!steps) return null;
 
   return (
@@ -23,14 +26,17 @@ export function HypothesisResidualWaterfall(props: Props) {
       steps={steps}
       title={
         props.variant === 'LandBuilding'
-          ? 'Residual Value Breakdown'
-          : 'Residual Value Breakdown (GDV → Final)'
+          ? t('viz.residualWaterfall.lb')
+          : t('viz.residualWaterfall.condo')
       }
     />
   );
 }
 
-function buildSteps(props: Props): WaterfallStep[] | null {
+function buildSteps(
+  props: Props,
+  t: TFunction<'pricingAnalysis'>,
+): WaterfallStep[] | null {
   if (props.variant === 'LandBuilding') {
     const s = props.summary;
     const revenue = s?.totalRevenue ?? 0;
@@ -45,14 +51,14 @@ function buildSteps(props: Props): WaterfallStep[] | null {
     const discountDrag = Math.max(0, current - final);
 
     return [
-      { label: 'Revenue', value: revenue, type: 'start', targetId: 'hyp-section-revenue' },
-      { label: 'Project Dev', value: devCost, type: 'subtract', targetId: 'hyp-section-dev' },
-      { label: 'Project Cost', value: projCost, type: 'subtract', targetId: 'hyp-section-project' },
-      { label: 'Gov Tax', value: govTax, type: 'subtract', targetId: 'hyp-section-tax' },
-      { label: 'Risk', value: risk, type: 'subtract', targetId: 'hyp-section-risk' },
-      { label: 'Current Value', value: current, type: 'total', targetId: 'hyp-section-final' },
-      { label: 'Discount', value: discountDrag, type: 'subtract', targetId: 'hyp-section-final' },
-      { label: 'Final Value', value: final, type: 'total', targetId: 'hyp-section-final' },
+      { label: t('viz.residualWaterfall.revenue'), value: revenue, type: 'start', targetId: 'hyp-section-revenue' },
+      { label: t('viz.residualWaterfall.projectDev'), value: devCost, type: 'subtract', targetId: 'hyp-section-dev' },
+      { label: t('viz.residualWaterfall.projectCost'), value: projCost, type: 'subtract', targetId: 'hyp-section-project' },
+      { label: t('viz.residualWaterfall.govTax'), value: govTax, type: 'subtract', targetId: 'hyp-section-tax' },
+      { label: t('viz.residualWaterfall.risk'), value: risk, type: 'subtract', targetId: 'hyp-section-risk' },
+      { label: t('viz.residualWaterfall.currentValue'), value: current, type: 'total', targetId: 'hyp-section-final' },
+      { label: t('viz.residualWaterfall.discount'), value: discountDrag, type: 'subtract', targetId: 'hyp-section-final' },
+      { label: t('viz.residualWaterfall.finalValue'), value: final, type: 'total', targetId: 'hyp-section-final' },
     ];
   }
 
@@ -69,15 +75,15 @@ function buildSteps(props: Props): WaterfallStep[] | null {
   const discountDrag = Math.max(0, remaining - finalRemaining);
 
   return [
-    { label: 'Revenue (GDV)', value: revenue, type: 'start', targetId: 'hyp-section-revenue' },
-    { label: 'Hard Cost', value: hard, type: 'subtract', targetId: 'hyp-section-hard' },
-    { label: 'Soft Cost', value: soft, type: 'subtract', targetId: 'hyp-section-soft' },
-    { label: 'Gov Tax', value: govTax, type: 'subtract', targetId: 'hyp-section-tax' },
-    { label: 'Risk & Profit', value: risk, type: 'subtract', targetId: 'hyp-section-risk' },
-    { label: 'Remaining', value: remaining, type: 'total', targetId: 'hyp-section-total-dev' },
-    { label: 'Discount', value: discountDrag, type: 'subtract', targetId: 'hyp-section-final' },
+    { label: t('viz.residualWaterfall.revenuGdv'), value: revenue, type: 'start', targetId: 'hyp-section-revenue' },
+    { label: t('viz.residualWaterfall.hardCost'), value: hard, type: 'subtract', targetId: 'hyp-section-hard' },
+    { label: t('viz.residualWaterfall.softCost'), value: soft, type: 'subtract', targetId: 'hyp-section-soft' },
+    { label: t('viz.residualWaterfall.govTax'), value: govTax, type: 'subtract', targetId: 'hyp-section-tax' },
+    { label: t('viz.residualWaterfall.riskProfit'), value: risk, type: 'subtract', targetId: 'hyp-section-risk' },
+    { label: t('viz.residualWaterfall.remaining'), value: remaining, type: 'total', targetId: 'hyp-section-total-dev' },
+    { label: t('viz.residualWaterfall.discount'), value: discountDrag, type: 'subtract', targetId: 'hyp-section-final' },
     {
-      label: 'Final Remaining',
+      label: t('viz.residualWaterfall.finalRemaining'),
       value: finalRemaining,
       type: 'total',
       targetId: 'hyp-section-final',

--- a/src/features/pricingAnalysis/components/viz/WaterfallChart.tsx
+++ b/src/features/pricingAnalysis/components/viz/WaterfallChart.tsx
@@ -1,4 +1,5 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import i18n from '@/i18n';
 
 export type WaterfallStepType = 'start' | 'add' | 'subtract' | 'total';
 
@@ -89,6 +90,7 @@ function buildWaterfallData(steps: WaterfallStep[]): WaterfallDatum[] {
 function WaterfallTooltip({ active, payload, label }: any) {
   if (!active || !payload?.length) return null;
   const row: WaterfallDatum = payload[0]?.payload ?? {};
+  const t = i18n.getFixedT(null, 'pricingAnalysis');
   return (
     <div style={tooltipStyle} className="bg-white px-3 py-2 shadow-md">
       <div className="text-gray-500 mb-1">{label}</div>
@@ -97,7 +99,7 @@ function WaterfallTooltip({ active, payload, label }: any) {
         {fmtTooltip(row.originalValue)}
       </div>
       <div className="border-t border-gray-100 mt-1 pt-1 text-gray-600">
-        Running Total: {fmtTooltip(row.runningTotal)}
+        {t('viz.waterfall.runningTotal')} {fmtTooltip(row.runningTotal)}
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/schemas/directComparisonForm.ts
+++ b/src/features/pricingAnalysis/schemas/directComparisonForm.ts
@@ -1,69 +1,106 @@
 import { z } from 'zod';
-const requireMsg = (fieldName: string, msg: string = 'is required.') => ({
-  required_error: `${fieldName} ${msg}`,
-  invalid_type_error: `${fieldName} ${msg}`,
-});
+import type { TFunction } from 'i18next';
 
-const ComparativeFactors = z
-  .object({
-    factorCode: z.string(requireMsg('Factor code')),
-  })
-  .passthrough();
+// Static type-inference export (uses key-passthrough function — never an object)
+const _t = ((key: string) => key) as unknown as TFunction<'pricingAnalysis'>;
 
-const DirectComparisonQualitativeSurvey = z
-  .object({
-    qualitativeLevel: z.string(requireMsg('Qualitative level')),
-  })
-  .passthrough();
+const ComparativeFactors = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      factorCode: z.string({
+        required_error: t('validation.factorCodeRequired'),
+        invalid_type_error: t('validation.factorCodeRequired'),
+      }),
+    })
+    .passthrough();
 
-const DirectComparisonQualitative = z.object({
-  factorCode: z.string(requireMsg('Factor code')),
-  qualitatives: z.array(DirectComparisonQualitativeSurvey),
-});
+const DirectComparisonQualitativeSurvey = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      qualitativeLevel: z.string({
+        required_error: t('validation.qualitativeLevelRequired'),
+        invalid_type_error: t('validation.qualitativeLevelRequired'),
+      }),
+    })
+    .passthrough();
 
-const DirectComparisonFinalValue = z
-  .object({
-    finalValueRounded: z.number(requireMsg('Final value (rounded)')),
-  })
-  .passthrough();
+const DirectComparisonQualitative = (t: TFunction<'pricingAnalysis'>) =>
+  z.object({
+    factorCode: z.string({
+      required_error: t('validation.factorCodeRequired'),
+      invalid_type_error: t('validation.factorCodeRequired'),
+    }),
+    qualitatives: z.array(DirectComparisonQualitativeSurvey(t)),
+  });
 
-const DirectComparisonAdjustmentPct = z
-  .object({
-    adjustPercent: z.number(requireMsg('Adjusted score pct')),
-  })
-  .passthrough();
+const DirectComparisonFinalValue = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      finalValueRounded: z.number({
+        required_error: t('validation.finalValueRoundedRequired'),
+        invalid_type_error: t('validation.finalValueRoundedRequired'),
+      }),
+    })
+    .passthrough();
 
-const DirectComparisonAdjustmentFactor = z
-  .object({
-    surveys: z.array(DirectComparisonAdjustmentPct),
-  })
-  .passthrough();
+const DirectComparisonAdjustmentPct = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      adjustPercent: z.number({
+        required_error: t('validation.adjustPercentRequired'),
+        invalid_type_error: t('validation.adjustPercentRequired'),
+      }),
+    })
+    .passthrough();
 
-const DirectComparisonAppraisalPrice = z
-  .object({
-    appraisalPriceRounded: z.number(requireMsg('Appraisal price (rounded)')),
-  })
-  .passthrough();
+const DirectComparisonAdjustmentFactor = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      surveys: z.array(DirectComparisonAdjustmentPct(t)),
+    })
+    .passthrough();
 
-export const DirectComparisonDto = z
-  .object({
-    collateralType: z.string(requireMsg('Collateral type')),
-    pricingTemplateCode: z.string(requireMsg('Template')),
-    comparativeFactors: z.array(ComparativeFactors),
-    /** Qualitative section */
-    directComparisonQualitatives: z.array(DirectComparisonQualitative),
-    /** Adjustment Factors (adjust percentage) section */
-    directComparisonAdjustmentFactors: z.array(DirectComparisonAdjustmentFactor),
-    /** Final value section */
-    directComparisonFinalValue: DirectComparisonFinalValue,
-    /** Apprisal price section */
-    directComparisonAppraisalPrice: DirectComparisonAppraisalPrice,
-  })
-  .passthrough();
+const DirectComparisonAppraisalPrice = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      appraisalPriceRounded: z.number({
+        required_error: t('validation.appraisalPriceRoundedRequired'),
+        invalid_type_error: t('validation.appraisalPriceRoundedRequired'),
+      }),
+    })
+    .passthrough();
+
+export const makeDirectComparisonDto = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      collateralType: z.string({
+        required_error: t('validation.collateralTypeRequired'),
+        invalid_type_error: t('validation.collateralTypeRequired'),
+      }),
+      pricingTemplateCode: z.string({
+        required_error: t('validation.templateRequired'),
+        invalid_type_error: t('validation.templateRequired'),
+      }),
+      comparativeFactors: z.array(ComparativeFactors(t)),
+      /** Qualitative section */
+      directComparisonQualitatives: z.array(DirectComparisonQualitative(t)),
+      /** Adjustment Factors (adjust percentage) section */
+      directComparisonAdjustmentFactors: z.array(DirectComparisonAdjustmentFactor(t)),
+      /** Final value section */
+      directComparisonFinalValue: DirectComparisonFinalValue(t),
+      /** Apprisal price section */
+      directComparisonAppraisalPrice: DirectComparisonAppraisalPrice(t),
+    })
+    .passthrough();
+
+// Static schema for type inference only — no runtime messages
+export const DirectComparisonDto = makeDirectComparisonDto(_t);
 
 export type DirectComparisonQualitativeSurveyFormType = z.infer<
-  typeof DirectComparisonQualitativeSurvey
+  ReturnType<typeof DirectComparisonQualitativeSurvey>
 >;
-export type ComparativeFactorsFormType = z.infer<typeof ComparativeFactors>;
-export type DirectComparisonQualitativeFormType = z.infer<typeof DirectComparisonQualitative>;
+export type ComparativeFactorsFormType = z.infer<ReturnType<typeof ComparativeFactors>>;
+export type DirectComparisonQualitativeFormType = z.infer<
+  ReturnType<typeof DirectComparisonQualitative>
+>;
 export type DirectComparisonType = z.infer<typeof DirectComparisonDto>;

--- a/src/features/pricingAnalysis/schemas/hypothesisForm.ts
+++ b/src/features/pricingAnalysis/schemas/hypothesisForm.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import type { TFunction } from 'i18next';
+
+// Static type-inference stand-in (key-passthrough — never an object)
+const _t = ((key: string) => key) as unknown as TFunction<'pricingAnalysis'>;
 
 // ─── Cost item row schema (shared by both variants) ───────────────────────────
 
@@ -40,29 +44,36 @@ export type HypothesisCostItemKindValue = z.infer<typeof HypothesisCostItemKindE
 
 // ─── Depreciation period sub-row ─────────────────────────────────────────────
 
-export const HypothesisDepreciationPeriodSchema = z
-  .object({
-    atYear: z.number().int().min(0),
-    toYear: z.number().int().min(0),
-    depreciationPerYear: z.number().min(0).max(100),
-  })
-  .refine(p => p.toYear >= p.atYear, { message: 'toYear must be >= atYear', path: ['toYear'] });
+export const makeHypothesisDepreciationPeriodSchema = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      atYear: z.number().int().min(0),
+      toYear: z.number().int().min(0),
+      depreciationPerYear: z.number().min(0).max(100),
+    })
+    .refine(p => p.toYear >= p.atYear, {
+      message: t('validation.toYearInvalid'),
+      path: ['toYear'],
+    });
+
+export const HypothesisDepreciationPeriodSchema = makeHypothesisDepreciationPeriodSchema(_t);
 
 export type HypothesisDepreciationPeriodFormRow = z.infer<
   typeof HypothesisDepreciationPeriodSchema
 >;
 
-export const HypothesisCostItemSchema = z.object({
-  /** Undefined for newly added rows (server assigns id on save) */
-  id: z.string().uuid().optional().nullable(),
-  category: HypothesisCostCategoryEnum,
-  /**
-   * Stable semantic key. Seeded rows get their kind from the server; ad-hoc rows must set 'Other' explicitly.
-   * Server ignores kind on UPDATE (uses id match). Kind is required on INSERT.
-   * Note: no `.default('Other')` here — Zod's input/output divergence with defaults breaks Resolver alignment with useForm. Factories set 'Other' explicitly.
-   */
-  kind: HypothesisCostItemKindEnum,
-  description: z.string().min(1, 'Description is required'),
+export const makeHypothesisCostItemSchema = (t: TFunction<'pricingAnalysis'>) =>
+  z.object({
+    /** Undefined for newly added rows (server assigns id on save) */
+    id: z.string().uuid().optional().nullable(),
+    category: HypothesisCostCategoryEnum,
+    /**
+     * Stable semantic key. Seeded rows get their kind from the server; ad-hoc rows must set 'Other' explicitly.
+     * Server ignores kind on UPDATE (uses id match). Kind is required on INSERT.
+     * Note: no `.default('Other')` here — Zod's input/output divergence with defaults breaks Resolver alignment with useForm. Factories set 'Other' explicitly.
+     */
+    kind: HypothesisCostItemKindEnum,
+    description: z.string().min(1, t('validation.descriptionRequired')),
   displaySequence: z.number().int().nonnegative(),
   amount: z.number().nonnegative(),
   rateAmount: z.number().optional().nullable(),
@@ -89,6 +100,9 @@ export const HypothesisCostItemSchema = z.object({
   /** Period sub-rows. Empty array unless method is Period. */
   depreciationPeriods: z.array(HypothesisDepreciationPeriodSchema),
 });
+
+// Static schema for type inference only
+export const HypothesisCostItemSchema = makeHypothesisCostItemSchema(_t);
 
 export type HypothesisCostItemFormRow = z.infer<typeof HypothesisCostItemSchema>;
 

--- a/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
@@ -1,76 +1,119 @@
 import { z } from 'zod';
-const requireMsg = (fieldName: string, msg: string = 'is required.') => ({
-  required_error: `${fieldName} ${msg}`,
-  invalid_type_error: `${fieldName} ${msg}`,
-});
+import type { TFunction } from 'i18next';
 
-const ComparativeFactors = z
-  .object({
-    factorCode: z.string(requireMsg('Factor code')),
-  })
-  .passthrough();
+// Static type-inference export (uses key-passthrough function — never an object)
+const _t = ((key: string) => key) as unknown as TFunction<'pricingAnalysis'>;
 
-const SaleAdjustmentGridQualitativeSurvey = z
-  .object({
-    qualitativeLevel: z.string(requireMsg('Qualitative level')),
-  })
-  .passthrough();
+const ComparativeFactors = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      factorCode: z.string({
+        required_error: t('validation.factorCodeRequired'),
+        invalid_type_error: t('validation.factorCodeRequired'),
+      }),
+    })
+    .passthrough();
 
-const SaleAdjustmentGridQualitative = z.object({
-  factorCode: z.string(requireMsg('Factor Code')),
-  qualitatives: z.array(SaleAdjustmentGridQualitativeSurvey),
-});
+const SaleAdjustmentGridQualitativeSurvey = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      qualitativeLevel: z.string({
+        required_error: t('validation.qualitativeLevelRequired'),
+        invalid_type_error: t('validation.qualitativeLevelRequired'),
+      }),
+    })
+    .passthrough();
 
-const SaleAdjustmentGridCalculation = z
-  .object({
-    weight: z.number(requireMsg('Weight')),
-  })
-  .passthrough();
+const SaleAdjustmentGridQualitative = (t: TFunction<'pricingAnalysis'>) =>
+  z.object({
+    factorCode: z.string({
+      required_error: t('validation.factorCodeRequired'),
+      invalid_type_error: t('validation.factorCodeRequired'),
+    }),
+    qualitatives: z.array(SaleAdjustmentGridQualitativeSurvey(t)),
+  });
 
-const SaleAdjustmentGridFinalValue = z
-  .object({
-    finalValueRounded: z.number(requireMsg('Final value (rounded)')),
-  })
-  .passthrough();
+const SaleAdjustmentGridCalculation = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      weight: z.number({
+        required_error: t('validation.weightRequired'),
+        invalid_type_error: t('validation.weightRequired'),
+      }),
+    })
+    .passthrough();
 
-const SaleAdjustmentGridAdjustmentPct = z
-  .object({
-    adjustPercent: z.number(requireMsg('Adjusted score pct')),
-  })
-  .passthrough();
+const SaleAdjustmentGridFinalValue = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      finalValueRounded: z.number({
+        required_error: t('validation.finalValueRoundedRequired'),
+        invalid_type_error: t('validation.finalValueRoundedRequired'),
+      }),
+    })
+    .passthrough();
 
-const SaleAdjustmentGridAdjustmentFactor = z.object({
-  surveys: z.array(SaleAdjustmentGridAdjustmentPct),
-});
+const SaleAdjustmentGridAdjustmentPct = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      adjustPercent: z.number({
+        required_error: t('validation.adjustPercentRequired'),
+        invalid_type_error: t('validation.adjustPercentRequired'),
+      }),
+    })
+    .passthrough();
 
-const SaleAdjustmentGridAppraisalPrice = z
-  .object({
-    appraisalPriceRounded: z.number(requireMsg('Appraisal price (rounded)')),
-  })
-  .passthrough();
+const SaleAdjustmentGridAdjustmentFactor = (t: TFunction<'pricingAnalysis'>) =>
+  z.object({
+    surveys: z.array(SaleAdjustmentGridAdjustmentPct(t)),
+  });
 
-export const SaleAdjustmentGridDto = z
-  .object({
-    collateralType: z.string(requireMsg('Collateral type')),
-    pricingTemplateCode: z.string(requireMsg('Template')),
-    comparativeFactors: z.array(ComparativeFactors),
-    /** Qualitative section */
-    saleAdjustmentGridQualitatives: z.array(SaleAdjustmentGridQualitative),
-    /** Calculation section */
-    saleAdjustmentGridCalculations: z.array(SaleAdjustmentGridCalculation),
-    /** Adjustment Factors (adjust percentage) section */
-    saleAdjustmentGridAdjustmentFactors: z.array(SaleAdjustmentGridAdjustmentFactor),
-    /** Final value section */
-    saleAdjustmentGridFinalValue: SaleAdjustmentGridFinalValue,
-    /** Apprisal price section */
-    saleAdjustmentGridAppraisalPrice: SaleAdjustmentGridAppraisalPrice,
-  })
-  .passthrough();
+const SaleAdjustmentGridAppraisalPrice = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      appraisalPriceRounded: z.number({
+        required_error: t('validation.appraisalPriceRoundedRequired'),
+        invalid_type_error: t('validation.appraisalPriceRoundedRequired'),
+      }),
+    })
+    .passthrough();
 
-export type SaleAdjustmentGridCalculationFormType = z.infer<typeof SaleAdjustmentGridCalculation>;
-export type SaleAdjustmentGridQualitativeSurveyFormType = z.infer<
-  typeof SaleAdjustmentGridQualitativeSurvey
+export const makeSaleAdjustmentGridDto = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      collateralType: z.string({
+        required_error: t('validation.collateralTypeRequired'),
+        invalid_type_error: t('validation.collateralTypeRequired'),
+      }),
+      pricingTemplateCode: z.string({
+        required_error: t('validation.templateRequired'),
+        invalid_type_error: t('validation.templateRequired'),
+      }),
+      comparativeFactors: z.array(ComparativeFactors(t)),
+      /** Qualitative section */
+      saleAdjustmentGridQualitatives: z.array(SaleAdjustmentGridQualitative(t)),
+      /** Calculation section */
+      saleAdjustmentGridCalculations: z.array(SaleAdjustmentGridCalculation(t)),
+      /** Adjustment Factors (adjust percentage) section */
+      saleAdjustmentGridAdjustmentFactors: z.array(SaleAdjustmentGridAdjustmentFactor(t)),
+      /** Final value section */
+      saleAdjustmentGridFinalValue: SaleAdjustmentGridFinalValue(t),
+      /** Apprisal price section */
+      saleAdjustmentGridAppraisalPrice: SaleAdjustmentGridAppraisalPrice(t),
+    })
+    .passthrough();
+
+// Static schema for type inference only — no runtime messages
+export const SaleAdjustmentGridDto = makeSaleAdjustmentGridDto(_t);
+
+export type SaleAdjustmentGridCalculationFormType = z.infer<
+  ReturnType<typeof SaleAdjustmentGridCalculation>
 >;
-export type ComparativeFactorsFormType = z.infer<typeof ComparativeFactors>;
-export type SaleAdjustmentGridQualitativeFormType = z.infer<typeof SaleAdjustmentGridQualitative>;
+export type SaleAdjustmentGridQualitativeSurveyFormType = z.infer<
+  ReturnType<typeof SaleAdjustmentGridQualitativeSurvey>
+>;
+export type ComparativeFactorsFormType = z.infer<ReturnType<typeof ComparativeFactors>>;
+export type SaleAdjustmentGridQualitativeFormType = z.infer<
+  ReturnType<typeof SaleAdjustmentGridQualitative>
+>;
 export type SaleAdjustmentGridType = z.infer<typeof SaleAdjustmentGridDto>;

--- a/src/features/pricingAnalysis/schemas/wqsForm.ts
+++ b/src/features/pricingAnalysis/schemas/wqsForm.ts
@@ -1,16 +1,19 @@
 import { z } from 'zod';
+import type { TFunction } from 'i18next';
 
-const requireMsg = (fieldName: string, msg: string = 'is required.') => ({
-  required_error: `${fieldName} ${msg}`,
-  invalid_type_error: `${fieldName} ${msg}`,
-});
+// Static type-inference export (uses key-passthrough function — never an object)
+const _t = ((key: string) => key) as unknown as TFunction<'pricingAnalysis'>;
 
 /** select surveys section */
-const ComparativeFactor = z
-  .object({
-    factorCode: z.string(requireMsg('Factor code')),
-  })
-  .passthrough();
+const ComparativeFactor = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      factorCode: z.string({
+        required_error: t('validation.factorCodeRequired'),
+        invalid_type_error: t('validation.factorCodeRequired'),
+      }),
+    })
+    .passthrough();
 
 /** WQS scoring section */
 const WQSSurveyScore = z
@@ -19,49 +22,81 @@ const WQSSurveyScore = z
   })
   .passthrough();
 
-const WQSScore = z.object({
-  factorCode: z.string(requireMsg('Factor code')),
-  weight: z.number(requireMsg('Weight')),
-  intensity: z.number(requireMsg('Intensity')),
-  surveys: z.array(WQSSurveyScore).superRefine((items, ctx) => {
-    for (const [i, item] of items.entries()) {
-      if (item.surveyScore == null) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Survey ${i + 1}'s score is required`, // 1-based index
-          path: [i, 'surveyScore'], // target the correct field
-        });
+const WQSScore = (t: TFunction<'pricingAnalysis'>) =>
+  z.object({
+    factorCode: z.string({
+      required_error: t('validation.factorCodeRequired'),
+      invalid_type_error: t('validation.factorCodeRequired'),
+    }),
+    weight: z.number({
+      required_error: t('validation.weightRequired'),
+      invalid_type_error: t('validation.weightRequired'),
+    }),
+    intensity: z.number({
+      required_error: t('validation.intensityRequired'),
+      invalid_type_error: t('validation.intensityRequired'),
+    }),
+    surveys: z.array(WQSSurveyScore).superRefine((items, ctx) => {
+      for (const [i, item] of items.entries()) {
+        if (item.surveyScore == null) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: t('validation.surveyScoreRequired', { n: i + 1 }),
+            path: [i, 'surveyScore'],
+          });
+        }
       }
-    }
-  }),
-  collateral: z.number(requireMsg('Collateral score')),
-});
+    }),
+    collateral: z.number({
+      required_error: t('validation.collateralScoreRequired'),
+      invalid_type_error: t('validation.collateralScoreRequired'),
+    }),
+  });
 
 /** Adjust final price section */
-const WQSFinalValue = z
-  .object({
-    finalValueRounded: z.number(requireMsg('Final value (rounded)')),
-    landValue: z.number(requireMsg('Land value')).optional(),
-    buildingCost: z.number(requireMsg('Building cost')).optional(),
-    appraisalPrice: z.number(requireMsg('Appraisal price')).optional(),
-  })
-  .passthrough();
+const WQSFinalValue = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      finalValueRounded: z.number({
+        required_error: t('validation.finalValueRoundedRequired'),
+        invalid_type_error: t('validation.finalValueRoundedRequired'),
+      }),
+      landValue: z
+        .number({
+          required_error: t('validation.landValueRequired'),
+          invalid_type_error: t('validation.landValueRequired'),
+        })
+        .optional(),
+      buildingCost: z.number().optional(),
+      appraisalPrice: z.number().optional(),
+    })
+    .passthrough();
 
-export const WQSDto = z
-  .object({
-    collateralType: z.string(requireMsg('Collateral type')),
-    pricingTemplateCode: z.string(requireMsg('Template')),
-    comparativeFactors: z.array(ComparativeFactor),
-    WQSScores: z.array(WQSScore),
-    WQSFinalValue: WQSFinalValue,
+export const makeWQSDto = (t: TFunction<'pricingAnalysis'>) =>
+  z
+    .object({
+      collateralType: z.string({
+        required_error: t('validation.collateralTypeRequired'),
+        invalid_type_error: t('validation.collateralTypeRequired'),
+      }),
+      pricingTemplateCode: z.string({
+        required_error: t('validation.templateRequired'),
+        invalid_type_error: t('validation.templateRequired'),
+      }),
+      comparativeFactors: z.array(ComparativeFactor(t)),
+      WQSScores: z.array(WQSScore(t)),
+      WQSFinalValue: WQSFinalValue(t),
 
-    generateAt: z.string(),
-  })
-  .passthrough();
+      generateAt: z.string(),
+    })
+    .passthrough();
+
+// Static schema for type inference only — no runtime messages
+export const WQSDto = makeWQSDto(_t);
 
 export type WQSSurveyScoreFormType = z.infer<typeof WQSSurveyScore>;
-export type WQSScoreFormType = z.infer<typeof WQSScore>;
-export type WQSFinalValueFormType = z.infer<typeof WQSFinalValue>;
+export type WQSScoreFormType = z.infer<ReturnType<typeof WQSScore>>;
+export type WQSFinalValueFormType = z.infer<ReturnType<typeof WQSFinalValue>>;
 
-export type ComparativeFactorFormType = z.infer<typeof ComparativeFactor>;
+export type ComparativeFactorFormType = z.infer<ReturnType<typeof ComparativeFactor>>;
 export type WQSFormType = z.infer<typeof WQSDto>;

--- a/src/features/pricingAnalysis/utils/leaseProperty.ts
+++ b/src/features/pricingAnalysis/utils/leaseProperty.ts
@@ -1,0 +1,39 @@
+/**
+ * Lease-agreement property type codes. Mirrors the backend
+ * `PropertyType.IsLeaseAgreement` (LSL / LSB / LS / LSU).
+ */
+export const LEASE_PROPERTY_TYPES = ['LS', 'LSL', 'LSB', 'LSU'] as const;
+
+export function isLeasePropertyType(propertyType: unknown): boolean {
+  return (
+    typeof propertyType === 'string' &&
+    (LEASE_PROPERTY_TYPES as readonly string[]).includes(propertyType)
+  );
+}
+
+/**
+ * Finds the lease-agreement property within a group. Returns `undefined` when the
+ * group has no lease-agreement property.
+ */
+export function findLeaseProperty<T extends { propertyType?: unknown }>(
+  properties: readonly T[] | undefined | null,
+): T | undefined {
+  return (properties ?? []).find(p => isLeasePropertyType(p.propertyType));
+}
+
+/**
+ * Finds the property that carries the rental schedule / lease-agreement detail
+ * for Leasehold / Profit-Rent. That is either a lease-agreement property
+ * (LS/LSL/LSB/LSU) or a plain land (L/LB) flagged "rented out to others"
+ * (`isRentedOut === true`). A mixed group only needs *at least one* such
+ * property — we pick it explicitly instead of assuming the first element.
+ *
+ * Returns `undefined` when no rental-bearing property exists.
+ */
+export function findRentalSourceProperty<
+  T extends { propertyType?: unknown; isRentedOut?: unknown },
+>(properties: readonly T[] | undefined | null): T | undefined {
+  return (properties ?? []).find(
+    p => isLeasePropertyType(p.propertyType) || p.isRentedOut === true,
+  );
+}

--- a/src/i18n/locales/en/pricingAnalysis.json
+++ b/src/i18n/locales/en/pricingAnalysis.json
@@ -82,7 +82,8 @@
     "uploadMaxSize": "File must be ≤ 5 MB",
     "uploadFailed": "Upload failed",
     "uploadDeleted": "Upload deleted",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "uploadSuccess": "Uploaded {{n}} rows"
   },
   "footer": {
     "cancel": "Cancel",
@@ -213,7 +214,61 @@
     "viewSummary": "View Assumption Summary"
   },
   "profitRent": {
-    "title": "Profit Rent Analysis"
+    "title": "Profit Rent Analysis",
+    "loadError": "Failed to load profit rent analysis",
+    "headerTitle": "Profit Rent",
+    "appraisalDate": "Appraisal Date",
+    "leaseStart": "Lease Start",
+    "leaseEnd": "Lease End",
+    "viewRentalInfo": "Rental Information",
+    "viewRentalInfoShort": "View",
+    "landArea": "Land Area",
+    "marketRentalFee": "Market Rental Fee",
+    "monthlyTotal": "Monthly Total",
+    "discountedRate": "Discounted Rate",
+    "marketRentalFeeIncrease": "Market Rental Fee Increase",
+    "rate": "Rate",
+    "every": "Every",
+    "interval": "Interval",
+    "fromYear": "From Year",
+    "toYear": "To Year",
+    "growthRatePercent": "Growth Rate (%)",
+    "addPeriods": "Add Periods",
+    "includeBuildingCost": "Include building cost",
+    "buildingCostSummary": "Building Cost Summary",
+    "afterDepre": "After Depre.",
+    "propertyCol": "Property",
+    "areaCol": "Area",
+    "beforeDepre": "Before Depre.",
+    "estimatePriceFromPv": "Estimate Price (from PV)",
+    "buildingCostAfterDepre": "Building Cost (after depre.)",
+    "appraisalPriceWithBuilding": "Appraisal Price w/ Building",
+    "appraisalPrice": "Appraisal Price",
+    "total": "Total",
+    "unitBahtPerSqWaPerMonth": "Baht/Sq.Wa/Mo",
+    "unitBahtPerMonth": "Baht/Mo",
+    "unitSqWa": "Sq. Wa",
+    "unitYear": "Year",
+    "resetConfirmMessage": "Are you sure you want to reset this method? All calculation data will be cleared.",
+    "tableHeaders": {
+      "year": "Year",
+      "periodStart": "Period Start Date",
+      "periodEnd": "Period End Date",
+      "numberOfMonth": "Number of Month",
+      "marketRentalFeePerSqWaMonth": "Market Rental Fee (Baht/Sq.Wa/Month)",
+      "marketRentalFeePerMonth": "Market Rental Fee (Baht/month)",
+      "marketRentalFeePerYear": "Market Rental Fee (Baht/year)",
+      "contractRentalFeePerYear": "Contract Rental Fee (Baht/year)",
+      "returnsFromLease": "Returns from Lease (Baht)",
+      "discountedRate": "Discounted Rate",
+      "presentValue": "Present Value (Baht)"
+    },
+    "kpi": {
+      "totalMarketRental": "Total Market Rental",
+      "totalContractRental": "Total Contract Rental",
+      "totalReturns": "Total Returns",
+      "presentValue": "Present Value"
+    }
   },
   "comparativeAnalysis": {
     "title": "Comparative Analysis",
@@ -290,7 +345,18 @@
     "landValueRequired": "Land value is required",
     "discountRateRequired": "Discount rate is required",
     "landGrowthRateRequired": "Land growth rate is required",
-    "depreciationRateRequired": "Depreciation rate is required"
+    "depreciationRateRequired": "Depreciation rate is required",
+    "factorCodeRequired": "Factor code is required",
+    "weightRequired": "Weight is required",
+    "intensityRequired": "Intensity is required",
+    "collateralScoreRequired": "Collateral score is required",
+    "surveyScoreRequired": "Survey {{n}}'s score is required",
+    "finalValueRoundedRequired": "Final value (rounded) is required",
+    "qualitativeLevelRequired": "Qualitative level is required",
+    "appraisalPriceRoundedRequired": "Appraisal price (rounded) is required",
+    "adjustPercentRequired": "Adjusted score pct is required",
+    "descriptionRequired": "Description is required",
+    "toYearInvalid": "toYear must be >= atYear"
   },
   "empty": {
     "noData": "No data available",
@@ -335,6 +401,14 @@
       "active": "Active"
     }
   },
+  "incomeLandRef": {
+    "copyFromCost": "Copy from Cost",
+    "pickerTitle": "Select Cost method to copy",
+    "pickerHint": "The selected method's comparables and scores will be cloned into a new editable reference.",
+    "noCostMethods": "No Cost-approach WQS/SAG/DC methods found. Add one via Approaches & Methods first.",
+    "copyFailed": "Failed to copy Cost method",
+    "openRef": "Open reference"
+  },
   "groupReferences": {
     "sectionTitle": "References",
     "openReference": "Open",
@@ -351,5 +425,73 @@
       "roomIncomeRef": "Room income",
       "profitRentRef": "Rental fee"
     }
+  },
+  "viz": {
+    "sensitivity": {
+      "title": "Discount Rate Sensitivity"
+    },
+    "profitRentChart": {
+      "title": "Market vs Contract Rental & Present Value",
+      "marketRental": "Market Rental (Year)",
+      "contractRental": "Contract Rental (Year)",
+      "presentValue": "Present Value",
+      "year": "Year {{n}}"
+    },
+    "waterfall": {
+      "runningTotal": "Running Total:",
+      "defaultTitle": "Value Breakdown"
+    },
+    "residualWaterfall": {
+      "lb": "Residual Value Breakdown",
+      "condo": "Residual Value Breakdown (GDV → Final)",
+      "revenue": "Revenue",
+      "revenuGdv": "Revenue (GDV)",
+      "projectDev": "Project Dev",
+      "projectCost": "Project Cost",
+      "govTax": "Gov Tax",
+      "risk": "Risk",
+      "currentValue": "Current Value",
+      "discount": "Discount",
+      "finalValue": "Final Value",
+      "hardCost": "Hard Cost",
+      "softCost": "Soft Cost",
+      "riskProfit": "Risk & Profit",
+      "remaining": "Remaining",
+      "finalRemaining": "Final Remaining"
+    },
+    "costDonut": {
+      "title": "Cost Composition",
+      "lb": {
+        "projectDevCost": "Project Dev Cost",
+        "projectCost": "Project Cost",
+        "govTax": "Gov Tax",
+        "riskPremium": "Risk Premium"
+      },
+      "condo": {
+        "hardCost": "Hard Cost",
+        "softCost": "Soft Cost",
+        "govTax": "Gov Tax",
+        "riskProfit": "Risk & Profit"
+      }
+    }
+  },
+  "upload": {
+    "uploading": "Uploading…",
+    "dropOrBrowse": "Drop an Excel file here or",
+    "browseLink": "browse",
+    "uploadHistory": "Upload History",
+    "fileCol": "File",
+    "uploadedCol": "Uploaded",
+    "rowsCol": "Rows",
+    "statusCol": "Status",
+    "statusPresent": "Present",
+    "statusHistoric": "Historic",
+    "unitListing": "Unit Listing ({{n}} units)",
+    "modelAnalysis": "Model Analysis",
+    "parseErrors": "Excel Parse Errors — fix these rows and re-upload",
+    "parseErrorRow": "Row",
+    "parseErrorField": "Field",
+    "parseErrorValue": "Value",
+    "parseErrorReason": "Reason"
   }
 }

--- a/src/i18n/locales/th/pricingAnalysis.json
+++ b/src/i18n/locales/th/pricingAnalysis.json
@@ -82,7 +82,8 @@
     "uploadMaxSize": "ไฟล์ต้องมีขนาดไม่เกิน 5 MB",
     "uploadFailed": "อัปโหลดไม่สำเร็จ",
     "uploadDeleted": "ลบการอัปโหลดแล้ว",
-    "deleteFailed": "ลบไม่สำเร็จ"
+    "deleteFailed": "ลบไม่สำเร็จ",
+    "uploadSuccess": "อัปโหลด {{n}} แถวสำเร็จ"
   },
   "footer": {
     "cancel": "ยกเลิก",
@@ -213,7 +214,61 @@
     "viewSummary": "ดูสรุปสมมติฐาน"
   },
   "profitRent": {
-    "title": "การวิเคราะห์กำไรจากค่าเช่า"
+    "title": "การวิเคราะห์กำไรจากค่าเช่า",
+    "loadError": "โหลดการวิเคราะห์กำไรจากค่าเช่าไม่สำเร็จ",
+    "headerTitle": "กำไรจากค่าเช่า",
+    "appraisalDate": "วันที่ประเมิน",
+    "leaseStart": "วันเริ่มต้นเช่า",
+    "leaseEnd": "วันสิ้นสุดเช่า",
+    "viewRentalInfo": "ข้อมูลการเช่า",
+    "viewRentalInfoShort": "ดู",
+    "landArea": "พื้นที่ที่ดิน",
+    "marketRentalFee": "ค่าเช่าตลาด",
+    "monthlyTotal": "รวมรายเดือน",
+    "discountedRate": "อัตราส่วนลด",
+    "marketRentalFeeIncrease": "การเพิ่มขึ้นของค่าเช่าตลาด",
+    "rate": "อัตรา",
+    "every": "ทุก",
+    "interval": "ช่วงเวลา",
+    "fromYear": "จากปี",
+    "toYear": "ถึงปี",
+    "growthRatePercent": "อัตราการเติบโต (%)",
+    "addPeriods": "เพิ่มช่วงเวลา",
+    "includeBuildingCost": "รวมต้นทุนอาคาร",
+    "buildingCostSummary": "สรุปต้นทุนอาคาร",
+    "afterDepre": "หลังค่าเสื่อมราคา",
+    "propertyCol": "ทรัพย์สิน",
+    "areaCol": "พื้นที่",
+    "beforeDepre": "ก่อนค่าเสื่อมราคา",
+    "estimatePriceFromPv": "ราคาประมาณ (จาก PV)",
+    "buildingCostAfterDepre": "ต้นทุนอาคาร (หลังค่าเสื่อม)",
+    "appraisalPriceWithBuilding": "ราคาประเมินรวมอาคาร",
+    "appraisalPrice": "ราคาประเมิน",
+    "total": "รวม",
+    "unitBahtPerSqWaPerMonth": "บาท/ตร.วา/เดือน",
+    "unitBahtPerMonth": "บาท/เดือน",
+    "unitSqWa": "ตร.วา",
+    "unitYear": "ปี",
+    "resetConfirmMessage": "คุณแน่ใจหรือไม่ที่จะรีเซ็ตวิธีนี้? ข้อมูลการคำนวณทั้งหมดจะถูกล้าง",
+    "tableHeaders": {
+      "year": "ปี",
+      "periodStart": "วันเริ่มต้นรอบ",
+      "periodEnd": "วันสิ้นสุดรอบ",
+      "numberOfMonth": "จำนวนเดือน",
+      "marketRentalFeePerSqWaMonth": "ค่าเช่าตลาด (บาท/ตร.วา/เดือน)",
+      "marketRentalFeePerMonth": "ค่าเช่าตลาด (บาท/เดือน)",
+      "marketRentalFeePerYear": "ค่าเช่าตลาด (บาท/ปี)",
+      "contractRentalFeePerYear": "ค่าเช่าตามสัญญา (บาท/ปี)",
+      "returnsFromLease": "ผลตอบแทนจากการเช่า (บาท)",
+      "discountedRate": "อัตราส่วนลด",
+      "presentValue": "มูลค่าปัจจุบัน (บาท)"
+    },
+    "kpi": {
+      "totalMarketRental": "ค่าเช่าตลาดรวม",
+      "totalContractRental": "ค่าเช่าสัญญารวม",
+      "totalReturns": "ผลตอบแทนรวม",
+      "presentValue": "มูลค่าปัจจุบัน"
+    }
   },
   "comparativeAnalysis": {
     "title": "การวิเคราะห์เปรียบเทียบ",
@@ -290,7 +345,18 @@
     "landValueRequired": "กรุณาระบุมูลค่าที่ดิน",
     "discountRateRequired": "กรุณาระบุอัตราส่วนลด",
     "landGrowthRateRequired": "กรุณาระบุอัตราการเติบโตของที่ดิน",
-    "depreciationRateRequired": "กรุณาระบุอัตราค่าเสื่อมราคา"
+    "depreciationRateRequired": "กรุณาระบุอัตราค่าเสื่อมราคา",
+    "factorCodeRequired": "กรุณาระบุรหัสปัจจัย",
+    "weightRequired": "กรุณาระบุน้ำหนัก",
+    "intensityRequired": "กรุณาระบุความเข้ม",
+    "collateralScoreRequired": "กรุณาระบุคะแนนหลักประกัน",
+    "surveyScoreRequired": "กรุณาระบุคะแนนของการสำรวจที่ {{n}}",
+    "finalValueRoundedRequired": "กรุณาระบุมูลค่าสุทธิ (ปัดเศษ)",
+    "qualitativeLevelRequired": "กรุณาระบุระดับคุณภาพ",
+    "appraisalPriceRoundedRequired": "กรุณาระบุราคาประเมิน (ปัดเศษ)",
+    "adjustPercentRequired": "กรุณาระบุเปอร์เซ็นต์ปรับ",
+    "descriptionRequired": "กรุณาระบุรายละเอียด",
+    "toYearInvalid": "ปีสิ้นสุดต้องมากกว่าหรือเท่ากับปีเริ่มต้น"
   },
   "empty": {
     "noData": "ไม่มีข้อมูล",
@@ -335,6 +401,14 @@
       "active": "ใช้งาน"
     }
   },
+  "incomeLandRef": {
+    "copyFromCost": "คัดลอกจากวิธีต้นทุน",
+    "pickerTitle": "เลือกวิธีต้นทุนที่ต้องการคัดลอก",
+    "pickerHint": "ข้อมูลเปรียบเทียบและคะแนนของวิธีที่เลือกจะถูกคัดลอกเป็นข้อมูลอ้างอิงที่แก้ไขได้",
+    "noCostMethods": "ไม่พบวิธี WQS/SAG/DC ในแนวทางต้นทุน กรุณาเพิ่มในส่วน Approaches & Methods ก่อน",
+    "copyFailed": "คัดลอกวิธีต้นทุนไม่สำเร็จ",
+    "openRef": "เปิดข้อมูลอ้างอิง"
+  },
   "groupReferences": {
     "sectionTitle": "ข้อมูลอ้างอิง",
     "openReference": "เปิด",
@@ -351,5 +425,73 @@
       "roomIncomeRef": "รายได้ห้องพัก",
       "profitRentRef": "ค่าเช่า"
     }
+  },
+  "viz": {
+    "sensitivity": {
+      "title": "ความไวต่ออัตราส่วนลด"
+    },
+    "profitRentChart": {
+      "title": "ค่าเช่าตลาดกับสัญญา & มูลค่าปัจจุบัน",
+      "marketRental": "ค่าเช่าตลาด (ปี)",
+      "contractRental": "ค่าเช่าสัญญา (ปี)",
+      "presentValue": "มูลค่าปัจจุบัน",
+      "year": "ปี {{n}}"
+    },
+    "waterfall": {
+      "runningTotal": "ผลรวมสะสม:",
+      "defaultTitle": "การวิเคราะห์มูลค่า"
+    },
+    "residualWaterfall": {
+      "lb": "การวิเคราะห์มูลค่าส่วนเกิน",
+      "condo": "การวิเคราะห์มูลค่าส่วนเกิน (GDV → สุดท้าย)",
+      "revenue": "รายได้",
+      "revenuGdv": "รายได้ (GDV)",
+      "projectDev": "ต้นทุนพัฒนาโครงการ",
+      "projectCost": "ต้นทุนโครงการ",
+      "govTax": "ภาษีรัฐบาล",
+      "risk": "ความเสี่ยง",
+      "currentValue": "มูลค่าปัจจุบัน",
+      "discount": "ส่วนลด",
+      "finalValue": "มูลค่าสุทธิ",
+      "hardCost": "ต้นทุนหลัก",
+      "softCost": "ต้นทุนรอง",
+      "riskProfit": "ความเสี่ยงและกำไร",
+      "remaining": "มูลค่าคงเหลือ",
+      "finalRemaining": "มูลค่าคงเหลือสุดท้าย"
+    },
+    "costDonut": {
+      "title": "สัดส่วนต้นทุน",
+      "lb": {
+        "projectDevCost": "ต้นทุนพัฒนาโครงการ",
+        "projectCost": "ต้นทุนโครงการ",
+        "govTax": "ภาษีรัฐบาล",
+        "riskPremium": "ค่าความเสี่ยง"
+      },
+      "condo": {
+        "hardCost": "ต้นทุนหลัก",
+        "softCost": "ต้นทุนรอง",
+        "govTax": "ภาษีรัฐบาล",
+        "riskProfit": "ความเสี่ยงและกำไร"
+      }
+    }
+  },
+  "upload": {
+    "uploading": "กำลังอัปโหลด…",
+    "dropOrBrowse": "วางไฟล์ Excel ที่นี่ หรือ",
+    "browseLink": "เลือกไฟล์",
+    "uploadHistory": "ประวัติการอัปโหลด",
+    "fileCol": "ไฟล์",
+    "uploadedCol": "อัปโหลดเมื่อ",
+    "rowsCol": "แถว",
+    "statusCol": "สถานะ",
+    "statusPresent": "ปัจจุบัน",
+    "statusHistoric": "ประวัติ",
+    "unitListing": "รายการหน่วย ({{n}} หน่วย)",
+    "modelAnalysis": "การวิเคราะห์โมเดล",
+    "parseErrors": "ข้อผิดพลาดการอ่านไฟล์ Excel — แก้ไขแถวเหล่านี้และอัปโหลดใหม่",
+    "parseErrorRow": "แถว",
+    "parseErrorField": "ฟิลด์",
+    "parseErrorValue": "ค่า",
+    "parseErrorReason": "เหตุผล"
   }
 }

--- a/src/i18n/locales/zh/pricingAnalysis.json
+++ b/src/i18n/locales/zh/pricingAnalysis.json
@@ -82,7 +82,8 @@
     "uploadMaxSize": "File must be ≤ 5 MB",
     "uploadFailed": "Upload failed",
     "uploadDeleted": "Upload deleted",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "uploadSuccess": "Uploaded {{n}} rows"
   },
   "footer": {
     "cancel": "Cancel",
@@ -213,7 +214,61 @@
     "viewSummary": "View Assumption Summary"
   },
   "profitRent": {
-    "title": "Profit Rent Analysis"
+    "title": "Profit Rent Analysis",
+    "loadError": "Failed to load profit rent analysis",
+    "headerTitle": "Profit Rent",
+    "appraisalDate": "Appraisal Date",
+    "leaseStart": "Lease Start",
+    "leaseEnd": "Lease End",
+    "viewRentalInfo": "Rental Information",
+    "viewRentalInfoShort": "View",
+    "landArea": "Land Area",
+    "marketRentalFee": "Market Rental Fee",
+    "monthlyTotal": "Monthly Total",
+    "discountedRate": "Discounted Rate",
+    "marketRentalFeeIncrease": "Market Rental Fee Increase",
+    "rate": "Rate",
+    "every": "Every",
+    "interval": "Interval",
+    "fromYear": "From Year",
+    "toYear": "To Year",
+    "growthRatePercent": "Growth Rate (%)",
+    "addPeriods": "Add Periods",
+    "includeBuildingCost": "Include building cost",
+    "buildingCostSummary": "Building Cost Summary",
+    "afterDepre": "After Depre.",
+    "propertyCol": "Property",
+    "areaCol": "Area",
+    "beforeDepre": "Before Depre.",
+    "estimatePriceFromPv": "Estimate Price (from PV)",
+    "buildingCostAfterDepre": "Building Cost (after depre.)",
+    "appraisalPriceWithBuilding": "Appraisal Price w/ Building",
+    "appraisalPrice": "Appraisal Price",
+    "total": "Total",
+    "unitBahtPerSqWaPerMonth": "Baht/Sq.Wa/Mo",
+    "unitBahtPerMonth": "Baht/Mo",
+    "unitSqWa": "Sq. Wa",
+    "unitYear": "Year",
+    "resetConfirmMessage": "Are you sure you want to reset this method? All calculation data will be cleared.",
+    "tableHeaders": {
+      "year": "Year",
+      "periodStart": "Period Start Date",
+      "periodEnd": "Period End Date",
+      "numberOfMonth": "Number of Month",
+      "marketRentalFeePerSqWaMonth": "Market Rental Fee (Baht/Sq.Wa/Month)",
+      "marketRentalFeePerMonth": "Market Rental Fee (Baht/month)",
+      "marketRentalFeePerYear": "Market Rental Fee (Baht/year)",
+      "contractRentalFeePerYear": "Contract Rental Fee (Baht/year)",
+      "returnsFromLease": "Returns from Lease (Baht)",
+      "discountedRate": "Discounted Rate",
+      "presentValue": "Present Value (Baht)"
+    },
+    "kpi": {
+      "totalMarketRental": "Total Market Rental",
+      "totalContractRental": "Total Contract Rental",
+      "totalReturns": "Total Returns",
+      "presentValue": "Present Value"
+    }
   },
   "comparativeAnalysis": {
     "title": "Comparative Analysis",
@@ -290,7 +345,18 @@
     "landValueRequired": "Land value is required",
     "discountRateRequired": "Discount rate is required",
     "landGrowthRateRequired": "Land growth rate is required",
-    "depreciationRateRequired": "Depreciation rate is required"
+    "depreciationRateRequired": "Depreciation rate is required",
+    "factorCodeRequired": "Factor code is required",
+    "weightRequired": "Weight is required",
+    "intensityRequired": "Intensity is required",
+    "collateralScoreRequired": "Collateral score is required",
+    "surveyScoreRequired": "Survey {{n}}'s score is required",
+    "finalValueRoundedRequired": "Final value (rounded) is required",
+    "qualitativeLevelRequired": "Qualitative level is required",
+    "appraisalPriceRoundedRequired": "Appraisal price (rounded) is required",
+    "adjustPercentRequired": "Adjusted score pct is required",
+    "descriptionRequired": "Description is required",
+    "toYearInvalid": "toYear must be >= atYear"
   },
   "empty": {
     "noData": "No data available",
@@ -335,6 +401,14 @@
       "active": "Active"
     }
   },
+  "incomeLandRef": {
+    "copyFromCost": "Copy from Cost",
+    "pickerTitle": "Select Cost method to copy",
+    "pickerHint": "The selected method's comparables and scores will be cloned into a new editable reference.",
+    "noCostMethods": "No Cost-approach WQS/SAG/DC methods found. Add one via Approaches & Methods first.",
+    "copyFailed": "Failed to copy Cost method",
+    "openRef": "Open reference"
+  },
   "groupReferences": {
     "sectionTitle": "References",
     "openReference": "Open",
@@ -351,5 +425,73 @@
       "roomIncomeRef": "Room income",
       "profitRentRef": "Rental fee"
     }
+  },
+  "viz": {
+    "sensitivity": {
+      "title": "Discount Rate Sensitivity"
+    },
+    "profitRentChart": {
+      "title": "Market vs Contract Rental & Present Value",
+      "marketRental": "Market Rental (Year)",
+      "contractRental": "Contract Rental (Year)",
+      "presentValue": "Present Value",
+      "year": "Year {{n}}"
+    },
+    "waterfall": {
+      "runningTotal": "Running Total:",
+      "defaultTitle": "Value Breakdown"
+    },
+    "residualWaterfall": {
+      "lb": "Residual Value Breakdown",
+      "condo": "Residual Value Breakdown (GDV → Final)",
+      "revenue": "Revenue",
+      "revenuGdv": "Revenue (GDV)",
+      "projectDev": "Project Dev",
+      "projectCost": "Project Cost",
+      "govTax": "Gov Tax",
+      "risk": "Risk",
+      "currentValue": "Current Value",
+      "discount": "Discount",
+      "finalValue": "Final Value",
+      "hardCost": "Hard Cost",
+      "softCost": "Soft Cost",
+      "riskProfit": "Risk & Profit",
+      "remaining": "Remaining",
+      "finalRemaining": "Final Remaining"
+    },
+    "costDonut": {
+      "title": "Cost Composition",
+      "lb": {
+        "projectDevCost": "Project Dev Cost",
+        "projectCost": "Project Cost",
+        "govTax": "Gov Tax",
+        "riskPremium": "Risk Premium"
+      },
+      "condo": {
+        "hardCost": "Hard Cost",
+        "softCost": "Soft Cost",
+        "govTax": "Gov Tax",
+        "riskProfit": "Risk & Profit"
+      }
+    }
+  },
+  "upload": {
+    "uploading": "Uploading…",
+    "dropOrBrowse": "Drop an Excel file here or",
+    "browseLink": "browse",
+    "uploadHistory": "Upload History",
+    "fileCol": "File",
+    "uploadedCol": "Uploaded",
+    "rowsCol": "Rows",
+    "statusCol": "Status",
+    "statusPresent": "Present",
+    "statusHistoric": "Historic",
+    "unitListing": "Unit Listing ({{n}} units)",
+    "modelAnalysis": "Model Analysis",
+    "parseErrors": "Excel Parse Errors — fix these rows and re-upload",
+    "parseErrorRow": "Row",
+    "parseErrorField": "Field",
+    "parseErrorValue": "Value",
+    "parseErrorReason": "Reason"
   }
 }

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -2514,6 +2514,7 @@ const PropertyGroupItemDto = z
     location: z.string().nullable(),
     latitude: z.number().nullable(),
     longitude: z.number().nullable(),
+    isRentedOut: z.boolean().nullable(),
     photos: z.array(PropertyPhotoDto).nullable(),
   })
   .partial()


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR isolates the **pricingAnalysis** feature changes.

## Changes
- DCF: highest & best use, panel, method modals, table/section renderers
- Leasehold panel, profit-rent panel/chart, sensitivity strip
- Market reference button/list/modal + group references section
- Sale-adjustment-grid, WQS, direct-comparison panels and their form schemas
- Hypothesis viz (cost donut, residual waterfall) and unit-detail tabs
- New `utils/leaseProperty.ts`
- **Shared schema:** adds `isRentedOut: z.boolean().nullable()` to `PropertyGroupItemDto` in `src/shared/schemas/v1.ts`
- en/th/zh `pricingAnalysis.json`

## Scope / coupling
The single shared line in `shared/schemas/v1.ts` (`isRentedOut`) is **also added identically** in the appraisal PR (both features consume it). Identical additive lines merge without conflict regardless of order.

## ⚠️ Known pre-existing issues
This feature carries ~25 type errors (implicit-any, RHF generic mismatches, i18n key overloads) that are **present in the original source changeset** (not introduced by the split), consistent with the documented pre-existing pricingAnalysis type-debt. Preserved as-is.

## Verification
- `tsc -b` → all new-vs-`main` errors confirmed present in the original working tree; **no errors introduced by the split**

🤖 Generated with [Claude Code](https://claude.com/claude-code)