### PR TITLE
feat(userManagement): teams, companies, audit logs & access reports

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -59,6 +59,10 @@ import PermissionListPage from '@features/userManagement/pages/PermissionListPag
 import RoleListPage from '@features/userManagement/pages/RoleListPage';
 import GroupListPage from '@features/userManagement/pages/GroupListPage';
 import UserProfilePage from '@features/userManagement/pages/UserProfilePage';
+import TeamListPage from '@features/userManagement/pages/TeamListPage';
+import AuditLogPage from '@features/userManagement/pages/AuditLogPage';
+import CompanyListPage from '@features/userManagement/pages/CompanyListPage';
+import AccessReportPage from '@features/userManagement/pages/AccessReportPage';
 import TaskLayout, { TaskIndexRedirect } from './TaskLayout';
 import OpeningTaskPage from '@/features/task/pages/OpeningTaskPage';
 import BlockProjectPage from '@/features/blockProject/pages/BlockProjectPage';
@@ -307,6 +311,26 @@ export const router = createBrowserRouter([
           { path: 'roles', element: <RoleListPage /> },
           { path: 'groups', element: <GroupListPage /> },
           { path: 'users', element: <UserProfilePage /> },
+          {
+            path: 'teams',
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanManageTeams" />,
+            children: [{ index: true, element: <TeamListPage /> }],
+          },
+          {
+            path: 'audit-logs',
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanViewAuthAudit" />,
+            children: [{ index: true, element: <AuditLogPage /> }],
+          },
+          {
+            path: 'companies',
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanManageCompanies" />,
+            children: [{ index: true, element: <CompanyListPage /> }],
+          },
+          {
+            path: 'access-report',
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanViewAuthAudit" />,
+            children: [{ index: true, element: <AccessReportPage /> }],
+          },
           { path: 'committees', element: <CommitteeAdminPage /> },
           { path: 'fee-approval-tiers', element: <FeeApprovalTierPage /> },
           { path: 'appointment-approval-rule', element: <AppointmentApprovalRulePage /> },

--- a/src/features/userManagement/api/auditLogs.ts
+++ b/src/features/userManagement/api/auditLogs.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import type { AuditLogResult, GetAuditLogsParams } from '../types';
+
+const QUERY_KEY = 'auditLogs';
+
+export const useGetAuditLogs = (params: GetAuditLogsParams = {}) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, params],
+    queryFn: async (): Promise<AuditLogResult> => {
+      const { data } = await axios.get<AuditLogResult>('/auth/audit-logs', {
+        params: {
+          entityType: params.entityType || undefined,
+          entityId: params.entityId || undefined,
+          actorUserId: params.actorUserId || undefined,
+          from: params.from || undefined,
+          to: params.to || undefined,
+          action: params.action || undefined,
+          pageNumber: params.pageNumber ?? 0,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+  });
+};

--- a/src/features/userManagement/api/companies.ts
+++ b/src/features/userManagement/api/companies.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import type {
+  Company,
+  CompanyListResult,
+  GetCompaniesParams,
+  CreateCompanyRequest,
+  UpdateCompanyRequest,
+  EligibleCompany,
+} from '../types';
+
+const QUERY_KEY = 'adminCompanies';
+
+export const useGetAdminCompanies = (params: GetCompaniesParams = {}) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, params],
+    queryFn: async (): Promise<CompanyListResult> => {
+      const { data } = await axios.get<CompanyListResult>('/companies', {
+        params: {
+          search: params.search || undefined,
+          isActive: params.isActive,
+          pageNumber: params.pageNumber ?? 1,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+export const useGetAdminCompanyById = (id: string | null) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, id],
+    queryFn: async (): Promise<Company> => {
+      const { data } = await axios.get<Company>(`/companies/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+};
+
+export const useCreateAdminCompany = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: CreateCompanyRequest) => {
+      const { data } = await axios.post('/companies', request);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+};
+
+export const useUpdateAdminCompany = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: UpdateCompanyRequest & { id: string }) => {
+      const { data } = await axios.put(`/companies/${id}`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, variables.id] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+      // Invalidate eligible companies so callers see refreshed data
+      queryClient.invalidateQueries({ queryKey: ['eligibleCompanies'] });
+    },
+  });
+};
+
+export const useDeleteAdminCompany = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await axios.delete(`/companies/${id}`);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: ['eligibleCompanies'] });
+    },
+  });
+};
+
+export const useGetEligibleCompanies = () => {
+  return useQuery({
+    queryKey: ['eligibleCompanies'],
+    queryFn: async (): Promise<EligibleCompany[]> => {
+      const { data } = await axios.get<EligibleCompany[]>('/companies/eligible');
+      return data;
+    },
+    staleTime: 30_000,
+  });
+};

--- a/src/features/userManagement/api/reports.ts
+++ b/src/features/userManagement/api/reports.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import type { UserAccessMatrixResult, GetUserAccessMatrixParams } from '../types';
+
+const QUERY_KEY = 'userAccessMatrix';
+
+export const useGetUserAccessMatrix = (params: GetUserAccessMatrixParams = {}) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, params],
+    queryFn: async (): Promise<UserAccessMatrixResult> => {
+      const { data } = await axios.get<UserAccessMatrixResult>('/auth/reports/user-access', {
+        params: {
+          scope: params.scope || undefined,
+          companyId: params.companyId || undefined,
+          roleName: params.roleName || undefined,
+          groupId: params.groupId || undefined,
+          teamId: params.teamId || undefined,
+          isActive: params.isActive,
+          search: params.search || undefined,
+          pageNumber: params.pageNumber ?? 0,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+/**
+ * Triggers a CSV download of the user access report with the current filters.
+ * The backend streams the file; we receive it as a blob and trigger a browser download.
+ */
+export const exportUserAccessReport = async (params: GetUserAccessMatrixParams = {}) => {
+  const response = await axios.get('/auth/reports/user-access/export', {
+    params: {
+      scope: params.scope || undefined,
+      companyId: params.companyId || undefined,
+      roleName: params.roleName || undefined,
+      groupId: params.groupId || undefined,
+      teamId: params.teamId || undefined,
+      isActive: params.isActive,
+      search: params.search || undefined,
+    },
+    responseType: 'blob',
+  });
+
+  const url = URL.createObjectURL(new Blob([response.data as BlobPart]));
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `user-access-report-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};

--- a/src/features/userManagement/api/teams.ts
+++ b/src/features/userManagement/api/teams.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import type {
+  TeamDetail,
+  TeamListResult,
+  GetTeamsParams,
+  CreateTeamRequest,
+  UpdateTeamRequest,
+  UpdateTeamMembersRequest,
+} from '../types';
+
+const QUERY_KEY = 'teams';
+
+export const useGetTeams = (params: GetTeamsParams = {}) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, params],
+    queryFn: async (): Promise<TeamListResult> => {
+      const { data } = await axios.get<TeamListResult>('/auth/teams', {
+        params: {
+          search: params.search || undefined,
+          pageNumber: params.pageNumber ?? 1,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+export const useGetTeamById = (id: string | null) => {
+  return useQuery({
+    queryKey: [QUERY_KEY, id],
+    queryFn: async (): Promise<TeamDetail> => {
+      const { data } = await axios.get<TeamDetail>(`/auth/teams/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+};
+
+export const useCreateTeam = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: CreateTeamRequest) => {
+      const { data } = await axios.post('/auth/teams', request);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+};
+
+export const useUpdateTeam = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: UpdateTeamRequest & { id: string }) => {
+      const { data } = await axios.put(`/auth/teams/${id}`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, variables.id] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+};
+
+export const useUpdateTeamMembers = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: UpdateTeamMembersRequest & { id: string }) => {
+      const { data } = await axios.put(`/auth/teams/${id}/members`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, variables.id] });
+    },
+  });
+};
+
+export const useDeleteTeam = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await axios.delete(`/auth/teams/${id}`);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+};

--- a/src/features/userManagement/api/users.ts
+++ b/src/features/userManagement/api/users.ts
@@ -11,8 +11,11 @@ import type {
   AdminUpdateUserRequest,
   UpdateUserRolesRequest,
   UpdateUserGroupsRequest,
+  UpdateUserTeamsRequest,
+  SetUserActivationRequest,
   CreateUserRequest,
   CreateUserResponse,
+  PasswordPolicy,
 } from '../types';
 
 const ME_KEY = ['me'];
@@ -66,6 +69,7 @@ export const useGetUsers = (params: GetUsersParams = {}) => {
           Search: params.search || undefined,
           Scope: params.scope || undefined,
           role: params.role || undefined,
+          isActive: params.isActive,
           PageNumber: params.pageNumber ?? 1,
           PageSize: params.pageSize ?? 20,
         },
@@ -162,5 +166,60 @@ export const useUpdateUserGroups = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: [USERS_KEY, variables.id] });
     },
+  });
+};
+
+/** Admin: update user teams */
+export const useUpdateUserTeams = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: UpdateUserTeamsRequest & { id: string }) => {
+      const { data } = await axios.put(`/auth/users/${id}/teams`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY, variables.id] });
+    },
+  });
+};
+
+/** Admin: activate or deactivate a user */
+export const useSetUserActivation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: SetUserActivationRequest & { id: string }) => {
+      const { data } = await axios.put(`/auth/users/${id}/activation`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY, variables.id] });
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
+    },
+  });
+};
+
+/** Admin: unlock a locked user account */
+export const useUnlockUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await axios.post(`/auth/users/${id}/unlock`);
+      return data;
+    },
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY, id] });
+    },
+  });
+};
+
+/** Get the global password policy */
+export const useGetPasswordPolicy = () => {
+  return useQuery({
+    queryKey: ['passwordPolicy'],
+    queryFn: async (): Promise<PasswordPolicy> => {
+      const { data } = await axios.get<PasswordPolicy>('/auth/password-policy');
+      return data;
+    },
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/src/features/userManagement/components/AssignmentTable.tsx
+++ b/src/features/userManagement/components/AssignmentTable.tsx
@@ -1,0 +1,260 @@
+import { useState, useMemo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import Badge from '@shared/components/Badge';
+import Icon from '@shared/components/Icon';
+
+export interface AssignmentColumn<T> {
+  key: string;
+  label: string;
+  render?: (item: T) => ReactNode;
+  sortable?: boolean;
+}
+
+interface AssignmentTableProps<T> {
+  items: T[];
+  getId: (item: T) => string;
+  getLabel: (item: T) => string;
+  columns: AssignmentColumn<T>[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  searchPlaceholder?: string;
+  searchFields?: (item: T) => string[];
+}
+
+type SortDir = 'asc' | 'desc';
+
+const AssignmentTable = <T,>({
+  items,
+  getId,
+  getLabel,
+  columns,
+  selectedIds,
+  onChange,
+  searchPlaceholder,
+  searchFields,
+}: AssignmentTableProps<T>) => {
+  const { t } = useTranslation(['userManagement', 'common']);
+
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let result = q
+      ? items.filter(item => {
+          const fields = searchFields ? searchFields(item) : [getLabel(item)];
+          return fields.some(f => f.toLowerCase().includes(q));
+        })
+      : items;
+
+    if (sortKey) {
+      const col = columns.find(c => c.key === sortKey);
+      if (col) {
+        result = [...result].sort((a, b) => {
+          const aVal = col.render
+            ? String(col.render(a) ?? '')
+            : String((a as Record<string, unknown>)[sortKey] ?? '');
+          const bVal = col.render
+            ? String(col.render(b) ?? '')
+            : String((b as Record<string, unknown>)[sortKey] ?? '');
+          const cmp = aVal.localeCompare(bVal);
+          return sortDir === 'asc' ? cmp : -cmp;
+        });
+      }
+    }
+
+    return result;
+  }, [items, search, sortKey, sortDir, columns, getLabel, searchFields]);
+
+  const filteredIds = useMemo(() => filtered.map(getId), [filtered, getId]);
+
+  const allFilteredSelected =
+    filteredIds.length > 0 && filteredIds.every(id => selectedIds.includes(id));
+  const someFilteredSelected = filteredIds.some(id => selectedIds.includes(id));
+
+  const toggleHeaderCheckbox = () => {
+    if (allFilteredSelected) {
+      onChange(selectedIds.filter(id => !filteredIds.includes(id)));
+    } else {
+      const toAdd = filteredIds.filter(id => !selectedIds.includes(id));
+      onChange([...selectedIds, ...toAdd]);
+    }
+  };
+
+  const toggleRow = (id: string) => {
+    onChange(
+      selectedIds.includes(id) ? selectedIds.filter(s => s !== id) : [...selectedIds, id],
+    );
+  };
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const selectedItems = useMemo(
+    () => items.filter(item => selectedIds.includes(getId(item))),
+    [items, selectedIds, getId],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Selected chips */}
+      {selectedItems.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selectedItems.map(item => {
+            const id = getId(item);
+            return (
+              <Badge
+                key={id}
+                badgeStyle="soft"
+                dot={false}
+                removable
+                onRemove={() => toggleRow(id)}
+                aria-label={t('aria.removeItem', { name: getLabel(item) })}
+              >
+                {getLabel(item)}
+              </Badge>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Search */}
+      <div className="relative">
+        <Icon
+          name="magnifying-glass"
+          style="regular"
+          className="size-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+        />
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder={searchPlaceholder ?? t('placeholders.searchRoles')}
+          aria-label={searchPlaceholder ?? t('placeholders.searchRoles')}
+          className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+        />
+      </div>
+
+      {/* Table */}
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        <div className="max-h-60 overflow-y-auto">
+          {filtered.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-gray-400">
+              <Icon name="magnifying-glass" style="regular" className="size-6 mb-2 text-gray-300" />
+              <p className="text-sm">{t('empty.noItemsFound')}</p>
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 bg-primary/10 z-10">
+                <tr>
+                  <th className="w-10 py-2.5 px-3">
+                    <input
+                      type="checkbox"
+                      checked={allFilteredSelected}
+                      ref={el => {
+                        if (el) el.indeterminate = someFilteredSelected && !allFilteredSelected;
+                      }}
+                      onChange={toggleHeaderCheckbox}
+                      className="rounded border-gray-300 text-primary focus:ring-primary/20"
+                    />
+                  </th>
+                  {columns.map(col => (
+                    <th
+                      key={col.key}
+                      className={clsx(
+                        'py-2.5 px-3 text-left text-xs font-semibold text-primary',
+                        col.sortable && 'cursor-pointer select-none hover:text-primary/80',
+                      )}
+                      onClick={col.sortable ? () => handleSort(col.key) : undefined}
+                    >
+                      <span className="inline-flex items-center gap-1">
+                        {col.label}
+                        {col.sortable && (
+                          <span className="inline-flex flex-col gap-px">
+                            <Icon
+                              name="chevron-up"
+                              style="solid"
+                              className={clsx(
+                                'size-2',
+                                sortKey === col.key && sortDir === 'asc'
+                                  ? 'text-primary'
+                                  : 'text-gray-300',
+                              )}
+                            />
+                            <Icon
+                              name="chevron-down"
+                              style="solid"
+                              className={clsx(
+                                'size-2',
+                                sortKey === col.key && sortDir === 'desc'
+                                  ? 'text-primary'
+                                  : 'text-gray-300',
+                              )}
+                            />
+                          </span>
+                        )}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filtered.map(item => {
+                  const id = getId(item);
+                  const selected = selectedIds.includes(id);
+                  return (
+                    <tr
+                      key={id}
+                      onClick={() => toggleRow(id)}
+                      className={clsx(
+                        'cursor-pointer transition-colors',
+                        selected ? 'bg-primary/5 hover:bg-primary/10' : 'hover:bg-gray-50',
+                      )}
+                    >
+                      <td className="py-2.5 px-3">
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          onChange={() => toggleRow(id)}
+                          onClick={e => e.stopPropagation()}
+                          className="rounded border-gray-300 text-primary focus:ring-primary/20"
+                        />
+                      </td>
+                      {columns.map(col => (
+                        <td key={col.key} className="py-2.5 px-3 text-gray-700">
+                          {col.render
+                            ? col.render(item)
+                            : String((item as Record<string, unknown>)[col.key] ?? '')}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* Count summary */}
+      <p className="text-xs text-gray-400">
+        {t('selectionCount.items', { count: selectedIds.length })}
+        {search.trim() && filtered.length !== items.length && (
+          <span className="ml-1">
+            ({filtered.length}/{items.length})
+          </span>
+        )}
+      </p>
+    </div>
+  );
+};
+
+export default AssignmentTable;

--- a/src/features/userManagement/components/ChangePasswordModal.tsx
+++ b/src/features/userManagement/components/ChangePasswordModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Modal from '@shared/components/Modal';
 import Button from '@shared/components/Button';
 import Icon from '@shared/components/Icon';
-import { useChangePassword } from '../api/users';
+import { useChangePassword, useGetPasswordPolicy } from '../api/users';
 
 interface ChangePasswordModalProps {
   isOpen: boolean;
@@ -18,14 +18,17 @@ const emptyForm = { currentPassword: '', newPassword: '', confirmPassword: '' };
 const ChangePasswordModal = ({ isOpen, onClose, userId }: ChangePasswordModalProps) => {
   const { t } = useTranslation(['userManagement', 'common']);
   const changePassword = useChangePassword(userId);
+  const { data: policy } = useGetPasswordPolicy();
   const [form, setForm] = useState(emptyForm);
   const [errors, setErrors] = useState<Partial<typeof emptyForm>>({});
   const [showPasswords, setShowPasswords] = useState(false);
 
+  const minLength = policy?.requiredLength ?? 8;
+
   const schema = z
     .object({
       currentPassword: z.string().min(1, t('validation.currentPasswordRequired')),
-      newPassword: z.string().min(8, t('validation.newPasswordMinLength')),
+      newPassword: z.string().min(minLength, t('validation.newPasswordMinLength')),
       confirmPassword: z.string().min(1, t('validation.confirmPasswordRequired')),
     })
     .refine(data => data.newPassword === data.confirmPassword, {
@@ -35,7 +38,6 @@ const ChangePasswordModal = ({ isOpen, onClose, userId }: ChangePasswordModalPro
 
   const updateField = (key: keyof typeof emptyForm, value: string) => {
     setForm(prev => ({ ...prev, [key]: value }));
-    // Clear error on change
     if (errors[key]) setErrors(prev => ({ ...prev, [key]: undefined }));
   };
 
@@ -69,6 +71,54 @@ const ChangePasswordModal = ({ isOpen, onClose, userId }: ChangePasswordModalPro
       },
     });
   };
+
+  // Derive which policy rules pass against the current new-password value
+  const pw = form.newPassword;
+  const policyChecks = policy
+    ? [
+        {
+          key: 'length',
+          label: t('passwordPolicy.minLength', { count: policy.requiredLength }),
+          passed: pw.length >= policy.requiredLength,
+        },
+        ...(policy.requireUppercase
+          ? [
+              {
+                key: 'upper',
+                label: t('passwordPolicy.requireUppercase'),
+                passed: /[A-Z]/.test(pw),
+              },
+            ]
+          : []),
+        ...(policy.requireLowercase
+          ? [
+              {
+                key: 'lower',
+                label: t('passwordPolicy.requireLowercase'),
+                passed: /[a-z]/.test(pw),
+              },
+            ]
+          : []),
+        ...(policy.requireDigit
+          ? [
+              {
+                key: 'digit',
+                label: t('passwordPolicy.requireDigit'),
+                passed: /[0-9]/.test(pw),
+              },
+            ]
+          : []),
+        ...(policy.requireNonAlphanumeric
+          ? [
+              {
+                key: 'symbol',
+                label: t('passwordPolicy.requireSymbol'),
+                passed: /[^a-zA-Z0-9]/.test(pw),
+              },
+            ]
+          : []),
+      ]
+    : [];
 
   const inputType = showPasswords ? 'text' : 'password';
 
@@ -115,6 +165,24 @@ const ChangePasswordModal = ({ isOpen, onClose, userId }: ChangePasswordModalPro
           />
           {errors.newPassword && <p className="mt-1 text-xs text-danger">{errors.newPassword}</p>}
         </div>
+
+        {/* Password policy checklist */}
+        {policyChecks.length > 0 && form.newPassword.length > 0 && (
+          <ul className="flex flex-col gap-1">
+            {policyChecks.map(check => (
+              <li key={check.key} className="flex items-center gap-1.5 text-xs">
+                <Icon
+                  name={check.passed ? 'circle-check' : 'circle-xmark'}
+                  style="solid"
+                  className={`size-3.5 shrink-0 ${check.passed ? 'text-green-500' : 'text-gray-300'}`}
+                />
+                <span className={check.passed ? 'text-green-700' : 'text-gray-400'}>
+                  {check.label}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
 
         {/* Confirm password */}
         <div>

--- a/src/features/userManagement/components/CompanyDetailPanel.tsx
+++ b/src/features/userManagement/components/CompanyDetailPanel.tsx
@@ -1,0 +1,374 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import Modal from '@shared/components/Modal';
+import TextInput from '@shared/components/inputs/TextInput';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { Skeleton } from '@shared/components/Skeleton';
+import {
+  useGetAdminCompanyById,
+  useUpdateAdminCompany,
+  useDeleteAdminCompany,
+} from '../api/companies';
+import type { UpdateCompanyRequest } from '../types';
+
+interface CompanyDetailPanelProps {
+  companyId: string;
+  onDeleted: () => void;
+}
+
+type EditForm = Omit<UpdateCompanyRequest, 'loanTypes'> & { loanTypesStr: string };
+
+const defaultForm = (): EditForm => ({
+  name: '',
+  taxId: '',
+  phone: '',
+  email: '',
+  street: '',
+  city: '',
+  province: '',
+  postalCode: '',
+  contactPerson: '',
+  loanTypesStr: '',
+  isActive: true,
+  bankAccountNo: '',
+  bankAccountName: '',
+});
+
+const CompanyDetailPanel = ({ companyId, onDeleted }: CompanyDetailPanelProps) => {
+  const { t } = useTranslation(['userManagement', 'common']);
+  const { data: company, isLoading } = useGetAdminCompanyById(companyId);
+  const updateCompany = useUpdateAdminCompany();
+  const deleteCompany = useDeleteAdminCompany();
+
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editForm, setEditForm] = useState<EditForm>(defaultForm());
+  const [showDelete, setShowDelete] = useState(false);
+
+  const handleOpenEdit = () => {
+    if (!company) return;
+    setEditForm({
+      name: company.name,
+      taxId: company.taxId ?? '',
+      phone: company.phone ?? '',
+      email: company.email ?? '',
+      street: company.street ?? '',
+      city: company.city ?? '',
+      province: company.province ?? '',
+      postalCode: company.postalCode ?? '',
+      contactPerson: company.contactPerson ?? '',
+      loanTypesStr: (company.loanTypes ?? []).join(', '),
+      isActive: company.isActive,
+      bankAccountNo: company.bankAccountNo ?? '',
+      bankAccountName: company.bankAccountName ?? '',
+    });
+    setShowEditModal(true);
+  };
+
+  const handleSave = () => {
+    if (!editForm.name) {
+      toast.error(t('validation.nameRequired'));
+      return;
+    }
+    const loanTypes = editForm.loanTypesStr
+      ? editForm.loanTypesStr
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+      : [];
+    updateCompany.mutate(
+      {
+        id: companyId,
+        name: editForm.name,
+        taxId: editForm.taxId || null,
+        phone: editForm.phone || null,
+        email: editForm.email || null,
+        street: editForm.street || null,
+        city: editForm.city || null,
+        province: editForm.province || null,
+        postalCode: editForm.postalCode || null,
+        contactPerson: editForm.contactPerson || null,
+        loanTypes,
+        isActive: editForm.isActive,
+        bankAccountNo: editForm.bankAccountNo || null,
+        bankAccountName: editForm.bankAccountName || null,
+      },
+      {
+        onSuccess: () => {
+          toast.success(t('toasts.companyUpdated'));
+          setShowEditModal(false);
+        },
+        onError: () => toast.error(t('toasts.companyUpdateFailed')),
+      },
+    );
+  };
+
+  const handleConfirmDelete = () => {
+    deleteCompany.mutate(companyId, {
+      onSuccess: () => {
+        toast.success(t('toasts.companyDeleted'));
+        setShowDelete(false);
+        onDeleted();
+      },
+      onError: () => toast.error(t('toasts.companyDeleteFailed')),
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-6">
+        <Skeleton className="h-6 w-40" variant="rounded" />
+        <Skeleton className="h-4 w-64" variant="rounded" />
+        <Skeleton className="h-32 w-full" variant="rounded" />
+        <Skeleton className="h-32 w-full" variant="rounded" />
+      </div>
+    );
+  }
+
+  if (!company) return null;
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      {/* General Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+          <div className="flex items-center gap-2">
+            <Icon name="building" style="solid" className="size-4 text-blue-500" />
+            <span className="text-sm font-semibold text-gray-800">{t('sections.general')}</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenEdit}
+            className="text-xs text-primary hover:underline flex items-center gap-1"
+          >
+            <Icon name="pen-to-square" style="regular" className="size-3.5" />
+            {t('buttons.edit')}
+          </button>
+        </div>
+        <div className="px-4 py-3 grid grid-cols-2 gap-x-6 gap-y-2">
+          <InfoRow label={t('fields.companyName')} value={company.name} />
+          <InfoRow label={t('fields.taxId')} value={company.taxId} />
+          <InfoRow label={t('fields.phone')} value={company.phone} />
+          <InfoRow label={t('fields.email')} value={company.email} />
+          <InfoRow label={t('fields.contactPerson')} value={company.contactPerson} />
+          <div>
+            <div className="text-xs text-gray-400 mb-0.5">{t('fields.status')}</div>
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                company.isActive ? 'bg-emerald-50 text-emerald-700' : 'bg-gray-100 text-gray-500'
+              }`}
+            >
+              {company.isActive ? t('status.active') : t('status.inactive')}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Address Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+          <Icon name="location-dot" style="solid" className="size-4 text-amber-500" />
+          <span className="text-sm font-semibold text-gray-800">{t('sections.address')}</span>
+        </div>
+        <div className="px-4 py-3 grid grid-cols-2 gap-x-6 gap-y-2">
+          <InfoRow label={t('fields.street')} value={company.street} />
+          <InfoRow label={t('fields.city')} value={company.city} />
+          <InfoRow label={t('fields.province')} value={company.province} />
+          <InfoRow label={t('fields.postalCode')} value={company.postalCode} />
+        </div>
+      </section>
+
+      {/* Bank Account Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+          <Icon name="landmark" style="solid" className="size-4 text-violet-500" />
+          <span className="text-sm font-semibold text-gray-800">{t('sections.bankAccount')}</span>
+        </div>
+        <div className="px-4 py-3 grid grid-cols-2 gap-x-6 gap-y-2">
+          <InfoRow label={t('fields.bankAccountNo')} value={company.bankAccountNo} />
+          <InfoRow label={t('fields.bankAccountName')} value={company.bankAccountName} />
+        </div>
+      </section>
+
+      {/* Loan Types */}
+      {(company.loanTypes ?? []).length > 0 && (
+        <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+            <Icon name="tags" style="solid" className="size-4 text-cyan-500" />
+            <span className="text-sm font-semibold text-gray-800">{t('fields.loanTypes')}</span>
+          </div>
+          <div className="px-4 py-3 flex flex-wrap gap-1.5">
+            {(company.loanTypes ?? []).map(lt => (
+              <span
+                key={lt}
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-50 text-cyan-700"
+              >
+                {lt}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Security Section */}
+      <section className="bg-white rounded-xl border border-red-100 shadow-sm overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-red-100">
+          <Icon name="triangle-exclamation" style="solid" className="size-4 text-danger" />
+          <span className="text-sm font-semibold text-gray-800">{t('sections.security')}</span>
+        </div>
+        <div className="px-4 py-3">
+          <p className="text-xs text-gray-500 mb-3">{t('security.deleteCompanyWarning')}</p>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => setShowDelete(true)}
+            leftIcon={<Icon name="trash-can" style="regular" className="size-3.5" />}
+          >
+            {t('buttons.deleteCompany')}
+          </Button>
+        </div>
+      </section>
+
+      {/* Edit Modal */}
+      <Modal
+        isOpen={showEditModal}
+        onClose={() => setShowEditModal(false)}
+        title={t('dialogs.editCompany.title')}
+        size="xl"
+      >
+        <div className="grid grid-cols-2 gap-4 p-6">
+          <TextInput
+            label={t('fields.companyName')}
+            value={editForm.name}
+            onChange={e => setEditForm(prev => ({ ...prev, name: e.currentTarget.value }))}
+            required
+            placeholder={t('placeholders.companyName')}
+          />
+          <TextInput
+            label={t('fields.taxId')}
+            value={editForm.taxId ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, taxId: e.currentTarget.value }))}
+            placeholder={t('placeholders.taxId')}
+          />
+          <TextInput
+            label={t('fields.phone')}
+            value={editForm.phone ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, phone: e.currentTarget.value }))}
+            placeholder={t('placeholders.phone')}
+          />
+          <TextInput
+            label={t('fields.email')}
+            value={editForm.email ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, email: e.currentTarget.value }))}
+            placeholder={t('placeholders.email')}
+          />
+          <TextInput
+            label={t('fields.contactPerson')}
+            value={editForm.contactPerson ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, contactPerson: e.currentTarget.value }))}
+            placeholder={t('placeholders.contactPerson')}
+          />
+          <div className="flex items-center gap-3 pt-5">
+            <input
+              type="checkbox"
+              id="company-isActive"
+              checked={editForm.isActive ?? true}
+              onChange={e => setEditForm(prev => ({ ...prev, isActive: e.target.checked }))}
+              className="rounded border-gray-300 text-primary focus:ring-primary/20"
+            />
+            <label htmlFor="company-isActive" className="text-sm text-gray-700">
+              {t('fields.isActive')}
+            </label>
+          </div>
+          <TextInput
+            label={t('fields.street')}
+            value={editForm.street ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, street: e.currentTarget.value }))}
+            placeholder={t('placeholders.street')}
+          />
+          <TextInput
+            label={t('fields.city')}
+            value={editForm.city ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, city: e.currentTarget.value }))}
+            placeholder={t('placeholders.city')}
+          />
+          <TextInput
+            label={t('fields.province')}
+            value={editForm.province ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, province: e.currentTarget.value }))}
+            placeholder={t('placeholders.province')}
+          />
+          <TextInput
+            label={t('fields.postalCode')}
+            value={editForm.postalCode ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, postalCode: e.currentTarget.value }))}
+            placeholder={t('placeholders.postalCode')}
+          />
+          <TextInput
+            label={t('fields.bankAccountNo')}
+            value={editForm.bankAccountNo ?? ''}
+            onChange={e => setEditForm(prev => ({ ...prev, bankAccountNo: e.currentTarget.value }))}
+            placeholder={t('placeholders.bankAccountNo')}
+          />
+          <TextInput
+            label={t('fields.bankAccountName')}
+            value={editForm.bankAccountName ?? ''}
+            onChange={e =>
+              setEditForm(prev => ({ ...prev, bankAccountName: e.currentTarget.value }))
+            }
+            placeholder={t('placeholders.bankAccountName')}
+          />
+          <div className="col-span-2">
+            <TextInput
+              label={t('fields.loanTypes')}
+              value={editForm.loanTypesStr}
+              onChange={e => setEditForm(prev => ({ ...prev, loanTypesStr: e.currentTarget.value }))}
+              placeholder={t('placeholders.loanTypes')}
+            />
+            <p className="text-xs text-gray-400 mt-1">{t('hints.loanTypesComma')}</p>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 px-6 pb-6">
+          <Button variant="ghost" size="sm" onClick={() => setShowEditModal(false)}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isLoading={updateCompany.isPending}
+            onClick={handleSave}
+          >
+            {t('common:actions.save')}
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Delete Confirm */}
+      <ConfirmDialog
+        isOpen={showDelete}
+        onClose={() => setShowDelete(false)}
+        onConfirm={handleConfirmDelete}
+        title={t('dialogs.deleteCompany.title')}
+        message={t('dialogs.deleteCompany.message', { name: company.name })}
+        confirmText={t('common:actions.delete')}
+        isLoading={deleteCompany.isPending}
+      />
+    </div>
+  );
+};
+
+interface InfoRowProps {
+  label: string;
+  value: string | null | undefined;
+}
+
+const InfoRow = ({ label, value }: InfoRowProps) => (
+  <div>
+    <div className="text-xs text-gray-400 mb-0.5">{label}</div>
+    <div className="text-sm text-gray-700">{value || '—'}</div>
+  </div>
+);
+
+export default CompanyDetailPanel;

