### PR TITLE
feat(block): block project reappraisal + unit maintenance breakdown

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -101,6 +101,8 @@ import MonitoringPage from '@/features/common/monitoring/pages/MonitoringPage';
 import HistorySearchPage from '@/features/common/historySearch/pages/HistorySearchPage';
 import BlockUnitMaintenancePage from '@/features/blockUnitMaintenance/pages/BlockUnitMaintenancePage';
 import BlockUnitMaintenanceDetailPage from '@/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage';
+import BlockReappraisalListPage from '@/features/blockReappraisal/pages/BlockReappraisalListPage';
+import BlockReappraisalDetailPage from '@/features/blockReappraisal/pages/BlockReappraisalDetailPage';
 import { SupportingDataMaintenanceListPage } from '@/features/supportingDataMaintenance/pages/SupportingDataMaintenanceListPage';
 import { CreateSupportingDataPage } from '@/features/supportingDataMaintenance/pages/CreateSupportingDataPage';
 import StepValidationRulesPage from '@features/workflowAdmin/pages/StepValidationRulesPage';
@@ -457,6 +459,15 @@ export const router = createBrowserRouter([
       {
         path: 'standalone/supporting-data-maintenance/:supportingId/data/:id',
         element: <CreateSupportingDataPage />,
+      },
+      // ─── Block Project Reappraisal ──────────────────────────────────────────
+      {
+        path: 'standalone/block-reappraisal',
+        element: <BlockReappraisalListPage />,
+      },
+      {
+        path: 'standalone/block-reappraisal/:collateralMasterId',
+        element: <BlockReappraisalDetailPage />,
       },
       // ─── Periodical Reappraisal (AS400) ────────────────────────────────────
       {

--- a/src/features/blockProject/api/projectUnit.ts
+++ b/src/features/blockProject/api/projectUnit.ts
@@ -100,6 +100,50 @@ export const useUploadProjectUnits = () => {
   });
 };
 
+// ── Reappraisal result type ───────────────────────────────────────────────────
+
+export interface ReappraisalUploadResult {
+  matchedUnsold: number;
+  autoSold: number;
+  added: number;
+}
+
+/**
+ * Re-upload an Excel file for a REAPPRAISAL appraisal.
+ * POST /appraisals/{appraisalId}/project/units/reappraisal-upload
+ *
+ * Matches rows to seeded unsold units: present rows stay UNSOLD, missing rows
+ * are auto-marked SOLD, new rows are counted but NOT persisted (v1).
+ * Same FormData field name as useUploadProjectUnits.
+ */
+export const useUploadReappraisalUnits = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      appraisalId: string;
+      file: File;
+    }): Promise<ReappraisalUploadResult> => {
+      const formData = new FormData();
+      formData.append('file', params.file);
+      const { data } = await axios.post(
+        `/appraisals/${params.appraisalId}/project/units/reappraisal-upload`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      );
+      return data.result ?? data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: projectUnitKeys.all(variables.appraisalId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: projectUnitKeys.uploads(variables.appraisalId),
+      });
+    },
+  });
+};
+
 /**
  * Delete a unit upload batch and its associated units.
  * DELETE /appraisals/{appraisalId}/project/units/uploads/{uploadId}

--- a/src/features/blockProject/components/ProjectTypePill.tsx
+++ b/src/features/blockProject/components/ProjectTypePill.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import Dropdown from '@/shared/components/inputs/Dropdown';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useParameterOptions } from '@/shared/utils/parameterUtils';
@@ -26,6 +27,7 @@ export default function ProjectTypePill({
   hasExistingProject,
   onPendingTypeChange,
 }: ProjectTypeSelectorProps) {
+  const { t } = useTranslation('blockProject');
   const typeOptions = useParameterOptions('ProjectType');
   const isReadOnly = usePageReadOnly();
   const canChange = !isReadOnly && hasExistingProject;
@@ -38,13 +40,13 @@ export default function ProjectTypePill({
 
   return (
     <Dropdown
-      label="Project Type"
+      label={t('projectInfo.fields.projectType')}
       options={typeOptions}
       value={pendingType ?? projectType}
       onChange={handleChange}
       disabled={!canChange}
       showValuePrefix={false}
-      placeholder="Select project type"
+      placeholder={t('projectTypePill.placeholder')}
     />
   );
 }

--- a/src/features/blockProject/components/RadioGroup.tsx
+++ b/src/features/blockProject/components/RadioGroup.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 interface RadioGroupProps {
   name: string;
   options: { value: string; label: string }[];
@@ -23,33 +25,37 @@ const RadioGroup = ({
   otherValue,
   onOtherChange,
   disabled,
-}: RadioGroupProps) => (
-  <div className="flex flex-wrap gap-x-4 gap-y-2">
-    {options.map(opt => (
-      <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
+}: RadioGroupProps) => {
+  const { t } = useTranslation('blockProject');
+
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-2">
+      {options.map(opt => (
+        <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            name={name}
+            value={opt.value}
+            checked={value === opt.value}
+            onChange={() => onChange(opt.value)}
+            disabled={disabled}
+            className="accent-primary"
+          />
+          <span className="text-sm text-gray-700">{opt.label}</span>
+        </label>
+      ))}
+      {showOther && value === 'Other' && (
         <input
-          type="radio"
-          name={name}
-          value={opt.value}
-          checked={value === opt.value}
-          onChange={() => onChange(opt.value)}
+          type="text"
+          value={otherValue ?? ''}
+          onChange={e => onOtherChange?.(e.target.value)}
+          placeholder={t('radioGroup.specifyPlaceholder')}
           disabled={disabled}
-          className="accent-primary"
+          className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:bg-gray-50 disabled:text-gray-400"
         />
-        <span className="text-sm text-gray-700">{opt.label}</span>
-      </label>
-    ))}
-    {showOther && value === 'Other' && (
-      <input
-        type="text"
-        value={otherValue ?? ''}
-        onChange={e => onOtherChange?.(e.target.value)}
-        placeholder="Please specify"
-        disabled={disabled}
-        className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:bg-gray-50 disabled:text-gray-400"
-      />
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 export default RadioGroup;

--- a/src/features/blockProject/components/tabs/ModelListingTab.tsx
+++ b/src/features/blockProject/components/tabs/ModelListingTab.tsx
@@ -271,7 +271,7 @@ function ModelCard({
             type="button"
             onClick={onDelete}
             className="absolute top-2 right-2 p-1.5 rounded-md bg-white/80 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100"
-            title="Delete model"
+            title={t('modelListing.aria.deleteModel')}
           >
             <Icon name="trash-can" style="regular" className="size-3.5" />
           </button>

--- a/src/features/blockProject/components/tabs/TowerListingTab.tsx
+++ b/src/features/blockProject/components/tabs/TowerListingTab.tsx
@@ -116,7 +116,7 @@ function TowerCard({ tower, viewMode, thumbnailSrc, readOnly, onClick, onDelete 
             type="button"
             onClick={onDelete}
             className="absolute top-2 right-2 p-1.5 rounded-md bg-white/80 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100"
-            title="Delete tower"
+            title={t('towerListing.aria.deleteTower')}
           >
             <Icon name="trash-can" style="regular" className="size-3.5" />
           </button>

--- a/src/features/blockProject/components/tabs/UnitListingTab.tsx
+++ b/src/features/blockProject/components/tabs/UnitListingTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
-import { useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
+import { useAppraisalId, useAppraisalContext } from '@/features/appraisal/context/AppraisalContext';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import Icon from '@/shared/components/Icon';
 import Badge from '@/shared/components/Badge';
@@ -13,6 +13,7 @@ import {
   useGetProjectUnits,
   useGetProjectUnitUploads,
   useUploadProjectUnits,
+  useUploadReappraisalUnits,
   useDeleteProjectUnitUpload,
 } from '../../api/projectUnit';
 import { isCondo } from '../../types';
@@ -318,12 +319,16 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
   const { t } = useTranslation('blockProject');
   const appraisalId = useAppraisalId();
   const readOnly = usePageReadOnly();
+  const { appraisal } = useAppraisalContext();
+  const isReappraisal = appraisal?.appraisalType === 'ReAppraisal';
 
   const { data: unitsData, isLoading: unitsLoading } = useGetProjectUnits(appraisalId ?? '');
   const { data: uploadsData, isLoading: uploadsLoading } = useGetProjectUnitUploads(
     appraisalId ?? '',
   );
   const { mutate: uploadUnits, isPending: isUploading } = useUploadProjectUnits();
+  const { mutate: uploadReappraisalUnits, isPending: isReappraisalUploading } =
+    useUploadReappraisalUnits();
   const { mutate: deleteUpload, isPending: isDeleting } = useDeleteProjectUnitUpload();
 
   const units = unitsData?.units ?? [];
@@ -377,6 +382,44 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
     setPendingFile(null);
   };
 
+  const handleReappraisalFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (readOnly || !file || !appraisalId) return;
+
+    const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+    let validationError: string | null = null;
+    if (!ALLOWED_EXTENSIONS.includes(ext)) {
+      validationError = t('toasts.units.invalidFileType', {
+        extensions: ALLOWED_EXTENSIONS.join(', '),
+      });
+    } else if (file.size > MAX_FILE_SIZE_BYTES) {
+      validationError = t('toasts.units.fileTooLarge');
+    }
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+
+    uploadReappraisalUnits(
+      { appraisalId, file },
+      {
+        onSuccess: data => {
+          toast.success(
+            t('unitListing.reappraisal.resultToast', {
+              matched: data.matchedUnsold,
+              autoSold: data.autoSold,
+              added: data.added,
+            }),
+          );
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? t('toasts.units.uploadFailed'));
+        },
+      },
+    );
+  };
+
   const handleConfirmDelete = () => {
     if (readOnly || !pendingDeleteUpload || !appraisalId) return;
     deleteUpload(
@@ -396,6 +439,9 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
           <h3 className="text-sm font-semibold text-gray-900 mb-4">
             {t('unitListing.importUnits')}
           </h3>
+          {isReappraisal && (
+            <p className="text-xs text-gray-500 mb-3">{t('unitListing.reappraisal.normalUploadNote')}</p>
+          )}
           <UploadArea
             onChange={handleFileChange}
             accept=".xlsx,.xls,.csv"
@@ -418,6 +464,22 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
           />
         </div>
       </div>
+
+      {isReappraisal && !readOnly && (
+        <div className="bg-white rounded-xl border border-amber-200 p-6">
+          <h3 className="text-sm font-semibold text-gray-900 mb-1">
+            {t('unitListing.reappraisal.title')}
+          </h3>
+          <p className="text-xs text-gray-500 mb-4">{t('unitListing.reappraisal.hint')}</p>
+          <UploadArea
+            onChange={handleReappraisalFileChange}
+            accept=".xlsx,.xls,.csv"
+            isLoading={isReappraisalUploading}
+            disabled={readOnly}
+            supportedText=".xlsx, .xls, .csv (max 10MB)"
+          />
+        </div>
+      )}
 
       <div className="bg-white rounded-xl border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-4">

--- a/src/features/blockReappraisal/api/blockReappraisal.ts
+++ b/src/features/blockReappraisal/api/blockReappraisal.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import type {
+  BlockReappraisalCreateResult,
+  BlockReappraisalDetailResult,
+  BlockReappraisalDueListItem,
+  BlockReappraisalListParams,
+  PaginatedResult,
+} from '../types';
+
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const blockReappraisalKeys = {
+  all: ['block-reappraisal'] as const,
+  lists: () => [...blockReappraisalKeys.all, 'list'] as const,
+  list: (params: BlockReappraisalListParams) =>
+    [...blockReappraisalKeys.lists(), params] as const,
+  details: () => [...blockReappraisalKeys.all, 'detail'] as const,
+  detail: (collateralMasterId: string) =>
+    [...blockReappraisalKeys.details(), collateralMasterId] as const,
+};
+
+// ─── List hook ────────────────────────────────────────────────────────────────
+
+export function useBlockReappraisalDueList(params: BlockReappraisalListParams = {}) {
+  return useQuery({
+    queryKey: blockReappraisalKeys.list(params),
+    queryFn: async (): Promise<PaginatedResult<BlockReappraisalDueListItem>> => {
+      const {
+        pageNumber = 0,
+        pageSize = 20,
+        projectName,
+        oldAppraisalNumber,
+      } = params;
+
+      const { data } = await axios.get('/block-reappraisal', {
+        params: {
+          pageNumber,
+          pageSize,
+          ...(projectName && { projectName }),
+          ...(oldAppraisalNumber && { oldAppraisalNumber }),
+        },
+      });
+
+      return data.result ?? data;
+    },
+    placeholderData: prev => prev,
+    staleTime: 30 * 1000,
+  });
+}
+
+// ─── Detail hook ──────────────────────────────────────────────────────────────
+
+export function useBlockReappraisalDetail(collateralMasterId: string) {
+  return useQuery({
+    queryKey: blockReappraisalKeys.detail(collateralMasterId),
+    queryFn: async (): Promise<BlockReappraisalDetailResult> => {
+      const { data } = await axios.get(`/block-reappraisal/${collateralMasterId}`);
+      return data.result ?? data;
+    },
+    enabled: !!collateralMasterId,
+    staleTime: 30 * 1000,
+  });
+}
+
+// ─── Create mutation ──────────────────────────────────────────────────────────
+
+export function useCreateBlockReappraisal() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (collateralMasterId: string): Promise<BlockReappraisalCreateResult> => {
+      const { data } = await axios.post(`/block-reappraisal/${collateralMasterId}/create`);
+      return data.result ?? data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: blockReappraisalKeys.lists() });
+    },
+  });
+}
+
+// ─── Opt-out mutation ─────────────────────────────────────────────────────────
+
+export function useMarkBlockReappraisalNotRequired() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (collateralMasterId: string): Promise<void> => {
+      await axios.post(`/block-reappraisal/${collateralMasterId}/opt-out`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: blockReappraisalKeys.lists() });
+    },
+  });
+}

--- a/src/features/blockReappraisal/components/BlockReappraisalFilterDialog.tsx
+++ b/src/features/blockReappraisal/components/BlockReappraisalFilterDialog.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from '@/shared/components/Modal';
+import Button from '@/shared/components/Button';
+import { TextInput } from '@/shared/components/inputs';
+import type { BlockReappraisalFilterValues } from '../types';
+
+interface BlockReappraisalFilterDialogProps {
+  open: boolean;
+  initialValues: BlockReappraisalFilterValues;
+  onApply: (values: BlockReappraisalFilterValues) => void;
+  onClose: () => void;
+}
+
+export function BlockReappraisalFilterDialog({
+  open,
+  initialValues,
+  onApply,
+  onClose,
+}: BlockReappraisalFilterDialogProps) {
+  const { t } = useTranslation(['blockReappraisal', 'common']);
+  const [values, setValues] = useState<BlockReappraisalFilterValues>(initialValues);
+
+  useEffect(() => {
+    if (open) setValues(initialValues);
+  }, [open, initialValues]);
+
+  const handleClear = () => setValues({});
+
+  const handleApply = () => {
+    onApply(values);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onClose} title={t('filter.title')} size="md">
+      <div className="space-y-5">
+        <section className="grid grid-cols-1 gap-4">
+          <TextInput
+            label={t('filter.fields.projectName')}
+            placeholder={t('filter.placeholders.projectName')}
+            value={values.projectName ?? ''}
+            onChange={e =>
+              setValues(v => ({ ...v, projectName: e.target.value || undefined }))
+            }
+          />
+          <TextInput
+            label={t('filter.fields.oldAppraisalNumber')}
+            placeholder={t('filter.placeholders.oldAppraisalNumber')}
+            value={values.oldAppraisalNumber ?? ''}
+            onChange={e =>
+              setValues(v => ({ ...v, oldAppraisalNumber: e.target.value || undefined }))
+            }
+          />
+        </section>
+
+        <div className="flex justify-end gap-2 pt-4 border-t border-gray-100">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleClear}>
+            {t('common:actions.clear')}
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleApply}>
+            {t('common:actions.apply')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
+++ b/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
@@ -1,0 +1,553 @@
+import { useMemo, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import Icon from '@/shared/components/Icon';
+import Button from '@/shared/components/Button';
+import Modal from '@/shared/components/Modal';
+import { TableRowSkeleton } from '@/shared/components/Skeleton';
+import { formatLocaleDate } from '@/shared/utils/dateUtils';
+import { SoldDonut } from '@/features/blockUnitMaintenance/components/SoldDonut';
+import { ModelBreakdown } from '@/features/blockUnitMaintenance/components/ModelBreakdown';
+import type { ModelStat } from '@/features/blockUnitMaintenance/components/ModelBreakdown';
+import {
+  useBlockReappraisalDetail,
+  useCreateBlockReappraisal,
+  useMarkBlockReappraisalNotRequired,
+} from '../api/blockReappraisal';
+import type { BlockReappraisalUnitDetail, BlockReappraisalCreateResult } from '../types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatNumber(n?: number | null): string {
+  if (n == null) return '-';
+  return n.toLocaleString();
+}
+
+function groupByModel(
+  units: BlockReappraisalUnitDetail[],
+  predicate: (u: BlockReappraisalUnitDetail) => boolean,
+): ModelStat[] {
+  const map = new Map<string, number>();
+  for (const u of units) {
+    if (!predicate(u)) continue;
+    const key = u.modelType?.trim() || '—';
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([modelName, count]) => ({ modelName, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+// ─── Create confirm modal ─────────────────────────────────────────────────────
+
+interface CreateConfirmModalProps {
+  open: boolean;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function CreateConfirmModal({ open, isPending, onConfirm, onClose }: CreateConfirmModalProps) {
+  const { t } = useTranslation(['blockReappraisal', 'common']);
+  return (
+    <Modal isOpen={open} onClose={onClose} title={t('detail.createModal.title')} size="sm">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-700">{t('detail.createModal.body')}</p>
+        <div className="flex justify-end gap-2 pt-2 border-t border-gray-100">
+          <Button variant="outline" size="sm" onClick={onClose} disabled={isPending}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button variant="primary" size="sm" onClick={onConfirm} isLoading={isPending}>
+            {t('common:actions.confirm')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ─── Create success modal ─────────────────────────────────────────────────────
+
+interface CreateSuccessModalProps {
+  open: boolean;
+  result: BlockReappraisalCreateResult;
+  onClose: () => void;
+}
+
+function CreateSuccessModal({ open, result, onClose }: CreateSuccessModalProps) {
+  const { t } = useTranslation(['blockReappraisal', 'common']);
+  return (
+    <Modal isOpen={open} onClose={onClose} title={t('detail.successModal.title')} size="sm">
+      <div className="space-y-4">
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="size-12 rounded-full bg-green-50 flex items-center justify-center">
+            <Icon style="solid" name="check" className="size-5 text-green-600" />
+          </div>
+          <div className="text-center">
+            <p className="text-sm font-semibold text-gray-800">
+              {t('detail.successModal.heading')}
+            </p>
+            {result.requestNumber && (
+              <p className="text-xs text-gray-500 mt-1">
+                {t('detail.successModal.requestNumber')}{' '}
+                <strong className="text-gray-800">{result.requestNumber}</strong>
+              </p>
+            )}
+            <p className="text-xs text-gray-500">
+              {t('detail.successModal.groupNumber')}{' '}
+              <strong className="text-gray-800">{result.groupNumber}</strong>
+            </p>
+          </div>
+        </div>
+
+        {result.skipped && (
+          <div className="rounded-md bg-amber-50 border border-amber-200 px-3 py-2.5">
+            <p className="text-xs font-medium text-amber-800">
+              {t('detail.successModal.alreadyInProgress')}
+            </p>
+            {result.skipReason && (
+              <p className="text-xs text-amber-700 mt-0.5">{result.skipReason}</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end pt-2 border-t border-gray-100">
+          <Button variant="primary" size="sm" onClick={onClose}>
+            {t('common:actions.close')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ─── Opt-out confirm modal ────────────────────────────────────────────────────
+
+interface OptOutConfirmModalProps {
+  open: boolean;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function OptOutConfirmModal({ open, isPending, onConfirm, onClose }: OptOutConfirmModalProps) {
+  const { t } = useTranslation(['blockReappraisal', 'common']);
+  return (
+    <Modal isOpen={open} onClose={onClose} title={t('detail.optOutModal.title')} size="sm">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-700">{t('detail.optOutModal.body')}</p>
+        <div className="flex justify-end gap-2 pt-2 border-t border-gray-100">
+          <Button variant="outline" size="sm" onClick={onClose} disabled={isPending}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button variant="danger" size="sm" onClick={onConfirm} isLoading={isPending}>
+            {t('detail.optOutModal.confirm')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ─── Field display pair ───────────────────────────────────────────────────────
+
+function Field({ label, value }: { label: string; value?: string | number | null }) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-400">{label}</dt>
+      <dd className="text-xs font-medium text-gray-800 mt-0.5">{value ?? '-'}</dd>
+    </div>
+  );
+}
+
+// ─── Read-only Condo units table ──────────────────────────────────────────────
+
+function CondoUnitsTable({ units }: { units: BlockReappraisalUnitDetail[] }) {
+  const { t } = useTranslation('blockReappraisal');
+  return (
+    <table className="w-full min-w-max text-xs">
+      <thead className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
+        <tr>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.floor')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.towerName')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.regNumber')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.roomNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.modelType')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.usableArea')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.sellingPrice')}
+          </th>
+          <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.isSold')}
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-100">
+        {units.map(u => (
+          <tr key={u.sequenceNumber} className="hover:bg-gray-50">
+            <td className="py-2 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
+            <td className="py-2 px-3 text-gray-700">{u.floor ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.towerName ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.condoRegistrationNumber ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.roomNumber ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.modelType ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+              {formatNumber(u.usableArea)}
+            </td>
+            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+              {formatNumber(u.sellingPrice)}
+            </td>
+            <td className="py-2 px-3 text-center">
+              {u.isSold ? (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-50 text-red-700 border border-red-200">
+                  {t('units.sold')}
+                </span>
+              ) : (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 text-green-700 border border-green-200">
+                  {t('units.available')}
+                </span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ─── Read-only Land & Building units table ────────────────────────────────────
+
+function LandBuildingUnitsTable({ units }: { units: BlockReappraisalUnitDetail[] }) {
+  const { t } = useTranslation('blockReappraisal');
+  return (
+    <table className="w-full min-w-max text-xs">
+      <thead className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
+        <tr>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.plotNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.houseNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.modelType')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.numFloors')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.landArea')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.usableArea')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.sellingPrice')}
+          </th>
+          <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('units.cols.isSold')}
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-100">
+        {units.map(u => (
+          <tr key={u.sequenceNumber} className="hover:bg-gray-50">
+            <td className="py-2 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
+            <td className="py-2 px-3 text-gray-700">{u.plotNumber ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.houseNumber ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.modelType ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700">{u.numberOfFloors ?? '-'}</td>
+            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+              {formatNumber(u.landArea)}
+            </td>
+            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+              {formatNumber(u.usableArea)}
+            </td>
+            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+              {formatNumber(u.sellingPrice)}
+            </td>
+            <td className="py-2 px-3 text-center">
+              {u.isSold ? (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-50 text-red-700 border border-red-200">
+                  {t('units.sold')}
+                </span>
+              ) : (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 text-green-700 border border-green-200">
+                  {t('units.available')}
+                </span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+function BlockReappraisalDetailPage() {
+  const { collateralMasterId } = useParams<{ collateralMasterId: string }>();
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation(['blockReappraisal', 'common']);
+
+  const {
+    data: detail,
+    isLoading,
+    isError,
+    error,
+  } = useBlockReappraisalDetail(collateralMasterId ?? '');
+
+  const createMutation = useCreateBlockReappraisal();
+  const optOutMutation = useMarkBlockReappraisalNotRequired();
+
+  // Modal states
+  const [createConfirmOpen, setCreateConfirmOpen] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
+  const [successResult, setSuccessResult] = useState<BlockReappraisalCreateResult | null>(null);
+  const [optOutConfirmOpen, setOptOutConfirmOpen] = useState(false);
+
+  // Overview chart stats derived from structure units
+  const units = detail?.structure.units ?? [];
+  const soldStats = useMemo(() => groupByModel(units, u => u.isSold), [units]);
+  const availableStats = useMemo(() => groupByModel(units, u => !u.isSold), [units]);
+
+  const handleCreateConfirm = () => {
+    if (!collateralMasterId) return;
+    createMutation.mutate(collateralMasterId, {
+      onSuccess: result => {
+        setCreateConfirmOpen(false);
+        setSuccessResult(result);
+        setSuccessModalOpen(true);
+      },
+      onError: () => {
+        toast.error(t('error.createFailed'));
+      },
+    });
+  };
+
+  const handleOptOutConfirm = () => {
+    if (!collateralMasterId) return;
+    optOutMutation.mutate(collateralMasterId, {
+      onSuccess: () => {
+        toast.success(t('success.optOut'));
+        navigate('/standalone/block-reappraisal');
+      },
+      onError: () => {
+        toast.error(t('error.optOutFailed'));
+      },
+    });
+  };
+
+  // ── Loading skeleton ──
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <div className="h-6 w-48 bg-gray-100 rounded animate-pulse" />
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-8 bg-gray-100 rounded animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error / not found ──
+  if (isError || !detail) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3">
+        <div className="size-12 rounded-full bg-red-50 flex items-center justify-center">
+          <Icon style="solid" name="triangle-exclamation" className="size-5 text-red-500" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-medium text-gray-800">
+            {isError ? t('detail.error.loadFailed') : t('detail.error.notFound')}
+          </p>
+          <p className="text-xs text-gray-400 mt-0.5">{(error as Error)?.message}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => navigate('/standalone/block-reappraisal')}>
+          {t('detail.backToList')}
+        </Button>
+      </div>
+    );
+  }
+
+  const isCondo = detail.projectType === 'Condo';
+
+  return (
+    <div className="flex flex-col h-full min-h-0 min-w-0 gap-4">
+      {/* ── Page header ── */}
+      <div className="shrink-0 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/standalone/block-reappraisal')}
+            className="flex items-center justify-center size-7 rounded-md border border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
+          >
+            <Icon style="solid" name="arrow-left" className="size-3.5" />
+          </button>
+          <div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-sm font-semibold text-gray-900">
+                {detail.projectName ?? t('detail.unnamedProject')}
+              </h2>
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium ${
+                  isCondo
+                    ? 'bg-blue-50 text-blue-700 border border-blue-100'
+                    : 'bg-amber-50 text-amber-700 border border-amber-100'
+                }`}
+              >
+                {isCondo ? t('projectType.condo') : t('projectType.landAndBuilding')}
+              </span>
+            </div>
+            {detail.oldAppraisalNumber && (
+              <p className="text-xs text-gray-500 mt-0.5">
+                {t('detail.oldAppraisalLabel')} {detail.oldAppraisalNumber}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOptOutConfirmOpen(true)}
+          >
+            {t('actions.notRequired')}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setCreateConfirmOpen(true)}
+            leftIcon={<Icon style="solid" name="plus" className="size-3" />}
+          >
+            {t('actions.createRequest')}
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Summary card ── */}
+      <section className="shrink-0 bg-white rounded-lg border border-gray-200 p-4">
+        <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4">
+          <Field
+            label={t('columns.lastAppraisedDate')}
+            value={formatLocaleDate(detail.lastAppraisedDate, i18n.language)}
+          />
+          <Field
+            label={t('detail.fields.dueDate')}
+            value={formatLocaleDate(detail.dueDate, i18n.language)}
+          />
+          <Field
+            label={t('columns.projectSellingPrice')}
+            value={formatNumber(detail.projectSellingPrice)}
+          />
+          <Field
+            label={t('columns.remainingTotalUnit')}
+            value={`${detail.remainingUnits} / ${detail.totalUnits}`}
+          />
+        </dl>
+      </section>
+
+      {/* ── Sold vs Available overview chart ── */}
+      <section className="shrink-0 bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-xs font-semibold text-gray-700 mb-4">{t('detail.overview.title')}</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-center px-2">
+          <ModelBreakdown
+            heading={t('detail.overview.sold')}
+            stats={soldStats}
+            emptyLabel={t('detail.overview.noSold')}
+            unitSuffix={t('detail.overview.unitSuffix')}
+          />
+          <div className="flex justify-center">
+            <SoldDonut
+              sold={detail.soldUnits}
+              total={detail.totalUnits}
+              soldLabel={t('detail.overview.donutSoldLabel')}
+            />
+          </div>
+          <ModelBreakdown
+            heading={t('detail.overview.available')}
+            stats={availableStats}
+            emptyLabel={t('detail.overview.noAvailable')}
+            unitSuffix={t('detail.overview.unitSuffix')}
+          />
+        </div>
+      </section>
+
+      {/* ── Units table (read-only) ── */}
+      <section className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
+        <div className="shrink-0 px-4 py-3 border-b border-gray-100 flex items-center justify-between">
+          <h3 className="text-xs font-semibold text-gray-700">{t('detail.units.title')}</h3>
+          <span className="text-xs text-gray-400 tabular-nums">
+            {detail.structure.units.length} {t('detail.units.count')}
+          </span>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-auto">
+          {detail.structure.units.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-32 gap-2">
+              <Icon style="regular" name="folder-open" className="size-8 text-gray-300" />
+              <p className="text-xs text-gray-400">{t('detail.units.empty')}</p>
+            </div>
+          ) : isLoading ? (
+            <table className="w-full text-xs">
+              <tbody>
+                <TableRowSkeleton columns={Array(9).fill({ width: 'w-16' })} rows={6} />
+              </tbody>
+            </table>
+          ) : isCondo ? (
+            <CondoUnitsTable units={detail.structure.units} />
+          ) : (
+            <LandBuildingUnitsTable units={detail.structure.units} />
+          )}
+        </div>
+      </section>
+
+      {/* ── Modals ── */}
+      <CreateConfirmModal
+        open={createConfirmOpen}
+        isPending={createMutation.isPending}
+        onConfirm={handleCreateConfirm}
+        onClose={() => setCreateConfirmOpen(false)}
+      />
+
+      {successResult && (
+        <CreateSuccessModal
+          open={successModalOpen}
+          result={successResult}
+          onClose={() => {
+            setSuccessModalOpen(false);
+            navigate('/standalone/block-reappraisal');
+          }}
+        />
+      )}
+
+      <OptOutConfirmModal
+        open={optOutConfirmOpen}
+        isPending={optOutMutation.isPending}
+        onConfirm={handleOptOutConfirm}
+        onClose={() => setOptOutConfirmOpen(false)}
+      />
+    </div>
+  );
+}
+
+export default BlockReappraisalDetailPage;

--- a/src/features/blockReappraisal/pages/BlockReappraisalListPage.tsx
+++ b/src/features/blockReappraisal/pages/BlockReappraisalListPage.tsx
@@ -1,0 +1,269 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import Icon from '@/shared/components/Icon';
+import Pagination from '@/shared/components/Pagination';
+import { TableRowSkeleton } from '@/shared/components/Skeleton';
+import { formatLocaleDate } from '@/shared/utils/dateUtils';
+import { useBlockReappraisalDueList } from '../api/blockReappraisal';
+import { BlockReappraisalFilterDialog } from '../components/BlockReappraisalFilterDialog';
+import type { BlockReappraisalFilterValues, BlockReappraisalListParams } from '../types';
+
+function formatNumber(n?: number | null): string {
+  if (n == null) return '-';
+  return n.toLocaleString();
+}
+
+function RemainingDayBadge({ days }: { days: number }) {
+  let cls = 'bg-green-50 text-green-700 border-green-200';
+  if (days <= 0) {
+    cls = 'bg-red-50 text-red-700 border-red-200';
+  } else if (days <= 30) {
+    cls = 'bg-amber-50 text-amber-700 border-amber-200';
+  }
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${cls}`}
+    >
+      {days <= 0 ? 'Overdue' : `${days}d`}
+    </span>
+  );
+}
+
+function BlockReappraisalListPage() {
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation(['blockReappraisal', 'common']);
+
+  const [pageNumber, setPageNumber] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [filterDialogOpen, setFilterDialogOpen] = useState(false);
+  const [filters, setFilters] = useState<BlockReappraisalFilterValues>({});
+
+  const queryParams: BlockReappraisalListParams = {
+    pageNumber,
+    pageSize,
+    ...filters,
+  };
+
+  const { data, isLoading, isError, error } = useBlockReappraisalDueList(queryParams);
+
+  const items = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  const activeFilterChips = Object.entries(filters).filter(
+    ([, v]) => v != null && v !== '',
+  ) as [keyof BlockReappraisalFilterValues, string][];
+
+  const removeFilter = (key: keyof BlockReappraisalFilterValues) => {
+    setFilters(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setPageNumber(0);
+  };
+
+  const handleApplyFilters = (v: BlockReappraisalFilterValues) => {
+    setFilters(v);
+    setPageNumber(0);
+  };
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3">
+        <div className="size-12 rounded-full bg-red-50 flex items-center justify-center">
+          <Icon style="solid" name="triangle-exclamation" className="size-5 text-red-500" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm font-medium text-gray-800">{t('error.loadFailed')}</p>
+          <p className="text-xs text-gray-400 mt-0.5">{(error as Error)?.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0 min-w-0">
+      {/* ── Page header ── */}
+      <div className="shrink-0 mb-3 flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">{t('page.list.title')}</h2>
+          <p className="text-xs text-gray-500 mt-0.5">{t('page.list.description')}</p>
+        </div>
+
+        {/* Filter button */}
+        <button
+          onClick={() => setFilterDialogOpen(true)}
+          className={`flex items-center gap-1.5 px-3 py-2 text-sm border rounded-lg transition-all ${
+            activeFilterChips.length > 0
+              ? 'border-primary/30 bg-primary/5 text-primary hover:bg-primary/10'
+              : 'border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700'
+          }`}
+        >
+          <Icon style="solid" name="sliders" className="size-3.5" />
+          {t('filter.button')}
+          {activeFilterChips.length > 0 && (
+            <span className="inline-flex items-center justify-center size-4 rounded-full bg-primary text-white text-[10px] font-semibold">
+              {activeFilterChips.length}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* ── Active filter chips ── */}
+      {activeFilterChips.length > 0 && (
+        <div className="shrink-0 flex items-center gap-1.5 flex-wrap mb-3">
+          {activeFilterChips.map(([key, value]) => (
+            <span
+              key={key}
+              className="inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-0.5 text-xs bg-primary/8 text-primary border border-primary/15 rounded-full font-medium"
+            >
+              <span className="text-primary/60">{t(`filter.chips.${key}`)}:</span>
+              {value}
+              <button onClick={() => removeFilter(key)} className="hover:text-primary/60 ml-0.5">
+                <Icon style="solid" name="xmark" className="size-2.5" />
+              </button>
+            </span>
+          ))}
+          <button
+            onClick={() => {
+              setFilters({});
+              setPageNumber(0);
+            }}
+            className="text-xs text-gray-400 hover:text-gray-600 hover:underline underline-offset-2"
+          >
+            {t('common:actions.clearAll')}
+          </button>
+        </div>
+      )}
+
+      {/* ── Filter dialog ── */}
+      <BlockReappraisalFilterDialog
+        open={filterDialogOpen}
+        initialValues={filters}
+        onApply={handleApplyFilters}
+        onClose={() => setFilterDialogOpen(false)}
+      />
+
+      {/* ── Table ── */}
+      <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
+        <div className="flex-1 min-h-0 overflow-auto">
+          <table className="w-full min-w-max text-sm">
+            <thead className="sticky top-0 z-10">
+              <tr className="bg-gray-50 border-b border-gray-200">
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.oldAppraisalNumber')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.projectName')}
+                </th>
+                <th className="px-4 py-2.5 text-right text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.projectSellingPrice')}
+                </th>
+                <th className="px-4 py-2.5 text-center text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.remainingTotalUnit')}
+                </th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.lastAppraisedDate')}
+                </th>
+                <th className="px-4 py-2.5 text-center text-xs font-medium text-gray-500 whitespace-nowrap">
+                  {t('columns.remainingDay')}
+                </th>
+                <th className="px-4 py-2.5 w-8 bg-gray-50" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {isLoading ? (
+                <TableRowSkeleton columns={Array(6).fill({ width: 'w-24' })} rows={8} />
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="py-24">
+                    <div className="flex flex-col items-center gap-4">
+                      <div className="size-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center">
+                        <Icon style="regular" name="inbox" className="size-7 text-gray-300" />
+                      </div>
+                      <div className="text-center">
+                        <p className="text-sm font-semibold text-gray-700">
+                          {activeFilterChips.length > 0
+                            ? t('empty.noMatching')
+                            : t('empty.noItems')}
+                        </p>
+                        <p className="text-xs text-gray-400 mt-1">
+                          {activeFilterChips.length > 0
+                            ? t('empty.tryAdjusting')
+                            : t('empty.noneAtThisTime')}
+                        </p>
+                      </div>
+                      {activeFilterChips.length > 0 && (
+                        <button
+                          onClick={() => {
+                            setFilters({});
+                            setPageNumber(0);
+                          }}
+                          className="text-xs text-primary hover:underline font-medium"
+                        >
+                          {t('empty.clearFilters')}
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                items.map(item => (
+                  <tr
+                    key={item.collateralMasterId}
+                    onClick={() =>
+                      navigate(`/standalone/block-reappraisal/${item.collateralMasterId}`)
+                    }
+                    className="group cursor-pointer transition-colors hover:bg-gray-50"
+                  >
+                    <td className="px-3 py-2 text-xs text-gray-900 font-medium whitespace-nowrap">
+                      {item.oldAppraisalNumber ?? '-'}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-600">
+                      {item.projectName ?? '-'}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-600 tabular-nums text-right whitespace-nowrap">
+                      {formatNumber(item.projectSellingPrice)}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-600 tabular-nums text-center whitespace-nowrap">
+                      {item.remainingUnits} / {item.totalUnits}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-600 whitespace-nowrap">
+                      {formatLocaleDate(item.lastAppraisedDate, i18n.language)}
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      <RemainingDayBadge days={item.remainingDay} />
+                    </td>
+                    <td className="px-3 py-2 w-8">
+                      <Icon
+                        style="solid"
+                        name="arrow-right"
+                        className="size-3 text-gray-200 group-hover:text-primary/40 transition-colors"
+                      />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <Pagination
+          currentPage={pageNumber}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={p => setPageNumber(p)}
+          onPageSizeChange={size => {
+            setPageSize(size);
+            setPageNumber(0);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default BlockReappraisalListPage;

--- a/src/features/blockReappraisal/types.ts
+++ b/src/features/blockReappraisal/types.ts
@@ -1,0 +1,103 @@
+// ─── List ──────────────────────────────────────────────────────────────────────
+
+export interface BlockReappraisalDueListItem {
+  collateralMasterId: string;
+  oldAppraisalNumber: string | null;
+  projectName: string | null;
+  projectType: 'Condo' | 'LandAndBuilding';
+  projectSellingPrice: number | null;
+  totalUnits: number;
+  remainingUnits: number;
+  lastAppraisedDate: string | null;
+  dueDate: string;
+  remainingDay: number;
+}
+
+// ─── List query params ─────────────────────────────────────────────────────────
+
+export interface BlockReappraisalListParams {
+  pageNumber?: number;
+  pageSize?: number;
+  projectName?: string;
+  oldAppraisalNumber?: string;
+}
+
+export type BlockReappraisalFilterValues = Omit<
+  BlockReappraisalListParams,
+  'pageNumber' | 'pageSize'
+>;
+
+// ─── Detail ────────────────────────────────────────────────────────────────────
+
+export interface BlockReappraisalUnitDetail {
+  sequenceNumber: number;
+  isSold: boolean;
+  modelType: string | null;
+  usableArea: number | null;
+  sellingPrice: number | null;
+  /** Condo only */
+  floor: number | null;
+  /** Condo only */
+  towerName: string | null;
+  /** Condo only */
+  condoRegistrationNumber: string | null;
+  /** Condo only */
+  roomNumber: string | null;
+  /** LandAndBuilding only */
+  plotNumber: string | null;
+  /** LandAndBuilding only */
+  houseNumber: string | null;
+  /** LandAndBuilding only */
+  numberOfFloors: number | null;
+  /** LandAndBuilding only */
+  landArea: number | null;
+}
+
+export interface BlockReappraisalStructure {
+  projectType: 'Condo' | 'LandAndBuilding';
+  projectName: string | null;
+  developer: string | null;
+  address: string | null;
+  province: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  totalUnits: number;
+  remainingUnits: number;
+  projectSellingPrice: number | null;
+  units: BlockReappraisalUnitDetail[];
+  models: Array<{ modelName: string }>;
+  towers: Array<{ towerName: string }>;
+}
+
+export interface BlockReappraisalDetailResult {
+  collateralMasterId: string;
+  oldAppraisalNumber: string | null;
+  projectName: string | null;
+  projectType: 'Condo' | 'LandAndBuilding';
+  projectSellingPrice: number | null;
+  totalUnits: number;
+  remainingUnits: number;
+  soldUnits: number;
+  lastAppraisedDate: string | null;
+  dueDate: string;
+  structure: BlockReappraisalStructure;
+}
+
+// ─── Create result ─────────────────────────────────────────────────────────────
+
+export interface BlockReappraisalCreateResult {
+  createdRequestId: string | null;
+  requestNumber: string | null;
+  groupNumber: string;
+  skipped: boolean;
+  skipReason: string | null;
+}
+
+// ─── Pagination wrapper (matches PaginatedResult<T> from the backend) ──────────
+
+export interface PaginatedResult<T> {
+  items: T[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}

--- a/src/features/blockUnitMaintenance/components/ModelBreakdown.tsx
+++ b/src/features/blockUnitMaintenance/components/ModelBreakdown.tsx
@@ -1,0 +1,50 @@
+export interface ModelStat {
+  modelName: string;
+  count: number;
+}
+
+interface ModelBreakdownProps {
+  heading: string;
+  stats: ModelStat[];
+  emptyLabel: string;
+  /** Pre-translated suffix shown after each count (e.g. "units"). */
+  unitSuffix: string;
+}
+
+/**
+ * Breakdown list of units grouped by model name (sold or available).
+ * Extracted from BlockUnitMaintenanceDetailPage for reuse in BlockReappraisalDetailPage.
+ * Labels are passed in (already translated) so the component stays namespace-agnostic.
+ */
+export const ModelBreakdown = ({
+  heading,
+  stats,
+  emptyLabel,
+  unitSuffix,
+}: ModelBreakdownProps) => {
+  return (
+    <div>
+      <h4 className="text-sm font-semibold text-gray-900 mb-2">{heading}</h4>
+      <div className="border-t border-gray-200">
+        {stats.length === 0 ? (
+          <div className="py-3 text-xs text-gray-400">{emptyLabel}</div>
+        ) : (
+          stats.map(s => (
+            <div
+              key={s.modelName}
+              className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0"
+            >
+              <span className="text-sm text-gray-700">{s.modelName}</span>
+              <div className="flex items-center gap-2 text-sm tabular-nums">
+                <span className="text-gray-700 font-medium">{s.count.toLocaleString('th-TH')}</span>
+                <span className="text-xs text-gray-400 w-8 text-right">
+                  {unitSuffix}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/features/blockUnitMaintenance/components/SoldDonut.tsx
+++ b/src/features/blockUnitMaintenance/components/SoldDonut.tsx
@@ -1,0 +1,64 @@
+interface SoldDonutProps {
+  sold: number;
+  total: number;
+  /** Pre-translated "Sold" caption shown under the percentage. */
+  soldLabel: string;
+}
+
+/**
+ * Gauge-style donut showing the sold-unit percentage.
+ * Extracted from BlockUnitMaintenanceDetailPage so it can be reused
+ * in BlockReappraisalDetailPage without duplication. Labels are passed in
+ * (already translated) so the component stays namespace-agnostic.
+ */
+export const SoldDonut = ({ sold, total, soldLabel }: SoldDonutProps) => {
+  const pct = total > 0 ? (sold / total) * 100 : 0;
+  const size = 180;
+  const stroke = 18;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const arcFraction = 0.75;
+  const visibleLen = circumference * arcFraction;
+  const filledLen = (pct / 100) * visibleLen;
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="-rotate-[135deg]">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="#e5e7eb"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${visibleLen} ${circumference}`}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="url(#donutGradBUR)"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${filledLen} ${circumference}`}
+        />
+        <defs>
+          <linearGradient id="donutGradBUR" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#a78bfa" />
+            <stop offset="100%" stopColor="#6366f1" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+        <span className="text-xs text-gray-500">{soldLabel}</span>
+        <span className="text-2xl font-semibold text-gray-900 tabular-nums mt-0.5">
+          {pct.toFixed(1)}%
+        </span>
+        <span className="text-xs text-gray-500 tabular-nums mt-0.5">
+          {sold} / {total}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
+++ b/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
@@ -11,6 +11,9 @@ import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { useGetProjectUnits, useUpdateUnitSaleStatus } from '../api/blockUnitMaintenance';
 import { UnitRow } from '../components/UnitRow';
+import { SoldDonut } from '../components/SoldDonut';
+import { ModelBreakdown } from '../components/ModelBreakdown';
+import type { ModelStat } from '../components/ModelBreakdown';
 import { isCondo } from '@/features/blockProject/types';
 import type { ProjectType, ProjectUnitDetail, PurchaseMethod, UnitEditState } from '../types';
 
@@ -22,105 +25,6 @@ function projectTypePillClass(code: ProjectType): string {
   if (code === 'U') return 'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200';
   return 'bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200';
 }
-
-// ─── Donut gauge ──────────────────────────────────────────────────────────────
-
-const SoldDonut = ({ sold, total }: { sold: number; total: number }) => {
-  const { t } = useTranslation('blockUnitMaintenance');
-  const pct = total > 0 ? (sold / total) * 100 : 0;
-  const size = 180;
-  const stroke = 18;
-  const radius = (size - stroke) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const arcFraction = 0.75;
-  const visibleLen = circumference * arcFraction;
-  const filledLen = (pct / 100) * visibleLen;
-  return (
-    <div className="relative" style={{ width: size, height: size }}>
-      <svg width={size} height={size} className="-rotate-[135deg]">
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke="#e5e7eb"
-          strokeWidth={stroke}
-          strokeLinecap="round"
-          strokeDasharray={`${visibleLen} ${circumference}`}
-        />
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke="url(#donutGrad)"
-          strokeWidth={stroke}
-          strokeLinecap="round"
-          strokeDasharray={`${filledLen} ${circumference}`}
-        />
-        <defs>
-          <linearGradient id="donutGrad" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor="#a78bfa" />
-            <stop offset="100%" stopColor="#6366f1" />
-          </linearGradient>
-        </defs>
-      </svg>
-      <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-        <span className="text-xs text-gray-500">{t('detail.donutSoldLabel')}</span>
-        <span className="text-2xl font-semibold text-gray-900 tabular-nums mt-0.5">
-          {pct.toFixed(1)}%
-        </span>
-        <span className="text-xs text-gray-500 tabular-nums mt-0.5">
-          {sold} / {total}
-        </span>
-      </div>
-    </div>
-  );
-};
-
-// ─── Model breakdown panel ───────────────────────────────────────────────────
-
-interface ModelStat {
-  modelName: string;
-  count: number;
-}
-
-const ModelBreakdown = ({
-  heading,
-  stats,
-  emptyLabel,
-}: {
-  heading: string;
-  stats: ModelStat[];
-  emptyLabel: string;
-}) => {
-  const { t } = useTranslation('blockUnitMaintenance');
-  return (
-    <div>
-      <h4 className="text-sm font-semibold text-gray-900 mb-2">{heading}</h4>
-      <div className="border-t border-gray-200">
-        {stats.length === 0 ? (
-          <div className="py-3 text-xs text-gray-400">{emptyLabel}</div>
-        ) : (
-          stats.map(s => (
-            <div
-              key={s.modelName}
-              className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0"
-            >
-              <span className="text-sm text-gray-700">{s.modelName}</span>
-              <div className="flex items-center gap-2 text-sm tabular-nums">
-                <span className="text-gray-700 font-medium">{s.count.toLocaleString('th-TH')}</span>
-                <span className="text-xs text-gray-400 w-8 text-right">
-                  {t('detail.unitSuffix')}
-                </span>
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-    </div>
-  );
-};
 
 // ─── Helper: filter + group ──────────────────────────────────────────────────
 
@@ -484,14 +388,16 @@ const BlockUnitMaintenanceDetailPage = () => {
           heading={t('detail.sold')}
           stats={soldStats}
           emptyLabel={t('detail.noSold')}
+          unitSuffix={t('detail.unitSuffix')}
         />
         <div className="flex justify-center">
-          <SoldDonut sold={soldCount} total={totalUnits} />
+          <SoldDonut sold={soldCount} total={totalUnits} soldLabel={t('detail.donutSoldLabel')} />
         </div>
         <ModelBreakdown
           heading={t('detail.available')}
           stats={availableStats}
           emptyLabel={t('detail.noAvailable')}
+          unitSuffix={t('detail.unitSuffix')}
         />
       </div>
 

--- a/src/i18n/__tests__/localeParity.test.ts
+++ b/src/i18n/__tests__/localeParity.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Guard rail: every locale namespace must expose an identical key set across
+ * en / th / zh, so the UI never falls back to a raw key or shows a blank label.
+ *
+ * - `en` is the source of truth.
+ * - `th` is production — every namespace MUST have a matching th file.
+ * - `zh` may legitimately fall back to English for a few namespaces that have
+ *   no zh file yet (registered as en-fallback in `src/i18n/index.ts`); those are
+ *   skipped here. When a zh file DOES exist, its keys must match en exactly.
+ */
+
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'locales');
+
+// Namespaces intentionally served from English in zh (no zh JSON file yet).
+const ZH_ENGLISH_FALLBACK = new Set([
+  'monitoring',
+  'historySearch',
+  'blockUnitMaintenance',
+  'feeAppointmentApproval',
+  'feeApprovalConfig',
+  'evaluationConfig',
+]);
+
+function flattenKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([k, v]) => {
+    const path = prefix ? `${prefix}.${k}` : k;
+    return v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? flattenKeys(v as Record<string, unknown>, path)
+      : [path];
+  });
+}
+
+function keySet(lang: string, ns: string): Set<string> {
+  const file = join(localesDir, lang, `${ns}.json`);
+  return new Set(flattenKeys(JSON.parse(readFileSync(file, 'utf-8'))));
+}
+
+const namespaces: string[] = readdirSync(join(localesDir, 'en'))
+  .filter((f: string) => f.endsWith('.json'))
+  .map((f: string) => f.replace(/\.json$/, ''));
+
+describe('i18n locale parity', () => {
+  it.each(namespaces)('th matches en for "%s"', (ns: string) => {
+    const en = keySet('en', ns);
+    expect(existsSync(join(localesDir, 'th', `${ns}.json`))).toBe(true);
+    const th = keySet('th', ns);
+    expect({ missingInTh: [...en].filter(k => !th.has(k)), extraInTh: [...th].filter(k => !en.has(k)) }).toEqual({
+      missingInTh: [],
+      extraInTh: [],
+    });
+  });
+
+  it.each(namespaces.filter(ns => !ZH_ENGLISH_FALLBACK.has(ns)))('zh matches en for "%s"', ns => {
+    const zhPath = join(localesDir, 'zh', `${ns}.json`);
+    // A non-fallback namespace must ship a zh file.
+    expect(existsSync(zhPath)).toBe(true);
+    const en = keySet('en', ns);
+    const zh = keySet('zh', ns);
+    expect({ missingInZh: [...en].filter(k => !zh.has(k)), extraInZh: [...zh].filter(k => !en.has(k)) }).toEqual({
+      missingInZh: [],
+      extraInZh: [],
+    });
+  });
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -33,6 +33,7 @@ import enFeeApprovalConfig from './locales/en/feeApprovalConfig.json';
 import enEvaluationConfig from './locales/en/evaluationConfig.json';
 import enBlockProject from './locales/en/blockProject.json';
 import enWorkflowBuilder from './locales/en/workflowBuilder.json';
+import enBlockReappraisal from './locales/en/blockReappraisal.json';
 
 import thCommon from './locales/th/common.json';
 import thNav from './locales/th/nav.json';
@@ -64,6 +65,7 @@ import thFeeApprovalConfig from './locales/th/feeApprovalConfig.json';
 import thEvaluationConfig from './locales/th/evaluationConfig.json';
 import thBlockProject from './locales/th/blockProject.json';
 import thWorkflowBuilder from './locales/th/workflowBuilder.json';
+import thBlockReappraisal from './locales/th/blockReappraisal.json';
 
 import zhCommon from './locales/zh/common.json';
 import zhNav from './locales/zh/nav.json';
@@ -89,6 +91,7 @@ import zhPricingAnalysis from './locales/zh/pricingAnalysis.json';
 import zhAppraisal from './locales/zh/appraisal.json';
 import zhBlockProject from './locales/zh/blockProject.json';
 import zhWorkflowBuilder from './locales/zh/workflowBuilder.json';
+import zhBlockReappraisal from './locales/zh/blockReappraisal.json';
 
 export const defaultNS = 'common' as const;
 
@@ -124,6 +127,7 @@ export const resources = {
     evaluationConfig: enEvaluationConfig,
     blockProject: enBlockProject,
     workflowBuilder: enWorkflowBuilder,
+    blockReappraisal: enBlockReappraisal,
   },
   th: {
     common: thCommon,
@@ -156,6 +160,7 @@ export const resources = {
     evaluationConfig: thEvaluationConfig,
     blockProject: thBlockProject,
     workflowBuilder: thWorkflowBuilder,
+    blockReappraisal: thBlockReappraisal,
   },
   zh: {
     common: zhCommon,
@@ -185,9 +190,12 @@ export const resources = {
     userManagement: zhUserManagement,
     pricingAnalysis: zhPricingAnalysis,
     appraisal: zhAppraisal,
+    feeAppointmentApproval: enFeeAppointmentApproval,
+    feeApprovalConfig: enFeeApprovalConfig,
     evaluationConfig: enEvaluationConfig,
     blockProject: zhBlockProject,
     workflowBuilder: zhWorkflowBuilder,
+    blockReappraisal: zhBlockReappraisal,
   },
 } as const;
 

--- a/src/i18n/locales/en/blockProject.json
+++ b/src/i18n/locales/en/blockProject.json
@@ -238,6 +238,12 @@
       "numFloors": "No. of Floors",
       "landAreaSqWa": "Land Area (Sq.Wa)"
     },
+    "reappraisal": {
+      "title": "Update Units from Revised Excel (Re-match)",
+      "hint": "Upload an updated Excel to re-match seeded units. Rows present in the file stay unsold; rows missing are auto-marked sold. New rows are counted but not added.",
+      "normalUploadNote": "Use this upload to add new unit inventory only.",
+      "resultToast": "Re-match complete: {{matched}} unsold, {{autoSold}} auto-sold, {{added}} new (not added)"
+    },
     "aria": {
       "deleteUpload": "Delete upload"
     }
@@ -622,6 +628,12 @@
   },
   "errors": {
     "failedToLoadProject": "Failed to load project"
+  },
+  "projectTypePill": {
+    "placeholder": "Select project type"
+  },
+  "radioGroup": {
+    "specifyPlaceholder": "Please specify"
   },
   "partialDate": {
     "year": "Year",

--- a/src/i18n/locales/en/blockReappraisal.json
+++ b/src/i18n/locales/en/blockReappraisal.json
@@ -1,0 +1,115 @@
+{
+  "page": {
+    "list": {
+      "title": "Block Project Reappraisal",
+      "description": "Block and village projects due for reappraisal"
+    }
+  },
+  "projectType": {
+    "condo": "Condo",
+    "landAndBuilding": "Land & Building"
+  },
+  "columns": {
+    "oldAppraisalNumber": "Old Appraisal Report No.",
+    "projectName": "Project Name",
+    "projectSellingPrice": "Project Selling Price (Baht)",
+    "remainingTotalUnit": "Remaining / Total Unit",
+    "lastAppraisedDate": "Last Appraised Date",
+    "remainingDay": "Remaining Day"
+  },
+  "filter": {
+    "title": "Filter",
+    "button": "Filters",
+    "fields": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Old Appraisal Report No."
+    },
+    "placeholders": {
+      "projectName": "Enter project name",
+      "oldAppraisalNumber": "Enter report number"
+    },
+    "chips": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Report No."
+    }
+  },
+  "empty": {
+    "noMatching": "No matching projects",
+    "noItems": "No projects due",
+    "tryAdjusting": "Try adjusting your filters.",
+    "noneAtThisTime": "No block projects are due for reappraisal at this time.",
+    "clearFilters": "Clear filters"
+  },
+  "error": {
+    "loadFailed": "Failed to load block reappraisal list",
+    "createFailed": "Failed to create appraisal request",
+    "optOutFailed": "Failed to mark as not required"
+  },
+  "success": {
+    "optOut": "Project marked as reappraisal not required"
+  },
+  "actions": {
+    "createRequest": "Create New Appraisal Request",
+    "notRequired": "Reappraisal Not Required"
+  },
+  "detail": {
+    "backToList": "Back to list",
+    "unnamedProject": "Unnamed Project",
+    "oldAppraisalLabel": "Old Appraisal No.:",
+    "fields": {
+      "dueDate": "Due Date"
+    },
+    "overview": {
+      "title": "Unit Overview",
+      "sold": "Sold",
+      "available": "Available",
+      "noSold": "No units sold yet",
+      "noAvailable": "All units sold",
+      "donutSoldLabel": "Sold Unit",
+      "unitSuffix": "Unit"
+    },
+    "units": {
+      "title": "Unit List",
+      "count": "units",
+      "empty": "No units found for this project"
+    },
+    "error": {
+      "loadFailed": "Failed to load project details",
+      "notFound": "Project not found"
+    },
+    "createModal": {
+      "title": "Create Appraisal Request",
+      "body": "Create a new appraisal request for this block project? The sold/unsold status of units will be decided later via Excel re-upload inside the reappraisal application."
+    },
+    "successModal": {
+      "title": "Appraisal Request Created",
+      "heading": "Request Created",
+      "requestNumber": "Request Number:",
+      "groupNumber": "Group Number:",
+      "alreadyInProgress": "A request for this project is already in progress."
+    },
+    "optOutModal": {
+      "title": "Reappraisal Not Required",
+      "body": "Mark this project as not requiring reappraisal? It will be removed from the due list.",
+      "confirm": "Confirm"
+    }
+  },
+  "units": {
+    "sold": "Sold",
+    "available": "Available",
+    "cols": {
+      "floor": "Floor",
+      "towerName": "Tower Name",
+      "regNumber": "Reg. Number",
+      "roomNo": "Room No",
+      "modelType": "Model Type",
+      "usableArea": "Usable Area (sq.m.)",
+      "sellingPrice": "Selling Price (Baht)",
+      "plotNo": "Plot No",
+      "houseNo": "House No",
+      "numFloors": "No. of Floors",
+      "landArea": "Land Area (Sq.Wa)",
+      "isSold": "Status"
+    }
+  }
+}

--- a/src/i18n/locales/th/blockProject.json
+++ b/src/i18n/locales/th/blockProject.json
@@ -238,6 +238,12 @@
       "numFloors": "จำนวนชั้น",
       "landAreaSqWa": "เนื้อที่ดิน (ตร.วา)"
     },
+    "reappraisal": {
+      "title": "อัปเดตยูนิตจาก Excel ที่แก้ไข (Re-match)",
+      "hint": "อัปโหลด Excel ที่อัปเดตเพื่อ re-match ยูนิตที่ seed ไว้ แถวที่มีในไฟล์จะคงสถานะยังไม่ขาย แถวที่ขาดหายจะถูกทำเครื่องหมายเป็นขายแล้วโดยอัตโนมัติ แถวใหม่จะถูกนับแต่ไม่ถูกเพิ่ม",
+      "normalUploadNote": "ใช้การอัปโหลดนี้เพื่อเพิ่มสินค้าคงคลังยูนิตใหม่เท่านั้น",
+      "resultToast": "Re-match เสร็จสิ้น: {{matched}} ยังไม่ขาย, {{autoSold}} ขายอัตโนมัติ, {{added}} ใหม่ (ไม่ถูกเพิ่ม)"
+    },
     "aria": {
       "deleteUpload": "ลบการอัปโหลด"
     }
@@ -622,6 +628,12 @@
   },
   "errors": {
     "failedToLoadProject": "โหลดข้อมูลโครงการไม่สำเร็จ"
+  },
+  "projectTypePill": {
+    "placeholder": "เลือกประเภทโครงการ"
+  },
+  "radioGroup": {
+    "specifyPlaceholder": "โปรดระบุ"
   },
   "partialDate": {
     "year": "ปี",

--- a/src/i18n/locales/th/blockReappraisal.json
+++ b/src/i18n/locales/th/blockReappraisal.json
@@ -1,0 +1,115 @@
+{
+  "page": {
+    "list": {
+      "title": "Block Project Reappraisal",
+      "description": "Block and village projects due for reappraisal"
+    }
+  },
+  "projectType": {
+    "condo": "Condo",
+    "landAndBuilding": "Land & Building"
+  },
+  "columns": {
+    "oldAppraisalNumber": "Old Appraisal Report No.",
+    "projectName": "Project Name",
+    "projectSellingPrice": "Project Selling Price (Baht)",
+    "remainingTotalUnit": "Remaining / Total Unit",
+    "lastAppraisedDate": "Last Appraised Date",
+    "remainingDay": "Remaining Day"
+  },
+  "filter": {
+    "title": "Filter",
+    "button": "Filters",
+    "fields": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Old Appraisal Report No."
+    },
+    "placeholders": {
+      "projectName": "Enter project name",
+      "oldAppraisalNumber": "Enter report number"
+    },
+    "chips": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Report No."
+    }
+  },
+  "empty": {
+    "noMatching": "No matching projects",
+    "noItems": "No projects due",
+    "tryAdjusting": "Try adjusting your filters.",
+    "noneAtThisTime": "No block projects are due for reappraisal at this time.",
+    "clearFilters": "Clear filters"
+  },
+  "error": {
+    "loadFailed": "Failed to load block reappraisal list",
+    "createFailed": "Failed to create appraisal request",
+    "optOutFailed": "Failed to mark as not required"
+  },
+  "success": {
+    "optOut": "Project marked as reappraisal not required"
+  },
+  "actions": {
+    "createRequest": "Create New Appraisal Request",
+    "notRequired": "Reappraisal Not Required"
+  },
+  "detail": {
+    "backToList": "Back to list",
+    "unnamedProject": "Unnamed Project",
+    "oldAppraisalLabel": "Old Appraisal No.:",
+    "fields": {
+      "dueDate": "Due Date"
+    },
+    "overview": {
+      "title": "Unit Overview",
+      "sold": "Sold",
+      "available": "Available",
+      "noSold": "No units sold yet",
+      "noAvailable": "All units sold",
+      "donutSoldLabel": "Sold Unit",
+      "unitSuffix": "Unit"
+    },
+    "units": {
+      "title": "Unit List",
+      "count": "units",
+      "empty": "No units found for this project"
+    },
+    "error": {
+      "loadFailed": "Failed to load project details",
+      "notFound": "Project not found"
+    },
+    "createModal": {
+      "title": "Create Appraisal Request",
+      "body": "Create a new appraisal request for this block project? The sold/unsold status of units will be decided later via Excel re-upload inside the reappraisal application."
+    },
+    "successModal": {
+      "title": "Appraisal Request Created",
+      "heading": "Request Created",
+      "requestNumber": "Request Number:",
+      "groupNumber": "Group Number:",
+      "alreadyInProgress": "A request for this project is already in progress."
+    },
+    "optOutModal": {
+      "title": "Reappraisal Not Required",
+      "body": "Mark this project as not requiring reappraisal? It will be removed from the due list.",
+      "confirm": "Confirm"
+    }
+  },
+  "units": {
+    "sold": "Sold",
+    "available": "Available",
+    "cols": {
+      "floor": "Floor",
+      "towerName": "Tower Name",
+      "regNumber": "Reg. Number",
+      "roomNo": "Room No",
+      "modelType": "Model Type",
+      "usableArea": "Usable Area (sq.m.)",
+      "sellingPrice": "Selling Price (Baht)",
+      "plotNo": "Plot No",
+      "houseNo": "House No",
+      "numFloors": "No. of Floors",
+      "landArea": "Land Area (Sq.Wa)",
+      "isSold": "Status"
+    }
+  }
+}

--- a/src/i18n/locales/zh/blockProject.json
+++ b/src/i18n/locales/zh/blockProject.json
@@ -238,6 +238,12 @@
       "numFloors": "No. of Floors",
       "landAreaSqWa": "Land Area (Sq.Wa)"
     },
+    "reappraisal": {
+      "title": "Update Units from Revised Excel (Re-match)",
+      "hint": "Upload an updated Excel to re-match seeded units. Rows present in the file stay unsold; rows missing are auto-marked sold. New rows are counted but not added.",
+      "normalUploadNote": "Use this upload to add new unit inventory only.",
+      "resultToast": "Re-match complete: {{matched}} unsold, {{autoSold}} auto-sold, {{added}} new (not added)"
+    },
     "aria": {
       "deleteUpload": "Delete upload"
     }
@@ -622,6 +628,12 @@
   },
   "errors": {
     "failedToLoadProject": "Failed to load project"
+  },
+  "projectTypePill": {
+    "placeholder": "Select project type"
+  },
+  "radioGroup": {
+    "specifyPlaceholder": "Please specify"
   },
   "partialDate": {
     "year": "Year",

--- a/src/i18n/locales/zh/blockReappraisal.json
+++ b/src/i18n/locales/zh/blockReappraisal.json
@@ -1,0 +1,115 @@
+{
+  "page": {
+    "list": {
+      "title": "Block Project Reappraisal",
+      "description": "Block and village projects due for reappraisal"
+    }
+  },
+  "projectType": {
+    "condo": "Condo",
+    "landAndBuilding": "Land & Building"
+  },
+  "columns": {
+    "oldAppraisalNumber": "Old Appraisal Report No.",
+    "projectName": "Project Name",
+    "projectSellingPrice": "Project Selling Price (Baht)",
+    "remainingTotalUnit": "Remaining / Total Unit",
+    "lastAppraisedDate": "Last Appraised Date",
+    "remainingDay": "Remaining Day"
+  },
+  "filter": {
+    "title": "Filter",
+    "button": "Filters",
+    "fields": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Old Appraisal Report No."
+    },
+    "placeholders": {
+      "projectName": "Enter project name",
+      "oldAppraisalNumber": "Enter report number"
+    },
+    "chips": {
+      "projectName": "Project Name",
+      "oldAppraisalNumber": "Report No."
+    }
+  },
+  "empty": {
+    "noMatching": "No matching projects",
+    "noItems": "No projects due",
+    "tryAdjusting": "Try adjusting your filters.",
+    "noneAtThisTime": "No block projects are due for reappraisal at this time.",
+    "clearFilters": "Clear filters"
+  },
+  "error": {
+    "loadFailed": "Failed to load block reappraisal list",
+    "createFailed": "Failed to create appraisal request",
+    "optOutFailed": "Failed to mark as not required"
+  },
+  "success": {
+    "optOut": "Project marked as reappraisal not required"
+  },
+  "actions": {
+    "createRequest": "Create New Appraisal Request",
+    "notRequired": "Reappraisal Not Required"
+  },
+  "detail": {
+    "backToList": "Back to list",
+    "unnamedProject": "Unnamed Project",
+    "oldAppraisalLabel": "Old Appraisal No.:",
+    "fields": {
+      "dueDate": "Due Date"
+    },
+    "overview": {
+      "title": "Unit Overview",
+      "sold": "Sold",
+      "available": "Available",
+      "noSold": "No units sold yet",
+      "noAvailable": "All units sold",
+      "donutSoldLabel": "Sold Unit",
+      "unitSuffix": "Unit"
+    },
+    "units": {
+      "title": "Unit List",
+      "count": "units",
+      "empty": "No units found for this project"
+    },
+    "error": {
+      "loadFailed": "Failed to load project details",
+      "notFound": "Project not found"
+    },
+    "createModal": {
+      "title": "Create Appraisal Request",
+      "body": "Create a new appraisal request for this block project? The sold/unsold status of units will be decided later via Excel re-upload inside the reappraisal application."
+    },
+    "successModal": {
+      "title": "Appraisal Request Created",
+      "heading": "Request Created",
+      "requestNumber": "Request Number:",
+      "groupNumber": "Group Number:",
+      "alreadyInProgress": "A request for this project is already in progress."
+    },
+    "optOutModal": {
+      "title": "Reappraisal Not Required",
+      "body": "Mark this project as not requiring reappraisal? It will be removed from the due list.",
+      "confirm": "Confirm"
+    }
+  },
+  "units": {
+    "sold": "Sold",
+    "available": "Available",
+    "cols": {
+      "floor": "Floor",
+      "towerName": "Tower Name",
+      "regNumber": "Reg. Number",
+      "roomNo": "Room No",
+      "modelType": "Model Type",
+      "usableArea": "Usable Area (sq.m.)",
+      "sellingPrice": "Selling Price (Baht)",
+      "plotNo": "Plot No",
+      "houseNo": "House No",
+      "numFloors": "No. of Floors",
+      "landArea": "Land Area (Sq.Wa)",
+      "isSold": "Status"
+    }
+  }
+}

--- a/src/i18n/locales/zh/workflowBuilder.json
+++ b/src/i18n/locales/zh/workflowBuilder.json
@@ -35,13 +35,15 @@
     "saveFailed": "Save failed",
     "migrationFailed": "Migration failed",
     "failedToLoadPreview": "Failed to load preview. You can still publish without impact analysis.",
-    "publishFailed": "Publish failed"
+    "publishFailed": "Publish failed",
+    "failedToCreateDraft": "Failed to create a new draft version"
   },
   "toasts": {
     "workflowCreated": "Workflow created",
     "draftSaved": "Draft saved",
     "workflowPublished": "Workflow published (v{{version}})",
-    "noInstancesSelected": "No instances selected for migration."
+    "noInstancesSelected": "No instances selected for migration.",
+    "draftVersionCreated": "New draft version created — you can now edit"
   },
   "toolbar": {
     "backToList": "Back to list",
@@ -52,7 +54,8 @@
     "saveDraft": "Save Draft",
     "publish": "Publish",
     "autoLayoutTitle": "Auto-arrange nodes",
-    "settingsTitle": "Workflow Settings"
+    "settingsTitle": "Workflow Settings",
+    "editNewVersion": "Edit (new version)"
   },
   "settings": {
     "title": "Workflow Settings",


### PR DESCRIPTION
## Summary
Part of splitting a large accumulated changeset into independent PRs. This PR bundles the three **block*** features, which are coupled by cross-imports.

## Changes
- **blockReappraisal** (new): list/detail pages, filter dialog, API, types
- **blockUnitMaintenance**: new `ModelBreakdown` + `SoldDonut` (consumed by blockReappraisal), detail-page refactor
- **blockProject**: tab listings, radio group, project-type pill, `projectUnit` API
- **Router:** adds `standalone/block-reappraisal` routes (router.tsx hunk-split — only block routes)
- **i18n:** `i18n/index.ts` (registers blockReappraisal + zh fallbacks for feeAppointmentApproval/feeApprovalConfig), en/th/zh `blockProject.json` + `blockReappraisal.json`, and a `zh/workflowBuilder.json` parity fix
- **New test:** `src/i18n/__tests__/localeParity.test.ts`

## Scope / coupling
- The three block features are bundled because `blockReappraisal` imports `ModelBreakdown`/`SoldDonut` from `blockUnitMaintenance`, which imports `blockProject`.
- The locale-parity test + the `zh/workflowBuilder.json` fix + the zh fallback registrations all travel together so the test passes.
- `router.tsx` is shared with the userManagement PR; this branch contains **only** the block route hunks.

## Verification
- `tsc -b` → **0 new errors** vs `main` baseline
- `vitest run src/i18n/__tests__/localeParity.test.ts` → **56 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)