### PR TITLE
fix(userManagement): address Copilot review on PR #175

### DIFF
--- a/src/features/userManagement/api/users.ts
+++ b/src/features/userManagement/api/users.ts
@@ -208,6 +208,8 @@ export const useUnlockUser = () => {
     },
     onSuccess: (_data, id) => {
       queryClient.invalidateQueries({ queryKey: [USERS_KEY, id] });
+      // The user list renders the lock icon, so refresh it too.
+      queryClient.invalidateQueries({ queryKey: [USERS_KEY] });
     },
   });
 };

--- a/src/features/userManagement/components/ChangePasswordModal.tsx
+++ b/src/features/userManagement/components/ChangePasswordModal.tsx
@@ -28,7 +28,7 @@ const ChangePasswordModal = ({ isOpen, onClose, userId }: ChangePasswordModalPro
   const schema = z
     .object({
       currentPassword: z.string().min(1, t('validation.currentPasswordRequired')),
-      newPassword: z.string().min(minLength, t('validation.newPasswordMinLength')),
+      newPassword: z.string().min(minLength, t('passwordPolicy.minLength', { count: minLength })),
       confirmPassword: z.string().min(1, t('validation.confirmPasswordRequired')),
     })
     .refine(data => data.newPassword === data.confirmPassword, {

--- a/src/features/userManagement/components/UserDetailPanel.tsx
+++ b/src/features/userManagement/components/UserDetailPanel.tsx
@@ -237,8 +237,6 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
   const initials =
     (user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '') || user.username[0].toUpperCase();
 
-  const isCompanyUser = !!user.companyId;
-
   return (
     <div className="flex flex-col gap-4 p-6">
       {/* Status Section */}
@@ -540,19 +538,19 @@ const UserDetailPanel = ({ userId }: UserDetailPanelProps) => {
             }}
             placeholder={t('placeholders.department')}
           />
-          {/* Company selector — only for company-scope users */}
-          {isCompanyUser && (
-            <div className="sm:col-span-2">
-              <Dropdown
-                label={t('fields.company')}
-                value={editForm.companyId ?? ''}
-                onChange={(val: string | null) =>
-                  setEditForm(prev => ({ ...prev, companyId: val || null }))
-                }
-                options={companyOptions}
-              />
-            </div>
-          )}
+          {/* Company selector — always available; empty = bank/internal staff.
+              Scope is defined by CompanyId, so gating on it would make a company
+              impossible to assign to a user who doesn't yet have one. */}
+          <div className="sm:col-span-2">
+            <Dropdown
+              label={t('fields.company')}
+              value={editForm.companyId ?? ''}
+              onChange={(val: string | null) =>
+                setEditForm(prev => ({ ...prev, companyId: val || null }))
+              }
+              options={companyOptions}
+            />
+          </div>
         </div>
         <div className="flex justify-end gap-2 px-6 pb-6">
           <Button variant="ghost" size="sm" onClick={() => setShowEditModal(false)}>

--- a/src/features/userManagement/pages/AuditLogPage.tsx
+++ b/src/features/userManagement/pages/AuditLogPage.tsx
@@ -56,7 +56,7 @@ const ChangesCell = ({ changesJson }: { changesJson: string | null }) => {
           </span>
         ))}
         {added.length === 0 && removed.length === 0 && (
-          <span className="text-gray-400 text-xs">no changes</span>
+          <span className="text-gray-400 text-xs">—</span>
         )}
       </div>
     );


### PR DESCRIPTION
Follow-up fixes for GitHub Copilot's review comments on #175.

- **UserDetailPanel**: always show the company selector. Scope is defined by `companyId`, so gating the selector on `!!companyId` made it impossible to assign a company to a user who didn't already have one.
- **ChangePasswordModal**: the min-length validation message now reflects the **dynamic** password policy (`passwordPolicy.minLength` with the computed length) instead of a hard-coded "at least 8".
- **useUnlockUser**: also invalidate the user **list** query (it renders the lock icon), so it refreshes without a manual reload.
- **AuditLogPage**: an empty change set renders an em dash (`—`) instead of the untranslated English "no changes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)