--- a/src/features/userManagement/components/GroupDetailPanel.tsx
+++ b/src/features/userManagement/components/GroupDetailPanel.tsx
@@ -66,8 +66,9 @@ const GroupDetailPanel = ({ groupId, onDeleted }: GroupDetailPanelProps) => {
     () =>
       (group?.users ?? []).map(u => ({
         id: u.userId,
-        userName: u.userName,
-        displayName: `${u.firstName} ${u.lastName}`.trim() || u.userName,
+        username: u.userName,
+        firstName: u.firstName,
+        lastName: u.lastName,
         email: '',
       })),
     [group?.users],
@@ -130,7 +131,7 @@ const GroupDetailPanel = ({ groupId, onDeleted }: GroupDetailPanelProps) => {
   if (!group) return null;
 
   return (
-    <div className="flex flex-col gap-4 p-6 h-full overflow-y-auto">
+    <div className="flex flex-col gap-4 p-6">
       {/* General Section */}
       <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
@@ -320,8 +321,7 @@ const GroupDetailPanel = ({ groupId, onDeleted }: GroupDetailPanelProps) => {
         onClose={() => setShowUserModal(false)}
         onSave={handleSaveUsers}
         currentUsers={adaptedUsers}
-        availableUsers={adaptedUsers}
-        isLoadingUsers={isLoading}
+        scope={group.scope}
         isSaving={updateUsers.isPending}
         title={t('dialogs.assignUsers.title')}
       />

--- a/src/features/userManagement/components/TeamDetailPanel.tsx
+++ b/src/features/userManagement/components/TeamDetailPanel.tsx
@@ -1,0 +1,348 @@
+import { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import Modal from '@shared/components/Modal';
+import TextInput from '@shared/components/inputs/TextInput';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { Skeleton } from '@shared/components/Skeleton';
+import AssignmentTable from './AssignmentTable';
+import {
+  useGetTeamById,
+  useUpdateTeam,
+  useUpdateTeamMembers,
+  useDeleteTeam,
+} from '../api/teams';
+import { useGetUsers } from '../api/users';
+import type { AdminUserListItem, TeamType } from '../types';
+
+interface TeamDetailPanelProps {
+  teamId: string;
+  onDeleted: () => void;
+}
+
+const TeamDetailPanel = ({ teamId, onDeleted }: TeamDetailPanelProps) => {
+  const { t } = useTranslation(['userManagement', 'common']);
+  const { data: team, isLoading } = useGetTeamById(teamId);
+
+  const updateTeam = useUpdateTeam();
+  const updateMembers = useUpdateTeamMembers();
+  const deleteTeam = useDeleteTeam();
+
+  // Fetch all users for assignment
+  const { data: usersData } = useGetUsers({ pageSize: 500 });
+  const allUsers: AdminUserListItem[] = useMemo(
+    () => usersData?.items ?? [],
+    [usersData],
+  );
+
+  // Edit general modal
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editForm, setEditForm] = useState<{ name: string; type: TeamType; isActive: boolean }>({
+    name: '',
+    type: 'Internal',
+    isActive: true,
+  });
+
+  const handleOpenEdit = () => {
+    if (!team) return;
+    setEditForm({ name: team.name, type: team.type, isActive: team.isActive });
+    setShowEditModal(true);
+  };
+
+  const handleSaveGeneral = () => {
+    if (!editForm.name) {
+      toast.error(t('validation.nameRequired'));
+      return;
+    }
+    updateTeam.mutate(
+      { id: teamId, name: editForm.name, type: editForm.type, isActive: editForm.isActive },
+      {
+        onSuccess: () => {
+          toast.success(t('toasts.teamUpdated'));
+          setShowEditModal(false);
+        },
+        onError: () => toast.error(t('toasts.teamUpdateFailed')),
+      },
+    );
+  };
+
+  // Member assignment
+  const [showMemberModal, setShowMemberModal] = useState(false);
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+
+  const handleOpenMemberModal = () => {
+    setSelectedMemberIds((team?.members ?? []).map(m => m.userId));
+    setShowMemberModal(true);
+  };
+
+  const handleSaveMembers = () => {
+    updateMembers.mutate(
+      { id: teamId, userIds: selectedMemberIds },
+      {
+        onSuccess: () => {
+          toast.success(t('toasts.usersUpdated'));
+          setShowMemberModal(false);
+        },
+        onError: () => toast.error(t('toasts.usersUpdateFailed')),
+      },
+    );
+  };
+
+  // Delete
+  const [showDelete, setShowDelete] = useState(false);
+
+  const handleConfirmDelete = () => {
+    deleteTeam.mutate(teamId, {
+      onSuccess: () => {
+        toast.success(t('toasts.teamDeleted'));
+        setShowDelete(false);
+        onDeleted();
+      },
+      onError: () => toast.error(t('toasts.teamDeleteFailed')),
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-6">
+        <Skeleton className="h-6 w-40" variant="rounded" />
+        <Skeleton className="h-4 w-64" variant="rounded" />
+        <Skeleton className="h-24 w-full" variant="rounded" />
+        <Skeleton className="h-24 w-full" variant="rounded" />
+      </div>
+    );
+  }
+
+  if (!team) return null;
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      {/* General Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+          <div className="flex items-center gap-2">
+            <Icon name="circle-info" style="solid" className="size-4 text-blue-500" />
+            <span className="text-sm font-semibold text-gray-800">{t('sections.general')}</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenEdit}
+            className="text-xs text-primary hover:underline flex items-center gap-1"
+          >
+            <Icon name="pen-to-square" style="regular" className="size-3.5" />
+            {t('buttons.edit')}
+          </button>
+        </div>
+        <div className="px-4 py-3 space-y-2">
+          <div>
+            <div className="text-xs text-gray-400 mb-0.5">{t('fields.name')}</div>
+            <div className="text-sm font-medium text-gray-900">{team.name}</div>
+          </div>
+          <div>
+            <div className="text-xs text-gray-400 mb-0.5">{t('fields.teamType')}</div>
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                team.type === 'Internal' ? 'bg-blue-50 text-blue-700' : 'bg-violet-50 text-violet-700'
+              }`}
+            >
+              {t(team.type === 'Internal' ? 'fields.teamTypeInternal' : 'fields.teamTypeExternal')}
+            </span>
+          </div>
+          <div>
+            <div className="text-xs text-gray-400 mb-0.5">{t('fields.isActive')}</div>
+            <span
+              className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${
+                team.isActive ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'
+              }`}
+            >
+              <span className={`size-1.5 rounded-full ${team.isActive ? 'bg-green-500' : 'bg-gray-400'}`} />
+              {team.isActive ? t('status.active') : t('status.inactive')}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Members Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+          <div className="flex items-center gap-2">
+            <Icon name="users" style="solid" className="size-4 text-violet-500" />
+            <span className="text-sm font-semibold text-gray-800">{t('sections.users')}</span>
+            <span className="inline-flex items-center justify-center size-5 rounded-full bg-gray-100 text-xs font-semibold text-gray-600">
+              {team.members.length}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenMemberModal}
+            className="text-xs text-primary hover:underline flex items-center gap-1"
+          >
+            <Icon name="pen-to-square" style="regular" className="size-3.5" />
+            {t('buttons.edit')}
+          </button>
+        </div>
+        <div className="divide-y divide-gray-50 max-h-48 overflow-y-auto">
+          {team.members.length === 0 ? (
+            <div className="px-4 py-4 text-sm text-gray-400 text-center">
+              {t('empty.noUsersAssigned')}
+            </div>
+          ) : (
+            team.members.map(m => (
+              <div key={m.userId} className="px-4 py-2.5 flex items-center gap-2">
+                <div className="size-7 rounded-full bg-gray-100 flex items-center justify-center text-xs font-semibold text-gray-500 shrink-0">
+                  {(m.firstName || m.userName || '?')[0]?.toUpperCase()}
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-gray-800 truncate">
+                    {`${m.firstName} ${m.lastName}`.trim() || m.userName}
+                  </div>
+                  <div className="text-xs text-gray-400 truncate">{m.userName}</div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      {/* Security Section */}
+      <section className="bg-white rounded-xl border border-red-100 shadow-sm overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-red-100">
+          <Icon name="triangle-exclamation" style="solid" className="size-4 text-danger" />
+          <span className="text-sm font-semibold text-gray-800">{t('sections.security')}</span>
+        </div>
+        <div className="px-4 py-3">
+          <p className="text-xs text-gray-500 mb-3">{t('security.deleteTeamWarning')}</p>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => setShowDelete(true)}
+            leftIcon={<Icon name="trash-can" style="regular" className="size-3.5" />}
+          >
+            {t('buttons.deleteTeam')}
+          </Button>
+        </div>
+      </section>
+
+      {/* General Edit Modal */}
+      <Modal
+        isOpen={showEditModal}
+        onClose={() => setShowEditModal(false)}
+        title={t('dialogs.editTeam.title')}
+        size="sm"
+      >
+        <div className="grid grid-cols-1 gap-4 p-6">
+          <TextInput
+            label={t('fields.name')}
+            value={editForm.name}
+            onChange={e => {
+              const value = e.currentTarget.value;
+              setEditForm(prev => ({ ...prev, name: value }));
+            }}
+            required
+            placeholder={t('placeholders.teamName')}
+          />
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              {t('fields.teamType')}
+            </label>
+            <select
+              value={editForm.type}
+              onChange={e => setEditForm(prev => ({ ...prev, type: e.target.value as TeamType }))}
+              className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="Internal">{t('fields.teamTypeInternal')}</option>
+              <option value="External">{t('fields.teamTypeExternal')}</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="team-isActive"
+              checked={editForm.isActive}
+              onChange={e => setEditForm(prev => ({ ...prev, isActive: e.target.checked }))}
+              className="size-4 rounded border-gray-300 text-primary focus:ring-primary"
+            />
+            <label htmlFor="team-isActive" className="text-sm text-gray-700">
+              {t('fields.isActive')}
+            </label>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 px-6 pb-6">
+          <Button variant="ghost" size="sm" onClick={() => setShowEditModal(false)}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isLoading={updateTeam.isPending}
+            onClick={handleSaveGeneral}
+          >
+            {t('common:actions.save')}
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Member Assignment Modal */}
+      <Modal
+        isOpen={showMemberModal}
+        onClose={() => setShowMemberModal(false)}
+        title={t('dialogs.assignUsers.title')}
+        size="lg"
+      >
+        <div className="p-6">
+          <AssignmentTable<AdminUserListItem>
+            items={allUsers}
+            getId={u => u.id}
+            getLabel={u => `${u.firstName} ${u.lastName}`.trim() || u.username}
+            columns={[
+              {
+                key: 'username',
+                label: t('fields.username'),
+                sortable: true,
+                render: u => u.username,
+              },
+              {
+                key: 'displayName',
+                label: t('fields.firstName'),
+                sortable: true,
+                render: u => `${u.firstName} ${u.lastName}`.trim(),
+              },
+            ]}
+            selectedIds={selectedMemberIds}
+            onChange={setSelectedMemberIds}
+            searchPlaceholder={t('placeholders.searchUsers')}
+            searchFields={u => [u.username, u.firstName, u.lastName]}
+          />
+        </div>
+        <div className="flex justify-end gap-2 px-6 pb-6">
+          <Button variant="ghost" size="sm" onClick={() => setShowMemberModal(false)}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isLoading={updateMembers.isPending}
+            onClick={handleSaveMembers}
+          >
+            {t('buttons.saveUsers')}
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Delete Confirm */}
+      <ConfirmDialog
+        isOpen={showDelete}
+        onClose={() => setShowDelete(false)}
+        onConfirm={handleConfirmDelete}
+        title={t('dialogs.deleteTeam.title')}
+        message={t('dialogs.deleteTeam.message', { name: team.name })}
+        confirmText={t('common:actions.delete')}
+        isLoading={deleteTeam.isPending}
+      />
+    </div>
+  );
+};
+
+export default TeamDetailPanel;

--- a/src/features/userManagement/components/UserAssignmentModal.tsx
+++ b/src/features/userManagement/components/UserAssignmentModal.tsx
@@ -47,7 +47,7 @@ const UserAssignmentModal = ({
       u =>
         `${u.firstName} ${u.lastName}`.toLowerCase().includes(q) ||
         (u.email ?? '').toLowerCase().includes(q) ||
-        (u.userName ?? '').toLowerCase().includes(q),
+        (u.username ?? '').toLowerCase().includes(q),
     );
   }, [allUsers, search]);
 
