### PR TITLE
feat(appraisal): appointment history, summary tables & create-page updates

### DIFF
--- a/src/features/appraisal/api/appointmentHistory.ts
+++ b/src/features/appraisal/api/appointmentHistory.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+import axios from '@shared/api/axiosInstance';
+
+// The API serializes with DefaultIgnoreCondition.WhenWritingNull, so null fields are OMITTED
+// from the JSON entirely. Use .nullish() (not .nullable()) for every optional field so a
+// missing key parses as undefined instead of throwing. Only eventType/title/occurredAt are
+// always present.
+export const appointmentHistoryEventSchema = z.object({
+  eventType: z.string(),
+  title: z.string(),
+  oldDate: z.string().nullish(),
+  newDate: z.string().nullish(),
+  feeCode: z.string().nullish(),
+  feeDescription: z.string().nullish(),
+  amount: z.number().nullish(),
+  // Lenient: an unexpected status from the backend must not hard-fail the whole timeline parse.
+  // Unknown values fall back to null (rendered as a neutral pill) instead of throwing.
+  status: z.enum(['Approved', 'Rejected', 'Pending', 'Auto', 'Cancelled']).nullish().catch(null),
+  actorCode: z.string().nullish(),
+  actorName: z.string().nullish(),
+  reason: z.string().nullish(),
+  occurredAt: z.string(),
+});
+
+export type AppointmentHistoryEvent = z.infer<typeof appointmentHistoryEventSchema>;
+
+const appointmentHistoryResponseSchema = z.object({
+  events: z.array(appointmentHistoryEventSchema),
+});
+
+/**
+ * Get the appointment + fee history timeline for an appraisal.
+ * GET /appraisals/{appraisalId}/appointment-history
+ */
+export const useGetAppointmentHistory = (appraisalId: string) => {
+  return useQuery({
+    queryKey: ['appraisal', appraisalId, 'appointment-history'],
+    queryFn: async (): Promise<AppointmentHistoryEvent[]> => {
+      const { data } = await axios.get(`/appraisals/${appraisalId}/appointment-history`);
+      const parsed = appointmentHistoryResponseSchema.parse(data);
+      return parsed.events;
+    },
+    enabled: !!appraisalId,
+  });
+};

--- a/src/features/appraisal/api/fee.ts
+++ b/src/features/appraisal/api/fee.ts
@@ -66,6 +66,7 @@ export const useUpdateAppraisalFee = () => {
       appraisalId: string;
       feeId: string;
       feePaymentType: string;
+      bankAbsorbAmount: number;
     }): Promise<void> => {
       await axios.patch(`/appraisals/${appraisalId}/fees/${feeId}`, body);
     },

