### PR TITLE
feat(realtime): consolidate SignalR into shared appHub + async report jobs

### DIFF
--- a/src/features/appraisal/services/activityProgressHub.ts
+++ b/src/features/appraisal/services/activityProgressHub.ts
@@ -1,154 +1,26 @@
 /**
- * Singleton SignalR connection for ActivityStepProgress events.
+ * Thin shim — delegates to the shared appHub singleton.
  *
- * Separate from useWorkflowHub (which handles per-task pool groups and is
- * recreated per component mount). This connection is long-lived, started once
- * after login, and used exclusively for the completion-progress overlay.
+ * All public exports are preserved so existing callers
+ * (useActivityCompletionProgress, ActivityProgressHubBootstrap) compile unchanged.
  */
 
-import { HubConnectionBuilder, HubConnectionState, type HubConnection } from '@microsoft/signalr';
-import { getAccessToken } from '@shared/api/axiosInstance';
-import { signalrLogger } from '@shared/utils/signalrLogger';
+import * as appHub from '@shared/realtime/appHub';
 
-// ──────────────────────────────────────────────────────────────────────────────
-// Hub URL (mirrors the pattern in useWorkflowHub)
-// ──────────────────────────────────────────────────────────────────────────────
-
-function getHubUrl(): string {
-  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
-  return apiUrl.replace(/\/api\/?$/, '') + '/workflowHub';
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Singleton state
-// ──────────────────────────────────────────────────────────────────────────────
-
-let _connection: HubConnection | null = null;
-let _userGroup: string | null = null;
-let _startPromise: Promise<void> | null = null;
-
-/** Subscriber set keyed by their handler function */
-const _subscribers = new Set<(event: ActivityStepProgressEvent) => void>();
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Public event types
-// ──────────────────────────────────────────────────────────────────────────────
-
-export interface ActivityStepDto {
-  stepName: string;
-  displayName: string;
-  sortOrder: number;
-  kind: string;
-}
-
-export type ActivityStepProgressEvent =
-  | {
-      phase: 'PipelineStarted';
-      workflowActivityExecutionId: string;
-      activityName: string;
-      steps: ActivityStepDto[];
-    }
-  | {
-      phase: 'StepStarted';
-      workflowActivityExecutionId: string;
-      step: ActivityStepDto;
-    }
-  | {
-      phase: 'StepFinished';
-      workflowActivityExecutionId: string;
-      step: ActivityStepDto;
-      outcome: string;
-      durationMs: number;
-    }
-  | {
-      phase: 'PipelineFinished';
-      workflowActivityExecutionId: string;
-      result: string;
-    };
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Internal helpers
-// ──────────────────────────────────────────────────────────────────────────────
-
-function buildConnection(): HubConnection {
-  return new HubConnectionBuilder()
-    .withUrl(getHubUrl(), {
-      accessTokenFactory: () => getAccessToken() ?? '',
-      withCredentials: true,
-    })
-    .withAutomaticReconnect()
-    .configureLogging(signalrLogger)
-    .build();
-}
-
-function attachHandlers(conn: HubConnection): void {
-  conn.on('ActivityStepProgress', (event: ActivityStepProgressEvent) => {
-    for (const sub of _subscribers) {
-      sub(event);
-    }
-  });
-
-  // Re-join user group after automatic reconnect
-  conn.onreconnected(async () => {
-    if (_userGroup) {
-      try {
-        await conn.invoke('JoinUserGroup', _userGroup);
-      } catch (err) {
-        console.warn('[ActivityProgressHub] Failed to re-join user group after reconnect:', err);
-      }
-    }
-  });
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Public API
-// ──────────────────────────────────────────────────────────────────────────────
+// Re-export types so import sites don't need to change
+export type { ActivityStepDto, ActivityStepProgressEvent } from '@shared/realtime/appHub';
 
 /**
- * Start the singleton connection and join the user's personal group.
- * Safe to call multiple times — subsequent calls are no-ops if already connecting/connected.
- *
- * @param username  The current user's username (= "name" claim = backend `completedBy`).
+ * Start the shared hub connection.
+ * The user group is auto-joined server-side — no explicit JoinUserGroup call needed.
  */
 export async function startActivityProgressHub(username: string): Promise<void> {
-  if (_startPromise) return _startPromise;
-  if (_connection && _connection.state !== HubConnectionState.Disconnected) {
-    return;
-  }
-
-  _connection = buildConnection();
-  attachHandlers(_connection);
-  // Store the bare username — the backend JoinUserGroup handler prepends "user-" itself
-  _userGroup = username;
-
-  const promise = _connection
-    .start()
-    .then(async () => {
-      if (_connection && _userGroup) {
-        await _connection.invoke('JoinUserGroup', _userGroup);
-        console.log('[ActivityProgressHub] Connected and joined user group for', _userGroup);
-      }
-    })
-    .catch(err => {
-      console.warn('[ActivityProgressHub] Connection failed (progress overlay degraded):', err);
-      // Don't re-throw — this is non-critical; completion still works without it
-    })
-    .finally(() => {
-      _startPromise = null;
-    });
-
-  _startPromise = promise;
-  return promise;
+  return appHub.start(username);
 }
 
-/** Stop and discard the singleton connection (call on logout). */
+/** Stop the shared hub connection (call on logout). */
 export async function stopActivityProgressHub(): Promise<void> {
-  _userGroup = null;
-  if (_connection && _connection.state !== HubConnectionState.Disconnected) {
-    await _connection.stop();
-  }
-  _connection = null;
-  _startPromise = null;
+  return appHub.stop();
 }
 
 /**
@@ -156,15 +28,12 @@ export async function stopActivityProgressHub(): Promise<void> {
  * Returns an unsubscribe function.
  */
 export function onActivityStepProgress(
-  handler: (event: ActivityStepProgressEvent) => void,
+  handler: (event: appHub.ActivityStepProgressEvent) => void,
 ): () => void {
-  _subscribers.add(handler);
-  return () => {
-    _subscribers.delete(handler);
-  };
+  return appHub.onActivityStepProgress(handler);
 }
 
-/** Whether the hub is currently connected. */
+/** Whether the shared hub is currently connected. */
 export function isActivityProgressHubConnected(): boolean {
-  return _connection?.state === HubConnectionState.Connected;
+  return appHub.isConnected();
 }

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../store.ts';
 import { useCurrentUser } from '../api.ts';
 import { getAccessToken } from '@shared/api/axiosInstance';
 import { useNotificationHub } from '@features/notification/hooks/useNotificationHub';
+import { useReportJobReconciler } from '@features/reportGeneration/hooks/useReportJobReconciler';
 import type { JSX } from 'react';
 
 export function ProtectedRoute({ component }: { component: JSX.Element }) {
@@ -16,6 +17,9 @@ export function ProtectedRoute({ component }: { component: JSX.Element }) {
   // above all layouts so it doesn't tear down on Layout↔AppraisalLayout↔TaskLayout
   // navigation. Hook returns early if no access token is present yet.
   useNotificationHub();
+  // Realtime + reconnect reconciler for async report jobs — zero overhead when
+  // no jobs are tracked.
+  useReportJobReconciler();
 
   // No token and not authenticated → go to login
   if (!hasToken && !isAuthenticated) {

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { broadcastLogout, setAccessToken } from '@shared/api/axiosInstance';
+import * as appHub from '@shared/realtime/appHub';
 import type { User } from './types';
 
 type AuthStore = {
@@ -35,6 +36,9 @@ export const useAuthStore = create<AuthStore>(set => ({
   },
 
   logout: () => {
+    // Tear down the realtime connection so it stops reconnecting with a stale
+    // token (otherwise the orphaned connection lingers for the session).
+    appHub.stop().catch(() => {});
     // Broadcast an explicit logout so other tabs clear auth + redirect.
     broadcastLogout();
     set({ user: null, isAuthenticated: false });

--- a/src/features/notification/components/ConnectionStatusIndicator.tsx
+++ b/src/features/notification/components/ConnectionStatusIndicator.tsx
@@ -1,0 +1,75 @@
+import type { MouseEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { useConnectionStatus } from '../hooks/useConnectionStatus';
+import { useAuthStore } from '@features/auth/store';
+import * as appHub from '@shared/realtime/appHub';
+
+/**
+ * Just the colored status dot — green when online (connected), grey otherwise.
+ * Reused on the user avatar as a presence indicator and inside the status row.
+ * `className` controls size/position; pass `ring` for a halo over the avatar.
+ *
+ * Display is two-state (online / offline): the underlying hub still tracks a
+ * transient 'reconnecting' state, but it shows as offline until it's back up.
+ */
+export function ConnectionStatusDot({
+  className = 'h-2.5 w-2.5',
+  ring = false,
+}: {
+  className?: string;
+  ring?: boolean;
+}) {
+  const status = useConnectionStatus();
+  const online = status === 'connected';
+  return (
+    <span
+      aria-hidden="true"
+      className={clsx(
+        'inline-flex rounded-full',
+        className,
+        online ? 'bg-success' : 'bg-gray-400',
+        ring && 'ring-2 ring-white dark:ring-base-100',
+      )}
+    />
+  );
+}
+
+/**
+ * Realtime connection status row for the user-profile dropdown. Shows a dot +
+ * "Online" / "Offline"; clicking the whole row toggles the connection (also
+ * handy for testing reconnect + catch-up).
+ */
+export default function ConnectionStatusIndicator() {
+  const { t } = useTranslation('notification');
+  const status = useConnectionStatus();
+  const username = useAuthStore(s => s.user?.username);
+  const online = status === 'connected';
+
+  const toggle = (e: MouseEvent) => {
+    // The dropdown stays open so the row can flip Online/Offline in place:
+    // this is a plain <button>, not a MenuItem, so Headless UI's quick-release
+    // ignores clicks on it (it only closes for [role="menuitem"] targets).
+    // stopPropagation is belt-and-suspenders, not the load-bearing mechanism.
+    e.stopPropagation();
+    if (online) {
+      appHub.stop().catch(() => {});
+    } else if (username) {
+      appHub.start(username).catch(() => {});
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={!online && !username}
+      className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-base-300 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <ConnectionStatusDot />
+      <span className="text-xs text-gray-500 dark:text-gray-400">
+        {online ? t('connection.online') : t('connection.offline')}
+      </span>
+    </button>
+  );
+}

--- a/src/features/notification/components/NotificationDropdown.tsx
+++ b/src/features/notification/components/NotificationDropdown.tsx
@@ -1,20 +1,53 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
 import Icon from '@shared/components/Icon';
 import { useNotificationStore } from '../store';
 import { notificationTypeConfig } from '../types';
 import { timeAgo } from '../utils/timeAgo';
 import { useAuthStore } from '@features/auth/store';
+import { downloadReportJobPdf } from '@features/reportGeneration/api/reports';
 import clsx from 'clsx';
+
+const REPORT_DOWNLOAD_RE = /^\/reports\/jobs\/([^/]+)\/download$/;
 
 export default function NotificationDropdown() {
   const { t } = useTranslation('notification');
   const { notifications, markAsRead, markAllAsRead, fetchNotifications } = useNotificationStore();
   const username = useAuthStore(s => s.user?.username ?? '');
+  const navigate = useNavigate();
   const unreadCount = notifications.filter(n => !n.isRead).length;
   const recent = notifications.slice(0, 5);
+
+  /**
+   * Handle a notification item click.
+   * - If actionUrl matches the report download pattern → download PDF via API
+   *   (avoids routing to a non-existent page and keeps auth headers).
+   * - Otherwise → navigate to actionUrl if present.
+   * - Always marks the notification as read.
+   */
+  async function handleNotificationClick(notificationId: string, actionUrl: string | null) {
+    void markAsRead(notificationId);
+    if (!actionUrl) return;
+
+    const match = REPORT_DOWNLOAD_RE.exec(actionUrl);
+    if (match) {
+      const jobId = match[1]!;
+      try {
+        const blob = await downloadReportJobPdf(jobId);
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank', 'noopener');
+        setTimeout(() => URL.revokeObjectURL(url), 60_000);
+      } catch {
+        toast.error('Failed to download report. It may have expired.');
+      }
+      return;
+    }
+
+    navigate(actionUrl);
+  }
 
   useEffect(() => {
     if (username) {
@@ -71,7 +104,7 @@ export default function NotificationDropdown() {
                   <button
                     key={notification.id}
                     type="button"
-                    onClick={() => markAsRead(notification.id)}
+                    onClick={() => handleNotificationClick(notification.id, notification.actionUrl)}
                     className={clsx(
                       'w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-base-300 transition-colors',
                       !notification.isRead && 'bg-blue-50/30',

--- a/src/features/notification/hooks/useConnectionStatus.ts
+++ b/src/features/notification/hooks/useConnectionStatus.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import * as appHub from '@shared/realtime/appHub';
+
+/**
+ * Reactive view of the shared SignalR connection status
+ * (connected / reconnecting / disconnected). Seeds from the current value and
+ * stays in sync via appHub.onConnectionStateChange.
+ */
+export function useConnectionStatus(): appHub.AppHubStatus {
+  const [status, setStatus] = useState<appHub.AppHubStatus>(() => appHub.getStatus());
+
+  useEffect(() => {
+    // Re-sync in case the status changed between the initial render and effect.
+    setStatus(appHub.getStatus());
+    return appHub.onConnectionStateChange(setStatus);
+  }, []);
+
+  return status;
+}

--- a/src/features/notification/hooks/useNotificationHub.tsx
+++ b/src/features/notification/hooks/useNotificationHub.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
-import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
-import { signalrLogger } from '@shared/utils/signalrLogger';
 import i18n from '@/i18n';
 import { useQueryClient } from '@tanstack/react-query';
-import { getAccessToken } from '@shared/api/axiosInstance';
+import { useAuthStore } from '@features/auth/store';
 import { useNotificationStore } from '../store';
 import { showNotificationToast } from '../components/NotificationToast';
 import { followupKeys } from '@/features/document-followup/api/followup';
 import type { Notification } from '../types';
+import * as appHub from '@shared/realtime/appHub';
 
 const FOLLOWUP_NOTIFICATION_TYPES = new Set([
   'DocumentFollowupRaised',
@@ -17,37 +16,27 @@ const FOLLOWUP_NOTIFICATION_TYPES = new Set([
   'DocumentLineItemDeclined',
 ]);
 
-const getHubUrl = () => {
-  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
-  return apiUrl.replace(/\/api\/?$/, '') + '/notificationHub';
-};
-
 export function useNotificationHub() {
-  const connectionRef = useRef<ReturnType<typeof HubConnectionBuilder.prototype.build> | null>(
-    null,
-  );
   const hasShownConnectErrorToast = useRef(false);
   const addNotification = useNotificationStore(s => s.addNotification);
+  const fetchNotifications = useNotificationStore(s => s.fetchNotifications);
   const queryClient = useQueryClient();
+  const username = useAuthStore(s => s.user?.username);
 
   useEffect(() => {
-    const token = getAccessToken();
-    if (!token) return;
+    if (!username) return;
 
-    const connection = new HubConnectionBuilder()
-      .withUrl(getHubUrl(), {
-        accessTokenFactory: () => getAccessToken() ?? '',
-        // skipNegotiation: true,
-        // transport: HttpTransportType.WebSockets,
-        withCredentials: true,
-      })
-      .withAutomaticReconnect()
-      .configureLogging(signalrLogger)
-      .build();
+    // Start the shared connection (idempotent — safe if already started by
+    // ActivityProgressHubBootstrap or a previous render).
+    appHub.start(username).catch(err => {
+      console.error('[NotificationHub] SignalR connection failed:', err);
+      if (!hasShownConnectErrorToast.current) {
+        toast.error(i18n.t('notification:realtimeUnavailable'));
+        hasShownConnectErrorToast.current = true;
+      }
+    });
 
-    connectionRef.current = connection;
-
-    connection.on('ReceiveNotification', (notification: Notification) => {
+    const unsub = appHub.on<Notification>('ReceiveNotification', notification => {
       console.log('[NotificationHub] ReceiveNotification fired', notification);
       addNotification(notification);
       try {
@@ -60,7 +49,6 @@ export function useNotificationHub() {
       // Invalidate document followup queries when relevant notifications arrive
       if (FOLLOWUP_NOTIFICATION_TYPES.has(notification.type)) {
         const meta = notification.metadata ?? {};
-        // Narrow followup query invalidation when IDs are present in metadata
         if (typeof meta.raisingTaskId === 'string') {
           queryClient.invalidateQueries({
             queryKey: followupKeys.byTask(meta.raisingTaskId),
@@ -71,10 +59,6 @@ export function useNotificationHub() {
             queryKey: followupKeys.detail(meta.followupId),
           });
         }
-        // Refresh the request maker's task inbox only when a NEW followup task
-        // is raised (DocumentFollowupRaised). The other three types (Resolved,
-        // Cancelled, LineItemDeclined) are directed at the checker and only
-        // need the followup queries above to update the banner.
         if (notification.type === 'DocumentFollowupRaised') {
           queryClient.invalidateQueries({ queryKey: ['my-tasks'] });
           queryClient.invalidateQueries({ queryKey: ['my-tasks-kanban'] });
@@ -83,28 +67,37 @@ export function useNotificationHub() {
       }
     });
 
-    let cancelled = false;
+    return unsub;
+    // addNotification and queryClient are stable refs; username drives re-subscription
+  }, [username, addNotification, queryClient]);
 
-    connection
-      .start()
-      .then(() => {
-        if (!cancelled) console.log('[NotificationHub] SignalR connected');
-      })
-      .catch(err => {
-        if (!cancelled) {
-          console.error('[NotificationHub] SignalR connection failed:', err);
-          if (!hasShownConnectErrorToast.current) {
-            toast.error(i18n.t('notification:realtimeUnavailable'));
-            hasShownConnectErrorToast.current = true;
-          }
-        }
-      });
+  // Catch up after a reconnect. SignalR does not buffer server→client messages
+  // while disconnected, so anything pushed during a network blip / sleep / long
+  // outage is lost over the wire. On every RE-connect (the first connect is
+  // skipped — NotificationDropdown already fetches on mount), re-fetch the
+  // notification list and reconcile task queries so the bell shows what was
+  // missed without a manual page refresh.
+  useEffect(() => {
+    if (!username) return;
 
-    return () => {
-      cancelled = true;
-      if (connection.state !== HubConnectionState.Disconnected) {
-        connection.stop();
+    // Skip only a genuine cold first-connect (NotificationDropdown already
+    // fetches on mount). Seed from hasEverConnected() — not the current status —
+    // so that attaching mid-reconnect (status === 'reconnecting') is still
+    // treated as a re-connect and the next 'connected' triggers the catch-up,
+    // which is exactly the missed-notification case this guards.
+    let primed = appHub.hasEverConnected();
+    const unsub = appHub.onConnectionStateChange(status => {
+      if (status !== 'connected') return;
+      if (!primed) {
+        primed = true;
+        return;
       }
-    };
-  }, [addNotification, queryClient]);
+      fetchNotifications(username);
+      queryClient.invalidateQueries({ queryKey: ['my-tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['my-tasks-kanban'] });
+      queryClient.invalidateQueries({ queryKey: ['task-counts'] });
+    });
+
+    return unsub;
+  }, [username, fetchNotifications, queryClient]);
 }

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -6,7 +6,9 @@ export type NotificationType =
   | 'DocumentFollowupRaised'
   | 'DocumentFollowupResolved'
   | 'DocumentFollowupCancelled'
-  | 'DocumentLineItemDeclined';
+  | 'DocumentLineItemDeclined'
+  | 'ReportReady'
+  | 'ReportFailed';
 
 export interface Notification {
   id: string;
@@ -47,4 +49,14 @@ export const notificationTypeConfig: Record<
     color: 'text-gray-500 bg-gray-50',
   },
   DocumentLineItemDeclined: { icon: 'hand', iconStyle: 'solid', color: 'text-red-500 bg-red-50' },
+  ReportReady: {
+    icon: 'file-check',
+    iconStyle: 'solid',
+    color: 'text-emerald-500 bg-emerald-50',
+  },
+  ReportFailed: {
+    icon: 'file-xmark',
+    iconStyle: 'solid',
+    color: 'text-red-500 bg-red-50',
+  },
 };

--- a/src/features/reportGeneration/api/reports.ts
+++ b/src/features/reportGeneration/api/reports.ts
@@ -1,5 +1,59 @@
 import axios from '@shared/api/axiosInstance';
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type ReportGenerationMode = 'Sync' | 'Async';
+
+export interface ReportDefinition {
+  reportTypeKey: string;
+  displayNameTh: string;
+  displayNameEn: string;
+  category: string;
+  generationMode: ReportGenerationMode;
+}
+
+export type ReportJobStatus = 'Pending' | 'Running' | 'Completed' | 'Failed';
+
+export interface ReportJobDetail {
+  jobId: string;
+  reportTypeKey: string;
+  entityId: string;
+  status: ReportJobStatus;
+  requestedAt: string;
+  startedAt: string | null | undefined;
+  completedAt: string | null | undefined;
+  fileSizeBytes: number | null | undefined;
+  durationMs: number | null | undefined;
+  errorMessage: string | null | undefined;
+}
+
+export interface ReportJobSummary {
+  jobId: string;
+  reportTypeKey: string;
+  entityId: string;
+  status: ReportJobStatus;
+  requestedAt: string;
+  completedAt: string | null | undefined;
+  fileSizeBytes: number | null | undefined;
+  errorMessage: string | null | undefined;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Query key factory
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const reportKeys = {
+  definitions: () => ['reportDefinitions'] as const,
+  jobs: () => ['reportJobs'] as const,
+  job: (jobId: string) => ['reportJob', jobId] as const,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sync report APIs (existing — kept as-is)
+// ──────────────────────────────────────────────────────────────────────────────
+
 /**
  * Fetches a report PDF as a Blob (Bearer auth auto-attached by axiosInstance).
  */
@@ -35,4 +89,48 @@ export const downloadReportPdf = async (
   link.click();
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Async report APIs
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** GET /reports/definitions */
+export const getReportDefinitions = async (): Promise<ReportDefinition[]> => {
+  const { data } = await axios.get<ReportDefinition[]>('/reports/definitions');
+  return data;
+};
+
+/** POST /reports/{reportTypeKey}/{entityId}/jobs → 202 { jobId } */
+export const enqueueReportJob = async (
+  reportTypeKey: string,
+  entityId: string,
+): Promise<{ jobId: string }> => {
+  const { data } = await axios.post<{ jobId: string }>(
+    `/reports/${reportTypeKey}/${entityId}/jobs`,
+  );
+  return data;
+};
+
+/** GET /reports/jobs/{jobId} */
+export const getReportJob = async (jobId: string): Promise<ReportJobDetail> => {
+  const { data } = await axios.get<ReportJobDetail>(`/reports/jobs/${jobId}`);
+  return data;
+};
+
+/** GET /reports/jobs — owner-scoped list, newest first, ≤50 */
+export const listReportJobs = async (): Promise<ReportJobSummary[]> => {
+  const { data } = await axios.get<ReportJobSummary[]>('/reports/jobs');
+  return data;
+};
+
+/**
+ * GET /reports/jobs/{jobId}/download → PDF blob.
+ * Returns 409 if not ready, 410 if artifact gone — callers should handle those.
+ */
+export const downloadReportJobPdf = async (jobId: string): Promise<Blob> => {
+  const { data } = await axios.get<Blob>(`/reports/jobs/${jobId}/download`, {
+    responseType: 'blob',
+  });
+  return data;
 };

--- a/src/features/reportGeneration/components/ReportActionButtons.tsx
+++ b/src/features/reportGeneration/components/ReportActionButtons.tsx
@@ -1,0 +1,162 @@
+import { Fragment } from 'react';
+import toast from 'react-hot-toast';
+import clsx from 'clsx';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+import { fetchReportPdf } from '../api/reports';
+import { useReportDefinitions } from '../hooks/useReportDefinitions';
+import { useAsyncReportJob, JobPoller } from '../hooks/useAsyncReportJob';
+import { useReportJobsStore } from '../store/reportJobsStore';
+import type { TrackedReportJob } from '../store/reportJobsStore';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Status chip — non-blocking inline indicator
+// ──────────────────────────────────────────────────────────────────────────────
+
+function StatusChip({ job }: { job: TrackedReportJob }) {
+  const status = job.status;
+
+  if (status === 'Pending' || status === 'Running') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-50 text-amber-600 border border-amber-200">
+        <svg className="animate-spin size-3" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+        </svg>
+        Generating…
+      </span>
+    );
+  }
+
+  if (status === 'Ready') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-emerald-50 text-emerald-600 border border-emerald-200">
+        <Icon name="circle-check" style="solid" className="size-3" />
+        Ready
+      </span>
+    );
+  }
+
+  if (status === 'Failed') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-red-50 text-red-600 border border-red-200">
+        <Icon name="circle-xmark" style="solid" className="size-3" />
+        Failed
+      </span>
+    );
+  }
+
+  return null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Props
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface ReportActionButtonsProps {
+  reportTypeKey: string;
+  entityId: string;
+  /** Forwarded to the View button so callers can hook in additional side-effects. */
+  onSyncBlobReady?: (blob: Blob, url: string) => void;
+  className?: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Component
+// ──────────────────────────────────────────────────────────────────────────────
+
+export function ReportActionButtons({
+  reportTypeKey,
+  entityId,
+  onSyncBlobReady,
+  className,
+}: ReportActionButtonsProps) {
+  const { modeByKey, isLoading: isLoadingDefs } = useReportDefinitions();
+  const { trigger, jobsForEntity } = useAsyncReportJob();
+  const jobs = useReportJobsStore(s => s.jobs);
+
+  // Pick the most recent job for this entity+type as the chip source
+  const entityJobs = jobsForEntity(entityId).filter(
+    j => j.reportTypeKey === reportTypeKey,
+  );
+  const latestJob = entityJobs.length > 0 ? entityJobs[entityJobs.length - 1] : null;
+
+  const generationMode = modeByKey.get(reportTypeKey) ?? 'Sync';
+  const isAsync = generationMode === 'Async';
+
+  // Derive whether there is an in-progress job so we can disable the button
+  const isEnqueuing =
+    latestJob != null &&
+    (latestJob.status === 'Pending' || latestJob.status === 'Running');
+
+  async function handleView() {
+    if (!entityId.trim()) {
+      toast.error('Entity ID is required.');
+      return;
+    }
+    if (isAsync) {
+      await trigger(reportTypeKey, entityId, { autoOpen: true });
+    } else {
+      try {
+        const blob = await fetchReportPdf(reportTypeKey, entityId);
+        const url = URL.createObjectURL(blob);
+        if (onSyncBlobReady) {
+          onSyncBlobReady(blob, url);
+        } else {
+          window.open(url, '_blank', 'noopener');
+          setTimeout(() => URL.revokeObjectURL(url), 60_000);
+        }
+      } catch {
+        toast.error('Failed to load PDF. Check the ID and try again.');
+      }
+    }
+  }
+
+  async function handleGenerate() {
+    if (!entityId.trim()) {
+      toast.error('Entity ID is required.');
+      return;
+    }
+    await trigger(reportTypeKey, entityId, { autoOpen: false });
+  }
+
+  return (
+    <div className={clsx('flex items-center gap-2 flex-wrap', className)}>
+      <Button
+        variant="primary"
+        size="sm"
+        disabled={isLoadingDefs || isEnqueuing}
+        onClick={handleView}
+        leftIcon={<Icon name="eye" style="regular" className="size-3.5" />}
+      >
+        View
+      </Button>
+
+      {isAsync && (
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isEnqueuing}
+          onClick={handleGenerate}
+          leftIcon={<Icon name="arrow-down-to-line" style="regular" className="size-3.5" />}
+        >
+          Generate
+        </Button>
+      )}
+
+      {latestJob != null && (
+        <Fragment>
+          <StatusChip job={latestJob} />
+          {/* Mount a zero-output poller for every unresolved tracked job */}
+          {Array.from(jobs.values())
+            .filter(j => j.entityId === entityId && j.reportTypeKey === reportTypeKey && !j.resolved)
+            .map(j => (
+              <JobPoller key={j.jobId} jobId={j.jobId} job={j} />
+            ))}
+        </Fragment>
+      )}
+    </div>
+  );
+}
+
+export default ReportActionButtons;

--- a/src/features/reportGeneration/hooks/useAsyncReportJob.ts
+++ b/src/features/reportGeneration/hooks/useAsyncReportJob.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import {
+  enqueueReportJob,
+  getReportJob,
+  downloadReportJobPdf,
+  reportKeys,
+} from '../api/reports';
+import type { ReportJobDetail } from '../api/reports';
+import { useReportJobsStore } from '../store/reportJobsStore';
+import type { TrackedReportJob } from '../store/reportJobsStore';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers (exported so the reconciler can reuse them)
+// ──────────────────────────────────────────────────────────────────────────────
+
+export function isTerminalJobStatus(status: string | undefined): boolean {
+  return status === 'Completed' || status === 'Failed';
+}
+
+/**
+ * Open a completed job's PDF in a new tab.
+ * Revokes the object URL after 60 s to avoid memory leaks.
+ */
+export async function openJobPdf(jobId: string): Promise<void> {
+  const blob = await downloadReportJobPdf(jobId);
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener');
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+/**
+ * Idempotent resolution — first-channel-wins.
+ *
+ * Both the polling channel (useJobPoller) and the realtime channel
+ * (useReportJobReconciler) call this. The `resolved` flag in the store is a
+ * one-way latch: whichever channel sets it first wins and fires the side-effect;
+ * the second caller finds `resolved === true` and returns immediately.
+ *
+ * The update is intentionally written to the Zustand store via getState() so
+ * it works outside of React render cycles (e.g. from a SignalR handler).
+ */
+export function resolveJob(
+  jobId: string,
+  status: 'Completed' | 'Failed',
+  opts: { autoOpen: boolean; error?: string | null },
+): void {
+  const store = useReportJobsStore.getState();
+  const job = store.get(jobId);
+  if (!job || job.resolved) return;
+
+  // Claim the resolution slot before firing async side-effects so the second
+  // concurrent call sees resolved=true even if the first is still in the
+  // download await.
+  store.update(jobId, { status: status === 'Completed' ? 'Ready' : 'Failed', resolved: true });
+
+  if (status === 'Completed') {
+    if (opts.autoOpen) {
+      openJobPdf(jobId).catch(() => {
+        toast.error('Report ready but failed to open. Check the notification bell.');
+      });
+    } else {
+      toast.success('Report is ready. Click the notification bell to download.');
+    }
+  } else {
+    const msg = opts.error ?? 'Report generation failed.';
+    store.update(jobId, { error: msg });
+    toast.error(msg);
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Per-job polling component (mounted inside ReportActionButtons)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Polls a single job until it reaches a terminal status, then calls resolveJob.
+ * Designed to be rendered as a zero-output component so polling starts as soon
+ * as the job is tracked without requiring a parent re-render.
+ */
+export function JobPoller({ jobId, job }: { jobId: string; job: TrackedReportJob }) {
+  const { data } = useQuery<ReportJobDetail>({
+    queryKey: reportKeys.job(jobId),
+    queryFn: () => getReportJob(jobId),
+    enabled: !job.resolved && !isTerminalJobStatus(job.status),
+    refetchInterval: query => {
+      const status = (query.state.data as ReportJobDetail | undefined)?.status;
+      return isTerminalJobStatus(status) ? false : 2500;
+    },
+    retry: 1,
+  });
+
+  // Track the last-seen jobId so the effect only fires when the terminal data
+  // arrives, not on every render.
+  const resolvedRef = useRef(false);
+
+  useEffect(() => {
+    if (!data || !isTerminalJobStatus(data.status) || resolvedRef.current) return;
+    resolvedRef.current = true;
+    resolveJob(data.jobId, data.status as 'Completed' | 'Failed', {
+      autoOpen: job.autoOpen,
+      error: data.errorMessage,
+    });
+  }, [data, job.autoOpen]);
+
+  return null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public hook
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface UseAsyncReportJobReturn {
+  trigger: (
+    reportTypeKey: string,
+    entityId: string,
+    opts: { autoOpen: boolean },
+  ) => Promise<void>;
+  /** Returns all tracked jobs for the given entityId. */
+  jobsForEntity: (entityId: string) => TrackedReportJob[];
+}
+
+export function useAsyncReportJob(): UseAsyncReportJobReturn {
+  const track = useReportJobsStore(s => s.track);
+  const jobs = useReportJobsStore(s => s.jobs);
+
+  const trigger = useCallback(
+    async (
+      reportTypeKey: string,
+      entityId: string,
+      opts: { autoOpen: boolean },
+    ): Promise<void> => {
+      try {
+        const { jobId } = await enqueueReportJob(reportTypeKey, entityId);
+        track({ jobId, reportTypeKey, entityId, status: 'Pending', autoOpen: opts.autoOpen });
+        toast('Generating report…', { icon: '⏳' });
+      } catch {
+        toast.error('Failed to queue report generation.');
+      }
+    },
+    [track],
+  );
+
+  const jobsForEntity = useCallback(
+    (entityId: string): TrackedReportJob[] => {
+      const result: TrackedReportJob[] = [];
+      for (const job of jobs.values()) {
+        if (job.entityId === entityId) result.push(job);
+      }
+      return result;
+    },
+    [jobs],
+  );
+
+  return { trigger, jobsForEntity };
+}

--- a/src/features/reportGeneration/hooks/useReportDefinitions.ts
+++ b/src/features/reportGeneration/hooks/useReportDefinitions.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { getReportDefinitions, reportKeys } from '../api/reports';
+import type { ReportDefinition, ReportGenerationMode } from '../api/reports';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface ReportDefinitionsLookup {
+  /** Full definition list, useful for dropdowns. */
+  definitions: ReportDefinition[];
+  /** Fast key → generationMode lookup. */
+  modeByKey: Map<string, ReportGenerationMode>;
+  isLoading: boolean;
+}
+
+/**
+ * Fetches and caches the report definition list with a long stale time (30 min).
+ * Returns a Map lookup so components can resolve generationMode in O(1).
+ */
+export function useReportDefinitions(): ReportDefinitionsLookup {
+  const { data, isLoading } = useQuery({
+    queryKey: reportKeys.definitions(),
+    queryFn: getReportDefinitions,
+    staleTime: 1000 * 60 * 30,
+    // Treat an empty/error response gracefully — callers fall back to Sync.
+    placeholderData: [],
+  });
+
+  const definitions = data ?? [];
+  const modeByKey = new Map<string, ReportGenerationMode>(
+    definitions.map(d => [d.reportTypeKey, d.generationMode]),
+  );
+
+  return { definitions, modeByKey, isLoading };
+}

--- a/src/features/reportGeneration/hooks/useReportJobReconciler.ts
+++ b/src/features/reportGeneration/hooks/useReportJobReconciler.ts
@@ -1,0 +1,110 @@
+import { useEffect } from 'react';
+import { useAuthStore } from '@features/auth/store';
+import * as appHub from '@shared/realtime/appHub';
+import { listReportJobs } from '../api/reports';
+import { useReportJobsStore } from '../store/reportJobsStore';
+import { resolveJob, isTerminalJobStatus } from './useAsyncReportJob';
+import type { Notification } from '@features/notification/types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * App-level hook — mount once near the app shell alongside useNotificationHub.
+ *
+ * Responsibilities:
+ * 1. Realtime: subscribes to ReceiveNotification and resolves any tracked job
+ *    when type === 'ReportReady' | 'ReportFailed'.
+ * 2. Reconcile on reconnect: on every re-connect (not cold first connect),
+ *    fetches /reports/jobs and resolves any tracked jobs that completed while
+ *    the SignalR connection was down.
+ * 3. Reconcile on mount: same reconcile pass so that jobs enqueued before a
+ *    full page reload are resolved from the server's current state.
+ */
+export function useReportJobReconciler() {
+  const username = useAuthStore(s => s.user?.username);
+
+  // ── Realtime channel ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!username) return;
+
+    const unsub = appHub.on<Notification>('ReceiveNotification', notification => {
+      if (
+        notification.type !== 'ReportReady' &&
+        notification.type !== 'ReportFailed'
+      ) {
+        return;
+      }
+
+      const meta = notification.metadata ?? {};
+      const jobId = typeof meta.jobId === 'string' ? meta.jobId : null;
+      if (!jobId) return;
+
+      const store = useReportJobsStore.getState();
+      const job = store.get(jobId);
+      if (!job) return;
+
+      // Update fileName from notification metadata if available
+      const fileName =
+        typeof meta.fileName === 'string' ? meta.fileName : undefined;
+      if (fileName) {
+        store.update(jobId, { fileName });
+      }
+
+      resolveJob(
+        jobId,
+        notification.type === 'ReportReady' ? 'Completed' : 'Failed',
+        { autoOpen: job.autoOpen },
+      );
+    });
+
+    return unsub;
+  }, [username]);
+
+  // ── Reconcile on mount + reconnect ─────────────────────────────────────────
+  useEffect(() => {
+    if (!username) return;
+
+    async function reconcile() {
+      try {
+        const serverJobs = await listReportJobs();
+        const store = useReportJobsStore.getState();
+
+        for (const serverJob of serverJobs) {
+          const tracked = store.get(serverJob.jobId);
+          if (!tracked) continue;
+          if (!isTerminalJobStatus(serverJob.status)) continue;
+
+          resolveJob(
+            serverJob.jobId,
+            serverJob.status as 'Completed' | 'Failed',
+            {
+              autoOpen: tracked.autoOpen,
+              error: serverJob.errorMessage,
+            },
+          );
+        }
+      } catch {
+        // Reconcile failures are non-fatal — polling will catch terminal state
+      }
+    }
+
+    // Reconcile immediately on mount so jobs enqueued before page reload are resolved
+    void reconcile();
+
+    // Reconcile again every time the SignalR connection is restored after a blip.
+    // Mirror the pattern in useNotificationHub: skip cold first connect (primed flag).
+    let primed = appHub.hasEverConnected();
+    const unsub = appHub.onConnectionStateChange(status => {
+      if (status !== 'connected') return;
+      if (!primed) {
+        primed = true;
+        return;
+      }
+      void reconcile();
+    });
+
+    return unsub;
+  }, [username]);
+}

--- a/src/features/reportGeneration/pages/ReportTestPage.tsx
+++ b/src/features/reportGeneration/pages/ReportTestPage.tsx
@@ -1,20 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
-import toast from 'react-hot-toast';
 import SectionHeader from '@shared/components/sections/SectionHeader';
-import Button from '@shared/components/Button';
 import Icon from '@shared/components/Icon';
-import { fetchReportPdf, downloadReportPdf } from '../api/reports';
+import ReportActionButtons from '../components/ReportActionButtons';
 
 const REPORT_TYPES = [
   { value: 'appointment-quotation-request', label: 'Appointment Quotation Request' },
+  // Unified entry: auto-picks the per-property summary forms and merges them into one PDF
+  // (block-only / construction-only / else land-building + condo + machine).
+  { value: 'appraisal-summary', label: 'Appraisal Summary' },
+  { value: 'external-appraisal-report', label: 'External Appraisal Report' },
+  { value: 'internal-report-construction', label: 'Internal Appraisal Report – Construction' },
+  { value: 'internal-report-block', label: 'Internal Appraisal Report – Block' },
+  { value: 'meeting-invitation', label: 'Meeting Invitation (entity = MeetingId)' },
+  { value: 'meeting-minute', label: 'Meeting Minute (entity = MeetingId)' },
 ] as const;
 
 const ReportTestPage = () => {
   const [entityId, setEntityId] = useState('');
   const [reportTypeKey, setReportTypeKey] = useState<string>(REPORT_TYPES[0].value);
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [isViewing, setIsViewing] = useState(false);
-  const [isDownloading, setIsDownloading] = useState(false);
 
   // Keep a ref to the current object URL so the cleanup effect always revokes
   // the most-recent one, even if state has already changed.
@@ -36,40 +40,6 @@ const ReportTestPage = () => {
       objectUrlRef.current = null;
     }
     setObjectUrl(null);
-  };
-
-  const handleView = async () => {
-    if (!entityId.trim()) {
-      toast.error('Please enter an Appraisal ID.');
-      return;
-    }
-    setIsViewing(true);
-    revokeCurrentUrl();
-    try {
-      const blob = await fetchReportPdf(reportTypeKey, entityId.trim());
-      const url = URL.createObjectURL(blob);
-      objectUrlRef.current = url;
-      setObjectUrl(url);
-    } catch {
-      toast.error('Failed to load PDF. Check the Appraisal ID and try again.');
-    } finally {
-      setIsViewing(false);
-    }
-  };
-
-  const handleDownload = async () => {
-    if (!entityId.trim()) {
-      toast.error('Please enter an Appraisal ID.');
-      return;
-    }
-    setIsDownloading(true);
-    try {
-      await downloadReportPdf(reportTypeKey, entityId.trim());
-    } catch {
-      toast.error('Failed to download PDF. Check the Appraisal ID and try again.');
-    } finally {
-      setIsDownloading(false);
-    }
   };
 
   return (
@@ -113,26 +83,23 @@ const ReportTestPage = () => {
           </div>
         </div>
 
-        {/* Action buttons */}
+        {/* Mode-aware actions — reads generationMode from /reports/definitions and routes
+            Sync → open inline, Async → enqueue a background job (realtime + polling + bell). */}
         <div className="flex items-center gap-2 mt-4">
-          <Button
-            variant="primary"
-            size="sm"
-            isLoading={isViewing}
-            onClick={handleView}
-            leftIcon={<Icon name="eye" style="regular" className="size-3.5" />}
-          >
-            View
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            isLoading={isDownloading}
-            onClick={handleDownload}
-            leftIcon={<Icon name="arrow-down-to-line" style="regular" className="size-3.5" />}
-          >
-            Download
-          </Button>
+          {entityId.trim() ? (
+            <ReportActionButtons
+              reportTypeKey={reportTypeKey}
+              entityId={entityId.trim()}
+              onSyncBlobReady={(_blob, url) => {
+                if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+                objectUrlRef.current = url;
+                setObjectUrl(url);
+              }}
+            />
+          ) : (
+            <p className="text-xs text-gray-400">Enter an Appraisal ID to view or generate.</p>
+          )}
+
           {objectUrl && (
             <button
               type="button"

--- a/src/features/reportGeneration/store/reportJobsStore.ts
+++ b/src/features/reportGeneration/store/reportJobsStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import type { ReportJobStatus } from '../api/reports';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface TrackedReportJob {
+  jobId: string;
+  reportTypeKey: string;
+  entityId: string;
+  /** Current status as known to the client (Pending → Running → Completed/Failed). */
+  status: ReportJobStatus | 'Ready';
+  /** Original filename from the ReportReady notification metadata, if available. */
+  fileName?: string | null;
+  /** If true, the PDF should be opened in a new tab when the job completes. */
+  autoOpen: boolean;
+  /** Set to true the first time this job is resolved (Completed or Failed) so that
+   *  the realtime channel and the polling channel cannot both fire the side-effects. */
+  resolved: boolean;
+  /** Surfaced error message for Failed jobs. */
+  error?: string | null;
+}
+
+type TrackedJobPatch = Partial<Omit<TrackedReportJob, 'jobId'>>;
+
+interface ReportJobsStore {
+  /** jobId → tracked job entry */
+  jobs: Map<string, TrackedReportJob>;
+  /** Add or replace a job entry. */
+  track: (job: Omit<TrackedReportJob, 'resolved'>) => void;
+  /** Shallow-patch a tracked job by jobId. No-op if the job is not tracked. */
+  update: (jobId: string, patch: TrackedJobPatch) => void;
+  /** Remove a job from tracking. */
+  remove: (jobId: string) => void;
+  /** Return the tracked entry or undefined. */
+  get: (jobId: string) => TrackedReportJob | undefined;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Store
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const useReportJobsStore = create<ReportJobsStore>((set, get) => ({
+  jobs: new Map(),
+
+  track: job => {
+    set(state => {
+      const next = new Map(state.jobs);
+      next.set(job.jobId, { ...job, resolved: false });
+      return { jobs: next };
+    });
+  },
+
+  update: (jobId, patch) => {
+    set(state => {
+      const existing = state.jobs.get(jobId);
+      if (!existing) return state;
+      const next = new Map(state.jobs);
+      next.set(jobId, { ...existing, ...patch });
+      return { jobs: next };
+    });
+  },
+
+  remove: jobId => {
+    set(state => {
+      const next = new Map(state.jobs);
+      next.delete(jobId);
+      return { jobs: next };
+    });
+  },
+
+  get: jobId => get().jobs.get(jobId),
+}));

--- a/src/features/task/hooks/useWorkflowHub.ts
+++ b/src/features/task/hooks/useWorkflowHub.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
-import { signalrLogger } from '@shared/utils/signalrLogger';
-import { getAccessToken } from '@shared/api/axiosInstance';
+import * as appHub from '@shared/realtime/appHub';
 
 export interface PoolTaskUpdateEvent {
   type: 'PoolTaskLocked' | 'PoolTaskUnlocked' | 'PoolTaskClaimed';
@@ -18,15 +16,7 @@ interface UseWorkflowHubOptions {
   onPoolTaskUpdate: (event: PoolTaskUpdateEvent) => void;
 }
 
-const getHubUrl = () => {
-  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
-  return apiUrl.replace(/\/api\/?$/, '') + '/workflowHub';
-};
-
 export function useWorkflowHub({ poolGroups, onPoolTaskUpdate }: UseWorkflowHubOptions) {
-  const connectionRef = useRef<ReturnType<typeof HubConnectionBuilder.prototype.build> | null>(
-    null,
-  );
   // Keep latest callback in a ref so the effect closure stays stable
   const callbackRef = useRef(onPoolTaskUpdate);
   callbackRef.current = onPoolTaskUpdate;
@@ -37,46 +27,21 @@ export function useWorkflowHub({ poolGroups, onPoolTaskUpdate }: UseWorkflowHubO
   useEffect(() => {
     if (poolGroups.length === 0) return;
 
-    const token = getAccessToken();
-    if (!token) return;
-
-    const connection = new HubConnectionBuilder()
-      .withUrl(getHubUrl(), {
-        accessTokenFactory: () => getAccessToken() ?? '',
-        // skipNegotiation: true,
-        // transport: HttpTransportType.WebSockets,
-        withCredentials: true,
-      })
-      .withAutomaticReconnect()
-      .configureLogging(signalrLogger)
-      .build();
-
-    connectionRef.current = connection;
-
-    connection.on('PoolTaskUpdate', (event: PoolTaskUpdateEvent) => {
+    // Subscribe to PoolTaskUpdate events on the shared connection
+    const unsub = appHub.on<PoolTaskUpdateEvent>('PoolTaskUpdate', event => {
       callbackRef.current(event);
     });
 
-    let cancelled = false;
-
-    connection
-      .start()
-      .then(() => {
-        if (cancelled) return;
-        console.log('[WorkflowHub] SignalR connected, joining pools:', poolGroups);
-        return Promise.all(poolGroups.map(g => connection.invoke('JoinPoolGroup', g)));
-      })
-      .catch(err => {
-        if (!cancelled) console.error('[WorkflowHub] SignalR connection failed:', err);
-      });
+    // Join each pool group on the server — the NEW generic JoinGroup method is used,
+    // and the client is responsible for passing the full 'pool-' prefix because the
+    // old JoinPoolGroup (which prepended the prefix server-side) has been removed.
+    const prefixedGroups = poolGroups.map(g => `pool-${g}`);
+    console.log('[WorkflowHub] Joining pool groups:', prefixedGroups);
+    prefixedGroups.forEach(g => appHub.joinGroup(g));
 
     return () => {
-      cancelled = true;
-      if (connection.state !== HubConnectionState.Disconnected) {
-        Promise.all(
-          poolGroups.map(g => connection.invoke('LeavePoolGroup', g).catch(() => {})),
-        ).finally(() => connection.stop());
-      }
+      unsub();
+      prefixedGroups.forEach(g => appHub.leaveGroup(g));
     };
     // groupKey is a stable derived string — safe to use instead of the array reference
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/i18n/locales/en/notification.json
+++ b/src/i18n/locales/en/notification.json
@@ -4,6 +4,10 @@
   "markAllRead": "Mark all as read",
   "viewAll": "View All",
   "realtimeUnavailable": "Real-time notifications unavailable",
+  "connection": {
+    "online": "Online",
+    "offline": "Offline"
+  },
   "timeAgo": {
     "justNow": "just now",
     "minutes": "{{n}}m ago",

--- a/src/i18n/locales/th/notification.json
+++ b/src/i18n/locales/th/notification.json
@@ -4,6 +4,10 @@
   "markAllRead": "ทำเครื่องหมายว่าอ่านแล้วทั้งหมด",
   "viewAll": "ดูทั้งหมด",
   "realtimeUnavailable": "ไม่สามารถใช้การแจ้งเตือนแบบเรียลไทม์ได้",
+  "connection": {
+    "online": "ออนไลน์",
+    "offline": "ออฟไลน์"
+  },
   "timeAgo": {
     "justNow": "เมื่อสักครู่",
     "minutes": "{{n}} นาทีที่แล้ว",

--- a/src/i18n/locales/zh/notification.json
+++ b/src/i18n/locales/zh/notification.json
@@ -4,6 +4,10 @@
   "markAllRead": "全部标记为已读",
   "viewAll": "查看全部",
   "realtimeUnavailable": "实时通知不可用",
+  "connection": {
+    "online": "在线",
+    "offline": "离线"
+  },
   "timeAgo": {
     "justNow": "刚刚",
     "minutes": "{{n}} 分钟前",

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -36,9 +36,7 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 let accessToken: string | null = null;
 
 // --- BroadcastChannel for multi-tab sync (feature-detected) ---
-type AuthChannelMessage =
-  | { type: 'token_update'; token: string | null }
-  | { type: 'logout' };
+type AuthChannelMessage = { type: 'token_update'; token: string | null } | { type: 'logout' };
 
 type AuthChannel = {
   postMessage: (message: AuthChannelMessage) => void;
@@ -116,6 +114,50 @@ async function refreshAccessToken(): Promise<string | null> {
   }
 }
 
+/**
+ * Decode a JWT's `exp` (seconds since epoch) and report whether it is expired
+ * (or expires within `skewSeconds`). Returns true on any decode failure so a
+ * malformed/unparsable token is treated as needing a refresh. */
+function isTokenExpired(token: string, skewSeconds = 30): boolean {
+  try {
+    const segment = token.split('.')[1];
+    if (!segment) return true;
+    // base64url → base64, restoring '=' padding to a multiple of 4.
+    const b64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '==='.slice((b64.length + 3) % 4);
+    const json = atob(padded);
+    const exp = JSON.parse(json).exp as number | undefined;
+    if (typeof exp !== 'number') return true;
+    return Date.now() >= (exp - skewSeconds) * 1000;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Return a usable access token, refreshing first if the in-memory token is
+ * missing or (about to be) expired. Reuses the same single-flight refresh
+ * promise as the 401 interceptor so concurrent callers share one refresh.
+ *
+ * Used by the SignalR accessTokenFactory so reconnects after idle/sleep don't
+ * negotiate with a stale token and 401-loop.
+ */
+export async function getFreshAccessToken(): Promise<string | null> {
+  if (accessToken && !isTokenExpired(accessToken)) {
+    return accessToken;
+  }
+  if (!refreshPromise) {
+    refreshPromise = refreshAccessToken().finally(() => {
+      refreshPromise = null;
+    });
+  }
+  const newToken = await refreshPromise;
+  if (newToken) {
+    setAccessToken(newToken);
+  }
+  return newToken;
+}
+
 // Create axios instance with base URL and default headers
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
@@ -157,12 +199,7 @@ axiosInstance.interceptors.response.use(
     // Skip refresh entirely for auth endpoints: a 401 from /auth/login is a
     // credential failure (not a stale token) and refresh/token endpoints
     // would loop or mask the real error.
-    if (
-      response &&
-      response.status === 401 &&
-      config &&
-      !isAuthEndpoint(config.url)
-    ) {
+    if (response && response.status === 401 && config && !isAuthEndpoint(config.url)) {
       // Only attempt refresh once per request
       if ((config as any)._retried) {
         broadcastLogout();
@@ -185,8 +222,8 @@ axiosInstance.interceptors.response.use(
       if (newToken) {
         setAccessToken(newToken);
         if (!config.headers) {
-        config.headers = new AxiosHeaders();
-      }
+          config.headers = new AxiosHeaders();
+        }
         config.headers.Authorization = `Bearer ${newToken}`;
         return axiosInstance(config);
       }

--- a/src/shared/components/Navbar.tsx
+++ b/src/shared/components/Navbar.tsx
@@ -8,13 +8,17 @@ import { broadcastLogout } from '@shared/api/axiosInstance';
 import { queryClient } from '@app/queryClient';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@shared/components/LanguageSwitcher';
-import ThemeToggle from '@shared/components/ThemeToggle';
+// import ThemeToggle from '@shared/components/ThemeToggle'; // hidden for now
 import Avatar from '@shared/components/Avatar';
 import { useGlobalSearch } from '@shared/hooks/useGlobalSearch';
 import SearchResults from '@shared/components/search/SearchResults';
 import SearchPreviewModal from '@shared/components/search/SearchPreviewModal';
 import type { SearchFilter } from '@shared/types/search';
 import NotificationDropdown from '@features/notification/components/NotificationDropdown';
+import ConnectionStatusIndicator, {
+  ConnectionStatusDot,
+} from '@features/notification/components/ConnectionStatusIndicator';
+import * as appHub from '@shared/realtime/appHub';
 import { HeaderFavoritesDropdown } from '@features/menuFavorites/components/HeaderFavoritesDropdown';
 
 const searchFilters = [
@@ -51,6 +55,10 @@ function handleLogout(href: string) {
   // to redirect to /login, which cancels the server logout navigation.
   // Clear storage directly without triggering React re-renders.
   // Use broadcastLogout so other tabs also clear auth + redirect.
+  // Tear down the realtime connection synchronously (stop() sets the
+  // intentional-stop flag + clears the restart timer before the redirect) so
+  // no auto-restart fires during the unload window.
+  appHub.stop().catch(() => {});
   broadcastLogout();
   queryClient.clear();
   sessionStorage.clear();
@@ -248,8 +256,8 @@ export default function Navbar({
             {/* Language Switcher */}
             <LanguageSwitcher />
 
-            {/* Theme Toggle */}
-            <ThemeToggle />
+            {/* Theme Toggle - hidden for now */}
+            {/* <ThemeToggle /> */}
 
             {/* Favorites button */}
             <HeaderFavoritesDropdown />
@@ -258,26 +266,34 @@ export default function Navbar({
             <NotificationDropdown />
 
             {/* Separator */}
-            <div aria-hidden="true" className="hidden lg:block lg:h-8 lg:w-px lg:bg-gray-200 dark:lg:bg-base-300" />
+            <div
+              aria-hidden="true"
+              className="hidden lg:block lg:h-8 lg:w-px lg:bg-gray-200 dark:lg:bg-base-300"
+            />
 
             {/* Profile dropdown */}
             <Menu as="div" className="relative">
               <MenuButton className="flex items-center gap-3 p-1.5 rounded-xl hover:bg-gray-50 dark:hover:bg-base-200 transition-all">
                 <span className="sr-only">Open user menu</span>
-                <Avatar
-                  src={currentUser?.avatarUrl}
-                  name={
-                    `${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`.trim() ||
-                    'User'
-                  }
-                  size="md"
-                  className="rounded-xl ring-2 ring-gray-100"
-                />
+                <span className="relative inline-block">
+                  <Avatar
+                    src={currentUser?.avatarUrl}
+                    name={
+                      `${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`.trim() ||
+                      'User'
+                    }
+                    size="md"
+                    className="rounded-xl ring-2 ring-gray-100"
+                  />
+                  <ConnectionStatusDot ring className="absolute -bottom-0.5 -right-0.5 h-3 w-3" />
+                </span>
                 <span className="hidden lg:flex lg:flex-col lg:items-start">
                   <span className="text-sm font-semibold text-gray-900 dark:text-base-content">
                     {`${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`}
                   </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">{currentUser?.position}</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    {currentUser?.position}
+                  </span>
                 </span>
                 <Icon
                   name="chevron-down"
@@ -292,8 +308,16 @@ export default function Navbar({
                 {/* User info header */}
                 <div className="px-4 py-3 border-b border-gray-100 dark:border-base-300">
                   <p className="text-sm font-medium text-gray-900 dark:text-base-content">{`${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`}</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{currentUser?.email}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {currentUser?.email}
+                  </p>
                 </div>
+
+                {/* Realtime connection status + control */}
+                <div className="border-b border-gray-100 dark:border-base-300">
+                  <ConnectionStatusIndicator />
+                </div>
+
                 {userNavigation.map(item =>
                   item.name === 'Sign out' ? (
                     <MenuItem

--- a/src/shared/realtime/appHub.ts
+++ b/src/shared/realtime/appHub.ts
@@ -1,0 +1,404 @@
+/**
+ * Shared singleton SignalR connection for the entire app.
+ *
+ * All real-time events (ReceiveNotification, ActivityStepProgress, PoolTaskUpdate)
+ * are delivered over a single /notificationHub connection.
+ *
+ * Group rules (server-side):
+ * - Every authenticated connection auto-joins `user-{username}` on connect —
+ *   no client-side join call needed for user-level events.
+ * - Pool task groups: client calls joinGroup('pool-'+g) / leaveGroup('pool-'+g).
+ */
+
+import { HubConnectionBuilder, HubConnectionState, type HubConnection } from '@microsoft/signalr';
+import { getFreshAccessToken } from '@shared/api/axiosInstance';
+import { signalrLogger } from '@shared/utils/signalrLogger';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hub URL
+// ──────────────────────────────────────────────────────────────────────────────
+
+function getHubUrl(): string {
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+  return apiUrl.replace(/\/api\/?$/, '') + '/notificationHub';
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types — re-exported so consumers don't need to import from the old locations
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface ActivityStepDto {
+  stepName: string;
+  displayName: string;
+  sortOrder: number;
+  kind: string;
+}
+
+export type ActivityStepProgressEvent =
+  | {
+      phase: 'PipelineStarted';
+      workflowActivityExecutionId: string;
+      activityName: string;
+      steps: ActivityStepDto[];
+    }
+  | {
+      phase: 'StepStarted';
+      workflowActivityExecutionId: string;
+      step: ActivityStepDto;
+    }
+  | {
+      phase: 'StepFinished';
+      workflowActivityExecutionId: string;
+      step: ActivityStepDto;
+      outcome: string;
+      durationMs: number;
+    }
+  | {
+      phase: 'PipelineFinished';
+      workflowActivityExecutionId: string;
+      result: string;
+    };
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Connection status
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** High-level connection status surfaced to the UI. */
+export type AppHubStatus = 'connected' | 'reconnecting' | 'disconnected';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Singleton state
+// ──────────────────────────────────────────────────────────────────────────────
+
+let _connection: HubConnection | null = null;
+let _startPromise: Promise<void> | null = null;
+
+/** Last username passed to start() — used by wake/close handlers to reconnect. */
+let _lastUsername: string | null = null;
+
+/** Set during stop() so the onclose handler doesn't auto-restart on logout. */
+let _intentionalStop = false;
+
+/** Pending auto-restart timer (after an unexpected close). */
+let _restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Whether the window-level wake listeners have been attached (once only). */
+let _wakeListenersAttached = false;
+
+/** Current high-level status. */
+let _status: AppHubStatus = 'disconnected';
+
+/** True once the connection has reached 'connected' at least once this session.
+ * Lets consumers distinguish a cold first-connect from a re-connect even when
+ * they attach mid-reconnect. */
+let _hasEverConnected = false;
+
+/** Generic groups the client has joined (e.g. 'pool-ROLE_A'). */
+const _activeGroups = new Set<string>();
+
+/** Per-event subscriber sets — fans out to multiple consumers. */
+const _subscribers = new Map<string, Set<(payload: unknown) => void>>();
+
+/** Event names with a live connection-level handler on the CURRENT connection.
+ * Cleared whenever a new connection is built so each connection is bound once. */
+const _boundEvents = new Set<string>();
+
+/** Listeners notified whenever the high-level status changes. */
+const _statusListeners = new Set<(status: AppHubStatus) => void>();
+
+function setStatus(status: AppHubStatus): void {
+  if (_status === status) return;
+  _status = status;
+  if (status === 'connected') _hasEverConnected = true;
+  for (const listener of _statusListeners) {
+    try {
+      listener(status);
+    } catch (err) {
+      console.warn('[AppHub] status listener threw:', err);
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function buildConnection(): HubConnection {
+  return (
+    new HubConnectionBuilder()
+      .withUrl(getHubUrl(), {
+        // Refresh the token before (re)connecting so reconnects after idle/sleep
+        // don't negotiate with an expired token and 401-loop.
+        // On refresh failure getFreshAccessToken() returns null → ''. We do NOT
+        // force a logout here: a null result also covers a transient network
+        // outage (offline), which is exactly when we want to keep retrying.
+        // A genuinely dead session is caught by the axios 401 interceptor on the
+        // next API call, which forces the logout/redirect.
+        accessTokenFactory: async () => (await getFreshAccessToken()) ?? '',
+        withCredentials: true,
+      })
+      // Never give up: capped exponential backoff that always returns a delay
+      // (the default policy stops after ~40s, killing real-time for the session).
+      // 0s, 2s, 4s, 8s, 16s, then 30s forever.
+      .withAutomaticReconnect({
+        nextRetryDelayInMilliseconds: ctx =>
+          ctx.previousRetryCount === 0
+            ? 0
+            : Math.min(30000, 1000 * 2 ** Math.min(ctx.previousRetryCount, 5)),
+      })
+      .configureLogging(signalrLogger)
+      .build()
+  );
+}
+
+/** Register the fan-out handler for `event` on `conn` at most once per
+ * connection. Idempotent — guarded by _boundEvents (cleared on each new
+ * connection) so the two call sites can't double-register on one connection. */
+function bindEvent(conn: HubConnection, event: string): void {
+  if (_boundEvents.has(event)) return;
+  _boundEvents.add(event);
+  conn.on(event, (payload: unknown) => {
+    for (const sub of _subscribers.get(event) ?? []) {
+      sub(payload);
+    }
+  });
+}
+
+function getOrCreateSubscriberSet(event: string): Set<(payload: unknown) => void> {
+  let set = _subscribers.get(event);
+  if (!set) {
+    set = new Set();
+    _subscribers.set(event, set);
+  }
+  // Register the connection handler the first time anyone subscribes to this
+  // event. Safe to call even before start() — SignalR queues on() calls.
+  if (_connection) {
+    bindEvent(_connection, event);
+  }
+  return set;
+}
+
+function attachConnectionHandlers(conn: HubConnection): void {
+  // Fresh connection — re-register handlers for every known event.
+  _boundEvents.clear();
+  // Register a handler for every event that already has subscribers (e.g. if
+  // on() was called before start() was invoked with a connection instance).
+  for (const [event] of _subscribers) {
+    bindEvent(conn, event);
+  }
+
+  // Connection dropped — automatic reconnection is now in progress.
+  conn.onreconnecting(() => {
+    setStatus('reconnecting');
+  });
+
+  // After reconnect: re-join all tracked generic groups, then signal connected.
+  // The user-level group (user-{username}) is auto-joined by the server, so we
+  // only need to restore the explicit pool/generic groups here.
+  // Status flips to 'connected' last so subscribers (e.g. the notification hook)
+  // re-fetch only once groups are restored — catching up anything missed while
+  // disconnected (SignalR does not buffer server→client messages).
+  conn.onreconnected(async () => {
+    for (const group of _activeGroups) {
+      try {
+        await conn.invoke('JoinGroup', group);
+      } catch (err) {
+        console.warn('[AppHub] Failed to re-join group after reconnect:', group, err);
+      }
+    }
+    setStatus('connected');
+  });
+
+  // Permanent close (retry policy exhausted — shouldn't happen with the
+  // never-give-up policy above, but also covers post-negotiation failures).
+  // Schedule a fresh start unless the close was an intentional stop().
+  conn.onclose(() => {
+    setStatus('disconnected');
+    if (_intentionalStop) return;
+    _connection = null;
+    scheduleRestart();
+  });
+}
+
+/** Schedule a reconnect attempt after an unexpected close. */
+function scheduleRestart(): void {
+  if (_restartTimer || _intentionalStop || !_lastUsername) return;
+  _restartTimer = setTimeout(() => {
+    _restartTimer = null;
+    if (!_lastUsername) return;
+    start(_lastUsername).catch(err => {
+      console.warn('[AppHub] auto-restart failed, will retry:', err);
+      scheduleRestart();
+    });
+  }, 5000);
+}
+
+/** Attach window/document wake listeners once — reconnect on network/focus.
+ * Gated on 'disconnected' (not !== 'connected') so a wake event during an
+ * in-progress 'reconnecting' window doesn't race a second connection against
+ * the automatic-reconnect machinery. */
+function attachWakeListeners(): void {
+  if (_wakeListenersAttached || typeof window === 'undefined') return;
+  _wakeListenersAttached = true;
+
+  window.addEventListener('online', () => {
+    if (_lastUsername && _status === 'disconnected') {
+      start(_lastUsername).catch(() => {});
+    }
+  });
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible' && _lastUsername && _status === 'disconnected') {
+        start(_lastUsername).catch(() => {});
+      }
+    });
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Start the shared connection.
+ * Safe to call multiple times — subsequent calls are no-ops while connecting/connected.
+ *
+ * The server auto-joins `user-{username}` on connect; no client join needed.
+ */
+export async function start(_username: string): Promise<void> {
+  _lastUsername = _username;
+  _intentionalStop = false;
+  attachWakeListeners();
+
+  if (_startPromise) return _startPromise;
+  if (_connection && _connection.state !== HubConnectionState.Disconnected) {
+    return;
+  }
+
+  _connection = buildConnection();
+  attachConnectionHandlers(_connection);
+
+  const promise = _connection
+    .start()
+    .then(() => {
+      console.log('[AppHub] Connected');
+      setStatus('connected');
+    })
+    .catch(err => {
+      console.warn('[AppHub] Connection failed:', err);
+      setStatus('disconnected');
+      // The initial start() isn't covered by the reconnect policy, so retry it
+      // ourselves — otherwise a transient failure at login means no real-time
+      // until a full page reload.
+      _connection = null;
+      scheduleRestart();
+      throw err; // re-throw so callers (useNotificationHub) can show a toast
+    })
+    .finally(() => {
+      _startPromise = null;
+    });
+
+  _startPromise = promise;
+  return promise;
+}
+
+/** Stop and discard the shared connection (call on logout). */
+export async function stop(): Promise<void> {
+  _intentionalStop = true;
+  _lastUsername = null;
+  if (_restartTimer) {
+    clearTimeout(_restartTimer);
+    _restartTimer = null;
+  }
+  _activeGroups.clear();
+  _boundEvents.clear();
+  _hasEverConnected = false;
+  if (_connection && _connection.state !== HubConnectionState.Disconnected) {
+    await _connection.stop();
+  }
+  _connection = null;
+  _startPromise = null;
+  setStatus('disconnected');
+}
+
+/**
+ * Subscribe to a hub event.
+ * Returns an unsubscribe function.
+ *
+ * @param event   The SignalR method name (e.g. 'ReceiveNotification').
+ * @param handler Called with the raw payload for each event.
+ */
+export function on<T>(event: string, handler: (payload: T) => void): () => void {
+  // getOrCreateSubscriberSet registers the connection.on() handler the first
+  // time a subscriber is added for this event (if _connection already exists).
+  const set = getOrCreateSubscriberSet(event);
+  set.add(handler as (payload: unknown) => void);
+  return () => {
+    set.delete(handler as (payload: unknown) => void);
+  };
+}
+
+/** Join a named SignalR group on the server. */
+export async function joinGroup(name: string): Promise<void> {
+  _activeGroups.add(name);
+  if (_connection && _connection.state === HubConnectionState.Connected) {
+    try {
+      await _connection.invoke('JoinGroup', name);
+    } catch (err) {
+      console.warn('[AppHub] joinGroup failed:', name, err);
+    }
+  }
+}
+
+/** Leave a named SignalR group on the server. */
+export async function leaveGroup(name: string): Promise<void> {
+  _activeGroups.delete(name);
+  if (_connection && _connection.state === HubConnectionState.Connected) {
+    try {
+      await _connection.invoke('LeaveGroup', name);
+    } catch (err) {
+      console.warn('[AppHub] leaveGroup failed:', name, err);
+    }
+  }
+}
+
+/** Whether the shared connection is currently connected. */
+export function isConnected(): boolean {
+  return _connection?.state === HubConnectionState.Connected;
+}
+
+/** Current high-level connection status. */
+export function getStatus(): AppHubStatus {
+  return _status;
+}
+
+/** Whether the connection has reached 'connected' at least once this session.
+ * Used to tell a cold first-connect apart from a re-connect (e.g. for
+ * catch-up refetch) regardless of when the caller started observing. */
+export function hasEverConnected(): boolean {
+  return _hasEverConnected;
+}
+
+/**
+ * Subscribe to connection status changes (connected / reconnecting /
+ * disconnected). Returns an unsubscribe function. The listener is NOT called
+ * immediately — read getStatus() for the current value when subscribing.
+ */
+export function onConnectionStateChange(listener: (status: AppHubStatus) => void): () => void {
+  _statusListeners.add(listener);
+  return () => {
+    _statusListeners.delete(listener);
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Typed convenience wrapper for ActivityStepProgress
+// (keeps useActivityCompletionProgress.ts import path working)
+// ──────────────────────────────────────────────────────────────────────────────
+
+export function onActivityStepProgress(
+  handler: (event: ActivityStepProgressEvent) => void,
+): () => void {
+  return on<ActivityStepProgressEvent>('ActivityStepProgress', handler);
+}


### PR DESCRIPTION
## Summary
Consolidates the three separate SignalR connections (notification hub, workflow hub, activity-progress hub) into a single long-lived `appHub` singleton, and builds async (job-based) report generation on top of it.

### Realtime core
- **New** `src/shared/realtime/appHub.ts` — one shared connection with connection-state tracking, reconnect catch-up, and intentional-stop on logout.
- `axiosInstance.ts` — `getFreshAccessToken()` so SignalR reconnects after idle/sleep don't negotiate with a stale token.
- **New** `useConnectionStatus` + `ConnectionStatusIndicator` (dot in navbar avatar + control in profile menu).
- `useNotificationHub`, `useWorkflowHub`, `activityProgressHub` refactored to delegate to `appHub` (public APIs preserved).
- `auth/store` + `Navbar` tear down the connection on logout.

### Async reports
- `reportGeneration/api/reports.ts` — job types + endpoints.
- **New** hooks (`useAsyncReportJob`, `useReportDefinitions`, `useReportJobReconciler`), `reportJobsStore`, `ReportActionButtons`.
- `ProtectedRoute` mounts the reconciler; `NotificationDropdown` downloads the PDF on a `ReportReady` click.
- `ReportReady`/`ReportFailed` notification types + i18n.

## Notes
- Reports depend on `appHub`, so both ship together.
- Type-check: **no new errors** vs `main` baseline.

## Test plan
- Log in → status dot green; trigger async report → `ReportReady` notification → click downloads PDF.
- Disconnect/reconnect network → bell catches up missed notifications without a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)