### PR TITLE
feat(block): reappraisal preview + verification dialog; rename to collateralMasterId

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -453,7 +453,7 @@ export const router = createBrowserRouter([
         element: <BlockUnitMaintenancePage />,
       },
       {
-        path: 'standalone/block-unit-maintenance/:projectId',
+        path: 'standalone/block-unit-maintenance/:collateralMasterId',
         element: <BlockUnitMaintenanceDetailPage />,
       },
       // ─── Service Quality Evaluation Routes ──────────────────────────────────

--- a/src/features/blockProject/api/projectUnit.ts
+++ b/src/features/blockProject/api/projectUnit.ts
@@ -100,6 +100,42 @@ export const useUploadProjectUnits = () => {
   });
 };
 
+// ── Reappraisal preview types ─────────────────────────────────────────────────
+
+export type ReappraisalUnitStatus = 'Sold' | 'NewlySold' | 'Available' | 'MatchDifference';
+
+export interface ReappraisalPreviewUnit {
+  id: string;
+  sequenceNumber: number;
+  modelType: string | null;
+  usableArea: number | null;
+  sellingPrice: number | null;
+  floor: number | null;
+  towerName: string | null;
+  condoRegistrationNumber: string | null;
+  roomNumber: string | null;
+  plotNumber: string | null;
+  houseNumber: string | null;
+  numberOfFloors: number | null;
+  landArea: number | null;
+  isSold: boolean;
+  status: ReappraisalUnitStatus;
+  diffFields: string[];
+}
+
+export interface ReappraisalPreviewSummary {
+  total: number;
+  sold: number;
+  newlySold: number;
+  available: number;
+  matchDifference: number;
+}
+
+export interface ReappraisalPreviewResult {
+  summary: ReappraisalPreviewSummary;
+  units: ReappraisalPreviewUnit[];
+}
+
 // ── Reappraisal result type ───────────────────────────────────────────────────
 
 export interface ReappraisalUploadResult {
@@ -107,6 +143,28 @@ export interface ReappraisalUploadResult {
   autoSold: number;
   added: number;
 }
+
+/**
+ * Dry-run preview for a reappraisal Excel re-upload — no DB write.
+ * POST /appraisals/{appraisalId}/project/units/reappraisal-preview
+ */
+export const useReappraisalPreview = () => {
+  return useMutation({
+    mutationFn: async (params: {
+      appraisalId: string;
+      file: File;
+    }): Promise<ReappraisalPreviewResult> => {
+      const formData = new FormData();
+      formData.append('file', params.file);
+      const { data } = await axios.post(
+        `/appraisals/${params.appraisalId}/project/units/reappraisal-preview`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      );
+      return data.result ?? data;
+    },
+  });
+};
 
 /**
  * Re-upload an Excel file for a REAPPRAISAL appraisal.

--- a/src/features/blockProject/components/UnitVerificationDialog.tsx
+++ b/src/features/blockProject/components/UnitVerificationDialog.tsx
@@ -1,0 +1,362 @@
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import Modal from '@/shared/components/Modal';
+import { type ProjectType, isCondo } from '../types';
+import type {
+  ReappraisalPreviewResult,
+  ReappraisalPreviewUnit,
+  ReappraisalUnitStatus,
+} from '../api/projectUnit';
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+const statusConfig: Record<
+  ReappraisalUnitStatus,
+  { dot: string; text: string; badge: string }
+> = {
+  Sold: {
+    dot: 'bg-blue-500',
+    text: 'text-blue-700',
+    badge: 'bg-blue-50 text-blue-700',
+  },
+  NewlySold: {
+    dot: 'bg-cyan-500',
+    text: 'text-cyan-700',
+    badge: 'bg-cyan-50 text-cyan-700',
+  },
+  Available: {
+    dot: 'bg-amber-500',
+    text: 'text-amber-700',
+    badge: 'bg-amber-50 text-amber-700',
+  },
+  MatchDifference: {
+    dot: 'bg-red-500',
+    text: 'text-red-700',
+    badge: 'bg-red-50 text-red-700',
+  },
+};
+
+function StatusBadge({ status }: { status: ReappraisalUnitStatus }) {
+  const { t } = useTranslation('blockProject');
+  const cfg = statusConfig[status];
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium',
+        cfg.badge,
+      )}
+    >
+      <span className={clsx('size-1.5 rounded-full shrink-0', cfg.dot)} />
+      {t(`unitVerification.status.${status}`)}
+    </span>
+  );
+}
+
+// ── Summary card ──────────────────────────────────────────────────────────────
+
+interface SummaryCardProps {
+  label: string;
+  count: number;
+  dotColor: string;
+  unitLabel: string;
+}
+
+function SummaryCard({ label, count, dotColor, unitLabel }: SummaryCardProps) {
+  return (
+    <div className="flex-1 flex flex-col items-center gap-1 px-3 py-3">
+      <div className="flex items-center gap-1.5 mb-0.5">
+        <span className={clsx('size-2 rounded-full shrink-0', dotColor)} />
+        <span className="text-xs text-gray-500 whitespace-nowrap">{label}</span>
+      </div>
+      <span className="text-xl font-bold text-gray-900">{count.toLocaleString()}</span>
+      <span className="text-[10px] text-gray-400">{unitLabel}</span>
+    </div>
+  );
+}
+
+// ── Cell with optional diff highlight ────────────────────────────────────────
+
+function Cell({
+  value,
+  fieldName,
+  diffFields,
+  align = 'left',
+}: {
+  value: React.ReactNode;
+  fieldName?: string;
+  diffFields: string[];
+  align?: 'left' | 'right';
+}) {
+  const isDiff = fieldName !== undefined && diffFields.includes(fieldName);
+  return (
+    <td
+      className={clsx(
+        'py-2 px-3 text-xs',
+        align === 'right' && 'text-right',
+        isDiff ? 'text-red-600 font-medium' : 'text-gray-800',
+      )}
+    >
+      {value ?? '-'}
+    </td>
+  );
+}
+
+// ── Condo table ───────────────────────────────────────────────────────────────
+
+function CondoTable({ units }: { units: ReappraisalPreviewUnit[] }) {
+  const { t } = useTranslation('blockProject');
+  return (
+    <table className="w-full text-xs">
+      <thead className="bg-gray-50 sticky top-0">
+        <tr>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.sqNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitVerification.cols.status')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.floor')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.towerName')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.regNumber')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.roomNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.modelType')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.usableAreaSqm')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.sellingPriceBaht')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {units.map(unit => (
+          <tr key={unit.id} className="border-b border-gray-100 hover:bg-gray-50">
+            <td className="py-2 px-3 text-xs text-gray-600">{unit.sequenceNumber}</td>
+            <td className="py-2 px-3">
+              <StatusBadge status={unit.status} />
+            </td>
+            <Cell value={unit.floor} fieldName="floor" diffFields={unit.diffFields} />
+            <Cell value={unit.towerName} fieldName="towerName" diffFields={unit.diffFields} />
+            <Cell
+              value={unit.condoRegistrationNumber}
+              fieldName="condoRegistrationNumber"
+              diffFields={unit.diffFields}
+            />
+            <Cell value={unit.roomNumber} fieldName="roomNumber" diffFields={unit.diffFields} />
+            <Cell value={unit.modelType} fieldName="modelType" diffFields={unit.diffFields} />
+            <Cell
+              value={unit.usableArea?.toLocaleString()}
+              fieldName="usableArea"
+              diffFields={unit.diffFields}
+              align="right"
+            />
+            <Cell
+              value={unit.sellingPrice?.toLocaleString()}
+              fieldName="sellingPrice"
+              diffFields={unit.diffFields}
+              align="right"
+            />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ── LandAndBuilding table ─────────────────────────────────────────────────────
+
+function LandAndBuildingTable({ units }: { units: ReappraisalPreviewUnit[] }) {
+  const { t } = useTranslation('blockProject');
+  return (
+    <table className="w-full text-xs">
+      <thead className="bg-gray-50 sticky top-0">
+        <tr>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.sqNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitVerification.cols.status')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.plotNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.houseNo')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.modelName')}
+          </th>
+          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.numFloors')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.landAreaSqWa')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.usableAreaSqm')}
+          </th>
+          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+            {t('unitListing.cols.sellingPriceBaht')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {units.map(unit => (
+          <tr key={unit.id} className="border-b border-gray-100 hover:bg-gray-50">
+            <td className="py-2 px-3 text-xs text-gray-600">{unit.sequenceNumber}</td>
+            <td className="py-2 px-3">
+              <StatusBadge status={unit.status} />
+            </td>
+            <Cell value={unit.plotNumber} fieldName="plotNumber" diffFields={unit.diffFields} />
+            <Cell value={unit.houseNumber} fieldName="houseNumber" diffFields={unit.diffFields} />
+            <Cell value={unit.modelType} fieldName="modelType" diffFields={unit.diffFields} />
+            <Cell
+              value={unit.numberOfFloors}
+              fieldName="numberOfFloors"
+              diffFields={unit.diffFields}
+            />
+            <Cell
+              value={unit.landArea?.toLocaleString()}
+              fieldName="landArea"
+              diffFields={unit.diffFields}
+              align="right"
+            />
+            <Cell
+              value={unit.usableArea?.toLocaleString()}
+              fieldName="usableArea"
+              diffFields={unit.diffFields}
+              align="right"
+            />
+            <Cell
+              value={unit.sellingPrice?.toLocaleString()}
+              fieldName="sellingPrice"
+              diffFields={unit.diffFields}
+              align="right"
+            />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ── Main dialog ───────────────────────────────────────────────────────────────
+
+interface UnitVerificationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: () => void;
+  result: ReappraisalPreviewResult;
+  projectType: ProjectType;
+  isApplying: boolean;
+}
+
+export default function UnitVerificationDialog({
+  isOpen,
+  onClose,
+  onApply,
+  result,
+  projectType,
+  isApplying,
+}: UnitVerificationDialogProps) {
+  const { t } = useTranslation('blockProject');
+  const { summary, units } = result;
+  const hasConflicts = summary.matchDifference > 0;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('unitVerification.title')} size="3xl">
+      {/* Summary row */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 mb-4">
+        <div className="px-4 pt-3 pb-1">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            {t('unitVerification.resultLabel')}
+          </span>
+        </div>
+        <div className="flex divide-x divide-gray-200">
+          <SummaryCard
+            label={t('unitVerification.summary.total')}
+            count={summary.total}
+            dotColor="bg-gray-400"
+            unitLabel={t('unitVerification.unitSuffix')}
+          />
+          <SummaryCard
+            label={t('unitVerification.summary.sold')}
+            count={summary.sold}
+            dotColor="bg-blue-500"
+            unitLabel={t('unitVerification.unitSuffix')}
+          />
+          <SummaryCard
+            label={t('unitVerification.summary.newlySold')}
+            count={summary.newlySold}
+            dotColor="bg-cyan-500"
+            unitLabel={t('unitVerification.unitSuffix')}
+          />
+          <SummaryCard
+            label={t('unitVerification.summary.available')}
+            count={summary.available}
+            dotColor="bg-amber-500"
+            unitLabel={t('unitVerification.unitSuffix')}
+          />
+          <SummaryCard
+            label={t('unitVerification.summary.matchDifference')}
+            count={summary.matchDifference}
+            dotColor="bg-red-500"
+            unitLabel={t('unitVerification.unitSuffix')}
+          />
+        </div>
+      </div>
+
+      {/* Units table */}
+      <div className="overflow-auto max-h-[50vh] rounded-lg border border-gray-200">
+        {isCondo(projectType) ? (
+          <CondoTable units={units} />
+        ) : (
+          <LandAndBuildingTable units={units} />
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200">
+        <div>
+          {hasConflicts && (
+            <p className="text-xs text-red-600">
+              {t('unitVerification.matchDifferenceHint', { count: summary.matchDifference })}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            {t('unitVerification.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={hasConflicts || isApplying}
+            className={clsx(
+              'px-4 py-2 text-sm font-medium rounded-lg transition-colors',
+              hasConflicts || isApplying
+                ? 'bg-primary/40 text-white cursor-not-allowed'
+                : 'bg-primary text-white hover:bg-primary/90',
+            )}
+          >
+            {isApplying ? t('unitVerification.applying') : t('unitVerification.apply')}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/blockProject/components/tabs/UnitListingTab.tsx
+++ b/src/features/blockProject/components/tabs/UnitListingTab.tsx
@@ -14,8 +14,11 @@ import {
   useGetProjectUnitUploads,
   useUploadProjectUnits,
   useUploadReappraisalUnits,
+  useReappraisalPreview,
   useDeleteProjectUnitUpload,
 } from '../../api/projectUnit';
+import type { ReappraisalPreviewResult } from '../../api/projectUnit';
+import UnitVerificationDialog from '../UnitVerificationDialog';
 import { isCondo } from '../../types';
 import type { ProjectType, ProjectUnit, ProjectUnitUpload } from '../../types';
 import type { AxiosError } from 'axios';
@@ -329,6 +332,7 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
   const { mutate: uploadUnits, isPending: isUploading } = useUploadProjectUnits();
   const { mutate: uploadReappraisalUnits, isPending: isReappraisalUploading } =
     useUploadReappraisalUnits();
+  const { mutate: previewReappraisal, isPending: isPreviewing } = useReappraisalPreview();
   const { mutate: deleteUpload, isPending: isDeleting } = useDeleteProjectUnitUpload();
 
   const units = unitsData?.units ?? [];
@@ -337,6 +341,10 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
 
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [pendingDeleteUpload, setPendingDeleteUpload] = useState<ProjectUnitUpload | null>(null);
+  const [verificationState, setVerificationState] = useState<{
+    file: File;
+    result: ReappraisalPreviewResult;
+  } | null>(null);
 
   const doUpload = (file: File) => {
     if (!appraisalId) return;
@@ -386,6 +394,9 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
     const file = e.target.files?.[0];
     if (readOnly || !file || !appraisalId) return;
 
+    // Reset the input so re-selecting the same file re-triggers the change event
+    e.target.value = '';
+
     const ext = '.' + file.name.split('.').pop()?.toLowerCase();
     let validationError: string | null = null;
     if (!ALLOWED_EXTENSIONS.includes(ext)) {
@@ -400,17 +411,11 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
       return;
     }
 
-    uploadReappraisalUnits(
+    previewReappraisal(
       { appraisalId, file },
       {
-        onSuccess: data => {
-          toast.success(
-            t('unitListing.reappraisal.resultToast', {
-              matched: data.matchedUnsold,
-              autoSold: data.autoSold,
-              added: data.added,
-            }),
-          );
+        onSuccess: result => {
+          setVerificationState({ file, result });
         },
         onError: (err: unknown) => {
           const error = err as AppError;
@@ -418,6 +423,27 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
         },
       },
     );
+  };
+
+  const handleVerificationApply = () => {
+    if (!verificationState || !appraisalId) return;
+    uploadReappraisalUnits(
+      { appraisalId, file: verificationState.file },
+      {
+        onSuccess: () => {
+          toast.success(t('unitVerification.applySuccess'));
+          setVerificationState(null);
+        },
+        onError: (err: unknown) => {
+          const error = err as AppError;
+          toast.error(error?.apiError?.detail ?? t('toasts.units.uploadFailed'));
+        },
+      },
+    );
+  };
+
+  const handleVerificationClose = () => {
+    setVerificationState(null);
   };
 
   const handleConfirmDelete = () => {
@@ -446,7 +472,7 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
             <UploadArea
               onChange={handleReappraisalFileChange}
               accept=".xlsx,.xls,.csv"
-              isLoading={isReappraisalUploading}
+              isLoading={isPreviewing || isReappraisalUploading}
               disabled={readOnly}
               supportedText=".xlsx, .xls, .csv (max 10MB)"
             />
@@ -518,6 +544,17 @@ export default function UnitListingTab({ projectType }: UnitListingTabProps) {
         variant="danger"
         isLoading={isDeleting}
       />
+
+      {verificationState && (
+        <UnitVerificationDialog
+          isOpen={true}
+          onClose={handleVerificationClose}
+          onApply={handleVerificationApply}
+          result={verificationState.result}
+          projectType={projectType}
+          isApplying={isReappraisalUploading}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/blockUnitMaintenance/api/blockUnitMaintenance.ts
+++ b/src/features/blockUnitMaintenance/api/blockUnitMaintenance.ts
@@ -14,8 +14,8 @@ export const blockUnitMaintenanceKeys = {
   lists: () => [...blockUnitMaintenanceKeys.all, 'list'] as const,
   list: (params: Record<string, unknown>) =>
     [...blockUnitMaintenanceKeys.lists(), params] as const,
-  units: (projectId: string) =>
-    [...blockUnitMaintenanceKeys.all, 'units', projectId] as const,
+  units: (collateralMasterId: string) =>
+    [...blockUnitMaintenanceKeys.all, 'units', collateralMasterId] as const,
 };
 
 // ─── Query Param Interface ────────────────────────────────────────────────────
@@ -59,41 +59,41 @@ export const useGetBlockUnitMaintenanceList = (
   });
 };
 
-// ─── GET /block-unit-maintenance/{projectId}/units ────────────────────────────
+// ─── GET /block-unit-maintenance/{collateralMasterId}/units ──────────────────
 
-export const useGetProjectUnits = (projectId: string | null) => {
+export const useGetProjectUnits = (collateralMasterId: string | null) => {
   return useQuery({
-    queryKey: blockUnitMaintenanceKeys.units(projectId ?? ''),
+    queryKey: blockUnitMaintenanceKeys.units(collateralMasterId ?? ''),
     queryFn: async (): Promise<BlockUnitMaintenanceDetail> => {
       const { data } = await axios.get<BlockUnitMaintenanceDetail>(
-        `/block-unit-maintenance/${projectId}/units`,
+        `/block-unit-maintenance/${collateralMasterId}/units`,
       );
       return data;
     },
-    enabled: !!projectId,
+    enabled: !!collateralMasterId,
     staleTime: 30_000,
   });
 };
 
-// ─── PUT /block-unit-maintenance/{projectId}/units ────────────────────────────
+// ─── PUT /block-unit-maintenance/{collateralMasterId}/units ──────────────────
 
 export const useUpdateUnitSaleStatus = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({
-      projectId,
+      collateralMasterId,
       payload,
     }: {
-      projectId: string;
+      collateralMasterId: string;
       payload: UpdateUnitSaleStatusPayload;
     }): Promise<void> => {
-      await axios.put(`/block-unit-maintenance/${projectId}/units`, payload);
+      await axios.put(`/block-unit-maintenance/${collateralMasterId}/units`, payload);
     },
-    onSuccess: (_data, { projectId }) => {
+    onSuccess: (_data, { collateralMasterId }) => {
       // Refresh the unit list for this project
       queryClient.invalidateQueries({
-        queryKey: blockUnitMaintenanceKeys.units(projectId),
+        queryKey: blockUnitMaintenanceKeys.units(collateralMasterId),
       });
       // Refresh listing rows so sold/unsold counts update
       queryClient.invalidateQueries({

--- a/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
+++ b/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
@@ -114,11 +114,11 @@ const StatusChips = ({
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 const BlockUnitMaintenanceDetailPage = () => {
-  const { projectId } = useParams<{ projectId: string }>();
+  const { collateralMasterId } = useParams<{ collateralMasterId: string }>();
   const navigate = useNavigate();
   const { t } = useTranslation('blockUnitMaintenance');
 
-  const { data, isLoading, isError } = useGetProjectUnits(projectId ?? null);
+  const { data, isLoading, isError } = useGetProjectUnits(collateralMasterId ?? null);
   const { mutateAsync: updateUnits, isPending } = useUpdateUnitSaleStatus();
 
   const project = data?.project;
@@ -235,7 +235,7 @@ const BlockUnitMaintenanceDetailPage = () => {
   };
 
   const handleSave = async () => {
-    if (!projectId) return;
+    if (!collateralMasterId) return;
     const validationError = validate();
     if (validationError) {
       toast.error(validationError);
@@ -252,7 +252,7 @@ const BlockUnitMaintenanceDetailPage = () => {
       };
     });
     try {
-      await updateUnits({ projectId, payload: { items } });
+      await updateUnits({ collateralMasterId, payload: { items } });
       toast.success(t('success.saved'));
     } catch {
       toast.error(t('errors.saveFailed'));

--- a/src/features/blockUnitMaintenance/pages/BlockUnitMaintenancePage.tsx
+++ b/src/features/blockUnitMaintenance/pages/BlockUnitMaintenancePage.tsx
@@ -290,10 +290,10 @@ const BlockUnitMaintenancePage = () => {
                   const pct = total > 0 ? Math.round((sold / total) * 100) : 0;
                   return (
                     <tr
-                      key={item.projectId}
+                      key={item.collateralMasterId}
                       className="hover:bg-gray-50 cursor-pointer transition-colors"
                       onClick={() =>
-                        navigate(`/standalone/block-unit-maintenance/${item.projectId}`)
+                        navigate(`/standalone/block-unit-maintenance/${item.collateralMasterId}`)
                       }
                     >
                       <td className="px-4 py-2.5">

--- a/src/features/blockUnitMaintenance/types/index.ts
+++ b/src/features/blockUnitMaintenance/types/index.ts
@@ -6,8 +6,7 @@ export type { ProjectType };
 // ─── List ─────────────────────────────────────────────────────────────────────
 
 export interface BlockUnitMaintenanceListItem {
-  projectId: string;
-  appraisalId: string;
+  collateralMasterId: string;
   appraisalReportNo: string | null;
   customerName: string | null;
   projectName: string | null;
@@ -30,7 +29,7 @@ export interface PaginatedBlockUnitMaintenance {
 // ─── Project Header (detail page hero) ────────────────────────────────────────
 
 export interface BlockUnitMaintenanceProject {
-  projectId: string;
+  collateralMasterId: string;
   appraisalReportNo: string | null;
   projectName: string | null;
   projectType: ProjectType;

--- a/src/i18n/locales/en/blockProject.json
+++ b/src/i18n/locales/en/blockProject.json
@@ -248,6 +248,32 @@
       "deleteUpload": "Delete upload"
     }
   },
+  "unitVerification": {
+    "title": "Units",
+    "resultLabel": "Result",
+    "unitSuffix": "Unit",
+    "summary": {
+      "total": "Total",
+      "sold": "Sold",
+      "newlySold": "Newly Sold",
+      "available": "Available",
+      "matchDifference": "Match Difference"
+    },
+    "status": {
+      "Sold": "Sold",
+      "NewlySold": "Newly Sold",
+      "Available": "Available",
+      "MatchDifference": "Match Difference"
+    },
+    "cols": {
+      "status": "Status"
+    },
+    "matchDifferenceHint": "Resolve {{count}} match difference(s): fix the Excel and re-upload.",
+    "apply": "Apply",
+    "applying": "Applying...",
+    "cancel": "Cancel",
+    "applySuccess": "Units updated successfully"
+  },
   "towerListing": {
     "grid": "Grid",
     "list": "List",

--- a/src/i18n/locales/th/blockProject.json
+++ b/src/i18n/locales/th/blockProject.json
@@ -248,6 +248,32 @@
       "deleteUpload": "ลบการอัปโหลด"
     }
   },
+  "unitVerification": {
+    "title": "ยูนิต",
+    "resultLabel": "ผลลัพธ์",
+    "unitSuffix": "ยูนิต",
+    "summary": {
+      "total": "ทั้งหมด",
+      "sold": "ขายแล้ว",
+      "newlySold": "ขายใหม่",
+      "available": "ยังไม่ขาย",
+      "matchDifference": "ข้อมูลไม่ตรง"
+    },
+    "status": {
+      "Sold": "ขายแล้ว",
+      "NewlySold": "ขายใหม่",
+      "Available": "ยังไม่ขาย",
+      "MatchDifference": "ข้อมูลไม่ตรง"
+    },
+    "cols": {
+      "status": "สถานะ"
+    },
+    "matchDifferenceHint": "พบ {{count}} รายการที่ข้อมูลไม่ตรงกัน: แก้ไข Excel แล้วอัปโหลดใหม่",
+    "apply": "ยืนยัน",
+    "applying": "กำลังบันทึก...",
+    "cancel": "ยกเลิก",
+    "applySuccess": "อัปเดตยูนิตสำเร็จ"
+  },
   "towerListing": {
     "grid": "กริด",
     "list": "รายการ",

--- a/src/i18n/locales/zh/blockProject.json
+++ b/src/i18n/locales/zh/blockProject.json
@@ -248,6 +248,32 @@
       "deleteUpload": "Delete upload"
     }
   },
+  "unitVerification": {
+    "title": "单元",
+    "resultLabel": "结果",
+    "unitSuffix": "套",
+    "summary": {
+      "total": "合计",
+      "sold": "已售",
+      "newlySold": "新售出",
+      "available": "可售",
+      "matchDifference": "数据不匹配"
+    },
+    "status": {
+      "Sold": "已售",
+      "NewlySold": "新售出",
+      "Available": "可售",
+      "MatchDifference": "数据不匹配"
+    },
+    "cols": {
+      "status": "状态"
+    },
+    "matchDifferenceHint": "发现 {{count}} 处数据不匹配，请修正 Excel 后重新上传。",
+    "apply": "应用",
+    "applying": "提交中...",
+    "cancel": "取消",
+    "applySuccess": "单元更新成功"
+  },
   "towerListing": {
     "grid": "Grid",
     "list": "List",


### PR DESCRIPTION
## Summary
- **New** `UnitVerificationDialog` + `useReappraisalPreview` (dry-run, no DB write) — preview classifies units (Sold / NewlySold / Available / MatchDifference) and the user confirms before the real re-upload applies.
- `UnitListingTab` switches the reappraisal flow to **preview → verify → apply**.
- Rename `projectId → collateralMasterId` across block-unit-maintenance (api, types, pages, query keys) and the router param.
- i18n: `blockProject` unit-verification keys (en/th/zh).

## Notes
- `router.tsx` here carries **only** the `block-unit-maintenance/:collateralMasterId` param change (the operational-reports route ships in its own PR).

## Test plan
- Upload a reappraisal Excel → verification dialog shows the summary → Apply succeeds.
- Block-unit-maintenance detail route resolves with `:collateralMasterId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)