### PR TITLE
feat(appraisal): redesign appointment card, gate history query, clean fee API

### DIFF
--- a/src/features/appraisal/api/appointmentHistory.ts
+++ b/src/features/appraisal/api/appointmentHistory.ts
@@ -33,7 +33,10 @@ const appointmentHistoryResponseSchema = z.object({
  * Get the appointment + fee history timeline for an appraisal.
  * GET /appraisals/{appraisalId}/appointment-history
  */
-export const useGetAppointmentHistory = (appraisalId: string) => {
+export const useGetAppointmentHistory = (
+  appraisalId: string,
+  options?: { enabled?: boolean },
+) => {
   return useQuery({
     queryKey: ['appraisal', appraisalId, 'appointment-history'],
     queryFn: async (): Promise<AppointmentHistoryEvent[]> => {
@@ -41,6 +44,8 @@ export const useGetAppointmentHistory = (appraisalId: string) => {
       const parsed = appointmentHistoryResponseSchema.parse(data);
       return parsed.events;
     },
-    enabled: !!appraisalId,
+    // Caller may gate fetching (e.g. only when the history drawer is open). Same queryKey,
+    // so the page's count query and the drawer share one cache entry.
+    enabled: !!appraisalId && (options?.enabled ?? true),
   });
 };

--- a/src/features/appraisal/api/fee.ts
+++ b/src/features/appraisal/api/fee.ts
@@ -3,9 +3,7 @@ import axios from '@shared/api/axiosInstance';
 import type {
   AddFeeItemRequestType,
   AppraisalFeeDtoType,
-  ApproveFeeItemRequestType,
   RecordPaymentRequestType,
-  RejectFeeItemRequestType,
   UpdateFeeItemRequestType,
   UpdatePaymentRequestType,
 } from '@shared/schemas/v1';
@@ -115,17 +113,17 @@ export const useApproveFeeItem = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // Actor is stamped server-side from the authenticated user — no body sent.
     mutationFn: async ({
       appraisalId,
       feeId,
       itemId,
-      ...body
-    }: ApproveFeeItemRequestType & {
+    }: {
       appraisalId: string;
       feeId: string;
       itemId: string;
     }): Promise<void> => {
-      await axios.patch(`/appraisals/${appraisalId}/fees/${feeId}/items/${itemId}/approve`, body);
+      await axios.patch(`/appraisals/${appraisalId}/fees/${feeId}/items/${itemId}/approve`);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
@@ -143,17 +141,21 @@ export const useRejectFeeItem = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // Actor is stamped server-side; only the reason is sent.
     mutationFn: async ({
       appraisalId,
       feeId,
       itemId,
-      ...body
-    }: RejectFeeItemRequestType & {
+      reason,
+    }: {
       appraisalId: string;
       feeId: string;
       itemId: string;
+      reason: string;
     }): Promise<void> => {
-      await axios.patch(`/appraisals/${appraisalId}/fees/${feeId}/items/${itemId}/reject`, body);
+      await axios.patch(`/appraisals/${appraisalId}/fees/${feeId}/items/${itemId}/reject`, {
+        reason,
+      });
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({

--- a/src/features/appraisal/components/360/PropertyGroupsSection.tsx
+++ b/src/features/appraisal/components/360/PropertyGroupsSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import Icon from '@/shared/components/Icon';
 import type { PropertyGroup, PropertyType } from '../../types';
 import PropertyGroupCard from './PropertyGroupCard';
@@ -13,6 +14,7 @@ const PropertyGroupsSection = ({
   isLoading,
   onPropertyClick,
 }: PropertyGroupsSectionProps) => {
+  const { t } = useTranslation('appraisal');
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -25,7 +27,7 @@ const PropertyGroupsSection = ({
     return (
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 text-center">
         <Icon name="buildings" style="regular" className="w-8 h-8 text-gray-300 mx-auto mb-2" />
-        <p className="text-sm text-gray-500">No property groups found.</p>
+        <p className="text-sm text-gray-500">{t('view360.propertyGroups.noGroups')}</p>
       </div>
     );
   }
@@ -35,7 +37,7 @@ const PropertyGroupsSection = ({
       <div className="flex items-center gap-2 px-1">
         <Icon name="buildings" style="solid" className="w-4 h-4 text-purple-500" />
         <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider">
-          Property Groups ({groups.length})
+          {t('view360.propertyGroups.title', { n: groups.length })}
         </h2>
       </div>
       {groups.map(group => (

--- a/src/features/appraisal/components/AppointmentHistoryDrawer.tsx
+++ b/src/features/appraisal/components/AppointmentHistoryDrawer.tsx
@@ -175,7 +175,11 @@ export default function AppointmentHistoryDrawer({
   const { t } = useTranslation(['appraisal', 'common']);
   const [activeFilter, setActiveFilter] = useState<FilterChip>('all');
 
-  const { data: events = [], isLoading, isError } = useGetAppointmentHistory(appraisalId);
+  // Only fetch when the drawer is open (the page already fetches the count on mount via the
+  // same queryKey, so an opened drawer reuses that cache).
+  const { data: events = [], isLoading, isError } = useGetAppointmentHistory(appraisalId, {
+    enabled: open,
+  });
 
   const filteredEvents = events.filter(event => {
     if (activeFilter === 'appointment') return isAppointmentEvent(event.eventType);
@@ -223,7 +227,7 @@ export default function AppointmentHistoryDrawer({
         {isLoading && (
           <div className="flex items-center justify-center py-12 text-gray-400 text-sm">
             <Icon name="spinner" style="solid" className="w-4 h-4 animate-spin mr-2" />
-            {t('common:loading', 'Loading…')}
+            {t('common:status.loading')}
           </div>
         )}
 

--- a/src/features/appraisal/components/AppointmentInfoCard.tsx
+++ b/src/features/appraisal/components/AppointmentInfoCard.tsx
@@ -99,71 +99,105 @@ export default function AppointmentInfoCard({
     );
   }
 
-  // Only surface the approval state — no badge for normal statuses (Approved/Pending/etc.).
   const status = (appointment.status ?? '').toLowerCase();
-  const statusBadge = approvalSubmitted
-    ? { label: t('approval.badge.awaiting'), cls: 'bg-blue-50 text-blue-700 border-blue-200' }
-    : approvalDraft
-      ? { label: t('approval.badge.needsApproval'), cls: 'bg-amber-50 text-amber-700 border-amber-200' }
-      : null;
-
   const rescheduleCount = appointment.rescheduleCount ?? 0;
   const isCancelled = status === 'cancelled';
-  const tileAccent = pendingApproval ? 'bg-amber-500' : 'bg-orange-500';
+
+  // Status pill — approval-pending states take precedence, otherwise reflect the appointment status.
+  const statusPill = approvalSubmitted
+    ? { label: t('approval.badge.awaiting'), cls: 'bg-blue-50 text-blue-700', dot: 'bg-blue-500' }
+    : approvalDraft
+      ? { label: t('approval.badge.needsApproval'), cls: 'bg-amber-50 text-amber-700', dot: 'bg-amber-500' }
+      : (() => {
+          switch (status) {
+            case 'approved':
+              return { label: t('history.status.Approved'), cls: 'bg-green-50 text-green-700', dot: 'bg-green-500' };
+            case 'pending':
+              return { label: t('history.status.Pending'), cls: 'bg-amber-50 text-amber-700', dot: 'bg-amber-500' };
+            case 'rejected':
+              return { label: t('history.status.Rejected'), cls: 'bg-red-50 text-red-700', dot: 'bg-red-500' };
+            case 'cancelled':
+              return { label: t('history.status.Cancelled'), cls: 'bg-gray-100 text-gray-600', dot: 'bg-gray-400' };
+            default:
+              return appointment.status
+                ? { label: appointment.status, cls: 'bg-gray-100 text-gray-600', dot: 'bg-gray-400' }
+                : null;
+          }
+        })();
+
+  // Initials for the contact avatar (e.g. "John Doe" → "JD").
+  const initials =
+    (appointment.contactPerson || '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((w) => w[0]!.toUpperCase())
+      .join('') || '—';
 
   return (
     <div
-      className={`rounded-xl shadow-sm overflow-hidden border ${
-        pendingApproval ? 'border-amber-200 bg-amber-50/40' : 'border-gray-200 bg-white'
+      className={`rounded-xl shadow-sm overflow-hidden border bg-white ${
+        pendingApproval ? 'border-amber-200' : 'border-gray-200'
       }`}
     >
-      {/* ── Top row: calendar tile · details · status + actions ── */}
-      <div className="flex items-start gap-5 p-5">
-        {/* Calendar date tile */}
-        <div
-          className={`flex-shrink-0 w-[76px] rounded-xl border overflow-hidden text-center bg-white ${
-            pendingApproval ? 'border-amber-200' : 'border-gray-200'
-          }`}
-        >
-          <div className={`text-[11px] font-bold uppercase tracking-wider text-white py-1 ${tileAccent}`}>
-            {formattedDate?.month}
+      {/* ── Header bar: title + status · view history ── */}
+      <div
+        className={`flex items-center justify-between gap-3 px-5 py-3 border-b ${
+          pendingApproval ? 'border-amber-100 bg-amber-50/50' : 'border-gray-100 bg-gray-50/70'
+        }`}
+      >
+        <div className="flex items-center gap-2.5">
+          <span className="text-xs font-bold uppercase tracking-wider text-gray-500">
+            {t('history.chips.appointment')}
+          </span>
+          {statusPill && (
+            <span
+              className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold ${statusPill.cls}`}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full ${statusPill.dot}`} />
+              {statusPill.label}
+            </span>
+          )}
+        </div>
+        {onViewHistory && (
+          <button
+            type="button"
+            onClick={onViewHistory}
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-primary transition-colors"
+          >
+            <Icon name="clock-rotate-left" style="regular" className="w-3.5 h-3.5" />
+            {t('history.viewHistory')}
+            {historyEventCount !== undefined && historyEventCount > 0 && ` (${historyEventCount})`}
+          </button>
+        )}
+      </div>
+
+      {/* ── Body: date · details · actions ── */}
+      <div className="flex items-center gap-5 px-5 py-4">
+        {/* Date column */}
+        <div className="flex-shrink-0">
+          {formattedPreviousDate && (
+            <div className="text-[11px] text-gray-400 line-through decoration-red-300 mb-0.5">
+              {formattedPreviousDate.fullDate} · {formattedPreviousDate.time}
+            </div>
+          )}
+          <div className={`text-xs font-semibold ${pendingApproval ? 'text-amber-500' : 'text-orange-500'}`}>
+            {formattedDate?.dayName}
           </div>
-          <div className="text-xl font-bold text-gray-800 leading-none pt-1.5">
-            {formattedDate?.day}
+          <div className="text-xl font-bold text-gray-900 leading-tight">
+            {formattedDate?.fullDate}
           </div>
-          <div className="text-[11px] text-gray-500 pb-1.5">{formattedDate?.weekday}</div>
+          <div className="text-sm text-gray-500">{formattedDate?.time}</div>
         </div>
 
         {/* Details */}
         <div className="flex-1 min-w-0">
-          {/* Time / pending old→new */}
-          {formattedPreviousDate ? (
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-xs font-medium text-gray-400 line-through decoration-red-300">
-                {formattedPreviousDate.fullDate} · {formattedPreviousDate.time}
-              </span>
-              <Icon name="arrow-right" style="solid" className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-              <span className="text-sm font-semibold text-gray-800">
-                {formattedDate?.fullDate} · {formattedDate?.time}
-              </span>
-            </div>
-          ) : (
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-800">
-                <Icon name="clock" style="regular" className="w-3.5 h-3.5 text-gray-400" />
-                {formattedDate?.time}
-              </span>
-              <span className="text-xs text-gray-400">
-                · {formattedDate?.dayName}, {formattedDate?.fullDate}
-              </span>
-            </div>
-          )}
-
           {/* Location */}
-          <div className="flex items-center gap-2 mt-2.5">
+          <div className="flex items-center gap-2">
             <Icon name="location-dot" style="light" className="w-4 h-4 text-gray-400 shrink-0" />
             <span
-              className={`text-xs line-clamp-1 break-words ${
+              className={`text-sm line-clamp-1 break-words ${
                 appointment.locationDetail ? 'text-gray-700' : 'text-gray-400'
               }`}
             >
@@ -172,88 +206,54 @@ export default function AppointmentInfoCard({
           </div>
 
           {/* Contact */}
-          <div className="flex items-center gap-2 mt-1.5">
-            <div className="w-5 h-5 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
-              <Icon name="user" style="solid" className="w-2.5 h-2.5 text-gray-500" />
+          <div className="flex items-center gap-2 mt-2">
+            <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+              <span className="text-[11px] font-semibold text-gray-600">{initials}</span>
             </div>
-            <span className="text-xs text-gray-700">
+            <span className="text-sm text-gray-700">
               {appointment.contactPerson || t('appointment.contactNotSpecified')}
               {appointment.contactPhone && (
                 <span className="text-gray-400"> · {appointment.contactPhone}</span>
               )}
             </span>
           </div>
-        </div>
 
-        {/* Status + action buttons */}
-        <div className="flex flex-col items-end gap-3 flex-shrink-0">
-          {statusBadge && (
-            <span
-              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border ${statusBadge.cls}`}
-            >
-              {statusBadge.label}
-            </span>
-          )}
-          {!readOnly && (
-            <div className="flex items-center gap-2">
-              {onCancel && !isCancelled && (
-                <button
-                  type="button"
-                  onClick={!approvalSubmitted ? onCancel : undefined}
-                  disabled={approvalSubmitted}
-                  title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
-                  className="flex items-center gap-2 px-4 py-2 rounded-lg border border-danger/30 bg-danger/10 text-danger hover:bg-danger/20 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-danger/10"
-                >
-                  <Icon name="xmark" style="solid" className="w-4 h-4" />
-                  <span className="text-sm font-medium">{t('appointment.cancelButton')}</span>
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={!approvalSubmitted ? onReschedule : undefined}
-                disabled={approvalSubmitted}
-                title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-secondary bg-secondary/20 text-secondary hover:bg-secondary/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-secondary/20"
-              >
-                <Icon name="clock-rotate-left" style="solid" className="w-5 h-5" />
-                <span className="text-sm font-medium uppercase tracking-wider">
-                  {t('appointment.rescheduleButton')}
-                </span>
-              </button>
+          {/* Reschedule count */}
+          {rescheduleCount > 0 && (
+            <div className="text-xs text-gray-400 mt-2 ml-9">
+              {t('appointment.rescheduledCount', { n: rescheduleCount })}
             </div>
           )}
         </div>
-      </div>
 
-      {/* ── Footer: reschedule count · history ── */}
-      {(rescheduleCount > 0 || onViewHistory) && (
-        <div
-          className={`flex items-center gap-2 px-5 py-2.5 border-t text-xs ${
-            pendingApproval ? 'border-amber-100 bg-amber-100/30' : 'border-gray-100 bg-gray-50/60'
-          }`}
-        >
-          {rescheduleCount > 0 && (
-            <span className="inline-flex items-center gap-1.5 text-gray-500">
-              <Icon name="clock-rotate-left" style="solid" className="w-3 h-3 text-gray-400" />
-              {t('appointment.rescheduledCount', { n: rescheduleCount })}
-            </span>
-          )}
-          {rescheduleCount > 0 && onViewHistory && (
-            <span className="text-gray-300" aria-hidden="true">·</span>
-          )}
-          {onViewHistory && (
+        {/* Action buttons */}
+        {!readOnly && (
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {onCancel && !isCancelled && (
+              <button
+                type="button"
+                onClick={!approvalSubmitted ? onCancel : undefined}
+                disabled={approvalSubmitted}
+                title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-red-200 bg-red-50 text-red-600 hover:bg-red-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-red-50"
+              >
+                <Icon name="xmark" style="solid" className="w-4 h-4" />
+                <span className="text-sm font-medium">{t('appointment.cancelButton')}</span>
+              </button>
+            )}
             <button
               type="button"
-              onClick={onViewHistory}
-              className="inline-flex items-center gap-1.5 font-semibold text-gray-500 hover:text-primary transition-colors"
+              onClick={!approvalSubmitted ? onReschedule : undefined}
+              disabled={approvalSubmitted}
+              title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-gray-900"
             >
-              <Icon name="clock-rotate-left" style="solid" className="w-3 h-3" />
-              {t('history.viewHistory')}
-              {historyEventCount !== undefined && historyEventCount > 0 && ` (${historyEventCount})`}
+              <Icon name="clock-rotate-left" style="solid" className="w-4 h-4" />
+              <span className="text-sm font-medium">{t('appointment.rescheduleButton')}</span>
             </button>
-          )}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/appraisal/forms/LandDetailForm.tsx
+++ b/src/features/appraisal/forms/LandDetailForm.tsx
@@ -1,7 +1,11 @@
-import { FormFields } from '@/shared/components/form';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useFormContext } from 'react-hook-form';
+import { FormFields, type FormField } from '@/shared/components/form';
 import Icon from '@/shared/components/Icon';
 import BoundaryFields from '../components/BoundaryFields';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
+import { MapLocationPicker, MapPickerTriggerIcon } from '@/shared/components/MapLocationPicker';
 import {
   allocationField,
   anticipationProsperityField,
@@ -58,28 +62,57 @@ const Card = ({ children }: { children: React.ReactNode }) => (
 );
 
 const LandDetailForm = () => {
+  const { t } = useTranslation('appraisal');
   const readOnly = usePageReadOnly();
+  const { watch, setValue } = useFormContext();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const lat = watch('latitude');
+  const lon = watch('longitude');
+  const parsedLat = lat !== undefined && lat !== '' ? Number(lat) : null;
+  const parsedLon = lon !== undefined && lon !== '' ? Number(lon) : null;
+  const initialLat = parsedLat != null && !Number.isNaN(parsedLat) ? parsedLat : null;
+  const initialLon = parsedLon != null && !Number.isNaN(parsedLon) ? parsedLon : null;
+
+  const pickerButton = useMemo(
+    () => <MapPickerTriggerIcon onClick={() => setPickerOpen(true)} />,
+    [],
+  );
+
+  // Inject the map-picker trigger onto the lat/lon inputs (hidden in read-only mode).
+  const landFields = useMemo<FormField[]>(
+    () =>
+      landInfoField.map(field =>
+        !readOnly &&
+        (field.name === 'latitude' || field.name === 'longitude') &&
+        field.type === 'number-input'
+          ? { ...field, rightIcon: pickerButton }
+          : field,
+      ),
+    [pickerButton, readOnly],
+  );
+
   return (
     <div className="w-full max-w-full overflow-hidden">
-      <h2 className="text-lg font-semibold text-gray-900 mb-6">Land Detail</h2>
+      <h2 className="text-lg font-semibold text-gray-900 mb-6">{t('forms.land.pageTitle')}</h2>
       <div className="grid grid-cols-1 xl:grid-cols-5 gap-x-6 gap-y-4">
-        <SectionRow title="Land Information" icon="info-circle">
-          <FormFields fields={landInfoField} />
+        <SectionRow title={t('forms.land.sectionTitleInfo')} icon="info-circle">
+          <FormFields fields={landFields} />
         </SectionRow>
 
-        <SectionRow title="Land Location" icon="map-location-dot">
+        <SectionRow title={t('forms.land.sectionTitleLocation')} icon="map-location-dot">
           <FormFields fields={landLocationField} />
         </SectionRow>
 
-        <SectionRow title="Plot Location" icon="location-dot">
+        <SectionRow title={t('forms.land.sectionTitlePlot')} icon="location-dot">
           <FormFields fields={plotLocationField} />
         </SectionRow>
 
-        <SectionRow title="Landfill" icon="mountain">
+        <SectionRow title={t('landCharacteristicsForm.sections.landfill')} icon="mountain">
           <FormFields fields={landFillField} />
         </SectionRow>
 
-        <SectionRow title="Road & Surface" icon="road">
+        <SectionRow title={t('forms.land.sectionTitleRoadSurface')} icon="road">
           <Card>
             <FormFields fields={roadField} />
           </Card>
@@ -88,7 +121,7 @@ const LandDetailForm = () => {
           </Card>
         </SectionRow>
 
-        <SectionRow title="Land Access & Utilities" icon="bolt">
+        <SectionRow title={t('forms.land.sectionTitleLandAccessUtilities')} icon="bolt">
           <Card>
             <FormFields fields={publicUtilityField} />
           </Card>
@@ -103,7 +136,7 @@ const LandDetailForm = () => {
           </Card>
         </SectionRow>
 
-        <SectionRow title="Limitation" icon="triangle-exclamation">
+        <SectionRow title={t('landCharacteristicsForm.sections.limitation')} icon="triangle-exclamation">
           <Card>
             <FormFields fields={expropriateField} />
           </Card>
@@ -118,7 +151,7 @@ const LandDetailForm = () => {
           </Card>
         </SectionRow>
 
-        <SectionRow title="Assessment" icon="chart-line">
+        <SectionRow title={t('forms.land.sectionTitleAssessment')} icon="chart-line">
           <Card>
             <FormFields fields={anticipationProsperityField} />
           </Card>
@@ -130,18 +163,29 @@ const LandDetailForm = () => {
           </Card>
         </SectionRow>
 
-        <SectionRow title="Size and Boundary" icon="ruler-combined">
+        <SectionRow title={t('forms.land.sectionTitleBoundary')} icon="ruler-combined">
           <BoundaryFields readOnly={readOnly} />
         </SectionRow>
 
-        <SectionRow title="Other Information" icon="circle-info">
+        <SectionRow title={t('forms.land.sectionTitleOtherInfo')} icon="circle-info">
           <FormFields fields={otherInformationField} />
         </SectionRow>
 
-        <SectionRow title="Remark" icon="comment" isLast>
+        <SectionRow title={t('landCharacteristicsForm.sections.remark')} icon="comment" isLast>
           <FormFields fields={remarkLandField} />
         </SectionRow>
       </div>
+
+      <MapLocationPicker
+        isOpen={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={(newLat, newLon) => {
+          setValue('latitude', newLat, { shouldDirty: true, shouldValidate: true });
+          setValue('longitude', newLon, { shouldDirty: true, shouldValidate: true });
+        }}
+        initialLat={initialLat}
+        initialLon={initialLon}
+      />
     </div>
   );
 };

--- a/src/features/appraisal/pages/AppointmentAndFeePage.tsx
+++ b/src/features/appraisal/pages/AppointmentAndFeePage.tsx
@@ -153,7 +153,6 @@ export default function AppointmentAndFeePage() {
         appraisalId,
         feeId,
         itemId,
-        approvedBy: currentUser?.username ?? '',
       });
       toast.success(t('fee.toasts.feeApproved'));
     } catch (error: any) {
@@ -167,7 +166,6 @@ export default function AppointmentAndFeePage() {
         appraisalId,
         feeId,
         itemId,
-        rejectedBy: currentUser?.username ?? '',
         reason: reason || 'Rejected',
       });
       toast.success(t('fee.toasts.feeRejected'));

--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -529,7 +529,9 @@
       "sectionTitle": "Request Information"
     },
     "propertyGroups": {
-      "sectionTitle": "Property Groups"
+      "sectionTitle": "Property Groups",
+      "title": "Property Groups ({{n}})",
+      "noGroups": "No property groups found."
     },
     "pricingAnalysis": {
       "sectionTitle": "Pricing Analysis"
@@ -692,11 +694,16 @@
   },
   "forms": {
     "land": {
+      "pageTitle": "Land Detail",
       "sectionTitleInfo": "Land Information",
       "sectionTitleLocation": "Land Location",
-      "sectionTitleBoundary": "Land Boundary",
+      "sectionTitleBoundary": "Size and Boundary",
       "sectionTitleCharacteristics": "Land Characteristics",
-      "sectionTitlePlot": "Plot Location"
+      "sectionTitlePlot": "Plot Location",
+      "sectionTitleRoadSurface": "Road & Surface",
+      "sectionTitleLandAccessUtilities": "Land Access & Utilities",
+      "sectionTitleAssessment": "Assessment",
+      "sectionTitleOtherInfo": "Other Information"
     },
     "building": {
       "sectionTitle": "Building Details"

--- a/src/i18n/locales/th/appraisal.json
+++ b/src/i18n/locales/th/appraisal.json
@@ -532,7 +532,9 @@
       "sectionTitle": "ข้อมูลคำขอ"
     },
     "propertyGroups": {
-      "sectionTitle": "กลุ่มทรัพย์สิน"
+      "sectionTitle": "กลุ่มทรัพย์สิน",
+      "title": "กลุ่มทรัพย์สิน ({{n}})",
+      "noGroups": "ไม่พบกลุ่มทรัพย์สิน"
     },
     "pricingAnalysis": {
       "sectionTitle": "การวิเคราะห์ราคา"
@@ -695,11 +697,16 @@
   },
   "forms": {
     "land": {
+      "pageTitle": "รายละเอียดที่ดิน",
       "sectionTitleInfo": "ข้อมูลที่ดิน",
       "sectionTitleLocation": "ที่ตั้งที่ดิน",
-      "sectionTitleBoundary": "แนวเขตที่ดิน",
+      "sectionTitleBoundary": "ขนาดและแนวเขต",
       "sectionTitleCharacteristics": "ลักษณะที่ดิน",
-      "sectionTitlePlot": "ที่ตั้งแปลง"
+      "sectionTitlePlot": "ที่ตั้งแปลง",
+      "sectionTitleRoadSurface": "ถนนและผิวจราจร",
+      "sectionTitleLandAccessUtilities": "การเข้าถึงและสาธารณูปโภค",
+      "sectionTitleAssessment": "การประเมิน",
+      "sectionTitleOtherInfo": "ข้อมูลอื่น ๆ"
     },
     "building": {
       "sectionTitle": "รายละเอียดอาคาร"

--- a/src/i18n/locales/zh/appraisal.json
+++ b/src/i18n/locales/zh/appraisal.json
@@ -532,7 +532,9 @@
       "sectionTitle": "请求信息"
     },
     "propertyGroups": {
-      "sectionTitle": "房产组"
+      "sectionTitle": "房产组",
+      "title": "房产组 ({{n}})",
+      "noGroups": "未找到房产组。"
     },
     "pricingAnalysis": {
       "sectionTitle": "定价分析"
@@ -695,11 +697,16 @@
   },
   "forms": {
     "land": {
+      "pageTitle": "Land Detail",
       "sectionTitleInfo": "土地信息",
       "sectionTitleLocation": "土地位置",
-      "sectionTitleBoundary": "土地边界",
+      "sectionTitleBoundary": "尺寸与边界",
       "sectionTitleCharacteristics": "土地特征",
-      "sectionTitlePlot": "地块位置"
+      "sectionTitlePlot": "地块位置",
+      "sectionTitleRoadSurface": "Road & Surface",
+      "sectionTitleLandAccessUtilities": "Land Access & Utilities",
+      "sectionTitleAssessment": "Assessment",
+      "sectionTitleOtherInfo": "Other Information"
     },
     "building": {
       "sectionTitle": "建筑详情"
@@ -953,24 +960,24 @@
     }
   },
   "createPage": {
-    "photosSection": "Photos",
-    "landSection": "Land Information",
-    "leaseAgreementSection": "Lease Agreement",
-    "rentalInfoSection": "Rental Info",
-    "condoSection": "Condo Information",
-    "buildingSection": "Building Information",
-    "constructionSection": "Construction Inspection",
-    "machinerySection": "Machinery Information",
-    "navPhotos": "Photos",
-    "navLand": "Land",
-    "navLeaseAgreement": "Lease Agreement",
-    "navRentalInfo": "Rental Info",
-    "navCondo": "Condo",
-    "navBuilding": "Building",
-    "navConstructionInspection": "Construction Inspection",
-    "navMachinery": "Machinery",
-    "saveDraft": "Save draft",
-    "save": "Save"
+    "photosSection": "照片",
+    "landSection": "土地信息",
+    "leaseAgreementSection": "租赁合同",
+    "rentalInfoSection": "租赁信息",
+    "condoSection": "公寓信息",
+    "buildingSection": "建筑信息",
+    "constructionSection": "施工检验",
+    "machinerySection": "机械信息",
+    "navPhotos": "照片",
+    "navLand": "土地",
+    "navLeaseAgreement": "租赁合同",
+    "navRentalInfo": "租赁信息",
+    "navCondo": "公寓",
+    "navBuilding": "建筑",
+    "navConstructionInspection": "施工检验",
+    "navMachinery": "机械",
+    "saveDraft": "保存草稿",
+    "save": "保存"
   },
   "landCharacteristicsForm": {
     "sections": {


### PR DESCRIPTION
## Summary
UI, query, and API improvements across the appraisal appointment/fee flow.

- **AppointmentInfoCard** — redesigned layout: header bar, status pill with colored dot, initials avatar, inline reschedule count
- **AppointmentHistoryDrawer / appointmentHistory** — add `enabled` option; fetch events only when the drawer is open (shares the cache key with the count query)
- **fee API** — approve/reject no longer send an actor (stamped server-side); reject sends only `reason`; drop `approvedBy`/`rejectedBy` from the `AppointmentAndFeePage` payload
- **LandDetailForm** — map-location picker trigger on lat/lon inputs; i18n section titles
- **PropertyGroupsSection** — i18n title + empty state
- **i18n** — add `forms.land.*` and `view360.propertyGroups.*` keys (en/th/zh)

## Verification
- `npx tsc --noEmit` — pre-existing errors only (AppointmentAndFeePage line errors exist at baseline; not introduced here)
- Locale JSON parses (en/th/zh)
- Manual: open an appraisal, check appointment card states + land form map picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)