@@ -101,7 +101,7 @@ const UserAssignmentModal = ({
           <div className="flex flex-wrap gap-1.5">
             {Array.from(selected).map(id => {
               const u = allUsers.find(u => u.id === id);
-              const label = u ? getDisplayName(u.firstName, u.lastName, u.userName) : id;
+              const label = u ? getDisplayName(u.firstName, u.lastName, u.username) : id;
               return (
                 <span
                   key={id}
@@ -147,7 +147,7 @@ const UserAssignmentModal = ({
                 />
                 <div className="min-w-0 flex-1">
                   <div className="text-sm font-medium text-gray-800 truncate">
-                    {getDisplayName(u.firstName, u.lastName, u.userName)}
+                    {getDisplayName(u.firstName, u.lastName, u.username)}
                   </div>
                   <div className="text-xs text-gray-400 truncate">{u.email}</div>
                 </div>

--- a/src/features/userManagement/components/UserDetailPanel.tsx
+++ b/src/features/userManagement/components/UserDetailPanel.tsx
@@ -5,17 +5,26 @@ import Button from '@shared/components/Button';
 import Icon from '@shared/components/Icon';
 import Modal from '@shared/components/Modal';
 import TextInput from '@shared/components/inputs/TextInput';
+import Dropdown from '@shared/components/inputs/Dropdown';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
 import { Skeleton } from '@shared/components/Skeleton';
+import { formatLocaleDateTime } from '@shared/utils/dateUtils';
 import {
   useGetUserById,
   useAdminUpdateUser,
   useUpdateUserRoles,
   useUpdateUserGroups,
+  useUpdateUserTeams,
+  useSetUserActivation,
+  useUnlockUser,
   useResetPassword,
 } from '../api/users';
 import { useGetRoles } from '../api/roles';
 import { useGetGroups } from '../api/groups';
+import { useGetTeams } from '../api/teams';
+import { useGetEligibleCompanies } from '../api/companies';
 import ChangePasswordModal from './ChangePasswordModal';
+import AssignmentTable from './AssignmentTable';
 import type { AdminUpdateUserRequest } from '../types';
 
 interface UserDetailPanelProps {
@@ -23,11 +32,14 @@ interface UserDetailPanelProps {
 }
 
 const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
-  const { t } = useTranslation(['userManagement', 'common']);
+  const { t, i18n } = useTranslation(['userManagement', 'common']);
   const { data: user, isLoading } = useGetUserById(userId);
   const updateUser = useAdminUpdateUser();
   const updateRoles = useUpdateUserRoles();
   const updateGroups = useUpdateUserGroups();
+  const updateTeams = useUpdateUserTeams();
+  const setActivation = useSetUserActivation();
+  const unlockUser = useUnlockUser();
 
   // General edit modal
   const [showEditModal, setShowEditModal] = useState(false);
@@ -38,6 +50,12 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
     department: '',
     companyId: null,
   });
+
+  const { data: eligibleCompanies } = useGetEligibleCompanies();
+  const companyOptions = [
+    { value: '', label: t('fields.noCompany') },
+    ...(eligibleCompanies ?? []).map(c => ({ value: c.id, label: c.name })),
+  ];
 
   const handleOpenEdit = () => {
     if (!user) return;
@@ -63,7 +81,7 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
         lastName: editForm.lastName,
         position: editForm.position || null,
         department: editForm.department || null,
-        companyId: editForm.companyId,
+        companyId: editForm.companyId || null,
       },
       {
         onSuccess: () => {
@@ -128,12 +146,6 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
     );
   };
 
-  const toggleRole = (roleName: string) => {
-    setSelectedRoleNames(prev =>
-      prev.includes(roleName) ? prev.filter(r => r !== roleName) : [...prev, roleName],
-    );
-  };
-
   // Group assignment modal
   const [showGroupModal, setShowGroupModal] = useState(false);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
@@ -159,10 +171,53 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
     );
   };
 
-  const toggleGroup = (groupId: string) => {
-    setSelectedGroupIds(prev =>
-      prev.includes(groupId) ? prev.filter(g => g !== groupId) : [...prev, groupId],
+  // Team assignment modal
+  const [showTeamModal, setShowTeamModal] = useState(false);
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+
+  const { data: teamsData } = useGetTeams({ pageSize: 200 });
+  const allTeams = teamsData?.items ?? [];
+
+  const handleOpenTeams = () => {
+    setSelectedTeamIds((user?.teams ?? []).map(tm => tm.id));
+    setShowTeamModal(true);
+  };
+
+  const handleSaveTeams = () => {
+    updateTeams.mutate(
+      { id: userId, teamIds: selectedTeamIds },
+      {
+        onSuccess: () => {
+          toast.success(t('toasts.teamsUpdated'));
+          setShowTeamModal(false);
+        },
+        onError: () => toast.error(t('toasts.teamsUpdateFailed')),
+      },
     );
+  };
+
+  // Activation confirm dialog
+  const [showActivationConfirm, setShowActivationConfirm] = useState(false);
+
+  const handleConfirmActivation = () => {
+    if (!user) return;
+    setActivation.mutate(
+      { id: userId, isActive: !user.isActive },
+      {
+        onSuccess: () => {
+          toast.success(user.isActive ? t('toasts.userDeactivated') : t('toasts.userActivated'));
+          setShowActivationConfirm(false);
+        },
+        onError: () => toast.error(t('toasts.userActivationFailed')),
+      },
+    );
+  };
+
+  const handleUnlock = () => {
+    unlockUser.mutate(userId, {
+      onSuccess: () => toast.success(t('toasts.userUnlocked')),
+      onError: () => toast.error(t('toasts.userUnlockFailed')),
+    });
   };
 
   if (isLoading) {
@@ -178,12 +233,75 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
 
   if (!user) return null;
 
-  const displayName = `${user.firstName} ${user.lastName}`.trim() || user.userName;
+  const displayName = `${user.firstName} ${user.lastName}`.trim() || user.username;
   const initials =
-    (user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '') || user.userName[0].toUpperCase();
+    (user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '') || user.username[0].toUpperCase();
+
+  const isCompanyUser = !!user.companyId;
 
   return (
-    <div className="flex flex-col gap-4 p-6 h-full overflow-y-auto">
+    <div className="flex flex-col gap-4 p-6">
+      {/* Status Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+          <Icon name="circle-user" style="solid" className="size-4 text-gray-500" />
+          <span className="text-sm font-semibold text-gray-800">{t('sections.status')}</span>
+        </div>
+        <div className="px-4 py-3 flex flex-wrap items-center gap-3">
+          {/* Active / Inactive badge */}
+          <span
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${
+              user.isActive
+                ? 'bg-green-50 text-green-700'
+                : 'bg-gray-100 text-gray-500'
+            }`}
+          >
+            <span className={`size-1.5 rounded-full ${user.isActive ? 'bg-green-500' : 'bg-gray-400'}`} />
+            {user.isActive ? t('status.active') : t('status.inactive')}
+          </span>
+
+          {/* Locked badge */}
+          {user.isLocked && (
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-red-50 text-red-700">
+              <Icon name="lock" style="solid" className="size-3" />
+              {t('status.locked')}
+            </span>
+          )}
+
+          {/* Last login */}
+          {user.lastLoginAt && (
+            <span className="text-xs text-gray-400 ml-auto">
+              {t('fields.lastLogin')}: {formatLocaleDateTime(user.lastLoginAt, i18n.language)}
+            </span>
+          )}
+        </div>
+        <div className="px-4 pb-3 flex flex-wrap gap-2">
+          <Button
+            variant={user.isActive ? 'outline' : 'primary'}
+            size="sm"
+            onClick={() => setShowActivationConfirm(true)}
+          >
+            <Icon
+              name={user.isActive ? 'user-slash' : 'user-check'}
+              style="solid"
+              className="size-3.5 mr-1.5"
+            />
+            {user.isActive ? t('buttons.deactivate') : t('buttons.activate')}
+          </Button>
+          {user.isLocked && (
+            <Button
+              variant="outline"
+              size="sm"
+              isLoading={unlockUser.isPending}
+              onClick={handleUnlock}
+            >
+              <Icon name="lock-open" style="solid" className="size-3.5 mr-1.5" />
+              {t('buttons.unlock')}
+            </Button>
+          )}
+        </div>
+      </section>
+
       {/* General Section */}
       <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
@@ -214,12 +332,16 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
           )}
           <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 flex-1">
             {[
-              { label: t('fields.username'), value: user.userName },
+              { label: t('fields.username'), value: user.username },
               { label: t('fields.email'), value: user.email },
               { label: t('fields.firstName'), value: user.firstName },
               { label: t('fields.lastName'), value: user.lastName },
               { label: t('fields.position'), value: user.position },
               { label: t('fields.department'), value: user.department },
+              ...(user.companyName
+                ? [{ label: t('fields.company'), value: user.companyName }]
+                : []),
+              { label: t('fields.authSource'), value: user.authSource },
             ].map(({ label, value }) => (
               <div key={label}>
                 <dt className="text-xs text-gray-400">{label}</dt>
@@ -312,6 +434,46 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
         </div>
       </section>
 
+      {/* Teams Section */}
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+          <div className="flex items-center gap-2">
+            <Icon name="people-group" style="solid" className="size-4 text-teal-500" />
+            <span className="text-sm font-semibold text-gray-800">{t('sections.teams')}</span>
+            <span className="inline-flex items-center justify-center size-5 rounded-full bg-gray-100 text-xs font-semibold text-gray-600">
+              {user.teams?.length ?? 0}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenTeams}
+            className="text-xs text-primary hover:underline flex items-center gap-1"
+          >
+            <Icon name="pen-to-square" style="regular" className="size-3.5" />
+            {t('buttons.edit')}
+          </button>
+        </div>
+        <div className="px-4 py-3">
+          {!user.teams || user.teams.length === 0 ? (
+            <p className="text-sm text-gray-400">{t('empty.noTeamsAssigned')}</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {user.teams.map(tm => (
+                <span
+                  key={tm.id}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-teal-50 text-teal-700"
+                >
+                  <span
+                    className={`size-1.5 rounded-full ${tm.type === 'Internal' ? 'bg-blue-400' : 'bg-teal-400'}`}
+                  />
+                  {tm.name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
       {/* Security Section */}
       {user.authSource === 'Local' && (
         <section className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
@@ -378,6 +540,19 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
             }}
             placeholder={t('placeholders.department')}
           />
+          {/* Company selector — only for company-scope users */}
+          {isCompanyUser && (
+            <div className="sm:col-span-2">
+              <Dropdown
+                label={t('fields.company')}
+                value={editForm.companyId ?? ''}
+                onChange={(val: string | null) =>
+                  setEditForm(prev => ({ ...prev, companyId: val || null }))
+                }
+                options={companyOptions}
+              />
+            </div>
+          )}
         </div>
         <div className="flex justify-end gap-2 px-6 pb-6">
           <Button variant="ghost" size="sm" onClick={() => setShowEditModal(false)}>
@@ -399,31 +574,25 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
         isOpen={showRoleModal}
         onClose={() => setShowRoleModal(false)}
         title={t('dialogs.editRoles.title')}
-        size="md"
+        size="lg"
       >
-        <div className="p-6">
-          <p className="text-xs text-gray-500 mb-3">{t('dialogs.editRoles.hint')}</p>
-          <div className="max-h-64 overflow-y-auto divide-y divide-gray-50 border border-gray-200 rounded-lg">
-            {allRoles.map(role => (
-              <label
-                key={role.id}
-                className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 cursor-pointer"
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedRoleNames.includes(role.name)}
-                  onChange={() => toggleRole(role.name)}
-                  className="rounded border-gray-300 text-primary focus:ring-primary/20"
-                />
-                <div className="min-w-0">
-                  <div className="text-sm font-medium text-gray-800">{role.name}</div>
-                  <div className="text-xs text-gray-400">{role.scope}</div>
-                </div>
-              </label>
-            ))}
-          </div>
+        <p className="text-xs text-gray-500 mb-3 px-6">{t('dialogs.editRoles.hint')}</p>
+        <div className="px-6">
+          <AssignmentTable
+            items={allRoles}
+            getId={r => r.name}
+            getLabel={r => r.name}
+            columns={[
+              { key: 'name', label: t('fields.name'), sortable: true },
+              { key: 'scope', label: t('fields.scope'), sortable: true },
+            ]}
+            selectedIds={selectedRoleNames}
+            onChange={setSelectedRoleNames}
+            searchPlaceholder={t('placeholders.searchRoles')}
+            searchFields={r => [r.name, r.scope]}
+          />
         </div>
-        <div className="flex justify-end gap-2 px-6 pb-6">
+        <div className="flex justify-end gap-2 px-6 pb-6 mt-4">
           <Button variant="ghost" size="sm" onClick={() => setShowRoleModal(false)}>
             {t('common:actions.cancel')}
           </Button>
@@ -443,31 +612,25 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
         isOpen={showGroupModal}
         onClose={() => setShowGroupModal(false)}
         title={t('dialogs.editGroups.title')}
-        size="md"
+        size="lg"
       >
-        <div className="p-6">
-          <p className="text-xs text-gray-500 mb-3">{t('dialogs.editGroups.hint')}</p>
-          <div className="max-h-64 overflow-y-auto divide-y divide-gray-50 border border-gray-200 rounded-lg">
-            {allGroups.map(group => (
-              <label
-                key={group.id}
-                className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 cursor-pointer"
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedGroupIds.includes(group.id)}
-                  onChange={() => toggleGroup(group.id)}
-                  className="rounded border-gray-300 text-primary focus:ring-primary/20"
-                />
-                <div className="min-w-0">
-                  <div className="text-sm font-medium text-gray-800">{group.name}</div>
-                  <div className="text-xs text-gray-400">{group.scope}</div>
-                </div>
-              </label>
-            ))}
-          </div>
+        <p className="text-xs text-gray-500 mb-3 px-6">{t('dialogs.editGroups.hint')}</p>
+        <div className="px-6">
+          <AssignmentTable
+            items={allGroups}
+            getId={g => g.id}
+            getLabel={g => g.name}
+            columns={[
+              { key: 'name', label: t('fields.name'), sortable: true },
+              { key: 'scope', label: t('fields.scope'), sortable: true },
+            ]}
+            selectedIds={selectedGroupIds}
+            onChange={setSelectedGroupIds}
+            searchPlaceholder={t('placeholders.searchGroups')}
+            searchFields={g => [g.name, g.scope]}
+          />
         </div>
-        <div className="flex justify-end gap-2 px-6 pb-6">
+        <div className="flex justify-end gap-2 px-6 pb-6 mt-4">
           <Button variant="ghost" size="sm" onClick={() => setShowGroupModal(false)}>
             {t('common:actions.cancel')}
           </Button>
@@ -476,6 +639,44 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
             size="sm"
             isLoading={updateGroups.isPending}
             onClick={handleSaveGroups}
+          >
+            {t('common:actions.save')}
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Team Assignment Modal */}
+      <Modal
+        isOpen={showTeamModal}
+        onClose={() => setShowTeamModal(false)}
+        title={t('dialogs.editTeams.title')}
+        size="lg"
+      >
+        <p className="text-xs text-gray-500 mb-3 px-6">{t('dialogs.editTeams.hint')}</p>
+        <div className="px-6">
+          <AssignmentTable
+            items={allTeams}
+            getId={tm => tm.id}
+            getLabel={tm => tm.name}
+            columns={[
+              { key: 'name', label: t('fields.name'), sortable: true },
+              { key: 'type', label: t('fields.teamType'), sortable: true },
+            ]}
+            selectedIds={selectedTeamIds}
+            onChange={setSelectedTeamIds}
+            searchPlaceholder={t('placeholders.searchTeams')}
+            searchFields={tm => [tm.name, tm.type]}
+          />
+        </div>
+        <div className="flex justify-end gap-2 px-6 pb-6 mt-4">
+          <Button variant="ghost" size="sm" onClick={() => setShowTeamModal(false)}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isLoading={updateTeams.isPending}
+            onClick={handleSaveTeams}
           >
             {t('common:actions.save')}
           </Button>
@@ -547,6 +748,22 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
           </Button>
         </div>
       </Modal>
+
+      {/* Activation Confirm Dialog */}
+      <ConfirmDialog
+        isOpen={showActivationConfirm}
+        onClose={() => setShowActivationConfirm(false)}
+        onConfirm={handleConfirmActivation}
+        title={user.isActive ? t('dialogs.deactivateUser.title') : t('dialogs.activateUser.title')}
+        message={
+          user.isActive
+            ? t('dialogs.deactivateUser.message', { name: displayName })
+            : t('dialogs.activateUser.message', { name: displayName })
+        }
+        confirmText={user.isActive ? t('buttons.deactivate') : t('buttons.activate')}
+        variant={user.isActive ? 'danger' : 'primary'}
+        isLoading={setActivation.isPending}
+      />
     </div>
   );
 };

--- a/src/features/userManagement/pages/AccessReportPage.tsx
+++ b/src/features/userManagement/pages/AccessReportPage.tsx
@@ -1,0 +1,345 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import Pagination from '@shared/components/Pagination';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import { useGetUserAccessMatrix, exportUserAccessReport } from '../api/reports';
+import { useGetTeams } from '../api/teams';
+import { useGetGroups } from '../api/groups';
+import type { GetUserAccessMatrixParams } from '../types';
+
+const AccessReportPage = () => {
+  const { t } = useTranslation(['userManagement', 'common']);
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const [filters, setFilters] = useState<Omit<GetUserAccessMatrixParams, 'pageNumber' | 'pageSize'>>(
+    {
+      scope: '',
+      companyId: '',
+      roleName: '',
+      groupId: '',
+      teamId: '',
+      search: '',
+    },
+  );
+
+  const { data, isLoading } = useGetUserAccessMatrix({
+    ...filters,
+    pageNumber: page,
+    pageSize,
+  });
+
+  // Groups and Teams for dropdowns
+  const { data: groupsData } = useGetGroups({ pageSize: 200 });
+  const { data: teamsData } = useGetTeams({ pageSize: 200 });
+
+  const rows = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  const handleFilterChange = (key: keyof typeof filters, value: string) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+    setPage(0);
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      await exportUserAccessReport(filters);
+    } catch {
+      toast.error(t('toasts.exportFailed'));
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8 h-full flex flex-col">
+      <SectionHeader
+        title={t('page.accessReport.title')}
+        subtitle={t('page.accessReport.subtitle')}
+        icon="table-list"
+        iconColor="primary"
+      />
+
+      {/* Filter bar */}
+      <div className="mt-4 bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+          {/* Search */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.search')}
+            </label>
+            <div className="relative">
+              <Icon
+                name="magnifying-glass"
+                style="regular"
+                className="size-3 absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400"
+              />
+              <input
+                type="text"
+                value={filters.search}
+                onChange={e => handleFilterChange('search', e.target.value)}
+                placeholder={t('placeholders.searchByNameOrEmail')}
+                className="w-full pl-7 pr-2 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              />
+            </div>
+          </div>
+
+          {/* Scope */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('fields.scope')}
+            </label>
+            <select
+              value={filters.scope}
+              onChange={e => handleFilterChange('scope', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              <option value="Bank">{t('tabs.bank')}</option>
+              <option value="Company">{t('tabs.company')}</option>
+            </select>
+          </div>
+
+          {/* Role name */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.roleName')}
+            </label>
+            <input
+              type="text"
+              value={filters.roleName}
+              onChange={e => handleFilterChange('roleName', e.target.value)}
+              placeholder={t('placeholders.roleName')}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+
+          {/* Group */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.group')}
+            </label>
+            <select
+              value={filters.groupId}
+              onChange={e => handleFilterChange('groupId', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              {(groupsData?.items ?? []).map(g => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Team */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.team')}
+            </label>
+            <select
+              value={filters.teamId}
+              onChange={e => handleFilterChange('teamId', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              {(teamsData?.items ?? []).map(tm => (
+                <option key={tm.id} value={tm.id}>
+                  {tm.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Active */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('fields.status')}
+            </label>
+            <select
+              value={
+                filters.isActive === undefined ? '' : filters.isActive === true ? 'true' : 'false'
+              }
+              onChange={e => {
+                const val = e.target.value;
+                setFilters(prev => ({
+                  ...prev,
+                  isActive: val === '' ? undefined : val === 'true',
+                }));
+                setPage(0);
+              }}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              <option value="true">{t('status.active')}</option>
+              <option value="false">{t('status.inactive')}</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Table + Export */}
+      <div className="flex items-center justify-between mt-4 mb-2">
+        <p className="text-xs text-gray-500">
+          {t('counts.results', { count: totalCount })}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          isLoading={isExporting}
+          onClick={handleExport}
+          leftIcon={<Icon name="file-csv" style="regular" className="size-3.5" />}
+        >
+          {t('buttons.exportCsv')}
+        </Button>
+      </div>
+
+      <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col min-h-0">
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-primary/10 z-10">
+              <tr>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.username')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.fullName')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.email')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.scope')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('fields.status')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary">
+                  {t('sections.roles')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary">
+                  {t('sections.groups')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary">
+                  {t('page.teams.title')}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {isLoading ? (
+                <TableRowSkeleton columns={Array(8).fill({ width: 'w-full' })} rows={10} />
+              ) : rows.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-12 text-center text-gray-400 text-sm">
+                    <Icon
+                      name="table-list"
+                      style="regular"
+                      className="size-8 mx-auto mb-2 opacity-30"
+                    />
+                    {t('empty.noResults')}
+                  </td>
+                </tr>
+              ) : (
+                rows.map(row => (
+                  <tr key={row.userId} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-2.5 text-xs font-medium text-gray-800">
+                      {row.userName}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-700">{row.fullName}</td>
+                    <td className="px-4 py-2.5 text-xs text-gray-500">{row.email}</td>
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          row.scope === 'Bank'
+                            ? 'bg-blue-50 text-blue-700'
+                            : 'bg-violet-50 text-violet-700'
+                        }`}
+                      >
+                        {row.scope}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          row.isActive
+                            ? 'bg-emerald-50 text-emerald-700'
+                            : 'bg-gray-100 text-gray-500'
+                        }`}
+                      >
+                        {row.isActive ? t('status.active') : t('status.inactive')}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 max-w-[160px]">
+                      <CommaSeparatedChips value={row.roles} color="blue" />
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 max-w-[160px]">
+                      <CommaSeparatedChips value={row.groups} color="amber" />
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600 max-w-[160px]">
+                      <CommaSeparatedChips value={row.teams} color="cyan" />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={size => {
+            setPageSize(size);
+            setPage(0);
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface CommaSeparatedChipsProps {
+  value: string;
+  color: 'blue' | 'amber' | 'cyan';
+}
+
+const chipColorMap: Record<string, string> = {
+  blue: 'bg-blue-50 text-blue-700',
+  amber: 'bg-amber-50 text-amber-700',
+  cyan: 'bg-cyan-50 text-cyan-700',
+};
+
+const CommaSeparatedChips = ({ value, color }: CommaSeparatedChipsProps) => {
+  if (!value) return <span className="text-gray-300">—</span>;
+  const items = value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (items.length === 0) return <span className="text-gray-300">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {items.map((item, i) => (
+        <span
+          key={i}
+          className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${chipColorMap[color]}`}
+        >
+          {item}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default AccessReportPage;

--- a/src/features/userManagement/pages/AuditLogPage.tsx
+++ b/src/features/userManagement/pages/AuditLogPage.tsx
@@ -1,0 +1,300 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Icon from '@shared/components/Icon';
+import Pagination from '@shared/components/Pagination';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import { formatLocaleDateTime } from '@shared/utils/dateUtils';
+import { useGetAuditLogs } from '../api/auditLogs';
+import type { AuditAction, AuditEntityType, GetAuditLogsParams } from '../types';
+
+const ENTITY_TYPES: AuditEntityType[] = ['User', 'Role', 'Permission', 'Group', 'Team'];
+const ACTIONS: AuditAction[] = ['Created', 'Updated', 'Deleted', 'AssignmentChanged'];
+
+interface ChangesJsonParsed {
+  setName?: string;
+  added?: string[];
+  removed?: string[];
+  [key: string]: unknown;
+}
+
+const parseChanges = (raw: string | null): ChangesJsonParsed | null => {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ChangesJsonParsed;
+  } catch {
+    return null;
+  }
+};
+
+const ChangesCell = ({ changesJson }: { changesJson: string | null }) => {
+  const parsed = parseChanges(changesJson);
+  if (!parsed) return <span className="text-gray-400 text-xs">—</span>;
+
+  if (parsed.added !== undefined || parsed.removed !== undefined) {
+    const added = parsed.added ?? [];
+    const removed = parsed.removed ?? [];
+    return (
+      <div className="flex flex-wrap gap-1">
+        {parsed.setName && (
+          <span className="text-xs text-gray-500 mr-1">{parsed.setName}:</span>
+        )}
+        {added.map((val, i) => (
+          <span
+            key={`add-${i}`}
+            className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700"
+          >
+            +{val}
+          </span>
+        ))}
+        {removed.map((val, i) => (
+          <span
+            key={`rem-${i}`}
+            className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-50 text-red-600"
+          >
+            -{val}
+          </span>
+        ))}
+        {added.length === 0 && removed.length === 0 && (
+          <span className="text-gray-400 text-xs">no changes</span>
+        )}
+      </div>
+    );
+  }
+
+  // Generic key-value display
+  const entries = Object.entries(parsed).slice(0, 4);
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([k, v]) => (
+        <span key={k} className="text-xs text-gray-600">
+          <span className="text-gray-400">{k}:</span> {String(v ?? '—')}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const actionBadgeClass: Record<AuditAction, string> = {
+  Created: 'bg-emerald-50 text-emerald-700',
+  Updated: 'bg-blue-50 text-blue-700',
+  Deleted: 'bg-red-50 text-red-700',
+  AssignmentChanged: 'bg-amber-50 text-amber-700',
+};
+
+const AuditLogPage = () => {
+  const { t, i18n } = useTranslation(['userManagement', 'common']);
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+
+  const [filters, setFilters] = useState<Omit<GetAuditLogsParams, 'pageNumber' | 'pageSize'>>({
+    entityType: '',
+    action: '',
+    actorUserId: '',
+    from: '',
+    to: '',
+  });
+
+  const { data, isLoading } = useGetAuditLogs({
+    ...filters,
+    pageNumber: page,
+    pageSize,
+  });
+
+  const rows = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  const handleFilterChange = (key: keyof typeof filters, value: string) => {
+    setFilters(prev => ({ ...prev, [key]: value }));
+    setPage(0);
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8 h-full flex flex-col">
+      <SectionHeader
+        title={t('page.auditLogs.title')}
+        subtitle={t('page.auditLogs.subtitle')}
+        icon="clock-rotate-left"
+        iconColor="purple"
+      />
+
+      {/* Filter bar */}
+      <div className="mt-4 bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          {/* Entity Type */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.entityType')}
+            </label>
+            <select
+              value={filters.entityType}
+              onChange={e => handleFilterChange('entityType', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              {ENTITY_TYPES.map(et => (
+                <option key={et} value={et}>
+                  {et}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Action */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.action')}
+            </label>
+            <select
+              value={filters.action}
+              onChange={e => handleFilterChange('action', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="">{t('filters.all')}</option>
+              {ACTIONS.map(a => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Actor */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.actor')}
+            </label>
+            <div className="relative">
+              <Icon
+                name="magnifying-glass"
+                style="regular"
+                className="size-3 absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400"
+              />
+              <input
+                type="text"
+                value={filters.actorUserId}
+                onChange={e => handleFilterChange('actorUserId', e.target.value)}
+                placeholder={t('placeholders.searchActor')}
+                className="w-full pl-7 pr-2 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              />
+            </div>
+          </div>
+
+          {/* From */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.from')}
+            </label>
+            <input
+              type="date"
+              value={filters.from}
+              onChange={e => handleFilterChange('from', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+
+          {/* To */}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {t('filters.to')}
+            </label>
+            <input
+              type="date"
+              value={filters.to}
+              onChange={e => handleFilterChange('to', e.target.value)}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 mt-4 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col min-h-0">
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-primary/10 z-10">
+              <tr>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.when')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.actor')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.action')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.entityType')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary whitespace-nowrap">
+                  {t('columns.entityName')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-primary">
+                  {t('columns.changes')}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {isLoading ? (
+                <TableRowSkeleton columns={Array(6).fill({ width: 'w-full' })} rows={10} />
+              ) : rows.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center text-gray-400 text-sm">
+                    <Icon
+                      name="clock-rotate-left"
+                      style="regular"
+                      className="size-8 mx-auto mb-2 opacity-30"
+                    />
+                    {t('empty.noAuditLogs')}
+                  </td>
+                </tr>
+              ) : (
+                rows.map(row => (
+                  <tr key={row.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-2.5 text-gray-600 text-xs whitespace-nowrap">
+                      {formatLocaleDateTime(row.occurredAt, i18n.language)}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <div className="text-xs font-medium text-gray-800">{row.actorName}</div>
+                      <div className="text-xs text-gray-400">{row.actorUserId}</div>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${actionBadgeClass[row.action] ?? 'bg-gray-100 text-gray-600'}`}
+                      >
+                        {row.action}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-gray-600">{row.entityType}</td>
+                    <td className="px-4 py-2.5 text-xs font-medium text-gray-800">
+                      {row.entityName}
+                    </td>
+                    <td className="px-4 py-2.5 max-w-xs">
+                      <ChangesCell changesJson={row.changesJson} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={size => {
+            setPageSize(size);
+            setPage(0);
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AuditLogPage;

--- a/src/features/userManagement/pages/CompanyListPage.tsx
+++ b/src/features/userManagement/pages/CompanyListPage.tsx
@@ -7,80 +7,52 @@ import Button from '@shared/components/Button';
 import Icon from '@shared/components/Icon';
 import Modal from '@shared/components/Modal';
 import TextInput from '@shared/components/inputs/TextInput';
-import Dropdown from '@shared/components/inputs/Dropdown';
 import { TableRowSkeleton } from '@shared/components/Skeleton';
-import RoleDetailPanel from '../components/RoleDetailPanel';
-import { useGetRoles, useCreateRole } from '../api/roles';
-import type { RoleScope } from '../types';
+import CompanyDetailPanel from '../components/CompanyDetailPanel';
+import { useGetAdminCompanies, useCreateAdminCompany } from '../api/companies';
 
-type ScopeTab = 'Bank' | 'Company';
-
-const RoleListPage = () => {
+const CompanyListPage = () => {
   const { t } = useTranslation(['userManagement', 'common']);
-  const [activeTab, setActiveTab] = useState<ScopeTab>('Bank');
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(null);
 
-  // Create modal state
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [createForm, setCreateForm] = useState({
-    name: '',
-    description: '',
-    scope: 'Bank' as RoleScope,
-  });
+  const [createForm, setCreateForm] = useState({ name: '' });
 
-  // Debounce search
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(search), 400);
     return () => clearTimeout(timer);
   }, [search]);
 
-  // Reset selection when tab changes
-  useEffect(() => {
-    setSelectedRoleId(null);
-  }, [activeTab]);
-
-  const { data, isLoading } = useGetRoles({
+  const { data, isLoading } = useGetAdminCompanies({
     search: debouncedSearch || undefined,
-    scope: activeTab,
     pageNumber: 1,
     pageSize: 50,
   });
 
-  const roles = data?.items ?? [];
-  const createRole = useCreateRole();
-
-  const SCOPE_OPTIONS = [
-    { value: 'Bank', label: t('tabs.bank') },
-    { value: 'Company', label: t('tabs.company') },
-  ];
+  const companies = data?.items ?? [];
+  const createCompany = useCreateAdminCompany();
 
   const handleOpenCreate = () => {
-    setCreateForm({ name: '', description: '', scope: activeTab });
+    setCreateForm({ name: '' });
     setShowCreateModal(true);
   };
 
   const handleCreate = () => {
-    if (!createForm.name || !createForm.scope) {
-      toast.error(t('validation.nameAndScopeRequired'));
+    if (!createForm.name) {
+      toast.error(t('validation.nameRequired'));
       return;
     }
-    createRole.mutate(
-      {
-        name: createForm.name,
-        description: createForm.description,
-        scope: createForm.scope,
-        permissionIds: [],
-      },
+    createCompany.mutate(
+      { name: createForm.name, isActive: true },
       {
         onSuccess: (data: any) => {
-          toast.success(t('toasts.roleCreated'));
+          toast.success(t('toasts.companyCreated'));
           setShowCreateModal(false);
-          // Select the newly created role if ID returned
-          if (data?.id) setSelectedRoleId(data.id);
+          if (data?.id) setSelectedCompanyId(data.id);
         },
-        onError: () => toast.error(t('toasts.roleCreateFailed')),
+        onError: () => toast.error(t('toasts.companyCreateFailed')),
       },
     );
   };
@@ -88,34 +60,15 @@ const RoleListPage = () => {
   return (
     <div className="px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-4">
       <SectionHeader
-        title={t('page.roles.title')}
-        subtitle={t('page.roles.subtitle')}
-        icon="user-shield"
-        iconColor="purple"
+        title={t('page.companies.title')}
+        subtitle={t('page.companies.subtitle')}
+        icon="building"
+        iconColor="emerald"
       />
 
       <div className="flex gap-4">
-        {/* Left panel — role list */}
+        {/* Left panel */}
         <div className="w-72 shrink-0 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col">
-          {/* Scope toggle tabs */}
-          <div className="flex border-b border-gray-100">
-            {(['Bank', 'Company'] as ScopeTab[]).map(tab => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setActiveTab(tab)}
-                className={clsx(
-                  'flex-1 py-2.5 text-sm font-medium transition-colors',
-                  activeTab === tab
-                    ? 'text-primary border-b-2 border-primary'
-                    : 'text-gray-500 hover:text-gray-700',
-                )}
-              >
-                {tab === 'Bank' ? t('tabs.bank') : t('tabs.company')}
-              </button>
-            ))}
-          </div>
-
           {/* Search + Add */}
           <div className="px-3 pt-3 pb-2 flex gap-2">
             <div className="relative flex-1">
@@ -128,22 +81,22 @@ const RoleListPage = () => {
                 type="text"
                 value={search}
                 onChange={e => setSearch(e.target.value)}
-                placeholder={t('placeholders.searchRoles')}
+                placeholder={t('placeholders.searchCompanies')}
                 className="w-full pl-8 pr-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
               />
             </div>
             <button
               type="button"
               onClick={handleOpenCreate}
-              title={t('aria.addRole')}
-              aria-label={t('aria.addRole')}
+              title={t('aria.addCompany')}
+              aria-label={t('aria.addCompany')}
               className="shrink-0 size-7 flex items-center justify-center rounded-lg bg-primary text-white hover:bg-primary/80 transition-colors"
             >
               <Icon name="plus" style="solid" className="size-3.5" />
             </button>
           </div>
 
-          {/* Role list */}
+          {/* Company list */}
           <div className="overflow-y-auto max-h-[calc(100vh-280px)] divide-y divide-gray-50">
             {isLoading ? (
               <table className="w-full">
@@ -151,27 +104,32 @@ const RoleListPage = () => {
                   <TableRowSkeleton columns={[{ width: 'w-full' }]} rows={6} />
                 </tbody>
               </table>
-            ) : roles.length === 0 ? (
+            ) : companies.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-10 text-gray-400 text-xs gap-1">
-                <Icon name="user-shield" style="regular" className="size-7 opacity-40" />
-                <span>{t('empty.noRolesFound')}</span>
+                <Icon name="building" style="regular" className="size-7 opacity-40" />
+                <span>{t('empty.noCompaniesFound')}</span>
               </div>
             ) : (
-              roles.map(role => (
+              companies.map(company => (
                 <button
-                  key={role.id}
+                  key={company.id}
                   type="button"
-                  onClick={() => setSelectedRoleId(role.id)}
+                  onClick={() => setSelectedCompanyId(company.id)}
                   className={clsx(
                     'w-full text-left px-3 py-2.5 transition-colors',
-                    selectedRoleId === role.id
+                    selectedCompanyId === company.id
                       ? 'bg-primary/5 border-l-2 border-primary'
                       : 'hover:bg-gray-50 border-l-2 border-transparent',
                   )}
                 >
-                  <div className="text-sm font-medium text-gray-800 truncate">{role.name}</div>
-                  {role.description && (
-                    <div className="text-xs text-gray-400 truncate mt-0.5">{role.description}</div>
+                  <div className="flex items-center justify-between gap-1">
+                    <div className="text-sm font-medium text-gray-800 truncate">{company.name}</div>
+                    {!company.isActive && (
+                      <span className="shrink-0 text-xs text-gray-400">{t('status.inactive')}</span>
+                    )}
+                  </div>
+                  {company.phone && (
+                    <div className="text-xs text-gray-400 truncate mt-0.5">{company.phone}</div>
                   )}
                 </button>
               ))
@@ -179,58 +137,40 @@ const RoleListPage = () => {
           </div>
         </div>
 
-        {/* Right panel — role detail */}
+        {/* Right panel */}
         <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm overflow-y-auto">
-          {selectedRoleId ? (
-            <RoleDetailPanel
-              key={selectedRoleId}
-              roleId={selectedRoleId}
-              onDeleted={() => setSelectedRoleId(null)}
+          {selectedCompanyId ? (
+            <CompanyDetailPanel
+              key={selectedCompanyId}
+              companyId={selectedCompanyId}
+              onDeleted={() => setSelectedCompanyId(null)}
             />
           ) : (
             <div className="flex flex-col items-center justify-center py-20 text-gray-400 gap-2">
-              <Icon name="user-shield" style="regular" className="size-12 opacity-30" />
-              <p className="text-sm">{t('empty.selectRole')}</p>
+              <Icon name="building" style="regular" className="size-12 opacity-30" />
+              <p className="text-sm">{t('empty.selectCompany')}</p>
             </div>
           )}
         </div>
       </div>
 
-      {/* Create Role Modal */}
+      {/* Create Company Modal */}
       <Modal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
-        title={t('dialogs.createRole.title')}
-        size="md"
+        title={t('dialogs.createCompany.title')}
+        size="sm"
       >
         <div className="grid grid-cols-1 gap-4 p-6">
           <TextInput
-            label={t('fields.name')}
+            label={t('fields.companyName')}
             value={createForm.name}
             onChange={e => {
               const value = e.currentTarget.value;
               setCreateForm(prev => ({ ...prev, name: value }));
             }}
             required
-            placeholder={t('placeholders.roleName')}
-          />
-          <Dropdown
-            label={t('fields.scope')}
-            value={createForm.scope}
-            onChange={(val: string | null) =>
-              setCreateForm(prev => ({ ...prev, scope: (val ?? 'Bank') as RoleScope }))
-            }
-            options={SCOPE_OPTIONS}
-            required
-          />
-          <TextInput
-            label={t('fields.description')}
-            value={createForm.description}
-            onChange={e => {
-              const value = e.currentTarget.value;
-              setCreateForm(prev => ({ ...prev, description: value }));
-            }}
-            placeholder={t('placeholders.roleDescription')}
+            placeholder={t('placeholders.companyName')}
           />
         </div>
         <div className="flex justify-end gap-2 px-6 pb-6">
@@ -240,7 +180,7 @@ const RoleListPage = () => {
           <Button
             variant="primary"
             size="sm"
-            isLoading={createRole.isPending}
+            isLoading={createCompany.isPending}
             onClick={handleCreate}
           >
             {t('buttons.create')}
@@ -251,4 +191,4 @@ const RoleListPage = () => {
   );
 };
 
-export default RoleListPage;
+export default CompanyListPage;

--- a/src/features/userManagement/pages/GroupListPage.tsx
+++ b/src/features/userManagement/pages/GroupListPage.tsx
@@ -74,7 +74,7 @@ const GroupListPage = () => {
   };
 
   return (
-    <div className="px-4 sm:px-6 lg:px-8 py-8 h-full flex flex-col">
+    <div className="px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-4">
       <SectionHeader
         title={t('page.groups.title')}
         subtitle={t('page.groups.subtitle')}
@@ -82,7 +82,7 @@ const GroupListPage = () => {
         iconColor="amber"
       />
 
-      <div className="flex gap-4 flex-1 min-h-0 mt-4">
+      <div className="flex gap-4">
         {/* Left panel — group list */}
         <div className="w-72 shrink-0 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col">
           {/* Scope toggle tabs */}
@@ -132,7 +132,7 @@ const GroupListPage = () => {
           </div>
 
           {/* Group list */}
-          <div className="flex-1 overflow-y-auto divide-y divide-gray-50">
+          <div className="overflow-y-auto max-h-[calc(100vh-280px)] divide-y divide-gray-50">
             {isLoading ? (
               <table className="w-full">
                 <tbody>
@@ -168,7 +168,7 @@ const GroupListPage = () => {
         </div>
 
         {/* Right panel — group detail */}
-        <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm min-h-0 overflow-hidden">
+        <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm overflow-y-auto">
           {selectedGroupId ? (
             <GroupDetailPanel
               key={selectedGroupId}
@@ -176,7 +176,7 @@ const GroupListPage = () => {
               onDeleted={() => setSelectedGroupId(null)}
             />
           ) : (
-            <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-2">
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400 gap-2">
               <Icon name="users-rectangle" style="regular" className="size-12 opacity-30" />
               <p className="text-sm">{t('empty.selectGroup')}</p>
             </div>

--- a/src/features/userManagement/pages/TeamListPage.tsx
+++ b/src/features/userManagement/pages/TeamListPage.tsx
@@ -7,80 +7,60 @@ import Button from '@shared/components/Button';
 import Icon from '@shared/components/Icon';
 import Modal from '@shared/components/Modal';
 import TextInput from '@shared/components/inputs/TextInput';
-import Dropdown from '@shared/components/inputs/Dropdown';
 import { TableRowSkeleton } from '@shared/components/Skeleton';
-import RoleDetailPanel from '../components/RoleDetailPanel';
-import { useGetRoles, useCreateRole } from '../api/roles';
-import type { RoleScope } from '../types';
+import TeamDetailPanel from '../components/TeamDetailPanel';
+import { useGetTeams, useCreateTeam } from '../api/teams';
+import type { TeamType } from '../types';
 
-type ScopeTab = 'Bank' | 'Company';
-
-const RoleListPage = () => {
+const TeamListPage = () => {
   const { t } = useTranslation(['userManagement', 'common']);
-  const [activeTab, setActiveTab] = useState<ScopeTab>('Bank');
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
 
-  // Create modal state
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [createForm, setCreateForm] = useState({
+  const [createForm, setCreateForm] = useState<{ name: string; type: TeamType }>({
     name: '',
-    description: '',
-    scope: 'Bank' as RoleScope,
+    type: 'Internal',
   });
 
-  // Debounce search
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(search), 400);
     return () => clearTimeout(timer);
   }, [search]);
 
-  // Reset selection when tab changes
-  useEffect(() => {
-    setSelectedRoleId(null);
-  }, [activeTab]);
-
-  const { data, isLoading } = useGetRoles({
+  const { data, isLoading } = useGetTeams({
     search: debouncedSearch || undefined,
-    scope: activeTab,
     pageNumber: 1,
     pageSize: 50,
   });
 
-  const roles = data?.items ?? [];
-  const createRole = useCreateRole();
-
-  const SCOPE_OPTIONS = [
-    { value: 'Bank', label: t('tabs.bank') },
-    { value: 'Company', label: t('tabs.company') },
-  ];
+  const teams = data?.items ?? [];
+  const createTeam = useCreateTeam();
 
   const handleOpenCreate = () => {
-    setCreateForm({ name: '', description: '', scope: activeTab });
+    setCreateForm({ name: '', type: 'Internal' });
     setShowCreateModal(true);
   };
 
   const handleCreate = () => {
-    if (!createForm.name || !createForm.scope) {
-      toast.error(t('validation.nameAndScopeRequired'));
+    if (!createForm.name) {
+      toast.error(t('validation.nameRequired'));
       return;
     }
-    createRole.mutate(
+    createTeam.mutate(
       {
         name: createForm.name,
-        description: createForm.description,
-        scope: createForm.scope,
-        permissionIds: [],
+        type: createForm.type,
+        isActive: true,
       },
       {
         onSuccess: (data: any) => {
-          toast.success(t('toasts.roleCreated'));
+          toast.success(t('toasts.teamCreated'));
           setShowCreateModal(false);
-          // Select the newly created role if ID returned
-          if (data?.id) setSelectedRoleId(data.id);
+          if (data?.id) setSelectedTeamId(data.id);
         },
-        onError: () => toast.error(t('toasts.roleCreateFailed')),
+        onError: () => toast.error(t('toasts.teamCreateFailed')),
       },
     );
   };
@@ -88,34 +68,15 @@ const RoleListPage = () => {
   return (
     <div className="px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-4">
       <SectionHeader
-        title={t('page.roles.title')}
-        subtitle={t('page.roles.subtitle')}
-        icon="user-shield"
-        iconColor="purple"
+        title={t('page.teams.title')}
+        subtitle={t('page.teams.subtitle')}
+        icon="people-group"
+        iconColor="cyan"
       />
 
       <div className="flex gap-4">
-        {/* Left panel — role list */}
+        {/* Left panel */}
         <div className="w-72 shrink-0 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col">
-          {/* Scope toggle tabs */}
-          <div className="flex border-b border-gray-100">
-            {(['Bank', 'Company'] as ScopeTab[]).map(tab => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => setActiveTab(tab)}
-                className={clsx(
-                  'flex-1 py-2.5 text-sm font-medium transition-colors',
-                  activeTab === tab
-                    ? 'text-primary border-b-2 border-primary'
-                    : 'text-gray-500 hover:text-gray-700',
-                )}
-              >
-                {tab === 'Bank' ? t('tabs.bank') : t('tabs.company')}
-              </button>
-            ))}
-          </div>
-
           {/* Search + Add */}
           <div className="px-3 pt-3 pb-2 flex gap-2">
             <div className="relative flex-1">
@@ -128,80 +89,105 @@ const RoleListPage = () => {
                 type="text"
                 value={search}
                 onChange={e => setSearch(e.target.value)}
-                placeholder={t('placeholders.searchRoles')}
+                placeholder={t('placeholders.searchTeams')}
                 className="w-full pl-8 pr-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
               />
             </div>
             <button
               type="button"
               onClick={handleOpenCreate}
-              title={t('aria.addRole')}
-              aria-label={t('aria.addRole')}
+              title={t('aria.addTeam')}
+              aria-label={t('aria.addTeam')}
               className="shrink-0 size-7 flex items-center justify-center rounded-lg bg-primary text-white hover:bg-primary/80 transition-colors"
             >
               <Icon name="plus" style="solid" className="size-3.5" />
             </button>
           </div>
 
-          {/* Role list */}
-          <div className="overflow-y-auto max-h-[calc(100vh-280px)] divide-y divide-gray-50">
+          {/* Team list */}
+          <div className="overflow-y-auto max-h-[calc(100vh-240px)] divide-y divide-gray-50">
             {isLoading ? (
               <table className="w-full">
                 <tbody>
                   <TableRowSkeleton columns={[{ width: 'w-full' }]} rows={6} />
                 </tbody>
               </table>
-            ) : roles.length === 0 ? (
+            ) : teams.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-10 text-gray-400 text-xs gap-1">
-                <Icon name="user-shield" style="regular" className="size-7 opacity-40" />
-                <span>{t('empty.noRolesFound')}</span>
+                <Icon name="people-group" style="regular" className="size-7 opacity-40" />
+                <span>{t('empty.noTeamsFound')}</span>
               </div>
             ) : (
-              roles.map(role => (
+              teams.map(team => (
                 <button
-                  key={role.id}
+                  key={team.id}
                   type="button"
-                  onClick={() => setSelectedRoleId(role.id)}
+                  onClick={() => setSelectedTeamId(team.id)}
                   className={clsx(
                     'w-full text-left px-3 py-2.5 transition-colors',
-                    selectedRoleId === role.id
+                    selectedTeamId === team.id
                       ? 'bg-primary/5 border-l-2 border-primary'
                       : 'hover:bg-gray-50 border-l-2 border-transparent',
                   )}
                 >
-                  <div className="text-sm font-medium text-gray-800 truncate">{role.name}</div>
-                  {role.description && (
-                    <div className="text-xs text-gray-400 truncate mt-0.5">{role.description}</div>
-                  )}
+                  <div className="text-sm font-medium text-gray-800 truncate">{team.name}</div>
+                  <div className="flex items-center gap-1.5 mt-0.5">
+                    {/* Type badge */}
+                    <span
+                      className={clsx(
+                        'shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium',
+                        team.type === 'Internal'
+                          ? 'bg-blue-50 text-blue-700'
+                          : 'bg-violet-50 text-violet-700',
+                      )}
+                    >
+                      {t(team.type === 'Internal' ? 'fields.teamTypeInternal' : 'fields.teamTypeExternal')}
+                    </span>
+                    {/* Active badge */}
+                    <span
+                      className={clsx(
+                        'shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium',
+                        team.isActive
+                          ? 'bg-green-50 text-green-700'
+                          : 'bg-gray-100 text-gray-500',
+                      )}
+                    >
+                      {team.isActive ? t('status.active') : t('status.inactive')}
+                    </span>
+                    {/* Member count */}
+                    <span className="shrink-0 text-xs text-gray-400 ml-auto">
+                      {t('counts.members', { count: team.memberCount })}
+                    </span>
+                  </div>
                 </button>
               ))
             )}
           </div>
         </div>
 
-        {/* Right panel — role detail */}
+        {/* Right panel — detail */}
         <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm overflow-y-auto">
-          {selectedRoleId ? (
-            <RoleDetailPanel
-              key={selectedRoleId}
-              roleId={selectedRoleId}
-              onDeleted={() => setSelectedRoleId(null)}
+          {selectedTeamId ? (
+            <TeamDetailPanel
+              key={selectedTeamId}
+              teamId={selectedTeamId}
+              onDeleted={() => setSelectedTeamId(null)}
             />
           ) : (
             <div className="flex flex-col items-center justify-center py-20 text-gray-400 gap-2">
-              <Icon name="user-shield" style="regular" className="size-12 opacity-30" />
-              <p className="text-sm">{t('empty.selectRole')}</p>
+              <Icon name="people-group" style="regular" className="size-12 opacity-30" />
+              <p className="text-sm">{t('empty.selectTeam')}</p>
             </div>
           )}
         </div>
       </div>
 
-      {/* Create Role Modal */}
+      {/* Create Team Modal */}
       <Modal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
-        title={t('dialogs.createRole.title')}
-        size="md"
+        title={t('dialogs.createTeam.title')}
+        size="sm"
       >
         <div className="grid grid-cols-1 gap-4 p-6">
           <TextInput
@@ -212,26 +198,21 @@ const RoleListPage = () => {
               setCreateForm(prev => ({ ...prev, name: value }));
             }}
             required
-            placeholder={t('placeholders.roleName')}
+            placeholder={t('placeholders.teamName')}
           />
-          <Dropdown
-            label={t('fields.scope')}
-            value={createForm.scope}
-            onChange={(val: string | null) =>
-              setCreateForm(prev => ({ ...prev, scope: (val ?? 'Bank') as RoleScope }))
-            }
-            options={SCOPE_OPTIONS}
-            required
-          />
-          <TextInput
-            label={t('fields.description')}
-            value={createForm.description}
-            onChange={e => {
-              const value = e.currentTarget.value;
-              setCreateForm(prev => ({ ...prev, description: value }));
-            }}
-            placeholder={t('placeholders.roleDescription')}
-          />
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              {t('fields.teamType')}
+            </label>
+            <select
+              value={createForm.type}
+              onChange={e => setCreateForm(prev => ({ ...prev, type: e.target.value as TeamType }))}
+              className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            >
+              <option value="Internal">{t('fields.teamTypeInternal')}</option>
+              <option value="External">{t('fields.teamTypeExternal')}</option>
+            </select>
+          </div>
         </div>
         <div className="flex justify-end gap-2 px-6 pb-6">
           <Button variant="ghost" size="sm" onClick={() => setShowCreateModal(false)}>
@@ -240,7 +221,7 @@ const RoleListPage = () => {
           <Button
             variant="primary"
             size="sm"
-            isLoading={createRole.isPending}
+            isLoading={createTeam.isPending}
             onClick={handleCreate}
           >
             {t('buttons.create')}
@@ -251,4 +232,4 @@ const RoleListPage = () => {
   );
 };
 
-export default RoleListPage;
+export default TeamListPage;

--- a/src/features/userManagement/pages/UserProfilePage.tsx
+++ b/src/features/userManagement/pages/UserProfilePage.tsx
@@ -9,12 +9,14 @@ import CreateUserModal from '../components/CreateUserModal';
 import { useGetUsers } from '../api/users';
 
 type ScopeTab = 'Bank' | 'Company';
+type StatusFilter = 'all' | 'active' | 'inactive';
 
 const UserProfilePage = () => {
   const { t } = useTranslation('userManagement');
   const [activeTab, setActiveTab] = useState<ScopeTab>('Bank');
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
 
@@ -27,17 +29,27 @@ const UserProfilePage = () => {
     setSelectedUserId(null);
   }, [activeTab]);
 
+  const isActiveParam =
+    statusFilter === 'active' ? true : statusFilter === 'inactive' ? false : undefined;
+
   const { data, isLoading } = useGetUsers({
     search: debouncedSearch || undefined,
     scope: activeTab,
+    isActive: isActiveParam,
     pageNumber: 1,
     pageSize: 50,
   });
 
   const filteredUsers = data?.items ?? [];
 
+  const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+    { value: 'all', label: t('filters.all') },
+    { value: 'active', label: t('status.active') },
+    { value: 'inactive', label: t('status.inactive') },
+  ];
+
   return (
-    <div className="px-4 sm:px-6 lg:px-8 py-8 h-full flex flex-col">
+    <div className="px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-4">
       <SectionHeader
         title={t('page.users.title')}
         subtitle={t('page.users.subtitle')}
@@ -45,7 +57,7 @@ const UserProfilePage = () => {
         iconColor="purple"
       />
 
-      <div className="flex gap-4 flex-1 min-h-0 mt-4">
+      <div className="flex gap-4">
         {/* Left panel — user list */}
         <div className="w-72 shrink-0 bg-white rounded-xl border border-gray-200 shadow-sm flex flex-col">
           {/* Bank / Company tabs */}
@@ -94,8 +106,27 @@ const UserProfilePage = () => {
             </button>
           </div>
 
+          {/* Status filter pills */}
+          <div className="px-3 pb-2 flex gap-1">
+            {STATUS_FILTERS.map(sf => (
+              <button
+                key={sf.value}
+                type="button"
+                onClick={() => setStatusFilter(sf.value)}
+                className={clsx(
+                  'px-2.5 py-0.5 rounded-full text-xs font-medium transition-colors',
+                  statusFilter === sf.value
+                    ? 'bg-primary text-white'
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                )}
+              >
+                {sf.label}
+              </button>
+            ))}
+          </div>
+
           {/* User list */}
-          <div className="flex-1 overflow-y-auto divide-y divide-gray-50">
+          <div className="overflow-y-auto max-h-[calc(100vh-320px)] divide-y divide-gray-50">
             {isLoading ? (
               <table className="w-full">
                 <tbody>
@@ -109,10 +140,10 @@ const UserProfilePage = () => {
               </div>
             ) : (
               filteredUsers.map(user => {
-                const displayName = `${user.firstName} ${user.lastName}`.trim() || user.userName;
+                const displayName = `${user.firstName} ${user.lastName}`.trim() || user.username;
                 const initials =
                   (user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '') ||
-                  user.userName[0].toUpperCase();
+                  user.username[0].toUpperCase();
                 return (
                   <button
                     key={user.id}
@@ -120,6 +151,7 @@ const UserProfilePage = () => {
                     onClick={() => setSelectedUserId(user.id)}
                     className={clsx(
                       'w-full text-left px-3 py-2.5 flex items-center gap-2.5 transition-colors',
+                      !user.isActive && 'opacity-50',
                       selectedUserId === user.id
                         ? 'bg-primary/5 border-l-2 border-primary'
                         : 'hover:bg-gray-50 border-l-2 border-transparent',
@@ -128,13 +160,23 @@ const UserProfilePage = () => {
                     <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center text-xs font-bold text-primary shrink-0">
                       {initials}
                     </div>
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium text-gray-800 truncate">
                         {displayName}
                       </div>
-                      {user.position && (
-                        <div className="text-xs text-gray-400 truncate">{user.position}</div>
-                      )}
+                      <div className="flex items-center gap-1.5">
+                        {user.position && (
+                          <span className="text-xs text-gray-400 truncate">{user.position}</span>
+                        )}
+                        {!user.isActive && (
+                          <span className="shrink-0 text-xs text-gray-400 italic">
+                            {t('status.inactive')}
+                          </span>
+                        )}
+                        {user.isLocked && (
+                          <Icon name="lock" style="solid" className="size-3 text-red-400 shrink-0" />
+                        )}
+                      </div>
                     </div>
                   </button>
                 );
@@ -144,11 +186,11 @@ const UserProfilePage = () => {
         </div>
 
         {/* Right panel — user detail */}
-        <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm min-h-0 overflow-hidden">
+        <div className="flex-1 bg-white rounded-xl border border-gray-200 shadow-sm overflow-y-auto">
           {selectedUserId ? (
             <UserDetailPanel key={selectedUserId} userId={selectedUserId} />
           ) : (
-            <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-2">
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400 gap-2">
               <Icon name="circle-user" style="regular" className="size-12 opacity-30" />
               <p className="text-sm">{t('empty.selectUser')}</p>
             </div>

--- a/src/features/userManagement/types/index.ts
+++ b/src/features/userManagement/types/index.ts
@@ -168,6 +168,8 @@ export interface UpdateGroupMonitoringRequest {
   monitoredGroupIds: string[];
 }
 
+export type TeamType = 'Internal' | 'External';
+
 // ─── User / Profile ──────────────────────────────────────────────────────────
 
 export interface UserRole {
@@ -180,6 +182,12 @@ export interface UserGroup {
   id: string;
   name: string;
   scope: string;
+}
+
+export interface UserTeam {
+  id: string;
+  name: string;
+  type: TeamType;
 }
 
 export interface UserProfile {
@@ -195,6 +203,15 @@ export interface UserProfile {
   companyId: string | null;
   roles: UserRole[];
   groups: UserGroup[];
+}
+
+export interface PasswordPolicy {
+  requiredLength: number;
+  requireDigit: boolean;
+  requireLowercase: boolean;
+  requireUppercase: boolean;
+  requireNonAlphanumeric: boolean;
+  requiredUniqueChars: number;
 }
 
 export interface UpdateProfileRequest {
@@ -221,12 +238,17 @@ export interface AdminUserListItem {
   department: string | null;
   companyId: string | null;
   roles: UserRole[];
+  isActive: boolean;
+  isLocked: boolean;
 }
 
 export interface AdminUserDetail extends AdminUserListItem {
   avatarUrl: string | null;
   authSource: 'Local' | 'External';
+  companyName: string | null;
   groups: UserGroup[];
+  teams: UserTeam[];
+  lastLoginAt: string | null;
 }
 
 export interface AdminUserListResult {
@@ -240,6 +262,7 @@ export interface GetUsersParams {
   search?: string;
   scope?: 'Bank' | 'Company';
   role?: string;
+  isActive?: boolean;
   pageNumber?: number;
   pageSize?: number;
 }
@@ -260,6 +283,14 @@ export interface UpdateUserGroupsRequest {
   groupIds: string[];
 }
 
+export interface UpdateUserTeamsRequest {
+  teamIds: string[];
+}
+
+export interface SetUserActivationRequest {
+  isActive: boolean;
+}
+
 export interface CreateUserRequest {
   username: string;
   password: string;
@@ -274,4 +305,206 @@ export interface CreateUserRequest {
 
 export interface CreateUserResponse {
   id: string;
+}
+
+// ─── Team ────────────────────────────────────────────────────────────────────
+
+export interface TeamMember {
+  userId: string;
+  userName: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface TeamDetail {
+  id: string;
+  name: string;
+  type: TeamType;
+  isActive: boolean;
+  members: TeamMember[];
+}
+
+export interface TeamListItem {
+  id: string;
+  name: string;
+  type: TeamType;
+  isActive: boolean;
+  memberCount: number;
+}
+
+export interface TeamListResult {
+  items: TeamListItem[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetTeamsParams {
+  search?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface CreateTeamRequest {
+  name: string;
+  type?: TeamType;
+  isActive?: boolean;
+}
+
+export interface UpdateTeamRequest {
+  name: string;
+  type: TeamType;
+  isActive: boolean;
+}
+
+export interface UpdateTeamMembersRequest {
+  userIds: string[];
+}
+
+// ─── Audit Log ───────────────────────────────────────────────────────────────
+
+export type AuditAction = 'Created' | 'Updated' | 'Deleted' | 'AssignmentChanged';
+export type AuditEntityType = 'User' | 'Role' | 'Permission' | 'Group' | 'Team';
+
+export interface AuditLogRow {
+  id: string;
+  occurredAt: string;
+  actorUserId: string;
+  actorName: string;
+  action: AuditAction;
+  entityType: AuditEntityType;
+  entityId: string;
+  entityName: string;
+  changesJson: string | null;
+}
+
+export interface AuditLogResult {
+  items: AuditLogRow[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetAuditLogsParams {
+  entityType?: AuditEntityType | '';
+  entityId?: string;
+  actorUserId?: string;
+  from?: string;
+  to?: string;
+  action?: AuditAction | '';
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+// ─── Company ─────────────────────────────────────────────────────────────────
+
+export interface Company {
+  id: string;
+  name: string;
+  taxId: string | null;
+  phone: string | null;
+  email: string | null;
+  street: string | null;
+  city: string | null;
+  province: string | null;
+  postalCode: string | null;
+  contactPerson: string | null;
+  loanTypes: string[];
+  isActive: boolean;
+  bankAccountNo: string | null;
+  bankAccountName: string | null;
+}
+
+export interface CompanyListItem {
+  id: string;
+  name: string;
+  taxId: string | null;
+  phone: string | null;
+  email: string | null;
+  isActive: boolean;
+}
+
+export interface CompanyListResult {
+  items: CompanyListItem[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetCompaniesParams {
+  search?: string;
+  isActive?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface CreateCompanyRequest {
+  name: string;
+  taxId?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  street?: string | null;
+  city?: string | null;
+  province?: string | null;
+  postalCode?: string | null;
+  contactPerson?: string | null;
+  loanTypes?: string[];
+  isActive?: boolean;
+  bankAccountNo?: string | null;
+  bankAccountName?: string | null;
+}
+
+export interface UpdateCompanyRequest {
+  name: string;
+  taxId?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  street?: string | null;
+  city?: string | null;
+  province?: string | null;
+  postalCode?: string | null;
+  contactPerson?: string | null;
+  loanTypes?: string[];
+  isActive?: boolean;
+  bankAccountNo?: string | null;
+  bankAccountName?: string | null;
+}
+
+export interface EligibleCompany {
+  id: string;
+  name: string;
+}
+
+// ─── Access Report ───────────────────────────────────────────────────────────
+
+export interface UserAccessMatrixRow {
+  userId: string;
+  userName: string;
+  fullName: string;
+  email: string;
+  companyName: string | null;
+  scope: string;
+  isActive: boolean;
+  roles: string;
+  groups: string;
+  teams: string;
+}
+
+export interface UserAccessMatrixResult {
+  items: UserAccessMatrixRow[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetUserAccessMatrixParams {
+  scope?: string;
+  companyId?: string;
+  roleName?: string;
+  groupId?: string;
+  teamId?: string;
+  isActive?: boolean;
+  search?: string;
+  pageNumber?: number;
+  pageSize?: number;
 }

--- a/src/i18n/locales/en/userManagement.json
+++ b/src/i18n/locales/en/userManagement.json
@@ -15,6 +15,22 @@
     "permissions": {
       "title": "Permissions",
       "subtitle": "Manage system permissions that can be assigned to roles"
+    },
+    "teams": {
+      "title": "Teams",
+      "subtitle": "Manage teams and their members"
+    },
+    "auditLogs": {
+      "title": "Audit Logs",
+      "subtitle": "Review a history of changes to users, roles, groups, and permissions"
+    },
+    "companies": {
+      "title": "Companies",
+      "subtitle": "Manage external appraisal companies and their details"
+    },
+    "accessReport": {
+      "title": "Access Report",
+      "subtitle": "View and export the full user access matrix"
     }
   },
   "tabs": {
@@ -25,10 +41,14 @@
     "general": "General",
     "roles": "Roles",
     "groups": "Groups",
+    "teams": "Teams",
     "users": "Users",
     "permissions": "Permissions",
     "security": "Security",
-    "monitoring": "Monitoring"
+    "status": "Status",
+    "monitoring": "Monitoring",
+    "address": "Address",
+    "bankAccount": "Bank Account"
   },
   "fields": {
     "username": "Username",
@@ -47,12 +67,35 @@
     "newPassword": "New Password",
     "confirmPassword": "Confirm Password",
     "currentPassword": "Current Password",
-    "confirmNewPassword": "Confirm New Password"
+    "confirmNewPassword": "Confirm New Password",
+    "companyName": "Company Name",
+    "taxId": "Tax ID",
+    "phone": "Phone",
+    "contactPerson": "Contact Person",
+    "street": "Street",
+    "city": "City",
+    "province": "Province",
+    "postalCode": "Postal Code",
+    "bankAccountNo": "Bank Account No.",
+    "bankAccountName": "Bank Account Name",
+    "loanTypes": "Loan Types",
+    "isActive": "Active",
+    "teamType": "Type",
+    "teamTypeInternal": "Internal",
+    "teamTypeExternal": "External",
+    "status": "Status",
+    "company": "Company",
+    "authSource": "Auth Source",
+    "lastLogin": "Last Login",
+    "noCompany": "No Company"
   },
   "placeholders": {
     "searchUsers": "Search users...",
     "searchRoles": "Search roles...",
     "searchGroups": "Search groups...",
+    "searchTeams": "Search teams...",
+    "searchCompanies": "Search companies...",
+    "searchActor": "Search by actor...",
     "searchPermissions": "Search by code or display name...",
     "searchPermissionsShort": "Search permissions...",
     "searchByNameOrEmail": "Search by name or email...",
@@ -61,6 +104,19 @@
     "roleDescription": "Brief description of this role",
     "groupName": "Group name",
     "groupDescription": "Brief description of this group",
+    "teamName": "Team name",
+    "teamDescription": "Brief description of this team",
+    "companyName": "Company name",
+    "taxId": "e.g. 0105556123456",
+    "phone": "e.g. 02-xxx-xxxx",
+    "contactPerson": "Contact person name",
+    "street": "Street address",
+    "city": "City",
+    "province": "Province",
+    "postalCode": "Postal code",
+    "bankAccountNo": "Bank account number",
+    "bankAccountName": "Account holder name",
+    "loanTypes": "e.g. HOUSING, AUTO",
     "briefDescription": "Brief description",
     "permissionCodeExample": "e.g., permissions.read",
     "displayNameExample": "e.g., View Permissions",
@@ -76,11 +132,41 @@
     "reEnterNewPassword": "Re-enter new password",
     "enterCurrentPassword": "Enter current password"
   },
+  "filters": {
+    "all": "All",
+    "entityType": "Entity Type",
+    "action": "Action",
+    "actor": "Actor",
+    "from": "From",
+    "to": "To",
+    "search": "Search",
+    "roleName": "Role",
+    "group": "Group",
+    "team": "Team"
+  },
+  "counts": {
+    "members": "{{count}} member",
+    "members_other": "{{count}} members",
+    "results": "{{count}} result",
+    "results_other": "{{count}} results"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive",
+    "locked": "Locked"
+  },
+  "hints": {
+    "loanTypesComma": "Separate multiple loan types with a comma"
+  },
   "empty": {
     "noUsersFound": "No users found",
     "noRolesFound": "No roles found",
     "noGroupsFound": "No groups found",
     "noPermissionsFound": "No permissions found",
+    "noTeamsFound": "No teams found",
+    "noCompaniesFound": "No companies found",
+    "noAuditLogs": "No audit log entries found",
+    "noResults": "No results found",
     "noRolesAssigned": "No roles assigned",
     "noGroupsAssigned": "No groups assigned",
     "noUsersAssigned": "No users assigned",
@@ -89,14 +175,20 @@
     "selectUser": "Select a user to view details",
     "selectRole": "Select a role to view details",
     "selectGroup": "Select a group to view details",
+    "selectTeam": "Select a team to view details",
+    "selectCompany": "Select a company to view details",
     "noRolesAvailable": "No roles available",
     "noOtherGroupsFound": "No other groups found",
+    "noItemsFound": "No items found",
+    "noTeamsAssigned": "No teams assigned",
     "loading": "Loading..."
   },
   "aria": {
     "addUser": "Add user",
     "addRole": "Add role",
     "addGroup": "Add group",
+    "addTeam": "Add team",
+    "addCompany": "Add company",
     "removeItem": "Remove {{name}}"
   },
   "buttons": {
@@ -104,6 +196,8 @@
     "edit": "Edit",
     "deleteRole": "Delete Role",
     "deleteGroup": "Delete Group",
+    "deleteTeam": "Delete Team",
+    "deleteCompany": "Delete Company",
     "changePassword": "Change Password",
     "resetPassword": "Reset Password",
     "savePermissions": "Save Permissions",
@@ -111,7 +205,11 @@
     "showPasswords": "Show passwords",
     "hidePasswords": "Hide passwords",
     "update": "Update",
-    "create": "Create"
+    "create": "Create",
+    "exportCsv": "Export CSV",
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "unlock": "Unlock"
   },
   "dialogs": {
     "createRole": {
@@ -132,6 +230,26 @@
     },
     "deleteGroup": {
       "title": "Delete Group",
+      "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
+    },
+    "createTeam": {
+      "title": "Create Team"
+    },
+    "editTeam": {
+      "title": "Edit Team"
+    },
+    "deleteTeam": {
+      "title": "Delete Team",
+      "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
+    },
+    "createCompany": {
+      "title": "Create Company"
+    },
+    "editCompany": {
+      "title": "Edit Company"
+    },
+    "deleteCompany": {
+      "title": "Delete Company",
       "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
     },
     "createUser": {
@@ -173,11 +291,25 @@
     },
     "selectMonitoredGroups": {
       "title": "Select Monitored Groups"
+    },
+    "editTeams": {
+      "title": "Edit Teams",
+      "hint": "Select teams to assign to this user."
+    },
+    "activateUser": {
+      "title": "Activate User",
+      "message": "Are you sure you want to activate \"{{name}}\"?"
+    },
+    "deactivateUser": {
+      "title": "Deactivate User",
+      "message": "Are you sure you want to deactivate \"{{name}}\"? They will not be able to sign in."
     }
   },
   "security": {
     "deleteRoleWarning": "Deleting this role will remove it from all assigned users. This action cannot be undone.",
-    "deleteGroupWarning": "Deleting this group will remove all user assignments. This action cannot be undone."
+    "deleteGroupWarning": "Deleting this group will remove all user assignments. This action cannot be undone.",
+    "deleteTeamWarning": "Deleting this team will remove all member assignments. This action cannot be undone.",
+    "deleteCompanyWarning": "Deleting this company will remove it from the system. This action cannot be undone."
   },
   "selectionCount": {
     "permissions": "{{count}} permission selected",
@@ -185,7 +317,9 @@
     "users": "{{count}} user selected",
     "users_other": "{{count}} users selected",
     "groups": "{{count}} group selected",
-    "groups_other": "{{count}} groups selected"
+    "groups_other": "{{count}} groups selected",
+    "items": "{{count}} item selected",
+    "items_other": "{{count}} items selected"
   },
   "loading": {
     "permissions": "Loading permissions...",
@@ -197,7 +331,17 @@
     "permissionCode": "Permission Code",
     "module": "Module",
     "description": "Description",
-    "actions": "Actions"
+    "actions": "Actions",
+    "when": "When",
+    "actor": "Actor",
+    "action": "Action",
+    "entityType": "Entity Type",
+    "entityName": "Entity",
+    "changes": "Changes",
+    "username": "Username",
+    "fullName": "Full Name",
+    "email": "Email",
+    "scope": "Scope"
   },
   "toasts": {
     "roleCreated": "Role created",
@@ -216,6 +360,19 @@
     "groupUpdateFailed": "Failed to update group",
     "groupDeleted": "Group deleted",
     "groupDeleteFailed": "Failed to delete group",
+    "teamCreated": "Team created",
+    "teamCreateFailed": "Failed to create team",
+    "teamUpdated": "Team updated",
+    "teamUpdateFailed": "Failed to update team",
+    "teamDeleted": "Team deleted",
+    "teamDeleteFailed": "Failed to delete team",
+    "companyCreated": "Company created",
+    "companyCreateFailed": "Failed to create company",
+    "companyUpdated": "Company updated",
+    "companyUpdateFailed": "Failed to update company",
+    "companyDeleted": "Company deleted",
+    "companyDeleteFailed": "Failed to delete company",
+    "exportFailed": "Failed to export report",
     "monitoredGroupsUpdated": "Monitored groups updated",
     "monitoredGroupsUpdateFailed": "Failed to update monitored groups",
     "userUpdated": "User updated",
@@ -236,7 +393,14 @@
     "permissionUpdated": "Permission updated successfully",
     "permissionUpdateFailed": "Failed to update permission",
     "permissionDeleted": "Permission deleted successfully",
-    "permissionDeleteFailed": "Failed to delete permission"
+    "permissionDeleteFailed": "Failed to delete permission",
+    "teamsUpdated": "Teams updated",
+    "teamsUpdateFailed": "Failed to update teams",
+    "userActivated": "User activated",
+    "userDeactivated": "User deactivated",
+    "userActivationFailed": "Failed to update user status",
+    "userUnlocked": "User account unlocked",
+    "userUnlockFailed": "Failed to unlock user account"
   },
   "validation": {
     "nameRequired": "Name is required",
@@ -261,6 +425,13 @@
     "passwordsDoNotMatch": "Passwords do not match",
     "passwordMinLengthReset": "Password must be at least 8 characters",
     "passwordsDoNotMatchReset": "Passwords do not match"
+  },
+  "passwordPolicy": {
+    "minLength": "At least {{count}} characters",
+    "requireUppercase": "One uppercase letter",
+    "requireLowercase": "One lowercase letter",
+    "requireDigit": "One digit",
+    "requireSymbol": "One special character"
   },
   "roles": {
     "displayNames": {

--- a/src/i18n/locales/th/userManagement.json
+++ b/src/i18n/locales/th/userManagement.json
@@ -15,6 +15,22 @@
     "permissions": {
       "title": "สิทธิ์",
       "subtitle": "จัดการสิทธิ์ระบบที่สามารถกำหนดให้กับบทบาทได้"
+    },
+    "teams": {
+      "title": "ทีม",
+      "subtitle": "จัดการทีมและสมาชิก"
+    },
+    "auditLogs": {
+      "title": "บันทึกการตรวจสอบ",
+      "subtitle": "ตรวจสอบประวัติการเปลี่ยนแปลงผู้ใช้ บทบาท กลุ่ม และสิทธิ์"
+    },
+    "companies": {
+      "title": "บริษัท",
+      "subtitle": "จัดการบริษัทประเมินภายนอกและรายละเอียด"
+    },
+    "accessReport": {
+      "title": "รายงานการเข้าถึง",
+      "subtitle": "ดูและส่งออกเมทริกซ์การเข้าถึงของผู้ใช้"
     }
   },
   "tabs": {
@@ -25,10 +41,14 @@
     "general": "ทั่วไป",
     "roles": "บทบาท",
     "groups": "กลุ่ม",
+    "teams": "ทีม",
     "users": "ผู้ใช้งาน",
     "permissions": "สิทธิ์",
     "security": "ความปลอดภัย",
-    "monitoring": "การติดตาม"
+    "status": "สถานะ",
+    "monitoring": "การติดตาม",
+    "address": "ที่อยู่",
+    "bankAccount": "บัญชีธนาคาร"
   },
   "fields": {
     "username": "ชื่อผู้ใช้",
@@ -47,12 +67,35 @@
     "newPassword": "รหัสผ่านใหม่",
     "confirmPassword": "ยืนยันรหัสผ่าน",
     "currentPassword": "รหัสผ่านปัจจุบัน",
-    "confirmNewPassword": "ยืนยันรหัสผ่านใหม่"
+    "confirmNewPassword": "ยืนยันรหัสผ่านใหม่",
+    "companyName": "ชื่อบริษัท",
+    "taxId": "เลขประจำตัวผู้เสียภาษี",
+    "phone": "โทรศัพท์",
+    "contactPerson": "ผู้ติดต่อ",
+    "street": "ที่อยู่",
+    "city": "เมือง",
+    "province": "จังหวัด",
+    "postalCode": "รหัสไปรษณีย์",
+    "bankAccountNo": "เลขที่บัญชีธนาคาร",
+    "bankAccountName": "ชื่อบัญชี",
+    "loanTypes": "ประเภทสินเชื่อ",
+    "isActive": "ใช้งาน",
+    "teamType": "ประเภท",
+    "teamTypeInternal": "ภายใน",
+    "teamTypeExternal": "ภายนอก",
+    "status": "สถานะ",
+    "company": "บริษัท",
+    "authSource": "แหล่งยืนยันตัวตน",
+    "lastLogin": "เข้าสู่ระบบล่าสุด",
+    "noCompany": "ไม่มีบริษัท"
   },
   "placeholders": {
     "searchUsers": "ค้นหาผู้ใช้...",
     "searchRoles": "ค้นหาบทบาท...",
     "searchGroups": "ค้นหากลุ่ม...",
+    "searchTeams": "ค้นหาทีม...",
+    "searchCompanies": "ค้นหาบริษัท...",
+    "searchActor": "ค้นหาผู้กระทำ...",
     "searchPermissions": "ค้นหาด้วยรหัสหรือชื่อที่แสดง...",
     "searchPermissionsShort": "ค้นหาสิทธิ์...",
     "searchByNameOrEmail": "ค้นหาด้วยชื่อหรืออีเมล...",
@@ -61,6 +104,19 @@
     "roleDescription": "คำอธิบายสั้น ๆ ของบทบาทนี้",
     "groupName": "ชื่อกลุ่ม",
     "groupDescription": "คำอธิบายสั้น ๆ ของกลุ่มนี้",
+    "teamName": "ชื่อทีม",
+    "teamDescription": "คำอธิบายสั้น ๆ ของทีมนี้",
+    "companyName": "ชื่อบริษัท",
+    "taxId": "เช่น 0105556123456",
+    "phone": "เช่น 02-xxx-xxxx",
+    "contactPerson": "ชื่อผู้ติดต่อ",
+    "street": "ที่อยู่",
+    "city": "เมือง",
+    "province": "จังหวัด",
+    "postalCode": "รหัสไปรษณีย์",
+    "bankAccountNo": "เลขที่บัญชีธนาคาร",
+    "bankAccountName": "ชื่อผู้ถือบัญชี",
+    "loanTypes": "เช่น HOUSING, AUTO",
     "briefDescription": "คำอธิบายสั้น ๆ",
     "permissionCodeExample": "เช่น permissions.read",
     "displayNameExample": "เช่น ดูสิทธิ์",
@@ -76,11 +132,41 @@
     "reEnterNewPassword": "ป้อนรหัสผ่านใหม่อีกครั้ง",
     "enterCurrentPassword": "ป้อนรหัสผ่านปัจจุบัน"
   },
+  "filters": {
+    "all": "ทั้งหมด",
+    "entityType": "ประเภทข้อมูล",
+    "action": "การดำเนินการ",
+    "actor": "ผู้กระทำ",
+    "from": "ตั้งแต่",
+    "to": "ถึง",
+    "search": "ค้นหา",
+    "roleName": "บทบาท",
+    "group": "กลุ่ม",
+    "team": "ทีม"
+  },
+  "counts": {
+    "members": "{{count}} สมาชิก",
+    "members_other": "{{count}} สมาชิก",
+    "results": "{{count}} รายการ",
+    "results_other": "{{count}} รายการ"
+  },
+  "status": {
+    "active": "ใช้งาน",
+    "inactive": "ไม่ใช้งาน",
+    "locked": "ถูกล็อก"
+  },
+  "hints": {
+    "loanTypesComma": "คั่นประเภทสินเชื่อหลายประเภทด้วยเครื่องหมายจุลภาค"
+  },
   "empty": {
     "noUsersFound": "ไม่พบผู้ใช้งาน",
     "noRolesFound": "ไม่พบบทบาท",
     "noGroupsFound": "ไม่พบกลุ่ม",
     "noPermissionsFound": "ไม่พบสิทธิ์",
+    "noTeamsFound": "ไม่พบทีม",
+    "noCompaniesFound": "ไม่พบบริษัท",
+    "noAuditLogs": "ไม่พบรายการบันทึกการตรวจสอบ",
+    "noResults": "ไม่พบผลลัพธ์",
     "noRolesAssigned": "ยังไม่มีบทบาทที่กำหนด",
     "noGroupsAssigned": "ยังไม่มีกลุ่มที่กำหนด",
     "noUsersAssigned": "ยังไม่มีผู้ใช้ที่กำหนด",
@@ -89,14 +175,20 @@
     "selectUser": "เลือกผู้ใช้เพื่อดูรายละเอียด",
     "selectRole": "เลือกบทบาทเพื่อดูรายละเอียด",
     "selectGroup": "เลือกกลุ่มเพื่อดูรายละเอียด",
+    "selectTeam": "เลือกทีมเพื่อดูรายละเอียด",
+    "selectCompany": "เลือกบริษัทเพื่อดูรายละเอียด",
     "noRolesAvailable": "ไม่มีบทบาทที่ใช้งานได้",
     "noOtherGroupsFound": "ไม่พบกลุ่มอื่น",
+    "noItemsFound": "ไม่พบรายการ",
+    "noTeamsAssigned": "ยังไม่มีทีมที่กำหนด",
     "loading": "กำลังโหลด..."
   },
   "aria": {
     "addUser": "เพิ่มผู้ใช้",
     "addRole": "เพิ่มบทบาท",
     "addGroup": "เพิ่มกลุ่ม",
+    "addTeam": "เพิ่มทีม",
+    "addCompany": "เพิ่มบริษัท",
     "removeItem": "ลบ {{name}}"
   },
   "buttons": {
@@ -104,6 +196,8 @@
     "edit": "แก้ไข",
     "deleteRole": "ลบบทบาท",
     "deleteGroup": "ลบกลุ่ม",
+    "deleteTeam": "ลบทีม",
+    "deleteCompany": "ลบบริษัท",
     "changePassword": "เปลี่ยนรหัสผ่าน",
     "resetPassword": "รีเซ็ตรหัสผ่าน",
     "savePermissions": "บันทึกสิทธิ์",
@@ -111,7 +205,11 @@
     "showPasswords": "แสดงรหัสผ่าน",
     "hidePasswords": "ซ่อนรหัสผ่าน",
     "update": "อัปเดต",
-    "create": "สร้าง"
+    "create": "สร้าง",
+    "exportCsv": "ส่งออก CSV",
+    "activate": "เปิดใช้งาน",
+    "deactivate": "ปิดใช้งาน",
+    "unlock": "ปลดล็อก"
   },
   "dialogs": {
     "createRole": {
@@ -132,6 +230,26 @@
     },
     "deleteGroup": {
       "title": "ลบกลุ่ม",
+      "message": "คุณแน่ใจหรือไม่ว่าต้องการลบ \"{{name}}\"? การดำเนินการนี้ไม่สามารถยกเลิกได้"
+    },
+    "createTeam": {
+      "title": "สร้างทีม"
+    },
+    "editTeam": {
+      "title": "แก้ไขทีม"
+    },
+    "deleteTeam": {
+      "title": "ลบทีม",
+      "message": "คุณแน่ใจหรือไม่ว่าต้องการลบ \"{{name}}\"? การดำเนินการนี้ไม่สามารถยกเลิกได้"
+    },
+    "createCompany": {
+      "title": "สร้างบริษัท"
+    },
+    "editCompany": {
+      "title": "แก้ไขบริษัท"
+    },
+    "deleteCompany": {
+      "title": "ลบบริษัท",
       "message": "คุณแน่ใจหรือไม่ว่าต้องการลบ \"{{name}}\"? การดำเนินการนี้ไม่สามารถยกเลิกได้"
     },
     "createUser": {
@@ -173,11 +291,25 @@
     },
     "selectMonitoredGroups": {
       "title": "เลือกกลุ่มที่ต้องการติดตาม"
+    },
+    "editTeams": {
+      "title": "แก้ไขทีม",
+      "hint": "เลือกทีมที่ต้องการกำหนดให้ผู้ใช้นี้"
+    },
+    "activateUser": {
+      "title": "เปิดใช้งานผู้ใช้",
+      "message": "คุณแน่ใจหรือไม่ว่าต้องการเปิดใช้งาน \"{{name}}\""
+    },
+    "deactivateUser": {
+      "title": "ปิดใช้งานผู้ใช้",
+      "message": "คุณแน่ใจหรือไม่ว่าต้องการปิดใช้งาน \"{{name}}\"? พวกเขาจะไม่สามารถเข้าสู่ระบบได้"
     }
   },
   "security": {
     "deleteRoleWarning": "การลบบทบาทนี้จะนำออกจากผู้ใช้ทั้งหมดที่ถูกกำหนด การดำเนินการนี้ไม่สามารถยกเลิกได้",
-    "deleteGroupWarning": "การลบกลุ่มนี้จะลบการกำหนดผู้ใช้ทั้งหมด การดำเนินการนี้ไม่สามารถยกเลิกได้"
+    "deleteGroupWarning": "การลบกลุ่มนี้จะลบการกำหนดผู้ใช้ทั้งหมด การดำเนินการนี้ไม่สามารถยกเลิกได้",
+    "deleteTeamWarning": "การลบทีมนี้จะลบสมาชิกทั้งหมด การดำเนินการนี้ไม่สามารถยกเลิกได้",
+    "deleteCompanyWarning": "การลบบริษัทนี้จะนำออกจากระบบ การดำเนินการนี้ไม่สามารถยกเลิกได้"
   },
   "selectionCount": {
     "permissions": "เลือก {{count}} สิทธิ์",
@@ -185,7 +317,9 @@
     "users": "เลือก {{count}} ผู้ใช้",
     "users_other": "เลือก {{count}} ผู้ใช้",
     "groups": "เลือก {{count}} กลุ่ม",
-    "groups_other": "เลือก {{count}} กลุ่ม"
+    "groups_other": "เลือก {{count}} กลุ่ม",
+    "items": "เลือก {{count}} รายการ",
+    "items_other": "เลือก {{count}} รายการ"
   },
   "loading": {
     "permissions": "กำลังโหลดสิทธิ์...",
@@ -197,7 +331,17 @@
     "permissionCode": "รหัสสิทธิ์",
     "module": "โมดูล",
     "description": "คำอธิบาย",
-    "actions": "การดำเนินการ"
+    "actions": "การดำเนินการ",
+    "when": "เวลา",
+    "actor": "ผู้กระทำ",
+    "action": "การดำเนินการ",
+    "entityType": "ประเภท",
+    "entityName": "ชื่อข้อมูล",
+    "changes": "การเปลี่ยนแปลง",
+    "username": "ชื่อผู้ใช้",
+    "fullName": "ชื่อ-นามสกุล",
+    "email": "อีเมล",
+    "scope": "ขอบเขต"
   },
   "toasts": {
     "roleCreated": "สร้างบทบาทเรียบร้อยแล้ว",
@@ -216,6 +360,19 @@
     "groupUpdateFailed": "ไม่สามารถอัปเดตกลุ่มได้",
     "groupDeleted": "ลบกลุ่มเรียบร้อยแล้ว",
     "groupDeleteFailed": "ไม่สามารถลบกลุ่มได้",
+    "teamCreated": "สร้างทีมเรียบร้อยแล้ว",
+    "teamCreateFailed": "ไม่สามารถสร้างทีมได้",
+    "teamUpdated": "อัปเดตทีมเรียบร้อยแล้ว",
+    "teamUpdateFailed": "ไม่สามารถอัปเดตทีมได้",
+    "teamDeleted": "ลบทีมเรียบร้อยแล้ว",
+    "teamDeleteFailed": "ไม่สามารถลบทีมได้",
+    "companyCreated": "สร้างบริษัทเรียบร้อยแล้ว",
+    "companyCreateFailed": "ไม่สามารถสร้างบริษัทได้",
+    "companyUpdated": "อัปเดตบริษัทเรียบร้อยแล้ว",
+    "companyUpdateFailed": "ไม่สามารถอัปเดตบริษัทได้",
+    "companyDeleted": "ลบบริษัทเรียบร้อยแล้ว",
+    "companyDeleteFailed": "ไม่สามารถลบบริษัทได้",
+    "exportFailed": "ไม่สามารถส่งออกรายงานได้",
     "monitoredGroupsUpdated": "อัปเดตกลุ่มที่ติดตามเรียบร้อยแล้ว",
     "monitoredGroupsUpdateFailed": "ไม่สามารถอัปเดตกลุ่มที่ติดตามได้",
     "userUpdated": "อัปเดตผู้ใช้เรียบร้อยแล้ว",
@@ -236,7 +393,14 @@
     "permissionUpdated": "อัปเดตสิทธิ์เรียบร้อยแล้ว",
     "permissionUpdateFailed": "ไม่สามารถอัปเดตสิทธิ์ได้",
     "permissionDeleted": "ลบสิทธิ์เรียบร้อยแล้ว",
-    "permissionDeleteFailed": "ไม่สามารถลบสิทธิ์ได้"
+    "permissionDeleteFailed": "ไม่สามารถลบสิทธิ์ได้",
+    "teamsUpdated": "อัปเดตทีมเรียบร้อยแล้ว",
+    "teamsUpdateFailed": "ไม่สามารถอัปเดตทีมได้",
+    "userActivated": "เปิดใช้งานผู้ใช้เรียบร้อยแล้ว",
+    "userDeactivated": "ปิดใช้งานผู้ใช้เรียบร้อยแล้ว",
+    "userActivationFailed": "ไม่สามารถอัปเดตสถานะผู้ใช้ได้",
+    "userUnlocked": "ปลดล็อกบัญชีผู้ใช้เรียบร้อยแล้ว",
+    "userUnlockFailed": "ไม่สามารถปลดล็อกบัญชีผู้ใช้ได้"
   },
   "validation": {
     "nameRequired": "ต้องระบุชื่อ",
@@ -261,6 +425,13 @@
     "passwordsDoNotMatch": "รหัสผ่านไม่ตรงกัน",
     "passwordMinLengthReset": "รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร",
     "passwordsDoNotMatchReset": "รหัสผ่านไม่ตรงกัน"
+  },
+  "passwordPolicy": {
+    "minLength": "อย่างน้อย {{count}} ตัวอักษร",
+    "requireUppercase": "ตัวพิมพ์ใหญ่อย่างน้อยหนึ่งตัว",
+    "requireLowercase": "ตัวพิมพ์เล็กอย่างน้อยหนึ่งตัว",
+    "requireDigit": "ตัวเลขอย่างน้อยหนึ่งตัว",
+    "requireSymbol": "อักขระพิเศษอย่างน้อยหนึ่งตัว"
   },
   "roles": {
     "displayNames": {

--- a/src/i18n/locales/zh/userManagement.json
+++ b/src/i18n/locales/zh/userManagement.json
@@ -15,6 +15,22 @@
     "permissions": {
       "title": "Permissions",
       "subtitle": "Manage system permissions that can be assigned to roles"
+    },
+    "teams": {
+      "title": "Teams",
+      "subtitle": "Manage teams and their members"
+    },
+    "auditLogs": {
+      "title": "Audit Logs",
+      "subtitle": "Review a history of changes to users, roles, groups, and permissions"
+    },
+    "companies": {
+      "title": "Companies",
+      "subtitle": "Manage external appraisal companies and their details"
+    },
+    "accessReport": {
+      "title": "Access Report",
+      "subtitle": "View and export the full user access matrix"
     }
   },
   "tabs": {
@@ -25,10 +41,14 @@
     "general": "General",
     "roles": "Roles",
     "groups": "Groups",
+    "teams": "Teams",
     "users": "Users",
     "permissions": "Permissions",
     "security": "Security",
-    "monitoring": "Monitoring"
+    "status": "Status",
+    "monitoring": "Monitoring",
+    "address": "Address",
+    "bankAccount": "Bank Account"
   },
   "fields": {
     "username": "Username",
@@ -47,12 +67,35 @@
     "newPassword": "New Password",
     "confirmPassword": "Confirm Password",
     "currentPassword": "Current Password",
-    "confirmNewPassword": "Confirm New Password"
+    "confirmNewPassword": "Confirm New Password",
+    "companyName": "Company Name",
+    "taxId": "Tax ID",
+    "phone": "Phone",
+    "contactPerson": "Contact Person",
+    "street": "Street",
+    "city": "City",
+    "province": "Province",
+    "postalCode": "Postal Code",
+    "bankAccountNo": "Bank Account No.",
+    "bankAccountName": "Bank Account Name",
+    "loanTypes": "Loan Types",
+    "isActive": "Active",
+    "teamType": "Type",
+    "teamTypeInternal": "Internal",
+    "teamTypeExternal": "External",
+    "status": "Status",
+    "company": "Company",
+    "authSource": "Auth Source",
+    "lastLogin": "Last Login",
+    "noCompany": "No Company"
   },
   "placeholders": {
     "searchUsers": "Search users...",
     "searchRoles": "Search roles...",
     "searchGroups": "Search groups...",
+    "searchTeams": "Search teams...",
+    "searchCompanies": "Search companies...",
+    "searchActor": "Search by actor...",
     "searchPermissions": "Search by code or display name...",
     "searchPermissionsShort": "Search permissions...",
     "searchByNameOrEmail": "Search by name or email...",
@@ -61,6 +104,19 @@
     "roleDescription": "Brief description of this role",
     "groupName": "Group name",
     "groupDescription": "Brief description of this group",
+    "teamName": "Team name",
+    "teamDescription": "Brief description of this team",
+    "companyName": "Company name",
+    "taxId": "e.g. 0105556123456",
+    "phone": "e.g. 02-xxx-xxxx",
+    "contactPerson": "Contact person name",
+    "street": "Street address",
+    "city": "City",
+    "province": "Province",
+    "postalCode": "Postal code",
+    "bankAccountNo": "Bank account number",
+    "bankAccountName": "Account holder name",
+    "loanTypes": "e.g. HOUSING, AUTO",
     "briefDescription": "Brief description",
     "permissionCodeExample": "e.g., permissions.read",
     "displayNameExample": "e.g., View Permissions",
@@ -76,11 +132,41 @@
     "reEnterNewPassword": "Re-enter new password",
     "enterCurrentPassword": "Enter current password"
   },
+  "filters": {
+    "all": "All",
+    "entityType": "Entity Type",
+    "action": "Action",
+    "actor": "Actor",
+    "from": "From",
+    "to": "To",
+    "search": "Search",
+    "roleName": "Role",
+    "group": "Group",
+    "team": "Team"
+  },
+  "counts": {
+    "members": "{{count}} member",
+    "members_other": "{{count}} members",
+    "results": "{{count}} result",
+    "results_other": "{{count}} results"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive",
+    "locked": "Locked"
+  },
+  "hints": {
+    "loanTypesComma": "Separate multiple loan types with a comma"
+  },
   "empty": {
     "noUsersFound": "No users found",
     "noRolesFound": "No roles found",
     "noGroupsFound": "No groups found",
     "noPermissionsFound": "No permissions found",
+    "noTeamsFound": "No teams found",
+    "noCompaniesFound": "No companies found",
+    "noAuditLogs": "No audit log entries found",
+    "noResults": "No results found",
     "noRolesAssigned": "No roles assigned",
     "noGroupsAssigned": "No groups assigned",
     "noUsersAssigned": "No users assigned",
@@ -89,14 +175,20 @@
     "selectUser": "Select a user to view details",
     "selectRole": "Select a role to view details",
     "selectGroup": "Select a group to view details",
+    "selectTeam": "Select a team to view details",
+    "selectCompany": "Select a company to view details",
     "noRolesAvailable": "No roles available",
     "noOtherGroupsFound": "No other groups found",
+    "noItemsFound": "No items found",
+    "noTeamsAssigned": "No teams assigned",
     "loading": "Loading..."
   },
   "aria": {
     "addUser": "Add user",
     "addRole": "Add role",
     "addGroup": "Add group",
+    "addTeam": "Add team",
+    "addCompany": "Add company",
     "removeItem": "Remove {{name}}"
   },
   "buttons": {
@@ -104,6 +196,8 @@
     "edit": "Edit",
     "deleteRole": "Delete Role",
     "deleteGroup": "Delete Group",
+    "deleteTeam": "Delete Team",
+    "deleteCompany": "Delete Company",
     "changePassword": "Change Password",
     "resetPassword": "Reset Password",
     "savePermissions": "Save Permissions",
@@ -111,7 +205,11 @@
     "showPasswords": "Show passwords",
     "hidePasswords": "Hide passwords",
     "update": "Update",
-    "create": "Create"
+    "create": "Create",
+    "exportCsv": "Export CSV",
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "unlock": "Unlock"
   },
   "dialogs": {
     "createRole": {
@@ -134,6 +232,26 @@
       "title": "Delete Group",
       "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
     },
+    "createTeam": {
+      "title": "Create Team"
+    },
+    "editTeam": {
+      "title": "Edit Team"
+    },
+    "deleteTeam": {
+      "title": "Delete Team",
+      "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
+    },
+    "createCompany": {
+      "title": "Create Company"
+    },
+    "editCompany": {
+      "title": "Edit Company"
+    },
+    "deleteCompany": {
+      "title": "Delete Company",
+      "message": "Are you sure you want to delete \"{{name}}\"? This cannot be undone."
+    },
     "createUser": {
       "title": "Create User"
     },
@@ -147,6 +265,10 @@
     "editGroups": {
       "title": "Edit Groups",
       "hint": "Select groups to assign to this user."
+    },
+    "editTeams": {
+      "title": "Edit Teams",
+      "hint": "Select teams to assign to this user."
     },
     "resetPassword": {
       "title": "Reset Password",
@@ -173,11 +295,21 @@
     },
     "selectMonitoredGroups": {
       "title": "Select Monitored Groups"
+    },
+    "activateUser": {
+      "title": "Activate User",
+      "message": "Are you sure you want to activate \"{{name}}\"?"
+    },
+    "deactivateUser": {
+      "title": "Deactivate User",
+      "message": "Are you sure you want to deactivate \"{{name}}\"? They will not be able to sign in."
     }
   },
   "security": {
     "deleteRoleWarning": "Deleting this role will remove it from all assigned users. This action cannot be undone.",
-    "deleteGroupWarning": "Deleting this group will remove all user assignments. This action cannot be undone."
+    "deleteGroupWarning": "Deleting this group will remove all user assignments. This action cannot be undone.",
+    "deleteTeamWarning": "Deleting this team will remove all member assignments. This action cannot be undone.",
+    "deleteCompanyWarning": "Deleting this company will remove it from the system. This action cannot be undone."
   },
   "selectionCount": {
     "permissions": "{{count}} permission selected",
@@ -185,7 +317,9 @@
     "users": "{{count}} user selected",
     "users_other": "{{count}} users selected",
     "groups": "{{count}} group selected",
-    "groups_other": "{{count}} groups selected"
+    "groups_other": "{{count}} groups selected",
+    "items": "{{count}} item selected",
+    "items_other": "{{count}} items selected"
   },
   "loading": {
     "permissions": "Loading permissions...",
@@ -197,7 +331,17 @@
     "permissionCode": "Permission Code",
     "module": "Module",
     "description": "Description",
-    "actions": "Actions"
+    "actions": "Actions",
+    "when": "When",
+    "actor": "Actor",
+    "action": "Action",
+    "entityType": "Entity Type",
+    "entityName": "Entity",
+    "changes": "Changes",
+    "username": "Username",
+    "fullName": "Full Name",
+    "email": "Email",
+    "scope": "Scope"
   },
   "toasts": {
     "roleCreated": "Role created",
@@ -216,6 +360,19 @@
     "groupUpdateFailed": "Failed to update group",
     "groupDeleted": "Group deleted",
     "groupDeleteFailed": "Failed to delete group",
+    "teamCreated": "Team created",
+    "teamCreateFailed": "Failed to create team",
+    "teamUpdated": "Team updated",
+    "teamUpdateFailed": "Failed to update team",
+    "teamDeleted": "Team deleted",
+    "teamDeleteFailed": "Failed to delete team",
+    "companyCreated": "Company created",
+    "companyCreateFailed": "Failed to create company",
+    "companyUpdated": "Company updated",
+    "companyUpdateFailed": "Failed to update company",
+    "companyDeleted": "Company deleted",
+    "companyDeleteFailed": "Failed to delete company",
+    "exportFailed": "Failed to export report",
     "monitoredGroupsUpdated": "Monitored groups updated",
     "monitoredGroupsUpdateFailed": "Failed to update monitored groups",
     "userUpdated": "User updated",
@@ -236,7 +393,14 @@
     "permissionUpdated": "Permission updated successfully",
     "permissionUpdateFailed": "Failed to update permission",
     "permissionDeleted": "Permission deleted successfully",
-    "permissionDeleteFailed": "Failed to delete permission"
+    "permissionDeleteFailed": "Failed to delete permission",
+    "teamsUpdated": "Teams updated",
+    "teamsUpdateFailed": "Failed to update teams",
+    "userActivated": "User activated",
+    "userDeactivated": "User deactivated",
+    "userActivationFailed": "Failed to update user status",
+    "userUnlocked": "User account unlocked",
+    "userUnlockFailed": "Failed to unlock user account"
   },
   "validation": {
     "nameRequired": "Name is required",
@@ -261,6 +425,13 @@
     "passwordsDoNotMatch": "Passwords do not match",
     "passwordMinLengthReset": "Password must be at least 8 characters",
     "passwordsDoNotMatchReset": "Passwords do not match"
+  },
+  "passwordPolicy": {
+    "minLength": "At least {{count}} characters",
+    "requireUppercase": "One uppercase letter",
+    "requireLowercase": "One lowercase letter",
+    "requireDigit": "One digit",
+    "requireSymbol": "One special character"
   },
   "roles": {
     "displayNames": {


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR isolates the **userManagement** admin feature changes.

## Changes
- New admin modules: teams, companies, audit logs, access reports (API + list pages + detail panels + assignment table)
- `UserDetailPanel`, `UserProfilePage`, `ChangePasswordModal`, `UserAssignmentModal`, group/role list pages, `users` API + types
- **Router:** adds `teams`, `audit-logs`, `companies`, `access-report` admin routes (router.tsx hunk-split — only these routes; block-reappraisal routes belong to #176)
- en/th/zh `userManagement.json`

## Scope / coupling
`router.tsx` is shared with the block* PR (#176); this branch contains **only** the userManagement route hunks. Independent off `main`.

## Verification
- `tsc -b` → **0 new errors** vs `main` baseline (resolves 10 pre-existing errors, including the `userName`/`username` mismatch on `UserProfilePage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)