--- a/src/features/appraisal/components/360/DecisionSummarySection.tsx
+++ b/src/features/appraisal/components/360/DecisionSummarySection.tsx
@@ -3,6 +3,7 @@ import FormCard from '@/shared/components/sections/FormCard';
 import { formatNumber } from '@/shared/utils/formatUtils';
 import GovernmentPriceTable from '../summary/GovernmentPriceTable';
 import type { GetDecisionSummaryResponse } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface DecisionSummarySectionProps {
   decisionSummary: GetDecisionSummaryResponse | undefined;
@@ -10,6 +11,8 @@ interface DecisionSummarySectionProps {
 }
 
 const DecisionSummarySection = ({ decisionSummary, isLoading }: DecisionSummarySectionProps) => {
+  const { t } = useTranslation('appraisal');
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -23,24 +26,30 @@ const DecisionSummarySection = ({ decisionSummary, isLoading }: DecisionSummaryS
       <div className="flex items-center gap-2 px-1">
         <Icon name="gavel" style="solid" className="w-4 h-4 text-sky-500" />
         <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider">
-          Decision & Summary
+          {t('view360.decisionSummarySection.title')}
         </h2>
       </div>
 
       {/* Appraisal Price Summary */}
-      <FormCard title="Appraisal Price Summary" icon="coins" iconColor="amber">
+      <FormCard title={t('view360.decisionSummarySection.appraisalPriceSummary')} icon="coins" iconColor="amber">
         <div className="grid grid-cols-3 gap-6">
           <ReadOnlyField
-            label="Total Appraisal Price"
+            label={t('view360.decisionSummarySection.totalAppraisalPrice')}
             value={decisionSummary?.totalAppraisalPrice}
           />
-          <ReadOnlyField label="Force Selling Price" value={decisionSummary?.forceSellingPrice} />
-          <ReadOnlyField label="Building Insurance" value={decisionSummary?.buildingInsurance} />
+          <ReadOnlyField
+            label={t('view360.decisionSummarySection.forceSellingPrice')}
+            value={decisionSummary?.forceSellingPrice}
+          />
+          <ReadOnlyField
+            label={t('view360.decisionSummarySection.buildingInsurance')}
+            value={decisionSummary?.buildingInsurance}
+          />
         </div>
       </FormCard>
 
       {/* Government Appraisal Price */}
-      <FormCard title="Government Appraisal Price" icon="landmark" iconColor="teal">
+      <FormCard title={t('view360.decisionSummarySection.governmentAppraisalPrice')} icon="landmark" iconColor="teal">
         {decisionSummary?.governmentPrices && decisionSummary.governmentPrices.length > 0 ? (
           <GovernmentPriceTable
             rows={decisionSummary.governmentPrices}
@@ -48,7 +57,7 @@ const DecisionSummarySection = ({ decisionSummary, isLoading }: DecisionSummaryS
             avgPerSqWa={decisionSummary.governmentPriceAvgPerSqWa ?? 0}
           />
         ) : (
-          <p className="text-sm text-gray-500">No government price data available.</p>
+          <p className="text-sm text-gray-500">{t('view360.decisionSummarySection.noGovernmentPrice')}</p>
         )}
       </FormCard>
     </div>

--- a/src/features/appraisal/components/360/PricingAnalysisSection.tsx
+++ b/src/features/appraisal/components/360/PricingAnalysisSection.tsx
@@ -2,6 +2,7 @@ import Icon from '@/shared/components/Icon';
 import FormCard from '@/shared/components/sections/FormCard';
 import ApproachMatrixTable from '../summary/ApproachMatrixTable';
 import type { GetDecisionSummaryResponse } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface PricingAnalysisSectionProps {
   decisionSummary: GetDecisionSummaryResponse | undefined;
@@ -14,9 +15,11 @@ const PricingAnalysisSection = ({
   isLoading,
   onGroupClick,
 }: PricingAnalysisSectionProps) => {
+  const { t } = useTranslation('appraisal');
+
   if (isLoading) {
     return (
-      <FormCard title="Pricing Analysis" icon="table-cells" iconColor="teal">
+      <FormCard title={t('view360.pricingAnalysisSection.heading')} icon="table-cells" iconColor="teal">
         <div className="flex items-center justify-center py-8">
           <Icon name="spinner" style="solid" className="w-6 h-6 animate-spin text-gray-400" />
         </div>
@@ -29,19 +32,19 @@ const PricingAnalysisSection = ({
       <div className="flex items-center gap-2 px-1">
         <Icon name="table-cells" style="solid" className="w-4 h-4 text-teal-500" />
         <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider">
-          Pricing Analysis
+          {t('view360.pricingAnalysisSection.heading')}
         </h2>
       </div>
 
       {/* Approach Matrix */}
-      <FormCard title="Decision Approach" icon="table-cells" iconColor="teal">
+      <FormCard title={t('view360.pricingAnalysisSection.decisionApproach')} icon="table-cells" iconColor="teal">
         {decisionSummary?.approachMatrix && decisionSummary.approachMatrix.length > 0 ? (
           <ApproachMatrixTable
             groups={decisionSummary.approachMatrix}
             onGroupClick={onGroupClick}
           />
         ) : (
-          <p className="text-sm text-gray-500">No approach data available.</p>
+          <p className="text-sm text-gray-500">{t('view360.pricingAnalysisSection.noApproachData')}</p>
         )}
       </FormCard>
     </div>

--- a/src/features/appraisal/components/360/RequestInfoSection.tsx
+++ b/src/features/appraisal/components/360/RequestInfoSection.tsx
@@ -1,5 +1,6 @@
 import FormCard from '@/shared/components/sections/FormCard';
 import ParameterDisplay from '@/shared/components/ParameterDisplay';
+import { useTranslation } from 'react-i18next';
 
 // Both come through .passthrough() so extra fields are untyped
 type AppraisalData = Record<string, any> | undefined;
@@ -11,29 +12,30 @@ interface RequestInfoSectionProps {
 }
 
 const RequestInfoSection = ({ appraisal, request }: RequestInfoSectionProps) => {
+  const { t } = useTranslation('appraisal');
   const customer = request?.customers?.[0];
 
   return (
-    <FormCard title="Request Information" icon="square-info" iconColor="emerald">
+    <FormCard title={t('view360.requestInfoSection.title')} icon="square-info" iconColor="emerald">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <InfoField label="Request Number" value={request?.requestNumber} />
-        <InfoField label="Customer Name" value={customer?.name} />
-        <InfoField label="Contact Number" value={customer?.contactNumber} />
+        <InfoField label={t('view360.requestInfoSection.requestNumber')} value={request?.requestNumber} />
+        <InfoField label={t('view360.requestInfoSection.customerName')} value={customer?.name} />
+        <InfoField label={t('view360.requestInfoSection.contactNumber')} value={customer?.contactNumber} />
         <div>
-          <p className="text-xs font-medium text-gray-500 mb-1">Purpose</p>
+          <p className="text-xs font-medium text-gray-500 mb-1">{t('view360.requestInfoSection.purpose')}</p>
           <p className="text-sm text-gray-900">
             <ParameterDisplay group="AppraisalPurpose" code={request?.purpose} />
           </p>
         </div>
-        <InfoField label="Appraisal Number" value={appraisal?.appraisalNumber} />
+        <InfoField label={t('view360.requestInfoSection.appraisalNumber')} value={appraisal?.appraisalNumber} />
         <div>
-          <p className="text-xs font-medium text-gray-500 mb-1">Channel</p>
+          <p className="text-xs font-medium text-gray-500 mb-1">{t('view360.requestInfoSection.channel')}</p>
           <p className="text-sm text-gray-900">
             <ParameterDisplay group="CHANNEL" code={request?.channel} />
           </p>
         </div>
-        <InfoField label="Status" value={appraisal?.status} />
-        <InfoField label="Requestor" value={request?.requestor?.username} />
+        <InfoField label={t('view360.requestInfoSection.status')} value={appraisal?.status} />
+        <InfoField label={t('view360.requestInfoSection.requestor')} value={request?.requestor?.username} />
       </div>
     </FormCard>
   );

--- a/src/features/appraisal/components/AppointmentHistoryDrawer.tsx
+++ b/src/features/appraisal/components/AppointmentHistoryDrawer.tsx
@@ -1,0 +1,258 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import SlideOverPanel from '@shared/components/SlideOverPanel';
+import Icon from '@shared/components/Icon';
+import { formatLocaleDateTime, formatLocaleDate } from '@shared/utils/dateUtils';
+import { useGetAppointmentHistory, type AppointmentHistoryEvent } from '../api/appointmentHistory';
+
+interface AppointmentHistoryDrawerProps {
+  appraisalId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+type FilterChip = 'all' | 'appointment' | 'fees';
+
+function isAppointmentEvent(eventType: string): boolean {
+  return eventType.startsWith('Appointment');
+}
+
+function isFeeEvent(eventType: string): boolean {
+  return eventType.startsWith('Fee') || eventType === 'Submitted';
+}
+
+/** Tailwind classes for the circular timeline node based on event type / status */
+function nodeClasses(event: AppointmentHistoryEvent): string {
+  if (event.status === 'Approved' || event.eventType === 'AppointmentApproved' || event.eventType === 'AppointmentAutoApplied' || event.eventType === 'FeeApproved') {
+    return 'bg-green-600';
+  }
+  if (event.status === 'Rejected' || event.eventType === 'AppointmentRejected' || event.eventType === 'FeeRejected') {
+    return 'bg-red-600';
+  }
+  // A user cancellation is neutral, visually distinct from an approver rejection.
+  if (event.status === 'Cancelled' || event.eventType === 'AppointmentCancelled') {
+    return 'bg-gray-400';
+  }
+  if (isFeeEvent(event.eventType)) {
+    return 'bg-purple-600';
+  }
+  // Appointment-related pending / rescheduled
+  return 'bg-blue-600';
+}
+
+/** Status pill styling */
+function statusPillClasses(status: string | null): string {
+  switch (status) {
+    case 'Approved': return 'bg-green-50 text-green-700 border border-green-200';
+    case 'Rejected': return 'bg-red-50 text-red-700 border border-red-200';
+    case 'Pending': return 'bg-amber-50 text-amber-700 border border-amber-200';
+    case 'Auto': return 'bg-gray-100 text-gray-500 border border-gray-200';
+    case 'Cancelled': return 'bg-slate-100 text-slate-600 border border-slate-300';
+    default: return 'bg-gray-100 text-gray-500 border border-gray-200';
+  }
+}
+
+function NodeIcon({ event }: { event: AppointmentHistoryEvent }) {
+  if (event.status === 'Approved' || event.eventType === 'AppointmentApproved' || event.eventType === 'AppointmentAutoApplied' || event.eventType === 'FeeApproved') {
+    return <Icon name="check" style="solid" className="w-2.5 h-2.5 text-white" />;
+  }
+  if (event.status === 'Rejected' || event.eventType === 'AppointmentRejected' || event.eventType === 'FeeRejected') {
+    return <Icon name="xmark" style="solid" className="w-2.5 h-2.5 text-white" />;
+  }
+  if (event.status === 'Cancelled' || event.eventType === 'AppointmentCancelled') {
+    return <Icon name="ban" style="solid" className="w-2.5 h-2.5 text-white" />;
+  }
+  if (isFeeEvent(event.eventType)) {
+    return <span className="text-[9px] font-bold text-white leading-none">฿</span>;
+  }
+  return <Icon name="clock-rotate-left" style="solid" className="w-2.5 h-2.5 text-white" />;
+}
+
+function TimelineItem({ event, isLast }: { event: AppointmentHistoryEvent; isLast: boolean }) {
+  const { t, i18n } = useTranslation('appraisal');
+
+  const showDateChange = (event.oldDate || event.newDate) && (event.eventType.includes('Reschedule') || event.eventType === 'AppointmentRescheduled' || event.eventType === 'AppointmentApproved' || event.eventType === 'AppointmentAutoApplied');
+  const isRejection = event.status === 'Rejected' || event.eventType === 'AppointmentRejected' || event.eventType === 'FeeRejected';
+
+  return (
+    <div className="relative flex gap-3 pb-6">
+      {/* Vertical connector line */}
+      {!isLast && (
+        <div className="absolute left-[10px] top-[22px] bottom-0 w-0.5 bg-gray-200" />
+      )}
+
+      {/* Circle node */}
+      <div
+        className={clsx(
+          'relative z-10 flex-shrink-0 w-[22px] h-[22px] rounded-full flex items-center justify-center mt-0.5',
+          nodeClasses(event),
+        )}
+      >
+        <NodeIcon event={event} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0 pt-0.5">
+        {/* Title row */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-semibold text-gray-900">{event.title}</span>
+          {event.status && (
+            <span className={clsx('inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold', statusPillClasses(event.status))}>
+              {t(`history.status.${event.status}`, event.status)}
+            </span>
+          )}
+        </div>
+
+        {/* Timestamp */}
+        <div className="text-[11px] text-gray-400 mt-0.5">
+          {formatLocaleDateTime(event.occurredAt, i18n.language)}
+        </div>
+
+        {/* Body */}
+        <div className="mt-1.5 space-y-1">
+          {/* Date change: old → new */}
+          {showDateChange && (event.oldDate || event.newDate) && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {event.oldDate && (
+                <span className="text-sm font-medium text-gray-400 line-through decoration-red-400">
+                  {formatLocaleDate(event.oldDate, i18n.language)}
+                </span>
+              )}
+              {event.oldDate && event.newDate && (
+                <Icon name="arrow-right" style="solid" className="w-3 h-3 text-amber-500 flex-shrink-0" />
+              )}
+              {event.newDate && (
+                <span className="text-sm font-semibold text-gray-800">
+                  {formatLocaleDate(event.newDate, i18n.language)}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Fee description + amount */}
+          {event.feeDescription && (
+            <div className="text-sm text-gray-600">
+              {event.feeDescription}
+              {event.amount != null && (
+                <> · <span className="font-semibold text-gray-800">฿ {event.amount.toLocaleString('th-TH', { minimumFractionDigits: 2 })}</span></>
+              )}
+            </div>
+          )}
+
+          {/* Actor */}
+          {event.actorName && (
+            <div className="text-[11px] text-gray-400">
+              {event.actorName}
+              {event.actorCode && ` (${event.actorCode})`}
+            </div>
+          )}
+
+          {/* Reason quote */}
+          {event.reason && (
+            <blockquote
+              className={clsx(
+                'mt-2 pl-3 py-1.5 pr-2 rounded-r-lg border-l-2 text-sm italic',
+                isRejection
+                  ? 'bg-red-50 border-red-400 text-red-800'
+                  : 'bg-gray-50 border-gray-300 text-gray-600',
+              )}
+            >
+              "{event.reason}"
+            </blockquote>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AppointmentHistoryDrawer({
+  appraisalId,
+  open,
+  onClose,
+}: AppointmentHistoryDrawerProps) {
+  const { t } = useTranslation(['appraisal', 'common']);
+  const [activeFilter, setActiveFilter] = useState<FilterChip>('all');
+
+  const { data: events = [], isLoading, isError } = useGetAppointmentHistory(appraisalId);
+
+  const filteredEvents = events.filter(event => {
+    if (activeFilter === 'appointment') return isAppointmentEvent(event.eventType);
+    if (activeFilter === 'fees') return isFeeEvent(event.eventType);
+    return true;
+  });
+
+  const eventCount = events.length;
+
+  const chips: { key: FilterChip; label: string }[] = [
+    { key: 'all', label: t('history.chips.all') },
+    { key: 'appointment', label: t('history.chips.appointment') },
+    { key: 'fees', label: t('history.chips.fees') },
+  ];
+
+  return (
+    <SlideOverPanel
+      isOpen={open}
+      onClose={onClose}
+      title={t('history.title')}
+      subtitle={eventCount > 0 ? t('history.eventCount', { count: eventCount }) : undefined}
+      width="md"
+    >
+      {/* Filter chips — sticky inside the scroll container */}
+      <div className="flex gap-2 pb-4 border-b border-gray-100">
+        {chips.map(chip => (
+          <button
+            key={chip.key}
+            type="button"
+            onClick={() => setActiveFilter(chip.key)}
+            className={clsx(
+              'px-3 py-1 rounded-full text-xs font-semibold border transition-colors',
+              activeFilter === chip.key
+                ? 'bg-gray-900 text-white border-gray-900'
+                : 'bg-white text-gray-500 border-gray-200 hover:border-gray-400',
+            )}
+          >
+            {chip.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Timeline body */}
+      <div className="mt-4">
+        {isLoading && (
+          <div className="flex items-center justify-center py-12 text-gray-400 text-sm">
+            <Icon name="spinner" style="solid" className="w-4 h-4 animate-spin mr-2" />
+            {t('common:loading', 'Loading…')}
+          </div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="flex flex-col items-center justify-center py-12 gap-2 text-sm text-red-600">
+            <Icon name="circle-exclamation" style="solid" className="w-5 h-5" />
+            <span>{t('history.loadError')}</span>
+          </div>
+        )}
+
+        {!isLoading && !isError && filteredEvents.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 gap-2 text-sm text-gray-400">
+            <Icon name="clock-rotate-left" style="regular" className="w-8 h-8 text-gray-300" />
+            <span>{t('history.emptyState')}</span>
+          </div>
+        )}
+
+        {!isLoading && !isError && filteredEvents.length > 0 && (
+          <div>
+            {filteredEvents.map((event, idx) => (
+              <TimelineItem
+                key={`${event.eventType}-${event.occurredAt}-${idx}`}
+                event={event}
+                isLast={idx === filteredEvents.length - 1}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </SlideOverPanel>
+  );
+}

--- a/src/features/appraisal/components/AppointmentInfoCard.tsx
+++ b/src/features/appraisal/components/AppointmentInfoCard.tsx
@@ -12,6 +12,10 @@ interface AppointmentInfoCardProps {
   approvalDraft?: boolean;
   /** When true, shows "Pending approval" badge and disables reschedule */
   approvalSubmitted?: boolean;
+  /** Opens the history drawer */
+  onViewHistory?: () => void;
+  /** Total event count for the badge on the View History button */
+  historyEventCount?: number;
 }
 
 /**
@@ -24,18 +28,26 @@ export default function AppointmentInfoCard({
   onCancel,
   approvalDraft = false,
   approvalSubmitted = false,
+  onViewHistory,
+  historyEventCount,
 }: AppointmentInfoCardProps) {
   const { t } = useTranslation('appraisal');
   const readOnly = usePageReadOnly();
   const hasAppointment = Boolean(appointment);
 
-  // Format date/time display
-  const formattedDate = appointment
-    ? {
-        dayName: format(parseISO(appointment.appointmentDateTime), 'EEEE'),
-        fullDate: format(parseISO(appointment.appointmentDateTime), 'MMMM d, yyyy'),
-        time: format(parseISO(appointment.appointmentDateTime), 'h:mm a'),
-      }
+  // Format date/time display (calendar-tile parts + readable line). Parse once.
+  const formattedDate = appointment?.appointmentDateTime
+    ? (() => {
+        const d = parseISO(appointment.appointmentDateTime);
+        return {
+          month: format(d, 'MMM'),
+          day: format(d, 'd'),
+          weekday: format(d, 'EEE'),
+          dayName: format(d, 'EEEE'),
+          fullDate: format(d, 'MMMM d, yyyy'),
+          time: format(d, 'h:mm a'),
+        };
+      })()
     : null;
 
   // Previous (pre-reschedule) date — shown struck-through next to the proposed date while the
@@ -47,6 +59,7 @@ export default function AppointmentInfoCard({
   const formattedPreviousDate =
     pendingApproval && previousDate
       ? {
+          dayName: format(parseISO(previousDate), 'EEEE'),
           fullDate: format(parseISO(previousDate), 'MMMM d, yyyy'),
           time: format(parseISO(previousDate), 'h:mm a'),
         }
@@ -86,96 +99,161 @@ export default function AppointmentInfoCard({
     );
   }
 
+  // Only surface the approval state — no badge for normal statuses (Approved/Pending/etc.).
+  const status = (appointment.status ?? '').toLowerCase();
+  const statusBadge = approvalSubmitted
+    ? { label: t('approval.badge.awaiting'), cls: 'bg-blue-50 text-blue-700 border-blue-200' }
+    : approvalDraft
+      ? { label: t('approval.badge.needsApproval'), cls: 'bg-amber-50 text-amber-700 border-amber-200' }
+      : null;
+
+  const rescheduleCount = appointment.rescheduleCount ?? 0;
+  const isCancelled = status === 'cancelled';
+  const tileAccent = pendingApproval ? 'bg-amber-500' : 'bg-orange-500';
+
   return (
-    <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6">
-      <div className="flex items-center justify-between">
-        {/* Left Section - Date/Time and Details */}
-        <div className="flex items-center gap-6">
-          {/* Date Time Display */}
-          <div className="flex flex-col gap-1">
-            <span className="text-xs text-accent font-normal">{formattedDate?.dayName}</span>
-            {formattedPreviousDate && (
-              <span className="text-xs text-gray-400 line-through">
+    <div
+      className={`rounded-xl shadow-sm overflow-hidden border ${
+        pendingApproval ? 'border-amber-200 bg-amber-50/40' : 'border-gray-200 bg-white'
+      }`}
+    >
+      {/* ── Top row: calendar tile · details · status + actions ── */}
+      <div className="flex items-start gap-5 p-5">
+        {/* Calendar date tile */}
+        <div
+          className={`flex-shrink-0 w-[76px] rounded-xl border overflow-hidden text-center bg-white ${
+            pendingApproval ? 'border-amber-200' : 'border-gray-200'
+          }`}
+        >
+          <div className={`text-[11px] font-bold uppercase tracking-wider text-white py-1 ${tileAccent}`}>
+            {formattedDate?.month}
+          </div>
+          <div className="text-xl font-bold text-gray-800 leading-none pt-1.5">
+            {formattedDate?.day}
+          </div>
+          <div className="text-[11px] text-gray-500 pb-1.5">{formattedDate?.weekday}</div>
+        </div>
+
+        {/* Details */}
+        <div className="flex-1 min-w-0">
+          {/* Time / pending old→new */}
+          {formattedPreviousDate ? (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs font-medium text-gray-400 line-through decoration-red-300">
                 {formattedPreviousDate.fullDate} · {formattedPreviousDate.time}
               </span>
-            )}
-            <span className="text-lg font-medium text-gray-800">{formattedDate?.fullDate}</span>
-            <span className="text-xs text-gray-800">{formattedDate?.time}</span>
+              <Icon name="arrow-right" style="solid" className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+              <span className="text-sm font-semibold text-gray-800">
+                {formattedDate?.fullDate} · {formattedDate?.time}
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-800">
+                <Icon name="clock" style="regular" className="w-3.5 h-3.5 text-gray-400" />
+                {formattedDate?.time}
+              </span>
+              <span className="text-xs text-gray-400">
+                · {formattedDate?.dayName}, {formattedDate?.fullDate}
+              </span>
+            </div>
+          )}
+
+          {/* Location */}
+          <div className="flex items-center gap-2 mt-2.5">
+            <Icon name="location-dot" style="light" className="w-4 h-4 text-gray-400 shrink-0" />
+            <span
+              className={`text-xs line-clamp-1 break-words ${
+                appointment.locationDetail ? 'text-gray-700' : 'text-gray-400'
+              }`}
+            >
+              {appointment.locationDetail || t('appointment.locationNotSpecified')}
+            </span>
           </div>
 
-          {/* Vertical Divider */}
-          <div className="h-10 w-px bg-gray-200" />
-
-          {/* Location and Contact Details */}
-          <div className="flex flex-col gap-1">
-            {/* Location */}
-            <div className="flex items-center gap-2">
-              <Icon name="location-dot" style="light" className="w-5 h-5 text-gray-800" />
-              <span className="text-xs text-gray-800 w-3/4 line-clamp-2 break-words">
-                {appointment.locationDetail || t('appointment.locationNotSpecified')}
-              </span>
+          {/* Contact */}
+          <div className="flex items-center gap-2 mt-1.5">
+            <div className="w-5 h-5 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
+              <Icon name="user" style="solid" className="w-2.5 h-2.5 text-gray-500" />
             </div>
-
-            {/* Contact Person */}
-            <div className="flex items-center gap-2">
-              <div className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center">
-                <Icon name="user" style="solid" className="w-3 h-3 text-gray-500" />
-              </div>
-              <span className="text-xs text-gray-800">
-                {appointment.contactPerson || t('appointment.contactNotSpecified')}
-                {appointment.contactPhone && ` (${appointment.contactPhone})`}
-              </span>
-            </div>
-
-            {/* Reschedule Count & Approval badges */}
-            <div className="flex items-center gap-2 mt-1 flex-wrap">
-              {(appointment.rescheduleCount ?? 0) > 0 && (
-                <span className="text-xs text-gray-400">
-                  {t('appointment.rescheduledCount', { n: appointment.rescheduleCount })}
-                </span>
+            <span className="text-xs text-gray-700">
+              {appointment.contactPerson || t('appointment.contactNotSpecified')}
+              {appointment.contactPhone && (
+                <span className="text-gray-400"> · {appointment.contactPhone}</span>
               )}
-              {approvalDraft && !approvalSubmitted && (
-                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 border border-amber-300">
-                  {t('approval.badge.needsApproval')}
-                </span>
-              )}
-              {approvalSubmitted && (
-                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700 border border-blue-300">
-                  {t('approval.badge.awaiting')}
-                </span>
-              )}
-            </div>
+            </span>
           </div>
         </div>
 
-        {/* Right Section - Action Buttons */}
-        {!readOnly && (
-          <div className="flex items-center gap-2">
-            {onCancel && (appointment.status ?? '').toLowerCase() !== 'cancelled' && (
+        {/* Status + action buttons */}
+        <div className="flex flex-col items-end gap-3 flex-shrink-0">
+          {statusBadge && (
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border ${statusBadge.cls}`}
+            >
+              {statusBadge.label}
+            </span>
+          )}
+          {!readOnly && (
+            <div className="flex items-center gap-2">
+              {onCancel && !isCancelled && (
+                <button
+                  type="button"
+                  onClick={!approvalSubmitted ? onCancel : undefined}
+                  disabled={approvalSubmitted}
+                  title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg border border-danger/30 bg-danger/10 text-danger hover:bg-danger/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-danger/10"
+                >
+                  <Icon name="xmark" style="solid" className="w-4 h-4" />
+                  <span className="text-sm font-medium">{t('appointment.cancelButton')}</span>
+                </button>
+              )}
               <button
                 type="button"
-                onClick={onCancel}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-danger/30 bg-danger/10 text-danger hover:bg-danger/20 transition-colors"
+                onClick={!approvalSubmitted ? onReschedule : undefined}
+                disabled={approvalSubmitted}
+                title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-secondary bg-secondary/20 text-secondary hover:bg-secondary/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-secondary/20"
               >
-                <Icon name="xmark" style="solid" className="w-4 h-4" />
-                <span className="text-sm font-medium">{t('appointment.cancelButton')}</span>
+                <Icon name="clock-rotate-left" style="solid" className="w-5 h-5" />
+                <span className="text-sm font-medium uppercase tracking-wider">
+                  {t('appointment.rescheduleButton')}
+                </span>
               </button>
-            )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Footer: reschedule count · history ── */}
+      {(rescheduleCount > 0 || onViewHistory) && (
+        <div
+          className={`flex items-center gap-2 px-5 py-2.5 border-t text-xs ${
+            pendingApproval ? 'border-amber-100 bg-amber-100/30' : 'border-gray-100 bg-gray-50/60'
+          }`}
+        >
+          {rescheduleCount > 0 && (
+            <span className="inline-flex items-center gap-1.5 text-gray-500">
+              <Icon name="clock-rotate-left" style="solid" className="w-3 h-3 text-gray-400" />
+              {t('appointment.rescheduledCount', { n: rescheduleCount })}
+            </span>
+          )}
+          {rescheduleCount > 0 && onViewHistory && (
+            <span className="text-gray-300" aria-hidden="true">·</span>
+          )}
+          {onViewHistory && (
             <button
               type="button"
-              onClick={!approvalSubmitted ? onReschedule : undefined}
-              disabled={approvalSubmitted}
-              title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg border border-secondary bg-secondary/20 text-secondary hover:bg-secondary/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-secondary/20"
+              onClick={onViewHistory}
+              className="inline-flex items-center gap-1.5 font-semibold text-gray-500 hover:text-primary transition-colors"
             >
-              <Icon name="clock-rotate-left" style="solid" className="w-5 h-5" />
-              <span className="text-sm font-medium uppercase tracking-wider">
-                {t('appointment.rescheduleButton')}
-              </span>
+              <Icon name="clock-rotate-left" style="solid" className="w-3 h-3" />
+              {t('history.viewHistory')}
+              {historyEventCount !== undefined && historyEventCount > 0 && ` (${historyEventCount})`}
             </button>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/appraisal/components/FeeInformationSection.tsx
+++ b/src/features/appraisal/components/FeeInformationSection.tsx
@@ -11,7 +11,10 @@ import type { AppraisalFeeItemDtoType } from '@shared/schemas/v1';
 import AddFeeModal from './AddFeeModal';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 
-export const BANK_ABSORB_FEE_TYPES = ['05', '06', '07'];
+export const BANK_ABSORB_FEE_TYPES = ['04'];
+/** Fee types for which the bank-absorb amount input is shown (required for '04', optional for '99'). */
+const BANK_ABSORB_SHOW_TYPES = ['04', '99'];
+
 interface FeeInformationSectionProps {
   items: AppraisalFeeItemDtoType[];
   vatRate?: number;
@@ -46,6 +49,14 @@ interface FeeInformationSectionProps {
   onUpdateConstructionInspectionFee?: (amount: number | null) => Promise<void>;
   isConstructionInspectionFeeUpdating?: boolean;
   totalFeePaid?: number | null;
+
+  /** Bank-absorb amount input — shown when feePaymentType ∈ ['04','99']. */
+  bankAbsorbAmount?: number | null;
+  /** Upper bound for the absorb input (totalFeeAfterVAT from backend). */
+  totalFeeAfterVAT?: number;
+  /** Called on blur when the value has changed; returns Promise so the section can rollback on error. */
+  onUpdateBankAbsorbAmount?: (amount: number) => Promise<void>;
+  isAbsorbAmountUpdating?: boolean;
 }
 
 /**
@@ -68,6 +79,10 @@ export default function FeeInformationSection({
   onUpdateConstructionInspectionFee,
   isConstructionInspectionFeeUpdating,
   totalFeePaid,
+  bankAbsorbAmount = null,
+  totalFeeAfterVAT,
+  onUpdateBankAbsorbAmount,
+  isAbsorbAmountUpdating,
 }: FeeInformationSectionProps) {
   const { t } = useTranslation('appraisal');
   const readOnly = usePageReadOnly();
@@ -89,6 +104,27 @@ export default function FeeInformationSection({
     } catch (error: any) {
       toast.error(error?.apiError?.detail || t('fee.toasts.ciFeesFailed'));
       setCiFeeDraft(constructionInspectionFeeAmount); // rollback
+    }
+  };
+
+  const [absorbDraft, setAbsorbDraft] = useState<number | null>(bankAbsorbAmount);
+  useEffect(() => {
+    setAbsorbDraft(bankAbsorbAmount);
+  }, [bankAbsorbAmount]);
+
+  const showAbsorbInput = BANK_ABSORB_SHOW_TYPES.includes(feePaymentType ?? '');
+  const absorbRequired = BANK_ABSORB_FEE_TYPES.includes(feePaymentType ?? '');
+
+  const handleAbsorbBlur = async () => {
+    if (!onUpdateBankAbsorbAmount) return;
+    const amount = absorbDraft ?? 0;
+    if (amount === (bankAbsorbAmount ?? 0)) return;
+    try {
+      await onUpdateBankAbsorbAmount(amount);
+      toast.success(t('fee.toasts.absorbAmountSaved'));
+    } catch (error: any) {
+      toast.error(error?.apiError?.detail || t('fee.toasts.absorbAmountFailed'));
+      setAbsorbDraft(bankAbsorbAmount); // rollback
     }
   };
 
@@ -268,6 +304,26 @@ export default function FeeInformationSection({
         onChange={value => onUpdateFeePaymentType?.(value)}
         disabled={readOnly || isFeePaymentTypeUpdating}
       />
+
+      {/* Bank Absorb Amount — visible when feePaymentType ∈ ['04','99'] */}
+      {showAbsorbInput && (
+        <div className="border border-blue-200 bg-blue-50/40 rounded-lg p-4">
+          <NumberInput
+            name="bankAbsorbAmount"
+            label={t('fee.bankAbsorbAmount')}
+            required={absorbRequired}
+            decimalPlaces={2}
+            min={0}
+            max={totalFeeAfterVAT}
+            value={absorbDraft}
+            onChange={e => setAbsorbDraft(e.target.value)}
+            onBlur={handleAbsorbBlur}
+            disabled={readOnly || editLocked || isAbsorbAmountUpdating}
+            placeholder="0.00"
+          />
+          <p className="mt-2 text-xs text-gray-500">{t('fee.bankAbsorbAmountHint')}</p>
+        </div>
+      )}
 
       {/* Fee Table */}
       <div className="border border-gray-200 rounded-lg overflow-hidden">

--- a/src/features/appraisal/components/PaymentInformationSection.tsx
+++ b/src/features/appraisal/components/PaymentInformationSection.tsx
@@ -26,7 +26,6 @@ interface PaymentInformationSectionProps {
   onRemovePayment?: (paymentId: string) => void;
   isPaymentPending?: boolean;
   requestedAt?: string | null;
-  isBankAbsorb?: boolean;
 }
 
 /**
@@ -40,7 +39,6 @@ export default function PaymentInformationSection({
   onRemovePayment,
   isPaymentPending,
   requestedAt,
-  isBankAbsorb = false,
 }: PaymentInformationSectionProps) {
   const { t } = useTranslation('appraisal');
   const readOnly = usePageReadOnly();
@@ -62,11 +60,11 @@ export default function PaymentInformationSection({
   const totalPaid = fee?.totalPaidAmount ?? 0;
   const remaining = fee?.outstandingAmount ?? totalFee - totalPaid - bankAbsorbAmount;
 
-  const effectiveBankAbsorbAmount = isBankAbsorb ? totalFee : bankAbsorbAmount;
-  const effectiveRemaining = isBankAbsorb ? 0 : remaining;
+  const effectiveBankAbsorbAmount = bankAbsorbAmount;
+  const effectiveRemaining = remaining;
   const paymentPercentage = totalFee > 0 ? Math.min((totalPaid / totalFee) * 100, 100) : 0;
 
-  // Determine payment status
+  // Determine payment status from the backend value.
   const getPaymentStatus = () => {
     if (fee) {
       return getFeePaymentStatusDisplay(fee.paymentStatus);
@@ -77,9 +75,7 @@ export default function PaymentInformationSection({
     return { label: 'Not Paid', color: 'danger' as const };
   };
 
-  const paymentStatus = isBankAbsorb
-    ? { label: 'Paid', color: 'success' as const }
-    : getPaymentStatus();
+  const paymentStatus = getPaymentStatus();
 
   // Only show 100% on the progress bar when the fee is fully paid (status === 'paid').
   // PendingInvoice means the customer portion is settled but the external invoice is outstanding —
@@ -195,7 +191,7 @@ export default function PaymentInformationSection({
             <div className="flex justify-between text-xs text-gray-500 mb-1">
               <span>{t('payment.paidPercent', { n: Math.round(effectivePaymentPercentage) })}</span>
               <span>
-                {isBankAbsorb ? formatCurrency(totalFee) : formatCurrency(totalPaid)} /
+                {formatCurrency(totalPaid)} /
                 {formatCurrency(totalFee)}
               </span>
             </div>
@@ -338,7 +334,7 @@ export default function PaymentInformationSection({
               )}
 
               {/* Add Payment Button */}
-              {!readOnly && !isBankAbsorb && (
+              {!readOnly && (
                 <button
                   type="button"
                   onClick={() => setIsAddPaymentModalOpen(true)}

--- a/src/features/appraisal/components/summary/ApproachMatrixTable.tsx
+++ b/src/features/appraisal/components/summary/ApproachMatrixTable.tsx
@@ -1,24 +1,31 @@
 import Icon from '@/shared/components/Icon';
 import { formatNumber } from '@/shared/utils/formatUtils';
 import type { ApproachMatrixGroup } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface ApproachMatrixTableProps {
   groups: ApproachMatrixGroup[];
   onGroupClick?: (groupId: string) => void;
 }
 
-const APPROACH_COLUMNS = [
-  { key: 'Market', label: 'Market Comparison Approach' },
-  { key: 'Cost', label: 'Cost Approach' },
-  { key: 'Income', label: 'Income Approach' },
-  { key: 'Residual', label: 'Residual Approach' },
-] as const;
+type ApproachKey = 'Market' | 'Cost' | 'Income' | 'Residual';
+
+const APPROACH_KEYS: ApproachKey[] = ['Market', 'Cost', 'Income', 'Residual'];
 
 /**
  * Read-only table displaying the decision approach matrix.
  * Each group contains nested approaches with approachType, approachValue, and isSelected.
  */
 const ApproachMatrixTable = ({ groups, onGroupClick }: ApproachMatrixTableProps) => {
+  const { t } = useTranslation('appraisal');
+
+  const approachColumns: { key: ApproachKey; label: string }[] = [
+    { key: 'Market', label: t('approachMatrixTable.columns.market') },
+    { key: 'Cost', label: t('approachMatrixTable.columns.cost') },
+    { key: 'Income', label: t('approachMatrixTable.columns.income') },
+    { key: 'Residual', label: t('approachMatrixTable.columns.residual') },
+  ];
+
   const sortedGroups = [...groups].sort((a, b) => a.groupNumber - b.groupNumber);
 
   // Derive which approaches have at least one selected group
@@ -33,8 +40,10 @@ const ApproachMatrixTable = ({ groups, onGroupClick }: ApproachMatrixTableProps)
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-gray-50 border-b border-gray-200">
-            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Group</th>
-            {APPROACH_COLUMNS.map(col => (
+            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">
+              {t('approachMatrixTable.columns.group')}
+            </th>
+            {approachColumns.map(col => (
               <th
                 key={col.key}
                 className="px-3 py-2 text-right text-xs font-semibold text-gray-600"
@@ -51,7 +60,9 @@ const ApproachMatrixTable = ({ groups, onGroupClick }: ApproachMatrixTableProps)
                 </div>
               </th>
             ))}
-            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">Summary</th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('approachMatrixTable.columns.summary')}
+            </th>
             {onGroupClick && (
               <th className="px-3 py-2 text-center text-xs font-semibold text-gray-600 w-10" />
             )}
@@ -69,13 +80,13 @@ const ApproachMatrixTable = ({ groups, onGroupClick }: ApproachMatrixTableProps)
               onClick={() => onGroupClick?.(group.propertyGroupId)}
             >
               <td className="px-3 py-2 font-medium text-gray-900">{group.groupNumber}</td>
-              {APPROACH_COLUMNS.map(col => {
-                const approach = group.approaches?.find(a => a.approachType === col.key);
+              {APPROACH_KEYS.map(key => {
+                const approach = group.approaches?.find(a => a.approachType === key);
                 const isSelected = approach?.isSelected ?? false;
 
                 return (
                   <td
-                    key={col.key}
+                    key={key}
                     className={`px-3 py-2 text-right ${
                       isSelected ? 'bg-teal-50 text-teal-800 font-semibold' : 'text-gray-700'
                     }`}
@@ -107,9 +118,9 @@ const ApproachMatrixTable = ({ groups, onGroupClick }: ApproachMatrixTableProps)
           <tr className="bg-gray-100 border-t-2 border-gray-400">
             <td
               className="px-3 py-3 text-gray-700 font-bold uppercase tracking-wider text-xs"
-              colSpan={APPROACH_COLUMNS.length + 1}
+              colSpan={approachColumns.length + 1}
             >
-              Total
+              {t('approachMatrixTable.footer.total')}
             </td>
             <td
               className="px-3 py-3 text-right text-gray-900 font-bold text-base tabular-nums"

--- a/src/features/appraisal/components/summary/ApprovalListSection.tsx
+++ b/src/features/appraisal/components/summary/ApprovalListSection.tsx
@@ -2,6 +2,7 @@ import Icon from '@/shared/components/Icon';
 import Badge from '@/shared/components/Badge';
 import FormCard from '@/shared/components/sections/FormCard';
 import MeetingChip from '@/features/meeting/components/MeetingChip';
+import { useTranslation } from 'react-i18next';
 
 import {
   useGetApprovalList,
@@ -14,41 +15,10 @@ import {
 /** Client-derived status from quorum/majority/route_back — backend does not emit a status string. */
 type DerivedStatus = 'Approved' | 'Returned' | 'Pending';
 
-const TIER_LABELS: Record<number, string> = {
-  1: 'Tier 1',
-  2: 'Tier 2',
-  3: 'Tier 3',
-};
-
-const COMMITTEE_CODE_LABELS: Record<string, string> = {
-  SUB_COMMITTEE: 'Sub-Committee',
-  COMMITTEE: 'Committee',
-  COMMITTEE_WITH_MEETING: 'Committee (with Meeting)',
-};
-
-const tierBadge = (tier: number | null, committeeCode: string | null): string => {
-  if (tier != null && TIER_LABELS[tier]) return TIER_LABELS[tier];
-  if (committeeCode && COMMITTEE_CODE_LABELS[committeeCode])
-    return COMMITTEE_CODE_LABELS[committeeCode];
-  return 'Committee';
-};
-
 const deriveStatus = (data: GetApprovalListResponse): DerivedStatus => {
   if (data.members.some(m => m.vote === 'route_back')) return 'Returned';
   if (data.quorumMet && data.majorityMet) return 'Approved';
   return 'Pending';
-};
-
-const conditionLabel = (condition: ApprovalCondition): string => {
-  if (condition.conditionType === 'RoleRequired') {
-    return condition.roleRequired
-      ? `${condition.roleRequired} must vote`
-      : 'Required role must vote';
-  }
-  // MinVotes
-  return condition.minVotesRequired != null
-    ? `At least ${condition.minVotesRequired} votes required`
-    : 'Minimum vote count required';
 };
 
 // ==================== Presentational Component ====================
@@ -60,9 +30,38 @@ interface ApprovalListSectionBaseProps {
 }
 
 const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSectionBaseProps) => {
+  const { t } = useTranslation('appraisal');
+
+  const tierLabel = (tier: number | null, committeeCode: string | null): string => {
+    const tierMap: Record<number, string> = {
+      1: t('approvalListSection.tierLabels.1'),
+      2: t('approvalListSection.tierLabels.2'),
+      3: t('approvalListSection.tierLabels.3'),
+    };
+    const codeMap: Record<string, string> = {
+      SUB_COMMITTEE: t('approvalListSection.committeeCodeLabels.SUB_COMMITTEE'),
+      COMMITTEE: t('approvalListSection.committeeCodeLabels.COMMITTEE'),
+      COMMITTEE_WITH_MEETING: t('approvalListSection.committeeCodeLabels.COMMITTEE_WITH_MEETING'),
+    };
+    if (tier != null && tierMap[tier]) return tierMap[tier];
+    if (committeeCode && codeMap[committeeCode]) return codeMap[committeeCode];
+    return t('approvalListSection.committeeDefault');
+  };
+
+  const conditionLabel = (condition: ApprovalCondition): string => {
+    if (condition.conditionType === 'RoleRequired') {
+      return condition.roleRequired
+        ? t('approvalListSection.conditionRoleRequired', { role: condition.roleRequired })
+        : t('approvalListSection.conditionRoleRequiredDefault');
+    }
+    return condition.minVotesRequired != null
+      ? t('approvalListSection.conditionMinVotes', { n: condition.minVotesRequired })
+      : t('approvalListSection.conditionMinVotesDefault');
+  };
+
   if (isLoading || (!data && !isError)) {
     return (
-      <FormCard title="Committee Approval" icon="users-gear" iconColor="blue">
+      <FormCard title={t('approvalListSection.title')} icon="users-gear" iconColor="blue">
         <div className="flex items-center justify-center py-8">
           <Icon name="spinner" style="solid" className="w-6 h-6 animate-spin text-gray-400" />
         </div>
@@ -71,27 +70,29 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
   }
 
   if (!data) {
-    // No data and not loading — either error or empty state handled by callers.
     return null;
   }
 
   const status = deriveStatus(data);
   const members: ApprovalMember[] = data.members;
   return (
-    <FormCard title="Committee Approval" icon="users-gear" iconColor="blue">
+    <FormCard title={t('approvalListSection.title')} icon="users-gear" iconColor="blue">
       <div className="space-y-4">
         {/* Header */}
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div className="flex items-center gap-3 flex-wrap">
             <Badge variant="primary" size="sm">
-              {tierBadge(data.tier, data.committeeCode)}
+              {tierLabel(data.tier, data.committeeCode)}
             </Badge>
             {data.committeeName && (
               <span className="text-sm font-medium text-gray-700">{data.committeeName}</span>
             )}
             <Badge type="status" value={status} size="sm" />
             <span className="text-xs text-gray-500">
-              {data.votesReceived}/{data.totalMembers} votes
+              {t('approvalListSection.votesDisplay', {
+                received: data.votesReceived,
+                total: data.totalMembers,
+              })}
             </span>
             {data.meetingRef && (
               <MeetingChip
@@ -108,7 +109,7 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
           <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border border-emerald-200 rounded-lg">
             <Icon name="circle-check" style="solid" className="w-5 h-5 text-emerald-500 shrink-0" />
             <p className="text-sm font-medium text-emerald-700">
-              This appraisal has been approved by the committee.
+              {t('approvalListSection.approvedBanner')}
             </p>
           </div>
         )}
@@ -116,7 +117,7 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
           <div className="flex items-center gap-2 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
             <Icon name="rotate-left" style="solid" className="w-5 h-5 text-amber-500 shrink-0" />
             <p className="text-sm font-medium text-amber-700">
-              This appraisal has been returned for revision.
+              {t('approvalListSection.returnedBanner')}
             </p>
           </div>
         )}
@@ -125,7 +126,7 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
         {data.conditions.length > 0 && (
           <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
             <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-2">
-              Approval Conditions
+              {t('approvalListSection.conditionsTitle')}
             </p>
             <ul className="space-y-1.5">
               {data.conditions.map((condition, idx) => (
@@ -153,19 +154,19 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
               <thead className="bg-gray-50">
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                    Member
+                    {t('approvalListSection.columns.member')}
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                    Role
+                    {t('approvalListSection.columns.role')}
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                    Vote
+                    {t('approvalListSection.columns.vote')}
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                    Date
+                    {t('approvalListSection.columns.date')}
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                    Comments
+                    {t('approvalListSection.columns.comments')}
                   </th>
                 </tr>
               </thead>
@@ -182,7 +183,7 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
                           <span>{member.username}</span>
                           {member.isCurrentUser && (
                             <Badge variant="info" size="xs">
-                              You
+                              {t('approvalListSection.youBadge')}
                             </Badge>
                           )}
                         </div>
@@ -196,7 +197,7 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
                         ) : (
                           <span className="inline-flex items-center gap-1 text-xs text-gray-500">
                             <Icon name="clock" style="regular" className="w-3.5 h-3.5" />
-                            Pending
+                            {t('approvalListSection.pendingVote')}
                           </span>
                         )}
                       </td>
@@ -244,17 +245,18 @@ export const LiveApprovalListSection = ({
   workflowInstanceId,
   activityId,
 }: LiveApprovalListSectionProps) => {
+  const { t } = useTranslation('appraisal');
   const { data, isLoading, isError } = useGetApprovalList(workflowInstanceId, activityId);
 
   if (!workflowInstanceId || !activityId) {
     return (
-      <FormCard title="Committee Approval" icon="users-gear" iconColor="blue">
+      <FormCard title={t('approvalListSection.title')} icon="users-gear" iconColor="blue">
         <div className="flex flex-col items-center justify-center py-8 gap-3">
           <div className="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center">
             <Icon name="users-gear" style="regular" className="w-6 h-6 text-blue-400" />
           </div>
           <p className="text-sm text-gray-500">
-            Committee approval is not active for this appraisal yet.
+            {t('approvalListSection.notActiveYet')}
           </p>
         </div>
       </FormCard>

--- a/src/features/appraisal/components/summary/BlockApproachMatrixTable.tsx
+++ b/src/features/appraisal/components/summary/BlockApproachMatrixTable.tsx
@@ -1,29 +1,40 @@
 import Icon from '@/shared/components/Icon';
 import { formatNumber } from '@/shared/utils/formatUtils';
 import type { BlockApproachMatrixRow } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface BlockApproachMatrixTableProps {
   rows: BlockApproachMatrixRow[];
   projectTotal: number;
 }
 
-const APPROACH_COLUMNS = [
-  { key: 'Market', label: 'Market Comparison Approach', valueKey: 'marketValue' as const },
-  { key: 'Cost', label: 'Cost Approach', valueKey: 'costValue' as const },
-  { key: 'Income', label: 'Income Approach', valueKey: 'incomeValue' as const },
-  { key: 'Residual', label: 'Residual Approach', valueKey: 'residualValue' as const },
-] as const;
+type ApproachKey = 'Market' | 'Cost' | 'Income' | 'Residual';
+type ValueKey = 'marketValue' | 'costValue' | 'incomeValue' | 'residualValue';
+
+const APPROACH_DEFS: { key: ApproachKey; valueKey: ValueKey }[] = [
+  { key: 'Market', valueKey: 'marketValue' },
+  { key: 'Cost', valueKey: 'costValue' },
+  { key: 'Income', valueKey: 'incomeValue' },
+  { key: 'Residual', valueKey: 'residualValue' },
+];
 
 /**
  * Read-only approach matrix for block appraisals.
  * One row per ProjectModel; approach cells show per-unit base value.
- * Summary cell mirrors the selected approach's per-unit value (matches existing
- * normal-flow ApproachMatrixTable pattern). Footer Project row carries the
- * project grand total appraisal price (sum of model totals).
+ * Summary cell mirrors the selected approach's per-unit value.
+ * Footer Project row carries the project grand total appraisal price.
  */
 const BlockApproachMatrixTable = ({ rows, projectTotal }: BlockApproachMatrixTableProps) => {
-  // Derive which approach types have at least one model that selected them —
-  // mirrors the header check-icon pattern from ApproachMatrixTable.
+  const { t } = useTranslation('appraisal');
+
+  const approachColumns: { key: ApproachKey; label: string; valueKey: ValueKey }[] = [
+    { key: 'Market', label: t('approachMatrixTable.columns.market'), valueKey: 'marketValue' },
+    { key: 'Cost', label: t('approachMatrixTable.columns.cost'), valueKey: 'costValue' },
+    { key: 'Income', label: t('approachMatrixTable.columns.income'), valueKey: 'incomeValue' },
+    { key: 'Residual', label: t('approachMatrixTable.columns.residual'), valueKey: 'residualValue' },
+  ];
+
+  // Derive which approach types have at least one model that selected them
   const selectedApproaches = new Set(
     rows.filter(r => r.selectedApproach != null).map(r => r.selectedApproach as string),
   );
@@ -33,8 +44,10 @@ const BlockApproachMatrixTable = ({ rows, projectTotal }: BlockApproachMatrixTab
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-gray-50 border-b border-gray-200">
-            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Model</th>
-            {APPROACH_COLUMNS.map(col => (
+            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">
+              {t('approachMatrixTable.columns.model')}
+            </th>
+            {approachColumns.map(col => (
               <th
                 key={col.key}
                 className="px-3 py-2 text-right text-xs font-semibold text-gray-600"
@@ -51,14 +64,16 @@ const BlockApproachMatrixTable = ({ rows, projectTotal }: BlockApproachMatrixTab
                 </div>
               </th>
             ))}
-            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">Summary</th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('approachMatrixTable.columns.summary')}
+            </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
           {rows.map(row => (
             <tr key={row.projectModelId} className="hover:bg-gray-50">
               <td className="px-3 py-2 font-medium text-gray-900">{row.modelName ?? '-'}</td>
-              {APPROACH_COLUMNS.map(col => {
+              {approachColumns.map(col => {
                 const value = row[col.valueKey];
                 const isSelected = row.selectedApproach === col.key;
 
@@ -76,10 +91,8 @@ const BlockApproachMatrixTable = ({ rows, projectTotal }: BlockApproachMatrixTab
               })}
               <td className="px-3 py-2 text-right font-medium text-gray-900">
                 {(() => {
-                  const summaryValue = APPROACH_COLUMNS.find(
-                    c => c.key === row.selectedApproach,
-                  )?.valueKey;
-                  const value = summaryValue ? row[summaryValue] : null;
+                  const def = APPROACH_DEFS.find(d => d.key === row.selectedApproach);
+                  const value = def ? row[def.valueKey] : null;
                   return value != null ? (
                     formatNumber(value, 2)
                   ) : (
@@ -92,8 +105,8 @@ const BlockApproachMatrixTable = ({ rows, projectTotal }: BlockApproachMatrixTab
         </tbody>
         <tfoot>
           <tr className="bg-gray-50 border-t border-gray-200 font-semibold">
-            <td className="px-3 py-2 text-gray-900" colSpan={APPROACH_COLUMNS.length + 1}>
-              Project
+            <td className="px-3 py-2 text-gray-900" colSpan={approachColumns.length + 1}>
+              {t('approachMatrixTable.footer.project')}
             </td>
             <td className="px-3 py-2 text-right text-gray-900">{formatNumber(projectTotal, 2)}</td>
           </tr>

--- a/src/features/appraisal/components/summary/BlockPriceSummaryTable.tsx
+++ b/src/features/appraisal/components/summary/BlockPriceSummaryTable.tsx
@@ -1,5 +1,6 @@
 import { formatNumber } from '@/shared/utils/formatUtils';
 import type { BlockModelPriceRow } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface BlockPriceSummaryTableProps {
   rows: BlockModelPriceRow[];
@@ -10,66 +11,72 @@ interface BlockPriceSummaryTableProps {
 
 /**
  * Read-only appraisal price summary for block appraisals.
- * Body rows show per-model totals: TotalAppraisalPrice, ForceSellingPrice (= total × 0.70),
- * and BuildingInsurance (= sum of unit CoverageAmount for that model).
- * Footer "Project" row carries the rolled-up grand totals.
+ * Body rows show per-model totals. Footer "Project" row carries grand totals.
  */
 const BlockPriceSummaryTable = ({
   rows,
   projectTotal,
   forceSellingPrice,
   buildingInsurance,
-}: BlockPriceSummaryTableProps) => (
-  <div className="overflow-x-auto border border-gray-200 rounded-sm">
-    <table className="w-full text-sm">
-      <thead>
-        <tr className="bg-gray-50 border-b border-gray-200">
-          <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Model</th>
-          <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">Unit Count</th>
-          <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
-            Total Appraisal Price
-          </th>
-          <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
-            Force Selling Price
-          </th>
-          <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
-            Building Insurance
-          </th>
-        </tr>
-      </thead>
-      <tbody className="divide-y divide-gray-100">
-        {rows.map(row => (
-          <tr key={row.projectModelId} className="hover:bg-gray-50">
-            <td className="px-3 py-2 font-medium text-gray-900">{row.modelName ?? '-'}</td>
-            <td className="px-3 py-2 text-right text-gray-700">{row.unitCount}</td>
-            <td className="px-3 py-2 text-right text-gray-700">
-              {formatNumber(row.totalAppraisalPrice, 2)}
+}: BlockPriceSummaryTableProps) => {
+  const { t } = useTranslation('appraisal');
+
+  return (
+    <div className="overflow-x-auto border border-gray-200 rounded-sm">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50 border-b border-gray-200">
+            <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">
+              {t('blockPriceSummaryTable.columns.model')}
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('blockPriceSummaryTable.columns.unitCount')}
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('blockPriceSummaryTable.columns.totalAppraisalPrice')}
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('blockPriceSummaryTable.columns.forceSellingPrice')}
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('blockPriceSummaryTable.columns.buildingInsurance')}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map(row => (
+            <tr key={row.projectModelId} className="hover:bg-gray-50">
+              <td className="px-3 py-2 font-medium text-gray-900">{row.modelName ?? '-'}</td>
+              <td className="px-3 py-2 text-right text-gray-700">{row.unitCount}</td>
+              <td className="px-3 py-2 text-right text-gray-700">
+                {formatNumber(row.totalAppraisalPrice, 2)}
+              </td>
+              <td className="px-3 py-2 text-right text-gray-700">
+                {formatNumber(row.forceSellingPrice, 2)}
+              </td>
+              <td className="px-3 py-2 text-right text-gray-700">
+                {formatNumber(row.buildingInsurance, 2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="bg-gray-50 border-t border-gray-200 font-semibold">
+            <td className="px-3 py-2 text-gray-900" colSpan={2}>
+              {t('blockPriceSummaryTable.footer.project')}
             </td>
-            <td className="px-3 py-2 text-right text-gray-700">
-              {formatNumber(row.forceSellingPrice, 2)}
+            <td className="px-3 py-2 text-right text-gray-900">{formatNumber(projectTotal, 2)}</td>
+            <td className="px-3 py-2 text-right text-gray-900">
+              {formatNumber(forceSellingPrice, 2)}
             </td>
-            <td className="px-3 py-2 text-right text-gray-700">
-              {formatNumber(row.buildingInsurance, 2)}
+            <td className="px-3 py-2 text-right text-gray-900">
+              {formatNumber(buildingInsurance, 2)}
             </td>
           </tr>
-        ))}
-      </tbody>
-      <tfoot>
-        <tr className="bg-gray-50 border-t border-gray-200 font-semibold">
-          <td className="px-3 py-2 text-gray-900" colSpan={2}>
-            Project
-          </td>
-          <td className="px-3 py-2 text-right text-gray-900">{formatNumber(projectTotal, 2)}</td>
-          <td className="px-3 py-2 text-right text-gray-900">
-            {formatNumber(forceSellingPrice, 2)}
-          </td>
-          <td className="px-3 py-2 text-right text-gray-900">
-            {formatNumber(buildingInsurance, 2)}
-          </td>
-        </tr>
-      </tfoot>
-    </table>
-  </div>
-);
+        </tfoot>
+      </table>
+    </div>
+  );
+};
 
 export default BlockPriceSummaryTable;

--- a/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
+++ b/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
@@ -2,6 +2,7 @@ import Icon from '@/shared/components/Icon';
 import { ConstructionTimelineBar } from '@/shared/components/ConstructionTimelineBar';
 import { formatNumber } from '@/shared/utils/formatUtils';
 import type { ConstructionSummaryRow } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   rows: ConstructionSummaryRow[];
@@ -75,6 +76,8 @@ const ROW_CONFIG: Record<
 const DEFAULT_CONFIG = ROW_CONFIG['Previous'];
 
 const ConstructionSummaryTable = ({ rows }: Props) => {
+  const { t } = useTranslation('appraisal');
+
   const previousRow = rows.find(r => r.label === 'Previous');
   const currentRow = rows.find(r => r.label === 'Current');
   const completeRow = rows.find(r => r.label === 'Complete ( 100% )');
@@ -92,31 +95,31 @@ const ConstructionSummaryTable = ({ rows }: Props) => {
           <thead>
             <tr className="bg-gray-50 border-b border-gray-200">
               <th className="px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-56">
-                Milestone
+                {t('constructionSummaryTable.columns.milestone')}
               </th>
               <th
                 className="px-3 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-40 leading-tight"
                 title="Land Value + under-construction value at this milestone + completed buildings"
               >
-                Total Appraisal Value
+                {t('constructionSummaryTable.columns.totalAppraisalValue')}
               </th>
               <th className="px-3 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-36 leading-tight">
-                Land Value
+                {t('constructionSummaryTable.columns.landValue')}
               </th>
               <th className="px-3 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-32 leading-tight">
-                Construction Progress (%)
+                {t('constructionSummaryTable.columns.constructionProgress')}
               </th>
               <th
                 className="px-3 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-36 leading-tight"
                 title="Current under-construction structure value at this milestone (CI only)"
               >
-                Building Value
+                {t('constructionSummaryTable.columns.buildingValue')}
               </th>
               <th
                 className="px-3 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-44 leading-tight"
                 title="Completed buildings registered before the construction inspection (non-CI)"
               >
-                Building Value Pre-inspection
+                {t('constructionSummaryTable.columns.buildingValuePreInspection')}
               </th>
             </tr>
           </thead>

--- a/src/features/appraisal/components/summary/GovernmentPriceTable.tsx
+++ b/src/features/appraisal/components/summary/GovernmentPriceTable.tsx
@@ -1,5 +1,6 @@
 import { formatNumber } from '@/shared/utils/formatUtils';
 import type { GovernmentPriceRow } from '../../api/decisionSummary';
+import { useTranslation } from 'react-i18next';
 
 interface GovernmentPriceTableProps {
   rows: GovernmentPriceRow[];
@@ -11,6 +12,7 @@ interface GovernmentPriceTableProps {
  * Read-only table for government appraisal prices.
  */
 const GovernmentPriceTable = ({ rows, totalArea, avgPerSqWa }: GovernmentPriceTableProps) => {
+  const { t } = useTranslation('appraisal');
   const totalPrice = rows.reduce((sum, row) => sum + (row.governmentPrice ?? 0), 0);
   const isSingleDeed = rows.length === 1;
 
@@ -20,13 +22,17 @@ const GovernmentPriceTable = ({ rows, totalArea, avgPerSqWa }: GovernmentPriceTa
         <thead>
           <tr className="bg-gray-50 border-b border-gray-200">
             <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">
-              Title Deed No.
+              {t('governmentPriceTable.columns.titleDeedNo')}
             </th>
-            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">Sq.Wa</th>
             <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
-              Baht / Sq.Wa
+              {t('governmentPriceTable.columns.sqWa')}
             </th>
-            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">Land Price</th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('governmentPriceTable.columns.bahtPerSqWa')}
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-semibold text-gray-600">
+              {t('governmentPriceTable.columns.landPrice')}
+            </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
@@ -37,7 +43,7 @@ const GovernmentPriceTable = ({ rows, totalArea, avgPerSqWa }: GovernmentPriceTa
                   {row.titleNumber ?? '-'}
                   {row.isMissingFromSurvey && (
                     <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-amber-200">
-                      Missing from survey
+                      {t('governmentPriceTable.missingFromSurvey')}
                     </span>
                   )}
                 </span>
@@ -66,14 +72,14 @@ const GovernmentPriceTable = ({ rows, totalArea, avgPerSqWa }: GovernmentPriceTa
           <tfoot>
             <tr className="bg-gray-100 border-t-2 border-gray-400">
               <td className="px-3 py-3 text-gray-700 font-bold uppercase tracking-wider text-xs">
-                Total
+                {t('governmentPriceTable.footer.total')}
               </td>
               <td className="px-3 py-3 text-right font-bold text-gray-900 tabular-nums">
                 {formatNumber(totalArea, 2)}
               </td>
               <td className="px-3 py-3 text-right text-gray-700 tabular-nums">
                 <span className="text-[10px] uppercase tracking-wider text-gray-400 font-medium mr-1.5">
-                  avg
+                  {t('governmentPriceTable.footer.avg')}
                 </span>
                 {formatNumber(avgPerSqWa, 2)}
               </td>

--- a/src/features/appraisal/forms/LandCharacteristicsForm.tsx
+++ b/src/features/appraisal/forms/LandCharacteristicsForm.tsx
@@ -2,139 +2,131 @@ import { FormFields, type FormField } from '@/shared/components/form';
 import RadioGroup from '@shared/components/inputs/RadioGroup';
 import CheckboxGroup from '@shared/components/inputs/CheckboxGroup';
 import { useFormContext } from 'react-hook-form';
-
-// Landfill Options
-const landfillOptions = [
-  { value: 'emptyLand', label: 'Empty Land' },
-  { value: 'filled', label: 'Filled' },
-  { value: 'notFilledYet', label: 'Not Filled yet' },
-  { value: 'partiallyFilled', label: 'Partially Filled' },
-  { value: 'other', label: 'Other' },
-];
-
-// Land Accessibility Options
-const landAccessibilityOptions = [
-  { value: 'able', label: 'Able' },
-  { value: 'unable', label: 'Unable' },
-  { value: 'inAllocation', label: 'In Allocation' },
-];
-
-// Road Surface Options
-const roadSurfaceOptions = [
-  { value: 'reinforcedConcrete', label: 'Reinforced Concrete' },
-  { value: 'gravelCrushedStone', label: 'Gravel/Crushed Stone' },
-  { value: 'soil', label: 'Soil' },
-  { value: 'paved', label: 'Paved' },
-  { value: 'other', label: 'Other' },
-];
-
-// Public Utility Options
-const publicUtilityOptions = [
-  { value: 'permanentElectricity', label: 'Permanent Electricity' },
-  { value: 'tapWaterGroundwater', label: 'Tap Water/Groundwater' },
-  { value: 'drainagePipeStone', label: 'Drainage Pipe/Stone' },
-  { value: 'streetlight', label: 'Streetlight' },
-  { value: 'other', label: 'Other' },
-];
-
-// Land Use Options
-const landUseOptions = [
-  { value: 'residence', label: 'Residence' },
-  { value: 'agriculture', label: 'Agriculture' },
-  { value: 'commercial', label: 'Commercial' },
-  { value: 'industry', label: 'Industry' },
-  { value: 'other', label: 'Other' },
-];
-
-// Land Entrance-Exit Options
-const landEntranceExitOptions = [
-  { value: 'publicInterest', label: 'Public Interest' },
-  { value: 'insideAllocationProject', label: 'Inside the Allocation Project' },
-  { value: 'personal', label: 'Personal' },
-  { value: 'servitude', label: 'Servitude' },
-  { value: 'other', label: 'Other' },
-];
-
-// Transportation Options
-const transportationOptions = [
-  { value: 'car', label: 'Car' },
-  { value: 'bus', label: 'Bus' },
-  { value: 'ship', label: 'Ship' },
-  { value: 'footpath', label: 'Footpath' },
-  { value: 'other', label: 'Other' },
-];
-
-// Anticipation of Property Options
-const anticipationOptions = [
-  { value: 'veryProspective', label: 'Very Prospective' },
-  { value: 'moderate', label: 'Moderate' },
-  { value: 'likelyToProsperInFuture', label: 'Likely to Prosper in the Future' },
-  { value: 'littleChanceOfProsperity', label: 'Little Chance of Prosperity' },
-];
-
-// Eviction Options
-const evictionOptions = [
-  { value: 'permanentElectricity', label: 'Permanent Electricity' },
-  { value: 'subwayLine', label: 'Subway Line' },
-  { value: 'other', label: 'Other' },
-];
-
-// Allocation Options
-const allocationOptions = [
-  { value: 'allocateNewProject', label: 'Allocate New Projects' },
-  { value: 'allocateOldProject', label: 'Allocate Old Projects' },
-  { value: 'notAllocate', label: 'Not Allocate' },
-];
-
-// Has Building Options
-const hasBuildingOptions = [
-  { value: 'yes', label: 'Yes' },
-  { value: 'no', label: 'No' },
-  { value: 'other', label: 'Other' },
-];
-
-const roadFields: FormField[] = [
-  {
-    type: 'text-input',
-    label: 'Road Width',
-    name: 'roadWidth',
-    wrapperClassName: 'col-span-3',
-  },
-  {
-    type: 'text-input',
-    label: 'Right of Way',
-    name: 'rightOfWay',
-    wrapperClassName: 'col-span-3',
-  },
-  {
-    type: 'text-input',
-    label: 'Road Frontage of land adjacent to the road',
-    name: 'roadFrontage',
-    wrapperClassName: 'col-span-3',
-  },
-  {
-    type: 'text-input',
-    label: 'Number of sides facing the road',
-    name: 'numberOrSidesFacingRoad',
-    wrapperClassName: 'col-span-3',
-  },
-  {
-    type: 'text-input',
-    label: 'Road running in front of the land',
-    name: 'roadRunningInFrontOfLand',
-    wrapperClassName: 'col-span-6',
-  },
-];
+import { useTranslation } from 'react-i18next';
 
 export default function LandCharacteristicsForm() {
   const { register } = useFormContext();
+  const { t } = useTranslation('appraisal');
+
+  // Option arrays built inside component so labels are translated
+  const landfillOptions = [
+    { value: 'emptyLand', label: t('landCharacteristicsForm.landfillOptions.emptyLand') },
+    { value: 'filled', label: t('landCharacteristicsForm.landfillOptions.filled') },
+    { value: 'notFilledYet', label: t('landCharacteristicsForm.landfillOptions.notFilledYet') },
+    { value: 'partiallyFilled', label: t('landCharacteristicsForm.landfillOptions.partiallyFilled') },
+    { value: 'other', label: t('landCharacteristicsForm.landfillOptions.other') },
+  ];
+
+  const landAccessibilityOptions = [
+    { value: 'able', label: t('landCharacteristicsForm.landAccessibilityOptions.able') },
+    { value: 'unable', label: t('landCharacteristicsForm.landAccessibilityOptions.unable') },
+    { value: 'inAllocation', label: t('landCharacteristicsForm.landAccessibilityOptions.inAllocation') },
+  ];
+
+  const roadSurfaceOptions = [
+    { value: 'reinforcedConcrete', label: t('landCharacteristicsForm.roadSurfaceOptions.reinforcedConcrete') },
+    { value: 'gravelCrushedStone', label: t('landCharacteristicsForm.roadSurfaceOptions.gravelCrushedStone') },
+    { value: 'soil', label: t('landCharacteristicsForm.roadSurfaceOptions.soil') },
+    { value: 'paved', label: t('landCharacteristicsForm.roadSurfaceOptions.paved') },
+    { value: 'other', label: t('landCharacteristicsForm.roadSurfaceOptions.other') },
+  ];
+
+  const publicUtilityOptions = [
+    { value: 'permanentElectricity', label: t('landCharacteristicsForm.publicUtilityOptions.permanentElectricity') },
+    { value: 'tapWaterGroundwater', label: t('landCharacteristicsForm.publicUtilityOptions.tapWaterGroundwater') },
+    { value: 'drainagePipeStone', label: t('landCharacteristicsForm.publicUtilityOptions.drainagePipeStone') },
+    { value: 'streetlight', label: t('landCharacteristicsForm.publicUtilityOptions.streetlight') },
+    { value: 'other', label: t('landCharacteristicsForm.publicUtilityOptions.other') },
+  ];
+
+  const landUseOptions = [
+    { value: 'residence', label: t('landCharacteristicsForm.landUseOptions.residence') },
+    { value: 'agriculture', label: t('landCharacteristicsForm.landUseOptions.agriculture') },
+    { value: 'commercial', label: t('landCharacteristicsForm.landUseOptions.commercial') },
+    { value: 'industry', label: t('landCharacteristicsForm.landUseOptions.industry') },
+    { value: 'other', label: t('landCharacteristicsForm.landUseOptions.other') },
+  ];
+
+  const landEntranceExitOptions = [
+    { value: 'publicInterest', label: t('landCharacteristicsForm.landEntranceExitOptions.publicInterest') },
+    { value: 'insideAllocationProject', label: t('landCharacteristicsForm.landEntranceExitOptions.insideAllocationProject') },
+    { value: 'personal', label: t('landCharacteristicsForm.landEntranceExitOptions.personal') },
+    { value: 'servitude', label: t('landCharacteristicsForm.landEntranceExitOptions.servitude') },
+    { value: 'other', label: t('landCharacteristicsForm.landEntranceExitOptions.other') },
+  ];
+
+  const transportationOptions = [
+    { value: 'car', label: t('landCharacteristicsForm.transportationOptions.car') },
+    { value: 'bus', label: t('landCharacteristicsForm.transportationOptions.bus') },
+    { value: 'ship', label: t('landCharacteristicsForm.transportationOptions.ship') },
+    { value: 'footpath', label: t('landCharacteristicsForm.transportationOptions.footpath') },
+    { value: 'other', label: t('landCharacteristicsForm.transportationOptions.other') },
+  ];
+
+  const anticipationOptions = [
+    { value: 'veryProspective', label: t('landCharacteristicsForm.anticipationOptions.veryProspective') },
+    { value: 'moderate', label: t('landCharacteristicsForm.anticipationOptions.moderate') },
+    { value: 'likelyToProsperInFuture', label: t('landCharacteristicsForm.anticipationOptions.likelyToProsperInFuture') },
+    { value: 'littleChanceOfProsperity', label: t('landCharacteristicsForm.anticipationOptions.littleChanceOfProsperity') },
+  ];
+
+  const evictionOptions = [
+    { value: 'permanentElectricity', label: t('landCharacteristicsForm.evictionOptions.permanentElectricity') },
+    { value: 'subwayLine', label: t('landCharacteristicsForm.evictionOptions.subwayLine') },
+    { value: 'other', label: t('landCharacteristicsForm.evictionOptions.other') },
+  ];
+
+  const allocationOptions = [
+    { value: 'allocateNewProject', label: t('landCharacteristicsForm.allocationOptions.allocateNewProject') },
+    { value: 'allocateOldProject', label: t('landCharacteristicsForm.allocationOptions.allocateOldProject') },
+    { value: 'notAllocate', label: t('landCharacteristicsForm.allocationOptions.notAllocate') },
+  ];
+
+  const hasBuildingOptions = [
+    { value: 'yes', label: t('landCharacteristicsForm.hasBuildingOptions.yes') },
+    { value: 'no', label: t('landCharacteristicsForm.hasBuildingOptions.no') },
+    { value: 'other', label: t('landCharacteristicsForm.hasBuildingOptions.other') },
+  ];
+
+  const roadFields: FormField[] = [
+    {
+      type: 'text-input',
+      label: t('landCharacteristicsForm.fields.roadWidth'),
+      name: 'roadWidth',
+      wrapperClassName: 'col-span-3',
+    },
+    {
+      type: 'text-input',
+      label: t('landCharacteristicsForm.fields.rightOfWay'),
+      name: 'rightOfWay',
+      wrapperClassName: 'col-span-3',
+    },
+    {
+      type: 'text-input',
+      label: t('landCharacteristicsForm.fields.roadFrontage'),
+      name: 'roadFrontage',
+      wrapperClassName: 'col-span-3',
+    },
+    {
+      type: 'text-input',
+      label: t('landCharacteristicsForm.fields.numberOrSidesFacingRoad'),
+      name: 'numberOrSidesFacingRoad',
+      wrapperClassName: 'col-span-3',
+    },
+    {
+      type: 'text-input',
+      label: t('landCharacteristicsForm.fields.roadRunningInFrontOfLand'),
+      name: 'roadRunningInFrontOfLand',
+      wrapperClassName: 'col-span-6',
+    },
+  ];
 
   return (
     <div className="flex flex-col gap-8">
       {/* Landfill Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Landfill</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.landfill')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <RadioGroup name="landfill" options={landfillOptions} />
@@ -143,13 +135,13 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'landfillOther',
                   wrapperClassName: 'col-span-3',
                 },
                 {
                   type: 'text-input',
-                  label: 'Landfill Height',
+                  label: t('landCharacteristicsForm.fields.landfillHeight'),
                   name: 'landfillHeight',
                   wrapperClassName: 'col-span-3',
                 },
@@ -164,7 +156,7 @@ export default function LandCharacteristicsForm() {
       {/* Road Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Road</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.road')}</h3>
         </div>
         <div className="flex-1">
           <div className="grid grid-cols-6 gap-4">
@@ -178,7 +170,7 @@ export default function LandCharacteristicsForm() {
       {/* Land Accessibility Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Land Accessibility</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.landAccessibility')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <RadioGroup name="landAccessibility" options={landAccessibilityOptions} />
@@ -187,7 +179,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Land Accessibility Description',
+                  label: t('landCharacteristicsForm.fields.landAccessibilityDescription'),
                   name: 'landAccessibilityDescription',
                   wrapperClassName: 'col-span-6',
                 },
@@ -202,7 +194,7 @@ export default function LandCharacteristicsForm() {
       {/* Road Surface Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Road Surface</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.roadSurface')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="roadSurface" options={roadSurfaceOptions} />
@@ -211,7 +203,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'roadSurfaceOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -226,7 +218,7 @@ export default function LandCharacteristicsForm() {
       {/* Public Utility Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Public Utility</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.publicUtility')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="publicUtility" options={publicUtilityOptions} />
@@ -235,7 +227,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'publicUtilityOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -250,7 +242,7 @@ export default function LandCharacteristicsForm() {
       {/* Land Use Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Land Use</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.landUse')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="landUse" options={landUseOptions} />
@@ -259,7 +251,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'landUseOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -274,7 +266,7 @@ export default function LandCharacteristicsForm() {
       {/* Land Entrance-Exit Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Land Entrance-Exit</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.landEntranceExit')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="landEntranceExit" options={landEntranceExitOptions} />
@@ -283,7 +275,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'landEntranceExitOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -298,7 +290,7 @@ export default function LandCharacteristicsForm() {
       {/* Transportation Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Transportation</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.transportation')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="transportation" options={transportationOptions} />
@@ -307,7 +299,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'transportationOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -322,7 +314,7 @@ export default function LandCharacteristicsForm() {
       {/* Anticipation of Property Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Anticipation of Property</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.anticipationOfProperty')}</h3>
         </div>
         <div className="flex-1">
           <RadioGroup name="anticipationOfProperty" options={anticipationOptions} />
@@ -334,7 +326,7 @@ export default function LandCharacteristicsForm() {
       {/* Limitation Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Limitation</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.limitation')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <div className="flex flex-wrap gap-4">
@@ -344,7 +336,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.isExpropriate')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Is Expropriate</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.isExpropriate')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -352,7 +344,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.inLineExpropriate')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">In Line Expropriate</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.inLineExpropriate')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -360,7 +352,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.royalDecree')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Royal Decree</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.royalDecree')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -368,7 +360,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.isEncroached')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Is Encroached</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.isEncroached')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -376,7 +368,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.electricity')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Electricity</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.electricity')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -384,7 +376,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.isLandlocked')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Is Landlocked</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.isLandlocked')}</span>
             </label>
             <label className="label cursor-pointer gap-2">
               <input
@@ -392,7 +384,7 @@ export default function LandCharacteristicsForm() {
                 {...register('limitation.isForestBoundary')}
                 className="checkbox checkbox-sm checkbox-primary"
               />
-              <span className="label-text">Is Forest Boundary</span>
+              <span className="label-text">{t('landCharacteristicsForm.fields.isForestBoundary')}</span>
             </label>
           </div>
           <div className="grid grid-cols-6 gap-4">
@@ -400,13 +392,13 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Area Sq.Wa',
+                  label: t('landCharacteristicsForm.fields.areaSqWa'),
                   name: 'limitation.areaSqWa',
                   wrapperClassName: 'col-span-3',
                 },
                 {
                   type: 'text-input',
-                  label: 'Distance',
+                  label: t('landCharacteristicsForm.fields.distance'),
                   name: 'limitation.distanceValue',
                   wrapperClassName: 'col-span-3',
                 },
@@ -421,7 +413,7 @@ export default function LandCharacteristicsForm() {
       {/* Eviction Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Eviction</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.eviction')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <CheckboxGroup name="eviction" options={evictionOptions} />
@@ -430,7 +422,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'evictionOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -445,7 +437,7 @@ export default function LandCharacteristicsForm() {
       {/* Allocation Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Allocation</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.allocation')}</h3>
         </div>
         <div className="flex-1">
           <RadioGroup name="allocation" options={allocationOptions} />
@@ -457,7 +449,7 @@ export default function LandCharacteristicsForm() {
       {/* Has Building Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Has Building</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.hasBuilding')}</h3>
         </div>
         <div className="flex-1 flex flex-col gap-4">
           <RadioGroup name="hasBuilding" options={hasBuildingOptions} />
@@ -466,7 +458,7 @@ export default function LandCharacteristicsForm() {
               fields={[
                 {
                   type: 'text-input',
-                  label: 'Other',
+                  label: t('landCharacteristicsForm.fields.other'),
                   name: 'hasBuildingOther',
                   wrapperClassName: 'col-span-6',
                 },
@@ -481,13 +473,13 @@ export default function LandCharacteristicsForm() {
       {/* Remark Section */}
       <div className="flex gap-6">
         <div className="w-44 flex-shrink-0">
-          <h3 className="text-base font-medium">Remark</h3>
+          <h3 className="text-base font-medium">{t('landCharacteristicsForm.sections.remark')}</h3>
         </div>
         <div className="flex-1">
           <textarea
             {...register('remark')}
             className="textarea textarea-bordered w-full h-24"
-            placeholder="Enter remarks..."
+            placeholder={t('landCharacteristicsForm.fields.remarkPlaceholder')}
           />
         </div>
       </div>

--- a/src/features/appraisal/pages/AppointmentAndFeePage.tsx
+++ b/src/features/appraisal/pages/AppointmentAndFeePage.tsx
@@ -8,17 +8,18 @@ import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useAppraisalContext } from '../context/AppraisalContext';
 import { useAuthStore } from '@/features/auth/store';
 import AppointmentInfoCard from '../components/AppointmentInfoCard';
+import AppointmentHistoryDrawer from '../components/AppointmentHistoryDrawer';
 import RescheduleModal from '../components/RescheduleModal';
 import FeeInformationSection, { BANK_ABSORB_FEE_TYPES } from '../components/FeeInformationSection';
 import PaymentInformationSection from '../components/PaymentInformationSection';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
-import { VAT_PERCENTAGE } from '../types/appointmentAndFee';
 import {
   useCancelAppointment,
   useCreateAppointment,
   useGetAppointment,
   useRescheduleAppointment,
 } from '../api/appointment';
+import { useGetAppointmentHistory } from '../api/appointmentHistory';
 import {
   useAddFeeItem,
   useApproveFeeItem,
@@ -46,6 +47,7 @@ export default function AppointmentAndFeePage() {
   const readOnly = usePageReadOnly();
   const [isRescheduleModalOpen, setIsRescheduleModalOpen] = useState(false);
   const [isCancelAppointmentModalOpen, setIsCancelAppointmentModalOpen] = useState(false);
+  const [isHistoryDrawerOpen, setIsHistoryDrawerOpen] = useState(false);
   const navigate = useNavigate();
   const { appraisal } = useAppraisalContext();
   const appraisalId = appraisal?.appraisalId ?? '';
@@ -53,6 +55,7 @@ export default function AppointmentAndFeePage() {
 
   // API hooks - Appointments
   const { data: appointment = null } = useGetAppointment(appraisalId);
+  const { data: historyEvents = [] } = useGetAppointmentHistory(appraisalId);
 
   // API hooks - Fees
   const { data: fees = [] } = useGetAppraisalFees(appraisalId);
@@ -77,8 +80,6 @@ export default function AppointmentAndFeePage() {
   // Get the first fee record
   const currentFee = fees.length > 0 ? fees[0] : null;
 
-  // Derive whether the current fee payment type is a bank-absorb type.
-  const isBankAbsorb = BANK_ABSORB_FEE_TYPES.includes((currentFee as any)?.feePaymentType ?? '');
 
   const isNewAppointment = !appointment;
 
@@ -108,7 +109,7 @@ export default function AppointmentAndFeePage() {
           appraisalId,
           assignmentId: appraisal?.appraisalId ?? '',
           appointmentDateTime: data.dateTime,
-          appointedBy: currentUser?.id ?? '',
+          appointedBy: currentUser?.username ?? '',
           locationDetail: data.location,
           contactPerson: null,
           contactPhone: null,
@@ -118,7 +119,7 @@ export default function AppointmentAndFeePage() {
         await rescheduleAppointment.mutateAsync({
           appraisalId,
           appointmentId: appointment!.id,
-          changedBy: currentUser?.id ?? '',
+          changedBy: currentUser?.username ?? '',
           newDateTime: data.dateTime,
           reason: data.reason || null,
         });
@@ -136,7 +137,7 @@ export default function AppointmentAndFeePage() {
       await cancelAppointment.mutateAsync({
         appraisalId,
         appointmentId: appointment.id,
-        changedBy: currentUser?.id ?? '',
+        changedBy: currentUser?.username ?? '',
         reason: null,
       });
       setIsCancelAppointmentModalOpen(false);
@@ -152,7 +153,7 @@ export default function AppointmentAndFeePage() {
         appraisalId,
         feeId,
         itemId,
-        approvedBy: currentUser?.id ?? '',
+        approvedBy: currentUser?.username ?? '',
       });
       toast.success(t('fee.toasts.feeApproved'));
     } catch (error: any) {
@@ -166,7 +167,7 @@ export default function AppointmentAndFeePage() {
         appraisalId,
         feeId,
         itemId,
-        rejectedBy: currentUser?.id ?? '',
+        rejectedBy: currentUser?.username ?? '',
         reason: reason || 'Rejected',
       });
       toast.success(t('fee.toasts.feeRejected'));
@@ -175,27 +176,31 @@ export default function AppointmentAndFeePage() {
     }
   };
 
-  const computeTotalFee = (items: Array<{ feeAmount?: number }>) => {
-    const vatRate = currentFee?.vatRate ?? VAT_PERCENTAGE;
-    const subtotal = items.reduce((sum, item) => sum + (item.feeAmount ?? 0), 0);
-    return subtotal * (1 + vatRate / 100);
-  };
-
-  const handleUpdateFeePaymentType = async (value: string, overrideTotalFee?: number) => {
+  const handleUpdateFeePaymentType = async (value: string) => {
     if (!currentFee) return;
-    const totalFee = overrideTotalFee ?? computeTotalFee(currentFee.items ?? []);
-    const isNewValueBankAbsorb = BANK_ABSORB_FEE_TYPES.includes(value);
     try {
       await updateAppraisalFee.mutateAsync({
         appraisalId,
         feeId: currentFee.id ?? '',
         feePaymentType: value,
-        bankAbsorbAmount: isNewValueBankAbsorb ? totalFee : 0,
+        bankAbsorbAmount: BANK_ABSORB_FEE_TYPES.includes(value)
+          ? (currentFee.bankAbsorbAmount ?? 0)
+          : 0,
       });
       toast.success(t('fee.toasts.feeTypeUpdated'));
     } catch (error: any) {
       toast.error(error.apiError?.detail || t('fee.toasts.feeTypeUpdateFailed'));
     }
+  };
+
+  const handleUpdateBankAbsorbAmount = async (amount: number) => {
+    if (!currentFee) return;
+    await updateAppraisalFee.mutateAsync({
+      appraisalId,
+      feeId: currentFee.id ?? '',
+      feePaymentType: currentFee.feePaymentType ?? '',
+      bankAbsorbAmount: amount,
+    });
   };
 
   const handleAddFeeItem = async (data: {
@@ -209,8 +214,6 @@ export default function AppointmentAndFeePage() {
       feeId: currentFee.id ?? '',
       ...data,
     });
-    const newItems = [...(currentFee.items ?? []), { feeAmount: data.feeAmount }];
-    handleUpdateFeePaymentType(currentFee.feePaymentType ?? '', computeTotalFee(newItems));
   };
 
   const handleUpdateFeeItem = async (
@@ -224,10 +227,6 @@ export default function AppointmentAndFeePage() {
       feeItemId,
       ...data,
     });
-    const newItems = (currentFee?.items ?? []).map(item =>
-      item.id === feeItemId ? { ...item, feeAmount: data.feeAmount } : item,
-    );
-    handleUpdateFeePaymentType(currentFee?.feePaymentType ?? '', computeTotalFee(newItems));
   };
 
   const handleRemoveFeeItem = async (feeId: string, feeItemId: string) => {
@@ -236,8 +235,6 @@ export default function AppointmentAndFeePage() {
       feeId,
       feeItemId,
     });
-    const newItems = (currentFee?.items ?? []).filter(item => item.id !== feeItemId);
-    handleUpdateFeePaymentType(currentFee?.feePaymentType ?? '', computeTotalFee(newItems));
   };
 
   const handleRecordPayment = async (data: {
@@ -337,6 +334,8 @@ export default function AppointmentAndFeePage() {
             onCancel={() => !readOnly && setIsCancelAppointmentModalOpen(true)}
             approvalDraft={approvalState.draftDateChange}
             approvalSubmitted={approvalState.submittedDateChange}
+            onViewHistory={() => setIsHistoryDrawerOpen(true)}
+            historyEventCount={historyEvents.length}
           />
 
           {/* Divider */}
@@ -362,6 +361,10 @@ export default function AppointmentAndFeePage() {
               onUpdateConstructionInspectionFee={handleUpdateConstructionInspectionFee}
               isConstructionInspectionFeeUpdating={updateConstructionInspectionFee.isPending}
               totalFeePaid={currentFee?.totalPaidAmount ?? 0}
+              bankAbsorbAmount={currentFee?.bankAbsorbAmount ?? null}
+              totalFeeAfterVAT={currentFee?.totalFeeAfterVAT ?? undefined}
+              onUpdateBankAbsorbAmount={handleUpdateBankAbsorbAmount}
+              isAbsorbAmountUpdating={updateAppraisalFee.isPending}
             />
 
             {/* Payment Information (Right Column) */}
@@ -372,7 +375,6 @@ export default function AppointmentAndFeePage() {
               onUpdatePayment={handleUpdatePayment}
               onRemovePayment={handleRemovePayment}
               requestedAt={appraisal?.requestedAt}
-              isBankAbsorb={isBankAbsorb}
               isPaymentPending={
                 recordPayment.isPending || updatePayment.isPending || removePayment.isPending
               }
@@ -383,7 +385,7 @@ export default function AppointmentAndFeePage() {
 
       {/* Sticky Footer */}
       <div className="shrink-0 bg-white border-t border-gray-200 px-4 py-3 pr-6 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center justify-between gap-3">
           <Button variant="ghost" type="button" onClick={() => navigate(-1)}>
             Cancel
           </Button>
@@ -428,6 +430,13 @@ export default function AppointmentAndFeePage() {
         confirmText={t('appointment.cancelDialog.confirm')}
         cancelText={t('appointment.cancelDialog.cancel')}
         variant="danger"
+      />
+
+      {/* Appointment & Fee History Drawer */}
+      <AppointmentHistoryDrawer
+        appraisalId={appraisalId}
+        open={isHistoryDrawerOpen}
+        onClose={() => setIsHistoryDrawerOpen(false)}
       />
     </div>
   );

--- a/src/features/appraisal/pages/CreateBuildingPage.tsx
+++ b/src/features/appraisal/pages/CreateBuildingPage.tsx
@@ -283,9 +283,9 @@ const CreateBuildingPage = () => {
         <NavAnchors
           containerId="form-scroll-container"
           anchors={[
-            { label: 'Photos', id: 'photos', icon: 'images' },
+            { label: t('createPage.navPhotos'), id: 'photos', icon: 'images' },
             {
-              label: 'Building',
+              label: t('createPage.navBuilding'),
               id: 'properties-section',
               icon: 'building',
               onClick: () => setActiveTab('building'),
@@ -293,7 +293,7 @@ const CreateBuildingPage = () => {
             ...(isUnderConstruction || isCiAppraisal
               ? [
                   {
-                    label: 'Construction Inspection',
+                    label: t('createPage.navConstructionInspection'),
                     id: 'construction-section',
                     icon: 'helmet-safety',
                     onClick: () => setActiveTab('construction'),
@@ -332,7 +332,7 @@ const CreateBuildingPage = () => {
                                 className="w-5 h-5 text-indigo-600"
                               />
                             </div>
-                            <h2 className="text-lg font-semibold text-gray-900">Photos</h2>
+                            <h2 className="text-lg font-semibold text-gray-900">{t('createPage.photosSection')}</h2>
                           </div>
                           <div className="h-px bg-gray-200 mb-4" />
                           {appraisalId && (
@@ -356,7 +356,7 @@ const CreateBuildingPage = () => {
                           <Icon name="building" style="solid" className="w-5 h-5 text-blue-600" />
                         </div>
                         <h2 className="text-lg font-semibold text-gray-900">
-                          Building Information
+                          {t('createPage.buildingSection')}
                         </h2>
                       </div>
                       <div className="h-px bg-gray-200" />
@@ -380,7 +380,7 @@ const CreateBuildingPage = () => {
                             />
                           </div>
                           <h2 className="text-lg font-semibold text-gray-900">
-                            Construction Inspection
+                            {t('createPage.constructionSection')}
                           </h2>
                         </div>
                         <div className="h-px bg-gray-200" />
@@ -420,7 +420,7 @@ const CreateBuildingPage = () => {
                     disabled={isPending}
                   >
                     <Icon name="floppy-disk" style="regular" className="size-4 mr-2" />
-                    Save draft
+                    {t('createPage.saveDraft')}
                   </Button>
                   <Button
                     type="submit"
@@ -428,7 +428,7 @@ const CreateBuildingPage = () => {
                     disabled={isPending}
                   >
                     <Icon name="check" style="solid" className="size-4 mr-2" />
-                    Save
+                    {t('createPage.save')}
                   </Button>
                 </ActionBar.Right>
               )}

--- a/src/features/appraisal/pages/CreateCondoPage.tsx
+++ b/src/features/appraisal/pages/CreateCondoPage.tsx
@@ -190,8 +190,8 @@ const CreateCondoPage = () => {
         <NavAnchors
           containerId="form-scroll-container"
           anchors={[
-            { label: 'Photos', id: 'photos', icon: 'images' },
-            { label: 'Condo', id: 'properties-section', icon: 'building' },
+            { label: t('createPage.navPhotos'), id: 'photos', icon: 'images' },
+            { label: t('createPage.navCondo'), id: 'properties-section', icon: 'building' },
           ]}
         />
       </div>
@@ -217,7 +217,7 @@ const CreateCondoPage = () => {
                       <div className="w-9 h-9 rounded-lg bg-indigo-100 flex items-center justify-center">
                         <Icon name="images" style="solid" className="w-5 h-5 text-indigo-600" />
                       </div>
-                      <h2 className="text-lg font-semibold text-gray-900">Photos</h2>
+                      <h2 className="text-lg font-semibold text-gray-900">{t('createPage.photosSection')}</h2>
                     </div>
                     <div className="h-px bg-gray-200 mb-4" />
                     {appraisalId && (
@@ -235,7 +235,7 @@ const CreateCondoPage = () => {
                       <div className="w-9 h-9 rounded-lg bg-violet-100 flex items-center justify-center">
                         <Icon name="building" style="solid" className="w-5 h-5 text-violet-600" />
                       </div>
-                      <h2 className="text-lg font-semibold text-gray-900">Condo Information</h2>
+                      <h2 className="text-lg font-semibold text-gray-900">{t('createPage.condoSection')}</h2>
                     </div>
                     <div className="h-px bg-gray-200" />
                   </Section>
@@ -274,7 +274,7 @@ const CreateCondoPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="floppy-disk" style="regular" className="size-4 mr-2" />
-                  Save draft
+                  {t('createPage.saveDraft')}
                 </Button>
                 <Button
                   type="submit"
@@ -282,7 +282,7 @@ const CreateCondoPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="check" style="solid" className="size-4 mr-2" />
-                  Save
+                  {t('createPage.save')}
                 </Button>
               </ActionBar.Right>
             )}

--- a/src/features/appraisal/pages/CreateLandBuildingPage.tsx
+++ b/src/features/appraisal/pages/CreateLandBuildingPage.tsx
@@ -252,15 +252,15 @@ const CreateLandBuildingPage = () => {
         <NavAnchors
           containerId="form-scroll-container"
           anchors={[
-            { label: 'Photos', id: 'photos', icon: 'images' },
+            { label: t('createPage.navPhotos'), id: 'photos', icon: 'images' },
             {
-              label: 'Land',
+              label: t('createPage.navLand'),
               id: 'land-section',
               icon: 'mountain-sun',
               onClick: () => setActiveTab('land'),
             },
             {
-              label: 'Building',
+              label: t('createPage.navBuilding'),
               id: 'building-section',
               icon: 'building',
               onClick: () => setActiveTab('building'),
@@ -268,7 +268,7 @@ const CreateLandBuildingPage = () => {
             ...(isUnderConstruction || isCiAppraisal
               ? [
                   {
-                    label: 'Construction Inspection',
+                    label: t('createPage.navConstructionInspection'),
                     id: 'construction-section',
                     icon: 'helmet-safety',
                     onClick: () => setActiveTab('construction'),
@@ -278,13 +278,13 @@ const CreateLandBuildingPage = () => {
             ...(isRentedOut
               ? [
                   {
-                    label: 'Lease Agreement',
+                    label: t('createPage.navLeaseAgreement'),
                     id: 'lease-agreement-section',
                     icon: 'file-contract',
                     onClick: () => setActiveTab('lease-agreement'),
                   },
                   {
-                    label: 'Rental Info',
+                    label: t('createPage.navRentalInfo'),
                     id: 'rental-info-section',
                     icon: 'calendar-days',
                     onClick: () => setActiveTab('rental-info'),
@@ -323,7 +323,7 @@ const CreateLandBuildingPage = () => {
                                 className="w-5 h-5 text-indigo-600"
                               />
                             </div>
-                            <h2 className="text-lg font-semibold text-gray-900">Photos</h2>
+                            <h2 className="text-lg font-semibold text-gray-900">{t('createPage.photosSection')}</h2>
                           </div>
                           <div className="h-px bg-gray-200 mb-4" />
                           {appraisalId && (
@@ -351,7 +351,7 @@ const CreateLandBuildingPage = () => {
                             className="w-5 h-5 text-amber-600"
                           />
                         </div>
-                        <h2 className="text-lg font-semibold text-gray-900">Land Information</h2>
+                        <h2 className="text-lg font-semibold text-gray-900">{t('createPage.landSection')}</h2>
                       </div>
                       <div className="h-px bg-gray-200" />
                       <Section
@@ -381,7 +381,7 @@ const CreateLandBuildingPage = () => {
                           <Icon name="building" style="solid" className="w-5 h-5 text-blue-600" />
                         </div>
                         <h2 className="text-lg font-semibold text-gray-900">
-                          Building Information
+                          {t('createPage.buildingSection')}
                         </h2>
                       </div>
                       <div className="h-px bg-gray-200" />
@@ -405,7 +405,7 @@ const CreateLandBuildingPage = () => {
                             />
                           </div>
                           <h2 className="text-lg font-semibold text-gray-900">
-                            Construction Inspection
+                            {t('createPage.constructionSection')}
                           </h2>
                         </div>
                         <div className="h-px bg-gray-200" />
@@ -436,7 +436,7 @@ const CreateLandBuildingPage = () => {
                                 className="w-5 h-5 text-purple-600"
                               />
                             </div>
-                            <h2 className="text-lg font-semibold text-gray-900">Lease Agreement</h2>
+                            <h2 className="text-lg font-semibold text-gray-900">{t('createPage.leaseAgreementSection')}</h2>
                           </div>
                           <div className="h-px bg-gray-200 mb-6" />
                           <LeaseAgreementForm namePrefix="leaseAgreement" />
@@ -459,7 +459,7 @@ const CreateLandBuildingPage = () => {
                                 className="w-5 h-5 text-teal-600"
                               />
                             </div>
-                            <h2 className="text-lg font-semibold text-gray-900">Rental Info</h2>
+                            <h2 className="text-lg font-semibold text-gray-900">{t('createPage.rentalInfoSection')}</h2>
                           </div>
                           <div className="h-px bg-gray-200 mb-6" />
                           <RentalInfoForm namePrefix="rentalInfo" />
@@ -492,7 +492,7 @@ const CreateLandBuildingPage = () => {
                     disabled={isPending}
                   >
                     <Icon name="floppy-disk" style="regular" className="size-4 mr-2" />
-                    Save draft
+                    {t('createPage.saveDraft')}
                   </Button>
                   <Button
                     type="submit"
@@ -500,7 +500,7 @@ const CreateLandBuildingPage = () => {
                     disabled={isPending}
                   >
                     <Icon name="check" style="solid" className="size-4 mr-2" />
-                    Save
+                    {t('createPage.save')}
                   </Button>
                 </ActionBar.Right>
               )}

--- a/src/features/appraisal/pages/CreateLandPage.tsx
+++ b/src/features/appraisal/pages/CreateLandPage.tsx
@@ -220,9 +220,9 @@ const CreateLandPage = () => {
         <NavAnchors
           containerId="form-scroll-container"
           anchors={[
-            { label: 'Photos', id: 'photos', icon: 'images' },
+            { label: t('createPage.navPhotos'), id: 'photos', icon: 'images' },
             {
-              label: 'Land',
+              label: t('createPage.navLand'),
               id: 'land-section',
               icon: 'mountain-sun',
               onClick: () => setActiveTab('land'),
@@ -230,13 +230,13 @@ const CreateLandPage = () => {
             ...(isRentedOut
               ? [
                   {
-                    label: 'Lease Agreement',
+                    label: t('createPage.navLeaseAgreement'),
                     id: 'lease-agreement-section',
                     icon: 'file-contract',
                     onClick: () => setActiveTab('lease-agreement'),
                   },
                   {
-                    label: 'Rental Info',
+                    label: t('createPage.navRentalInfo'),
                     id: 'rental-info-section',
                     icon: 'calendar-days',
                     onClick: () => setActiveTab('rental-info'),
@@ -268,7 +268,7 @@ const CreateLandPage = () => {
                       <div className="w-9 h-9 rounded-lg bg-indigo-100 flex items-center justify-center">
                         <Icon name="images" style="solid" className="w-5 h-5 text-indigo-600" />
                       </div>
-                      <h2 className="text-lg font-semibold text-gray-900">Photos</h2>
+                      <h2 className="text-lg font-semibold text-gray-900">{t('createPage.photosSection')}</h2>
                     </div>
                     <div className="h-px bg-gray-200 mb-4" />
                     {appraisalId && (
@@ -294,7 +294,7 @@ const CreateLandPage = () => {
                             className="w-5 h-5 text-amber-600"
                           />
                         </div>
-                        <h2 className="text-lg font-semibold text-gray-900">Land Information</h2>
+                        <h2 className="text-lg font-semibold text-gray-900">{t('createPage.landSection')}</h2>
                       </div>
                       <div className="h-px bg-gray-200" />
                     </Section>
@@ -330,7 +330,7 @@ const CreateLandPage = () => {
                               className="w-5 h-5 text-purple-600"
                             />
                           </div>
-                          <h2 className="text-lg font-semibold text-gray-900">Lease Agreement</h2>
+                          <h2 className="text-lg font-semibold text-gray-900">{t('createPage.leaseAgreementSection')}</h2>
                         </div>
                         <div className="h-px bg-gray-200 mb-6" />
                         <LeaseAgreementForm namePrefix="leaseAgreement" />
@@ -353,7 +353,7 @@ const CreateLandPage = () => {
                               className="w-5 h-5 text-teal-600"
                             />
                           </div>
-                          <h2 className="text-lg font-semibold text-gray-900">Rental Info</h2>
+                          <h2 className="text-lg font-semibold text-gray-900">{t('createPage.rentalInfoSection')}</h2>
                         </div>
                         <div className="h-px bg-gray-200 mb-6" />
                         <RentalInfoForm namePrefix="rentalInfo" />
@@ -386,7 +386,7 @@ const CreateLandPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="floppy-disk" style="regular" className="size-4 mr-2" />
-                  Save draft
+                  {t('createPage.saveDraft')}
                 </Button>
                 <Button
                   type="submit"
@@ -394,7 +394,7 @@ const CreateLandPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="check" style="solid" className="size-4 mr-2" />
-                  Save
+                  {t('createPage.save')}
                 </Button>
               </ActionBar.Right>
             )}

--- a/src/features/appraisal/pages/CreateMachineryPage.tsx
+++ b/src/features/appraisal/pages/CreateMachineryPage.tsx
@@ -194,8 +194,8 @@ const CreateMachineryPage = () => {
         <NavAnchors
           containerId="form-scroll-container"
           anchors={[
-            { label: 'Photos', id: 'photos', icon: 'images' },
-            { label: 'Machinery', id: 'properties-section', icon: 'tractor' },
+            { label: t('createPage.navPhotos'), id: 'photos', icon: 'images' },
+            { label: t('createPage.navMachinery'), id: 'properties-section', icon: 'tractor' },
           ]}
         />
       </div>
@@ -221,7 +221,7 @@ const CreateMachineryPage = () => {
                       <div className="w-9 h-9 rounded-lg bg-indigo-100 flex items-center justify-center">
                         <Icon name="images" style="solid" className="w-5 h-5 text-indigo-600" />
                       </div>
-                      <h2 className="text-lg font-semibold text-gray-900">Photos</h2>
+                      <h2 className="text-lg font-semibold text-gray-900">{t('createPage.photosSection')}</h2>
                     </div>
                     <div className="h-px bg-gray-200 mb-4" />
                     {appraisalId && (
@@ -243,7 +243,7 @@ const CreateMachineryPage = () => {
                           className="w-5 h-5 text-amber-600"
                         />
                       </div>
-                      <h2 className="text-lg font-semibold text-gray-900">Machinery Information</h2>
+                      <h2 className="text-lg font-semibold text-gray-900">{t('createPage.machinerySection')}</h2>
                     </div>
                     <div className="h-px bg-gray-200" />
                   </Section>
@@ -282,7 +282,7 @@ const CreateMachineryPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="floppy-disk" style="regular" className="size-4 mr-2" />
-                  Save draft
+                  {t('createPage.saveDraft')}
                 </Button>
                 <Button
                   type="submit"
@@ -290,7 +290,7 @@ const CreateMachineryPage = () => {
                   disabled={isPending}
                 >
                   <Icon name="check" style="solid" className="size-4 mr-2" />
-                  Save
+                  {t('createPage.save')}
                 </Button>
               </ActionBar.Right>
             )}

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -817,7 +817,7 @@ const DecisionSummaryPage = () => {
                   )}
                   {showSection('governmentPrice') && (
                     <InlineSubSection
-                      title="Government Appraisal Price"
+                      title={t('decisionSummaryPageExtra.governmentAppraisalPrice')}
                       rightSlot={
                         data?.governmentPrices ? `(${data.governmentPrices.length})` : undefined
                       }
@@ -838,7 +838,7 @@ const DecisionSummaryPage = () => {
 
               {/* Construction Summary — only on Construction Inspection appraisals */}
               {isCiAppraisal && showSection('constructionSummary') && data?.constructionSummary && (
-                <GroupCard icon="helmet-safety" iconColor="yellow" title="Construction Summary">
+                <GroupCard icon="helmet-safety" iconColor="yellow" title={t('decisionSummaryPageExtra.constructionSummaryTitle')}>
                   <ConstructionSummaryTable rows={data.constructionSummary.rows} />
                 </GroupCard>
               )}
@@ -982,7 +982,7 @@ const DecisionSummaryPage = () => {
               <div className="flex justify-between items-center">
                 <div className="flex items-center gap-4">
                   <Button variant="ghost" type="button" onClick={handleCancel}>
-                    Cancel
+                    {t('decisionSummaryPageExtra.cancelButton')}
                   </Button>
                   <div className="h-6 w-px bg-gray-200" />
                   {/* History Search map icon — opens nearby appraisal/MC map */}
@@ -1011,7 +1011,7 @@ const DecisionSummaryPage = () => {
                       disabled={!appraisalId || !isDirty || isSaving}
                     >
                       <Icon style="regular" name="floppy-disk" className="size-4 mr-2" />
-                      Save
+                      {t('decisionSummaryPageExtra.saveButton')}
                     </Button>
                   )}
                   <Button
@@ -1026,7 +1026,7 @@ const DecisionSummaryPage = () => {
                     onClick={() => setIsConfirmOpen(true)}
                   >
                     <Icon style="solid" name="paper-plane" className="size-4 mr-2" />
-                    Submit
+                    {t('decisionSummaryPageExtra.submitButton')}
                   </Button>
                 </div>
               </div>

--- a/src/features/appraisal/types/landDetail.ts
+++ b/src/features/appraisal/types/landDetail.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 // Land Detail Table Item Schema
 export const LandDetailItemSchema = z.object({
@@ -22,8 +24,36 @@ export const LandDetailItemSchema = z.object({
 
 export type LandDetailItem = z.infer<typeof LandDetailItemSchema>;
 
-// Main Land Detail Form Schema
-export const LandDetailFormSchema = z.object({
+/**
+ * Factory that builds the land detail form schema with translated validation messages.
+ * Use `makeLandDetailFormSchema(t)` in components; the static export below is a
+ * type-only stand-in so callers can derive `LandDetailFormType` without a `t` instance.
+ */
+export const makeLandDetailFormSchema = (t: TFunction<'appraisal'>) =>
+  buildLandDetailFormSchema(
+    t('landDetailSchema.latitudeRequired'),
+    t('landDetailSchema.longitudeRequired'),
+    t('landDetailSchema.subDistrictRequired'),
+    t('landDetailSchema.districtRequired'),
+    t('landDetailSchema.provinceRequired'),
+    t('landDetailSchema.landOfficeRequired'),
+  );
+
+/** Hook to resolve the schema per render (for zodResolver). */
+export const useLandDetailFormSchema = () => {
+  const { t } = useTranslation('appraisal');
+  return makeLandDetailFormSchema(t);
+};
+
+function buildLandDetailFormSchema(
+  latitudeMsg: string,
+  longitudeMsg: string,
+  subDistrictMsg: string,
+  districtMsg: string,
+  provinceMsg: string,
+  landOfficeMsg: string,
+) {
+  return z.object({
   // Group selection
   groupId: z.string(),
 
@@ -32,12 +62,12 @@ export const LandDetailFormSchema = z.object({
 
   // Land Information
   propertyName: z.string().optional(),
-  latitude: z.string().min(1, 'Latitude is required'),
-  longitude: z.string().min(1, 'Longitude is required'),
-  subDistrict: z.string().min(1, 'Sub-District is required'),
-  district: z.string().min(1, 'District is required'),
-  province: z.string().min(1, 'Province is required'),
-  landOffice: z.string().min(1, 'Land Office is required'),
+  latitude: z.string().min(1, latitudeMsg),
+  longitude: z.string().min(1, longitudeMsg),
+  subDistrict: z.string().min(1, subDistrictMsg),
+  district: z.string().min(1, districtMsg),
+  province: z.string().min(1, provinceMsg),
+  landOffice: z.string().min(1, landOfficeMsg),
   landDescription: z.string().optional(),
 
   // Check Owner
@@ -200,7 +230,18 @@ export const LandDetailFormSchema = z.object({
 
   // Remark
   remark: z.string().optional(),
-});
+  }); // end buildLandDetailFormSchema return
+} // end buildLandDetailFormSchema
+
+/** Static schema with English stand-in messages — use for type derivation only. */
+export const LandDetailFormSchema = buildLandDetailFormSchema(
+  'Latitude is required',
+  'Longitude is required',
+  'Sub-District is required',
+  'District is required',
+  'Province is required',
+  'Land Office is required',
+);
 
 export type LandDetailFormType = z.infer<typeof LandDetailFormSchema>;
 

--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -128,6 +128,8 @@
     "total": "Total",
     "constructionInspectionFee": "Construction Inspection Fee",
     "constructionInspectionFeeHint": "This fee is reused as the appraisal fee on the next Construction Inspection application for this collateral.",
+    "bankAbsorbAmount": "Bank Absorb Amount",
+    "bankAbsorbAmountHint": "Amount the bank absorbs; the customer is charged the remainder.",
     "addFeeModal": {
       "titleAdd": "Add Fee",
       "titleEdit": "Edit Fee",
@@ -163,7 +165,9 @@
       "feeRejected": "Fee item rejected",
       "feeRejectFailed": "Failed to reject fee item.",
       "ciFeesSaved": "Construction inspection fee saved",
-      "ciFeesFailed": "Failed to save construction inspection fee."
+      "ciFeesFailed": "Failed to save construction inspection fee.",
+      "absorbAmountSaved": "Bank absorb amount saved",
+      "absorbAmountFailed": "Failed to save bank absorb amount."
     }
   },
   "payment": {
@@ -532,6 +536,32 @@
     },
     "decisionSummary": {
       "sectionTitle": "Decision Summary"
+    },
+    "decisionSummarySection": {
+      "title": "Decision & Summary",
+      "appraisalPriceSummary": "Appraisal Price Summary",
+      "governmentAppraisalPrice": "Government Appraisal Price",
+      "totalAppraisalPrice": "Total Appraisal Price",
+      "forceSellingPrice": "Force Selling Price",
+      "buildingInsurance": "Building Insurance",
+      "noApproachData": "No approach data available.",
+      "noGovernmentPrice": "No government price data available."
+    },
+    "pricingAnalysisSection": {
+      "heading": "Pricing Analysis",
+      "decisionApproach": "Decision Approach",
+      "noApproachData": "No approach data available."
+    },
+    "requestInfoSection": {
+      "title": "Request Information",
+      "requestNumber": "Request Number",
+      "customerName": "Customer Name",
+      "contactNumber": "Contact Number",
+      "purpose": "Purpose",
+      "appraisalNumber": "Appraisal Number",
+      "channel": "Channel",
+      "status": "Status",
+      "requestor": "Requestor"
     }
   },
   "activityTracking": {
@@ -878,6 +908,26 @@
       "createFailed": "Failed to create quotation request"
     }
   },
+  "history": {
+    "title": "History",
+    "viewHistory": "View history",
+    "eventCount_one": "{{count}} event",
+    "eventCount_other": "{{count}} events",
+    "chips": {
+      "all": "All",
+      "appointment": "Appointment",
+      "fees": "Fees"
+    },
+    "status": {
+      "Approved": "Approved",
+      "Rejected": "Rejected",
+      "Pending": "Pending",
+      "Auto": "Auto",
+      "Cancelled": "Cancelled"
+    },
+    "emptyState": "No history yet",
+    "loadError": "Failed to load history"
+  },
   "approval": {
     "banner": {
       "needsApproval": "This change needs bank approval — submit it for review before it takes effect.",
@@ -898,5 +948,235 @@
       "submitted": "Submitted for bank approval",
       "submitFailed": "Failed to submit for approval"
     }
+  },
+  "createPage": {
+    "photosSection": "Photos",
+    "landSection": "Land Information",
+    "leaseAgreementSection": "Lease Agreement",
+    "rentalInfoSection": "Rental Info",
+    "condoSection": "Condo Information",
+    "buildingSection": "Building Information",
+    "constructionSection": "Construction Inspection",
+    "machinerySection": "Machinery Information",
+    "navPhotos": "Photos",
+    "navLand": "Land",
+    "navLeaseAgreement": "Lease Agreement",
+    "navRentalInfo": "Rental Info",
+    "navCondo": "Condo",
+    "navBuilding": "Building",
+    "navConstructionInspection": "Construction Inspection",
+    "navMachinery": "Machinery",
+    "saveDraft": "Save draft",
+    "save": "Save"
+  },
+  "landCharacteristicsForm": {
+    "sections": {
+      "landfill": "Landfill",
+      "road": "Road",
+      "landAccessibility": "Land Accessibility",
+      "roadSurface": "Road Surface",
+      "publicUtility": "Public Utility",
+      "landUse": "Land Use",
+      "landEntranceExit": "Land Entrance-Exit",
+      "transportation": "Transportation",
+      "anticipationOfProperty": "Anticipation of Property",
+      "limitation": "Limitation",
+      "eviction": "Eviction",
+      "allocation": "Allocation",
+      "hasBuilding": "Has Building",
+      "remark": "Remark"
+    },
+    "fields": {
+      "other": "Other",
+      "landfillHeight": "Landfill Height",
+      "landAccessibilityDescription": "Land Accessibility Description",
+      "roadWidth": "Road Width",
+      "rightOfWay": "Right of Way",
+      "roadFrontage": "Road Frontage of land adjacent to the road",
+      "numberOrSidesFacingRoad": "Number of sides facing the road",
+      "roadRunningInFrontOfLand": "Road running in front of the land",
+      "areaSqWa": "Area Sq.Wa",
+      "distance": "Distance",
+      "remarkPlaceholder": "Enter remarks...",
+      "isExpropriate": "Is Expropriate",
+      "inLineExpropriate": "In Line Expropriate",
+      "royalDecree": "Royal Decree",
+      "isEncroached": "Is Encroached",
+      "electricity": "Electricity",
+      "isLandlocked": "Is Landlocked",
+      "isForestBoundary": "Is Forest Boundary"
+    },
+    "landfillOptions": {
+      "emptyLand": "Empty Land",
+      "filled": "Filled",
+      "notFilledYet": "Not Filled yet",
+      "partiallyFilled": "Partially Filled",
+      "other": "Other"
+    },
+    "landAccessibilityOptions": {
+      "able": "Able",
+      "unable": "Unable",
+      "inAllocation": "In Allocation"
+    },
+    "roadSurfaceOptions": {
+      "reinforcedConcrete": "Reinforced Concrete",
+      "gravelCrushedStone": "Gravel/Crushed Stone",
+      "soil": "Soil",
+      "paved": "Paved",
+      "other": "Other"
+    },
+    "publicUtilityOptions": {
+      "permanentElectricity": "Permanent Electricity",
+      "tapWaterGroundwater": "Tap Water/Groundwater",
+      "drainagePipeStone": "Drainage Pipe/Stone",
+      "streetlight": "Streetlight",
+      "other": "Other"
+    },
+    "landUseOptions": {
+      "residence": "Residence",
+      "agriculture": "Agriculture",
+      "commercial": "Commercial",
+      "industry": "Industry",
+      "other": "Other"
+    },
+    "landEntranceExitOptions": {
+      "publicInterest": "Public Interest",
+      "insideAllocationProject": "Inside the Allocation Project",
+      "personal": "Personal",
+      "servitude": "Servitude",
+      "other": "Other"
+    },
+    "transportationOptions": {
+      "car": "Car",
+      "bus": "Bus",
+      "ship": "Ship",
+      "footpath": "Footpath",
+      "other": "Other"
+    },
+    "anticipationOptions": {
+      "veryProspective": "Very Prospective",
+      "moderate": "Moderate",
+      "likelyToProsperInFuture": "Likely to Prosper in the Future",
+      "littleChanceOfProsperity": "Little Chance of Prosperity"
+    },
+    "evictionOptions": {
+      "permanentElectricity": "Permanent Electricity",
+      "subwayLine": "Subway Line",
+      "other": "Other"
+    },
+    "allocationOptions": {
+      "allocateNewProject": "Allocate New Projects",
+      "allocateOldProject": "Allocate Old Projects",
+      "notAllocate": "Not Allocate"
+    },
+    "hasBuildingOptions": {
+      "yes": "Yes",
+      "no": "No",
+      "other": "Other"
+    }
+  },
+  "approachMatrixTable": {
+    "columns": {
+      "group": "Group",
+      "model": "Model",
+      "market": "Market Comparison Approach",
+      "cost": "Cost Approach",
+      "income": "Income Approach",
+      "residual": "Residual Approach",
+      "summary": "Summary"
+    },
+    "footer": {
+      "total": "Total",
+      "project": "Project"
+    }
+  },
+  "blockPriceSummaryTable": {
+    "columns": {
+      "model": "Model",
+      "unitCount": "Unit Count",
+      "totalAppraisalPrice": "Total Appraisal Price",
+      "forceSellingPrice": "Force Selling Price",
+      "buildingInsurance": "Building Insurance"
+    },
+    "footer": {
+      "project": "Project"
+    }
+  },
+  "governmentPriceTable": {
+    "columns": {
+      "titleDeedNo": "Title Deed No.",
+      "sqWa": "Sq.Wa",
+      "bahtPerSqWa": "Baht / Sq.Wa",
+      "landPrice": "Land Price"
+    },
+    "footer": {
+      "total": "Total",
+      "avg": "avg"
+    },
+    "missingFromSurvey": "Missing from survey"
+  },
+  "constructionSummaryTable": {
+    "columns": {
+      "milestone": "Milestone",
+      "totalAppraisalValue": "Total Appraisal Value",
+      "landValue": "Land Value",
+      "constructionProgress": "Construction Progress (%)",
+      "buildingValue": "Building Value",
+      "buildingValuePreInspection": "Building Value Pre-inspection"
+    },
+    "rows": {
+      "Previous": "Previous",
+      "ConstructionIncreased": "Construction Increased",
+      "Current": "Current",
+      "RemainingConstruction": "Remaining construction",
+      "Complete100": "Complete ( 100% )"
+    }
+  },
+  "approvalListSection": {
+    "title": "Committee Approval",
+    "notActiveYet": "Committee approval is not active for this appraisal yet.",
+    "approvedBanner": "This appraisal has been approved by the committee.",
+    "returnedBanner": "This appraisal has been returned for revision.",
+    "conditionsTitle": "Approval Conditions",
+    "votesDisplay": "{{received}}/{{total}} votes",
+    "youBadge": "You",
+    "pendingVote": "Pending",
+    "tierLabels": {
+      "1": "Tier 1",
+      "2": "Tier 2",
+      "3": "Tier 3"
+    },
+    "committeeCodeLabels": {
+      "SUB_COMMITTEE": "Sub-Committee",
+      "COMMITTEE": "Committee",
+      "COMMITTEE_WITH_MEETING": "Committee (with Meeting)"
+    },
+    "committeeDefault": "Committee",
+    "conditionRoleRequired": "{{role}} must vote",
+    "conditionRoleRequiredDefault": "Required role must vote",
+    "conditionMinVotes": "At least {{n}} votes required",
+    "conditionMinVotesDefault": "Minimum vote count required",
+    "columns": {
+      "member": "Member",
+      "role": "Role",
+      "vote": "Vote",
+      "date": "Date",
+      "comments": "Comments"
+    }
+  },
+  "decisionSummaryPageExtra": {
+    "governmentAppraisalPrice": "Government Appraisal Price",
+    "constructionSummaryTitle": "Construction Summary",
+    "cancelButton": "Cancel",
+    "saveButton": "Save",
+    "submitButton": "Submit"
+  },
+  "landDetailSchema": {
+    "latitudeRequired": "Latitude is required",
+    "longitudeRequired": "Longitude is required",
+    "subDistrictRequired": "Sub-District is required",
+    "districtRequired": "District is required",
+    "provinceRequired": "Province is required",
+    "landOfficeRequired": "Land Office is required"
   }
 }

--- a/src/i18n/locales/th/appraisal.json
+++ b/src/i18n/locales/th/appraisal.json
@@ -128,6 +128,8 @@
     "total": "รวมทั้งสิ้น",
     "constructionInspectionFee": "ค่าตรวจสอบการก่อสร้าง",
     "constructionInspectionFeeHint": "ค่าธรรมเนียมนี้จะนำมาใช้เป็นค่าประเมินในการขอตรวจสอบการก่อสร้างครั้งถัดไปสำหรับหลักประกันนี้",
+    "bankAbsorbAmount": "จำนวนที่ธนาคารรับผิดชอบ",
+    "bankAbsorbAmountHint": "จำนวนเงินที่ธนาคารรับผิดชอบ ส่วนที่เหลือจะเรียกเก็บจากลูกค้า",
     "addFeeModal": {
       "titleAdd": "เพิ่มค่าธรรมเนียม",
       "titleEdit": "แก้ไขค่าธรรมเนียม",
@@ -163,7 +165,9 @@
       "feeRejected": "ปฏิเสธรายการค่าธรรมเนียมแล้ว",
       "feeRejectFailed": "ไม่สามารถปฏิเสธรายการค่าธรรมเนียมได้",
       "ciFeesSaved": "บันทึกค่าตรวจสอบการก่อสร้างแล้ว",
-      "ciFeesFailed": "ไม่สามารถบันทึกค่าตรวจสอบการก่อสร้างได้"
+      "ciFeesFailed": "ไม่สามารถบันทึกค่าตรวจสอบการก่อสร้างได้",
+      "absorbAmountSaved": "บันทึกจำนวนที่ธนาคารรับผิดชอบแล้ว",
+      "absorbAmountFailed": "ไม่สามารถบันทึกจำนวนที่ธนาคารรับผิดชอบได้"
     }
   },
   "payment": {
@@ -535,6 +539,32 @@
     },
     "decisionSummary": {
       "sectionTitle": "สรุปการตัดสินใจ"
+    },
+    "decisionSummarySection": {
+      "title": "การตัดสินใจและสรุป",
+      "appraisalPriceSummary": "สรุปราคาประเมิน",
+      "governmentAppraisalPrice": "ราคาประเมินของทางราชการ",
+      "totalAppraisalPrice": "ราคาประเมินรวม",
+      "forceSellingPrice": "ราคาบังคับขาย",
+      "buildingInsurance": "ทุนประกันอาคาร",
+      "noApproachData": "ไม่มีข้อมูลวิธีการประเมิน",
+      "noGovernmentPrice": "ไม่มีข้อมูลราคาประเมินของทางราชการ"
+    },
+    "pricingAnalysisSection": {
+      "heading": "การวิเคราะห์ราคา",
+      "decisionApproach": "วิธีการตัดสินใจ",
+      "noApproachData": "ไม่มีข้อมูลวิธีการประเมิน"
+    },
+    "requestInfoSection": {
+      "title": "ข้อมูลคำขอ",
+      "requestNumber": "เลขที่คำขอ",
+      "customerName": "ชื่อลูกค้า",
+      "contactNumber": "เบอร์ติดต่อ",
+      "purpose": "วัตถุประสงค์",
+      "appraisalNumber": "เลขที่ประเมิน",
+      "channel": "ช่องทาง",
+      "status": "สถานะ",
+      "requestor": "ผู้ขอ"
     }
   },
   "activityTracking": {
@@ -881,6 +911,26 @@
       "createFailed": "ไม่สามารถสร้างคำขอใบเสนอราคาได้"
     }
   },
+  "history": {
+    "title": "ประวัติ",
+    "viewHistory": "ดูประวัติ",
+    "eventCount_one": "{{count}} รายการ",
+    "eventCount_other": "{{count}} รายการ",
+    "chips": {
+      "all": "ทั้งหมด",
+      "appointment": "การนัดหมาย",
+      "fees": "ค่าธรรมเนียม"
+    },
+    "status": {
+      "Approved": "อนุมัติแล้ว",
+      "Rejected": "ปฏิเสธแล้ว",
+      "Pending": "รออนุมัติ",
+      "Auto": "อัตโนมัติ",
+      "Cancelled": "ยกเลิกแล้ว"
+    },
+    "emptyState": "ยังไม่มีประวัติ",
+    "loadError": "ไม่สามารถโหลดประวัติได้"
+  },
   "approval": {
     "banner": {
       "needsApproval": "การเปลี่ยนแปลงนี้ต้องได้รับอนุมัติจากธนาคาร — กรุณาส่งเพื่อรับการพิจารณาก่อนมีผล",
@@ -901,5 +951,235 @@
       "submitted": "ส่งขออนุมัติจากธนาคารแล้ว",
       "submitFailed": "ส่งขออนุมัติไม่สำเร็จ"
     }
+  },
+  "createPage": {
+    "photosSection": "รูปภาพ",
+    "landSection": "ข้อมูลที่ดิน",
+    "leaseAgreementSection": "สัญญาเช่า",
+    "rentalInfoSection": "ข้อมูลการเช่า",
+    "condoSection": "ข้อมูลคอนโด",
+    "buildingSection": "ข้อมูลอาคาร",
+    "constructionSection": "การตรวจสอบการก่อสร้าง",
+    "machinerySection": "ข้อมูลเครื่องจักร",
+    "navPhotos": "รูปภาพ",
+    "navLand": "ที่ดิน",
+    "navLeaseAgreement": "สัญญาเช่า",
+    "navRentalInfo": "ข้อมูลการเช่า",
+    "navCondo": "คอนโด",
+    "navBuilding": "อาคาร",
+    "navConstructionInspection": "การตรวจสอบการก่อสร้าง",
+    "navMachinery": "เครื่องจักร",
+    "saveDraft": "บันทึกร่าง",
+    "save": "บันทึก"
+  },
+  "landCharacteristicsForm": {
+    "sections": {
+      "landfill": "การถมที่",
+      "road": "ถนน",
+      "landAccessibility": "การเข้าถึงที่ดิน",
+      "roadSurface": "ผิวถนน",
+      "publicUtility": "สาธารณูปโภค",
+      "landUse": "การใช้ที่ดิน",
+      "landEntranceExit": "ทางเข้า-ออก",
+      "transportation": "การคมนาคม",
+      "anticipationOfProperty": "การคาดการณ์อสังหาริมทรัพย์",
+      "limitation": "ข้อจำกัด",
+      "eviction": "การไล่รื้อ",
+      "allocation": "การจัดสรร",
+      "hasBuilding": "มีอาคาร",
+      "remark": "หมายเหตุ"
+    },
+    "fields": {
+      "other": "อื่นๆ",
+      "landfillHeight": "ความสูงการถม",
+      "landAccessibilityDescription": "รายละเอียดการเข้าถึงที่ดิน",
+      "roadWidth": "ความกว้างถนน",
+      "rightOfWay": "สิทธิทาง",
+      "roadFrontage": "หน้าที่ดินติดถนน",
+      "numberOrSidesFacingRoad": "จำนวนด้านที่ติดถนน",
+      "roadRunningInFrontOfLand": "ถนนหน้าที่ดิน",
+      "areaSqWa": "พื้นที่ (ตร.วา)",
+      "distance": "ระยะทาง",
+      "remarkPlaceholder": "ใส่หมายเหตุ...",
+      "isExpropriate": "อยู่ในแนวเวนคืน",
+      "inLineExpropriate": "อยู่ในแนวเขต",
+      "royalDecree": "พระราชกฤษฎีกา",
+      "isEncroached": "มีการบุกรุก",
+      "electricity": "ไฟฟ้า",
+      "isLandlocked": "ที่ดินตาบอด",
+      "isForestBoundary": "แนวเขตป่า"
+    },
+    "landfillOptions": {
+      "emptyLand": "ที่ดินเปล่า",
+      "filled": "ถมแล้ว",
+      "notFilledYet": "ยังไม่ได้ถม",
+      "partiallyFilled": "ถมบางส่วน",
+      "other": "อื่นๆ"
+    },
+    "landAccessibilityOptions": {
+      "able": "เข้าถึงได้",
+      "unable": "เข้าถึงไม่ได้",
+      "inAllocation": "อยู่ในโครงการจัดสรร"
+    },
+    "roadSurfaceOptions": {
+      "reinforcedConcrete": "คอนกรีตเสริมเหล็ก",
+      "gravelCrushedStone": "กรวด/หินคลุก",
+      "soil": "ดิน",
+      "paved": "ลาดยาง",
+      "other": "อื่นๆ"
+    },
+    "publicUtilityOptions": {
+      "permanentElectricity": "ไฟฟ้าถาวร",
+      "tapWaterGroundwater": "ประปา/น้ำบาดาล",
+      "drainagePipeStone": "ท่อระบายน้ำ/หิน",
+      "streetlight": "ไฟถนน",
+      "other": "อื่นๆ"
+    },
+    "landUseOptions": {
+      "residence": "ที่อยู่อาศัย",
+      "agriculture": "เกษตรกรรม",
+      "commercial": "พาณิชยกรรม",
+      "industry": "อุตสาหกรรม",
+      "other": "อื่นๆ"
+    },
+    "landEntranceExitOptions": {
+      "publicInterest": "ทางสาธารณะ",
+      "insideAllocationProject": "ภายในโครงการจัดสรร",
+      "personal": "ส่วนตัว",
+      "servitude": "ภาระจำยอม",
+      "other": "อื่นๆ"
+    },
+    "transportationOptions": {
+      "car": "รถยนต์",
+      "bus": "รถโดยสาร",
+      "ship": "เรือ",
+      "footpath": "ทางเดินเท้า",
+      "other": "อื่นๆ"
+    },
+    "anticipationOptions": {
+      "veryProspective": "มีโอกาสสูงมาก",
+      "moderate": "ปานกลาง",
+      "likelyToProsperInFuture": "อาจเจริญในอนาคต",
+      "littleChanceOfProsperity": "โอกาสเจริญน้อย"
+    },
+    "evictionOptions": {
+      "permanentElectricity": "ไฟฟ้าถาวร",
+      "subwayLine": "รถไฟใต้ดิน",
+      "other": "อื่นๆ"
+    },
+    "allocationOptions": {
+      "allocateNewProject": "จัดสรรโครงการใหม่",
+      "allocateOldProject": "จัดสรรโครงการเก่า",
+      "notAllocate": "ไม่จัดสรร"
+    },
+    "hasBuildingOptions": {
+      "yes": "มี",
+      "no": "ไม่มี",
+      "other": "อื่นๆ"
+    }
+  },
+  "approachMatrixTable": {
+    "columns": {
+      "group": "กลุ่ม",
+      "model": "รูปแบบ",
+      "market": "วิธีเปรียบเทียบตลาด",
+      "cost": "วิธีต้นทุน",
+      "income": "วิธีรายได้",
+      "residual": "วิธีส่วนเหลือ",
+      "summary": "สรุป"
+    },
+    "footer": {
+      "total": "รวม",
+      "project": "โครงการ"
+    }
+  },
+  "blockPriceSummaryTable": {
+    "columns": {
+      "model": "รูปแบบ",
+      "unitCount": "จำนวนยูนิต",
+      "totalAppraisalPrice": "ราคาประเมินรวม",
+      "forceSellingPrice": "ราคาบังคับขาย",
+      "buildingInsurance": "ทุนประกันอาคาร"
+    },
+    "footer": {
+      "project": "โครงการ"
+    }
+  },
+  "governmentPriceTable": {
+    "columns": {
+      "titleDeedNo": "เลขที่โฉนด",
+      "sqWa": "ตร.วา",
+      "bahtPerSqWa": "บาท / ตร.วา",
+      "landPrice": "ราคาที่ดิน"
+    },
+    "footer": {
+      "total": "รวม",
+      "avg": "เฉลี่ย"
+    },
+    "missingFromSurvey": "ไม่พบในรังวัด"
+  },
+  "constructionSummaryTable": {
+    "columns": {
+      "milestone": "ช่วงการก่อสร้าง",
+      "totalAppraisalValue": "มูลค่าประเมินรวม",
+      "landValue": "มูลค่าที่ดิน",
+      "constructionProgress": "ความคืบหน้าการก่อสร้าง (%)",
+      "buildingValue": "มูลค่าอาคาร",
+      "buildingValuePreInspection": "มูลค่าอาคารก่อนตรวจสอบ"
+    },
+    "rows": {
+      "Previous": "งวดก่อนหน้า",
+      "ConstructionIncreased": "การก่อสร้างเพิ่มขึ้น",
+      "Current": "งวดปัจจุบัน",
+      "RemainingConstruction": "งานก่อสร้างที่เหลือ",
+      "Complete100": "สมบูรณ์ (100%)"
+    }
+  },
+  "approvalListSection": {
+    "title": "การอนุมัติของคณะกรรมการ",
+    "notActiveYet": "การอนุมัติของคณะกรรมการยังไม่เริ่มต้นสำหรับการประเมินนี้",
+    "approvedBanner": "การประเมินนี้ได้รับการอนุมัติจากคณะกรรมการแล้ว",
+    "returnedBanner": "การประเมินนี้ถูกส่งกลับเพื่อแก้ไข",
+    "conditionsTitle": "เงื่อนไขการอนุมัติ",
+    "votesDisplay": "{{received}}/{{total}} คะแนนเสียง",
+    "youBadge": "คุณ",
+    "pendingVote": "รอดำเนินการ",
+    "tierLabels": {
+      "1": "ระดับ 1",
+      "2": "ระดับ 2",
+      "3": "ระดับ 3"
+    },
+    "committeeCodeLabels": {
+      "SUB_COMMITTEE": "อนุกรรมการ",
+      "COMMITTEE": "คณะกรรมการ",
+      "COMMITTEE_WITH_MEETING": "คณะกรรมการ (พร้อมการประชุม)"
+    },
+    "committeeDefault": "คณะกรรมการ",
+    "conditionRoleRequired": "{{role}} ต้องลงคะแนน",
+    "conditionRoleRequiredDefault": "ต้องมีผู้มีสิทธิ์ลงคะแนน",
+    "conditionMinVotes": "ต้องการอย่างน้อย {{n}} คะแนน",
+    "conditionMinVotesDefault": "ต้องการจำนวนคะแนนขั้นต่ำ",
+    "columns": {
+      "member": "สมาชิก",
+      "role": "บทบาท",
+      "vote": "คะแนนเสียง",
+      "date": "วันที่",
+      "comments": "ความคิดเห็น"
+    }
+  },
+  "decisionSummaryPageExtra": {
+    "governmentAppraisalPrice": "ราคาประเมินของทางราชการ",
+    "constructionSummaryTitle": "สรุปการก่อสร้าง",
+    "cancelButton": "ยกเลิก",
+    "saveButton": "บันทึก",
+    "submitButton": "ส่ง"
+  },
+  "landDetailSchema": {
+    "latitudeRequired": "กรุณากรอกละติจูด",
+    "longitudeRequired": "กรุณากรอกลองจิจูด",
+    "subDistrictRequired": "กรุณาเลือกตำบล/แขวง",
+    "districtRequired": "กรุณาเลือกอำเภอ/เขต",
+    "provinceRequired": "กรุณาเลือกจังหวัด",
+    "landOfficeRequired": "กรุณาระบุสำนักงานที่ดิน"
   }
 }

--- a/src/i18n/locales/zh/appraisal.json
+++ b/src/i18n/locales/zh/appraisal.json
@@ -128,6 +128,8 @@
     "total": "合计",
     "constructionInspectionFee": "施工检验费",
     "constructionInspectionFeeHint": "此费用将用于该抵押品下次施工检验申请的评估费。",
+    "bankAbsorbAmount": "银行承担金额",
+    "bankAbsorbAmountHint": "银行承担的金额，其余部分将向客户收取。",
     "addFeeModal": {
       "titleAdd": "添加费用",
       "titleEdit": "编辑费用",
@@ -163,7 +165,9 @@
       "feeRejected": "费用项已拒绝",
       "feeRejectFailed": "拒绝费用项失败。",
       "ciFeesSaved": "施工检验费已保存",
-      "ciFeesFailed": "保存施工检验费失败。"
+      "ciFeesFailed": "保存施工检验费失败。",
+      "absorbAmountSaved": "银行承担金额已保存",
+      "absorbAmountFailed": "保存银行承担金额失败。"
     }
   },
   "payment": {
@@ -535,6 +539,32 @@
     },
     "decisionSummary": {
       "sectionTitle": "决策摘要"
+    },
+    "decisionSummarySection": {
+      "title": "决策与汇总",
+      "appraisalPriceSummary": "评估价格汇总",
+      "governmentAppraisalPrice": "政府评估价格",
+      "totalAppraisalPrice": "评估总价",
+      "forceSellingPrice": "强制销售价",
+      "buildingInsurance": "建筑保险",
+      "noApproachData": "暂无评估方法数据。",
+      "noGovernmentPrice": "暂无政府评估价格数据。"
+    },
+    "pricingAnalysisSection": {
+      "heading": "定价分析",
+      "decisionApproach": "决策方法",
+      "noApproachData": "暂无评估方法数据。"
+    },
+    "requestInfoSection": {
+      "title": "请求信息",
+      "requestNumber": "请求编号",
+      "customerName": "客户姓名",
+      "contactNumber": "联系电话",
+      "purpose": "用途",
+      "appraisalNumber": "评估编号",
+      "channel": "渠道",
+      "status": "状态",
+      "requestor": "申请人"
     }
   },
   "activityTracking": {
@@ -881,6 +911,26 @@
       "createFailed": "创建报价请求失败"
     }
   },
+  "history": {
+    "title": "历史记录",
+    "viewHistory": "查看历史",
+    "eventCount_one": "{{count}} 条记录",
+    "eventCount_other": "{{count}} 条记录",
+    "chips": {
+      "all": "全部",
+      "appointment": "预约",
+      "fees": "费用"
+    },
+    "status": {
+      "Approved": "已批准",
+      "Rejected": "已拒绝",
+      "Pending": "待批准",
+      "Auto": "自动",
+      "Cancelled": "已取消"
+    },
+    "emptyState": "暂无历史记录",
+    "loadError": "无法加载历史记录"
+  },
   "approval": {
     "banner": {
       "needsApproval": "此变更需要银行审批 — 请提交以供审核后才能生效。",
@@ -901,5 +951,235 @@
       "submitted": "已提交银行审批",
       "submitFailed": "提交审批失败"
     }
+  },
+  "createPage": {
+    "photosSection": "Photos",
+    "landSection": "Land Information",
+    "leaseAgreementSection": "Lease Agreement",
+    "rentalInfoSection": "Rental Info",
+    "condoSection": "Condo Information",
+    "buildingSection": "Building Information",
+    "constructionSection": "Construction Inspection",
+    "machinerySection": "Machinery Information",
+    "navPhotos": "Photos",
+    "navLand": "Land",
+    "navLeaseAgreement": "Lease Agreement",
+    "navRentalInfo": "Rental Info",
+    "navCondo": "Condo",
+    "navBuilding": "Building",
+    "navConstructionInspection": "Construction Inspection",
+    "navMachinery": "Machinery",
+    "saveDraft": "Save draft",
+    "save": "Save"
+  },
+  "landCharacteristicsForm": {
+    "sections": {
+      "landfill": "填土",
+      "road": "道路",
+      "landAccessibility": "土地可达性",
+      "roadSurface": "路面",
+      "publicUtility": "公共设施",
+      "landUse": "土地用途",
+      "landEntranceExit": "出入口",
+      "transportation": "交通",
+      "anticipationOfProperty": "物业前景",
+      "limitation": "限制",
+      "eviction": "征收",
+      "allocation": "分配",
+      "hasBuilding": "有无建筑",
+      "remark": "备注"
+    },
+    "fields": {
+      "other": "其他",
+      "landfillHeight": "填土高度",
+      "landAccessibilityDescription": "可达性描述",
+      "roadWidth": "路宽",
+      "rightOfWay": "通行权",
+      "roadFrontage": "临路长度",
+      "numberOrSidesFacingRoad": "临路面数",
+      "roadRunningInFrontOfLand": "地块前道路",
+      "areaSqWa": "面积（平方哇）",
+      "distance": "距离",
+      "remarkPlaceholder": "输入备注...",
+      "isExpropriate": "征收中",
+      "inLineExpropriate": "位于征收线内",
+      "royalDecree": "皇家法令",
+      "isEncroached": "被侵占",
+      "electricity": "电力",
+      "isLandlocked": "内陆地",
+      "isForestBoundary": "森林边界"
+    },
+    "landfillOptions": {
+      "emptyLand": "空地",
+      "filled": "已填",
+      "notFilledYet": "未填",
+      "partiallyFilled": "部分填充",
+      "other": "其他"
+    },
+    "landAccessibilityOptions": {
+      "able": "可进入",
+      "unable": "不可进入",
+      "inAllocation": "在分配项目内"
+    },
+    "roadSurfaceOptions": {
+      "reinforcedConcrete": "钢筋混凝土",
+      "gravelCrushedStone": "砾石/碎石",
+      "soil": "土路",
+      "paved": "铺装路面",
+      "other": "其他"
+    },
+    "publicUtilityOptions": {
+      "permanentElectricity": "永久电力",
+      "tapWaterGroundwater": "自来水/地下水",
+      "drainagePipeStone": "排水管/石",
+      "streetlight": "路灯",
+      "other": "其他"
+    },
+    "landUseOptions": {
+      "residence": "住宅",
+      "agriculture": "农业",
+      "commercial": "商业",
+      "industry": "工业",
+      "other": "其他"
+    },
+    "landEntranceExitOptions": {
+      "publicInterest": "公共通道",
+      "insideAllocationProject": "分配项目内",
+      "personal": "私人",
+      "servitude": "地役权",
+      "other": "其他"
+    },
+    "transportationOptions": {
+      "car": "轿车",
+      "bus": "公共汽车",
+      "ship": "船",
+      "footpath": "步行道",
+      "other": "其他"
+    },
+    "anticipationOptions": {
+      "veryProspective": "非常有前景",
+      "moderate": "一般",
+      "likelyToProsperInFuture": "未来可能繁荣",
+      "littleChanceOfProsperity": "发展机会较少"
+    },
+    "evictionOptions": {
+      "permanentElectricity": "永久电力",
+      "subwayLine": "地铁线路",
+      "other": "其他"
+    },
+    "allocationOptions": {
+      "allocateNewProject": "新项目分配",
+      "allocateOldProject": "旧项目分配",
+      "notAllocate": "不分配"
+    },
+    "hasBuildingOptions": {
+      "yes": "有",
+      "no": "无",
+      "other": "其他"
+    }
+  },
+  "approachMatrixTable": {
+    "columns": {
+      "group": "组别",
+      "model": "模型",
+      "market": "市场比较法",
+      "cost": "成本法",
+      "income": "收益法",
+      "residual": "剩余法",
+      "summary": "汇总"
+    },
+    "footer": {
+      "total": "合计",
+      "project": "项目"
+    }
+  },
+  "blockPriceSummaryTable": {
+    "columns": {
+      "model": "模型",
+      "unitCount": "单元数量",
+      "totalAppraisalPrice": "评估总价",
+      "forceSellingPrice": "强制销售价",
+      "buildingInsurance": "建筑保险"
+    },
+    "footer": {
+      "project": "项目"
+    }
+  },
+  "governmentPriceTable": {
+    "columns": {
+      "titleDeedNo": "地契编号",
+      "sqWa": "平方哇",
+      "bahtPerSqWa": "泰铢/平方哇",
+      "landPrice": "土地价格"
+    },
+    "footer": {
+      "total": "合计",
+      "avg": "平均"
+    },
+    "missingFromSurvey": "勘测中缺失"
+  },
+  "constructionSummaryTable": {
+    "columns": {
+      "milestone": "里程碑",
+      "totalAppraisalValue": "评估总价值",
+      "landValue": "土地价值",
+      "constructionProgress": "建设进度 (%)",
+      "buildingValue": "建筑价值",
+      "buildingValuePreInspection": "检验前建筑价值"
+    },
+    "rows": {
+      "Previous": "上期",
+      "ConstructionIncreased": "建设增量",
+      "Current": "本期",
+      "RemainingConstruction": "剩余建设",
+      "Complete100": "竣工（100%）"
+    }
+  },
+  "approvalListSection": {
+    "title": "委员会审批",
+    "notActiveYet": "此评估的委员会审批尚未启动。",
+    "approvedBanner": "此评估已获委员会批准。",
+    "returnedBanner": "此评估已被退回修改。",
+    "conditionsTitle": "审批条件",
+    "votesDisplay": "{{received}}/{{total}} 票",
+    "youBadge": "您",
+    "pendingVote": "待处理",
+    "tierLabels": {
+      "1": "层级 1",
+      "2": "层级 2",
+      "3": "层级 3"
+    },
+    "committeeCodeLabels": {
+      "SUB_COMMITTEE": "小组委员会",
+      "COMMITTEE": "委员会",
+      "COMMITTEE_WITH_MEETING": "委员会（含会议）"
+    },
+    "committeeDefault": "委员会",
+    "conditionRoleRequired": "{{role}} 必须投票",
+    "conditionRoleRequiredDefault": "所需角色必须投票",
+    "conditionMinVotes": "至少需要 {{n}} 票",
+    "conditionMinVotesDefault": "需达到最低投票数",
+    "columns": {
+      "member": "成员",
+      "role": "角色",
+      "vote": "投票",
+      "date": "日期",
+      "comments": "评论"
+    }
+  },
+  "decisionSummaryPageExtra": {
+    "governmentAppraisalPrice": "政府评估价格",
+    "constructionSummaryTitle": "建设汇总",
+    "cancelButton": "取消",
+    "saveButton": "保存",
+    "submitButton": "提交"
+  },
+  "landDetailSchema": {
+    "latitudeRequired": "纬度为必填项",
+    "longitudeRequired": "经度为必填项",
+    "subDistrictRequired": "街道/区为必填项",
+    "districtRequired": "区/县为必填项",
+    "provinceRequired": "省份为必填项",
+    "landOfficeRequired": "土地办公室为必填项"
   }
 }

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -2514,6 +2514,7 @@ const PropertyGroupItemDto = z
     location: z.string().nullable(),
     latitude: z.number().nullable(),
     longitude: z.number().nullable(),
+    isRentedOut: z.boolean().nullable(),
     photos: z.array(PropertyPhotoDto).nullable(),
   })
   .partial()


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR isolates the **appraisal** feature changes.

## Changes
- New appointment history: `api/appointmentHistory.ts` + `AppointmentHistoryDrawer`
- Summary tables reworked: approach matrix, approval list, block approach/price summary, construction, government price
- 360 sections (decision summary, pricing analysis, request info), appointment info card, fee/payment sections
- `LandCharacteristicsForm`, create pages (building/condo/land/landBuilding/machinery), decision summary page
- `api/fee.ts` adds `bankAbsorbAmount`
- **Shared schema:** adds `isRentedOut` to `PropertyGroupItemDto` (`src/shared/schemas/v1.ts`)
- en/th/zh `appraisal.json`

## Scope / coupling
The `isRentedOut` line in `shared/schemas/v1.ts` is **identical** to the one in the pricingAnalysis PR (#173); both consume the field. Identical additive lines merge cleanly regardless of order.

## ⚠️ Known pre-existing issues
~22 type errors carried from the original source changeset (preserved as-is); **no errors introduced by the split**.

## Verification
- `tsc -b` → all new-vs-`main` errors confirmed present in the original working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)