### PR TITLE
feat(reports): operational reports (RCAS001–012) feature + route

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -111,6 +111,7 @@ import { SupportingDataMaintenanceListPage } from '@/features/supportingDataMain
 import { CreateSupportingDataPage } from '@/features/supportingDataMaintenance/pages/CreateSupportingDataPage';
 import StepValidationRulesPage from '@features/workflowAdmin/pages/StepValidationRulesPage';
 import ReportTestPage from '@features/reportGeneration/pages/ReportTestPage';
+import OperationalReportRoute from '@features/common/operationalReports/pages/OperationalReportRoute';
 
 /**
  * Thin wrappers that bind PricingAnalysisPage to a project-model subject.
@@ -233,6 +234,19 @@ export const router = createBrowserRouter([
       {
         path: 'monitoring',
         element: <MonitoringPage />,
+      },
+      // ─── Operational Reports (RCAS001–012) ─────────────────────────────────
+      // Menu items at /reports/operational/rcasNNN are server-seeded and gated
+      // by REPORT_OP_VIEW. The :slug param is matched to a ReportConfig in
+      // OperationalReportRoute, so a single route handles all 12 reports.
+      {
+        element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="REPORT_OP_VIEW" />,
+        children: [
+          {
+            path: 'reports/operational/:slug',
+            element: <OperationalReportRoute />,
+          },
+        ],
       },
       // History Search (Pin) — FSD §2.6.7 geo-filtered appraisal + MC map view
       {

--- a/src/features/common/operationalReports/api/operationalReportsApi.ts
+++ b/src/features/common/operationalReports/api/operationalReportsApi.ts
@@ -1,0 +1,147 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from '@shared/api/axiosInstance';
+import { useCallback, useRef, useState } from 'react';
+import type { AnyReportRow, BaseReportFilter, PaginatedResult, SortDir } from './types';
+
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const operationalReportKeys = {
+  all: ['reports', 'operational'] as const,
+  list: (slug: string, filter: BaseReportFilter) =>
+    ['reports', 'operational', slug, filter] as const,
+};
+
+// ─── Filter → query params ────────────────────────────────────────────────────
+
+function buildParams(filter: BaseReportFilter): Record<string, string | number | undefined> {
+  const params: Record<string, string | number | undefined> = {
+    pageNumber: filter.pageNumber ?? 0,
+    pageSize: filter.pageSize ?? 20,
+  };
+
+  if (filter.sortBy) params.sortBy = filter.sortBy;
+  if (filter.sortDir) params.sortDir = filter.sortDir;
+  if (filter.createdFrom) params.createdFrom = filter.createdFrom;
+  if (filter.createdTo) params.createdTo = filter.createdTo;
+  if (filter.approvedFrom) params.approvedFrom = filter.approvedFrom;
+  if (filter.approvedTo) params.approvedTo = filter.approvedTo;
+  if (filter.status) params.status = filter.status;
+  if (filter.bankingSegment) params.bankingSegment = filter.bankingSegment;
+  if (filter.appraisalCompany) params.appraisalCompany = filter.appraisalCompany;
+  if (filter.internalStaff) params.internalStaff = filter.internalStaff;
+  if (filter.channel) params.channel = filter.channel;
+  if (filter.reviewType) params.reviewType = filter.reviewType;
+  if (filter.stage) params.stage = filter.stage;
+  if (filter.customerName) params.customerName = filter.customerName;
+  if (filter.evaluationStatus) params.evaluationStatus = filter.evaluationStatus;
+  if (filter.payType) params.payType = filter.payType;
+  if (filter.feeStatus) params.feeStatus = filter.feeStatus;
+  if (filter.assignType) params.assignType = filter.assignType;
+
+  return params;
+}
+
+// ─── Preview (paginated list) hook ────────────────────────────────────────────
+
+export function useOperationalReport<T extends AnyReportRow = AnyReportRow>(
+  slug: string,
+  filter: BaseReportFilter = {},
+) {
+  return useQuery({
+    queryKey: operationalReportKeys.list(slug, filter),
+    queryFn: async (): Promise<PaginatedResult<T>> => {
+      const { data } = await axios.get(`/reports/operational/${slug}`, {
+        params: buildParams(filter),
+      });
+      return data.result ?? data;
+    },
+    enabled: Boolean(slug),
+    staleTime: 2 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+// ─── Export hook ──────────────────────────────────────────────────────────────
+
+export type ExportFormat = 'xlsx' | 'csv' | 'pdf';
+
+interface UseReportExportReturn {
+  exportReport: (format: ExportFormat) => Promise<void>;
+  isExporting: boolean;
+}
+
+/**
+ * Triggers a real browser file download by fetching the export endpoint as a
+ * blob (so the auth header from axiosInstance is included) and creating an
+ * <a download> element. This is required because the endpoint is auth-gated and
+ * cannot be opened via a plain window.open / href navigation.
+ */
+export function useReportExport(slug: string, filter: BaseReportFilter = {}): UseReportExportReturn {
+  // Ref guards against re-entrant calls; state drives the UI (disabled buttons + spinner).
+  const isExportingRef = useRef(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportReport = useCallback(
+    async (format: ExportFormat) => {
+      if (isExportingRef.current) return;
+      isExportingRef.current = true;
+      setIsExporting(true);
+
+      try {
+        // Build export params without pagination — server returns all matching rows
+        const exportParams: Record<string, string | number | undefined> = { format };
+        if (filter.sortBy) exportParams.sortBy = filter.sortBy;
+        if (filter.sortDir) exportParams.sortDir = filter.sortDir;
+        if (filter.createdFrom) exportParams.createdFrom = filter.createdFrom;
+        if (filter.createdTo) exportParams.createdTo = filter.createdTo;
+        if (filter.approvedFrom) exportParams.approvedFrom = filter.approvedFrom;
+        if (filter.approvedTo) exportParams.approvedTo = filter.approvedTo;
+        if (filter.status) exportParams.status = filter.status;
+        if (filter.bankingSegment) exportParams.bankingSegment = filter.bankingSegment;
+        if (filter.appraisalCompany) exportParams.appraisalCompany = filter.appraisalCompany;
+        if (filter.internalStaff) exportParams.internalStaff = filter.internalStaff;
+        if (filter.channel) exportParams.channel = filter.channel;
+        if (filter.reviewType) exportParams.reviewType = filter.reviewType;
+        if (filter.stage) exportParams.stage = filter.stage;
+        if (filter.customerName) exportParams.customerName = filter.customerName;
+        if (filter.evaluationStatus) exportParams.evaluationStatus = filter.evaluationStatus;
+        if (filter.payType) exportParams.payType = filter.payType;
+        if (filter.feeStatus) exportParams.feeStatus = filter.feeStatus;
+        if (filter.assignType) exportParams.assignType = filter.assignType;
+        const params = exportParams;
+
+        const response = await axios.get(`/reports/operational/${slug}/export`, {
+          params,
+          responseType: 'blob',
+        });
+
+        // Derive filename from Content-Disposition if present, else fall back
+        const disposition = response.headers['content-disposition'] as string | undefined;
+        let filename = `${slug}-report.${format}`;
+        if (disposition) {
+          const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i);
+          if (match?.[1]) {
+            filename = match[1].replace(/['"]/g, '');
+          }
+        }
+
+        const url = URL.createObjectURL(response.data as Blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } finally {
+        isExportingRef.current = false;
+        setIsExporting(false);
+      }
+    },
+    [slug, filter],
+  );
+
+  return { exportReport, isExporting };
+}
+
+export type { BaseReportFilter, SortDir };

--- a/src/features/common/operationalReports/api/types.ts
+++ b/src/features/common/operationalReports/api/types.ts
@@ -1,0 +1,185 @@
+// ─── Shared pagination result (mirrors monitoring PaginatedResult) ─────────────
+
+export interface PaginatedResult<T> {
+  items: T[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+// ─── Shared filter base ────────────────────────────────────────────────────────
+
+export type SortDir = 'asc' | 'desc';
+
+export interface BaseReportFilter {
+  pageNumber?: number;
+  pageSize?: number;
+  sortBy?: string;
+  sortDir?: SortDir;
+  // Date filters (yyyy-MM-dd)
+  createdFrom?: string;
+  createdTo?: string;
+  approvedFrom?: string;
+  approvedTo?: string;
+  // Common string filters
+  status?: string;
+  bankingSegment?: string;
+  appraisalCompany?: string;
+  internalStaff?: string;
+  channel?: string;
+  // rcas002
+  reviewType?: string;
+  stage?: string;
+  customerName?: string;
+  // rcas008
+  evaluationStatus?: string;
+  // rcas009
+  payType?: string;
+  feeStatus?: string;
+  // rcas010
+  assignType?: string;
+}
+
+// ─── Row types per report ──────────────────────────────────────────────────────
+
+export interface Rcas001Row {
+  appraisalCreateDate?: string | null;
+  appraisalNumber?: string | null;
+  customerName?: string | null;
+  appraisalPurpose?: string | null;
+  applyLimitAmount?: number | null;
+  collateralType?: string | null;
+  approachMethod?: string | null;
+  appraisalPrice?: number | null;
+  appraisalStatus?: string | null;
+  requestorCode?: string | null;
+  requestorDepartment?: string | null;
+  bankingSegment?: string | null;
+  internalAppraisalStaff?: string | null;
+  appraisalCompany?: string | null;
+  approveDate?: string | null;
+}
+
+export interface Rcas002Row {
+  reviewType?: string | null;
+  stage?: string | null;
+  appraisalNumber?: string | null;
+  previousAppraisalNumber?: string | null;
+  collateralNumber?: string | null;
+  cifNumber?: string | null;
+  customerName?: string | null;
+  applyLimitAmount?: number | null;
+  collateralType?: string | null;
+  titleDeedNumber?: string | null;
+  bankingSegment?: string | null;
+  appraisalCompany?: string | null;
+  internalAppraisalStaff?: string | null;
+  oldAppraisalValue?: number | null;
+  pastDueDay?: number | null;
+  valuationDate?: string | null;
+  nextValuationDate?: string | null;
+  remainingDays?: number | null;
+}
+
+export interface Rcas003Row {
+  appraisalNumber?: string | null;
+  customerName?: string | null;
+  purpose?: string | null;
+  applyLimitAmount?: number | null;
+  collateralType?: string | null;
+  channel?: string | null;
+  appraisalCompany?: string | null;
+  internalAppraisalStaff?: string | null;
+  appointmentDate?: string | null;
+  assignDate?: string | null;
+  receiveDate?: string | null;
+  olaAppraisal?: number | null;
+  olaInternalStaffVerify?: number | null;
+  olaInternalChecker?: number | null;
+  olaInternalStaffPlusChecker?: number | null;
+  olaInternalVerify?: number | null;
+  olaApproval?: number | null;
+  appraisalStatus?: string | null;
+}
+
+// rcas005, rcas006, rcas007, rcas011, rcas012 share the OLA shape
+export type Rcas005Row = Rcas003Row;
+export type Rcas006Row = Rcas003Row;
+export type Rcas007Row = Rcas003Row;
+export type Rcas011Row = Rcas003Row;
+export type Rcas012Row = Rcas003Row;
+
+export interface Rcas004Row {
+  appraisalNumber?: string | null;
+  customerName?: string | null;
+  purpose?: string | null;
+  applyLimitAmount?: number | null;
+  collateralType?: string | null;
+  channel?: string | null;
+  appraisalCompany?: string | null;
+  internalAppraisalStaff?: string | null;
+  appraisalValue?: number | null;
+  previousAppraisalNumber?: string | null;
+  appointmentDate?: string | null;
+  appraisalStatus?: string | null;
+  progressiveInspectionPct?: number | null;
+}
+
+export interface Rcas008Row {
+  appraisalNumber?: string | null;
+  appraisalCompany?: string | null;
+  approvedDate?: string | null;
+  bankingSegment?: string | null;
+  totalScorePct?: number | null;
+  scoreReportQuality?: number | null;
+  scoreDeliveryTime?: number | null;
+  scorePersonnel?: number | null;
+  scoreResponseTime?: number | null;
+  scoreCoordination?: number | null;
+  remark?: string | null;
+  evaluationStatus?: string | null;
+}
+
+export interface Rcas009Row {
+  appraisalNumber?: string | null;
+  customerName?: string | null;
+  assignType?: string | null;
+  payType?: string | null;
+  purpose?: string | null;
+  appraisalCreateDate?: string | null;
+  collateralType?: string | null;
+  appraisalStatus?: string | null;
+  requestorCode?: string | null;
+  requestorDepartment?: string | null;
+  bankingSegment?: string | null;
+  appraisalCompany?: string | null;
+  internalAppraisalStaff?: string | null;
+  invoiceNumber?: string | null;
+  costCenter?: string | null;
+  appraisalFee?: number | null;
+  vat?: number | null;
+  includeVat?: number | null;
+  feeStatus?: string | null;
+}
+
+export interface Rcas010Row {
+  channel?: string | null;
+  assignType?: string | null;
+  bookCount?: number | null;
+  totalFee?: number | null;
+  customerPaidCount?: number | null;
+  customerPaidFee?: number | null;
+  bankAbsorbCount?: number | null;
+  bankAbsorbFee?: number | null;
+}
+
+// ─── Union of all row types ────────────────────────────────────────────────────
+
+export type AnyReportRow =
+  | Rcas001Row
+  | Rcas002Row
+  | Rcas003Row
+  | Rcas004Row
+  | Rcas008Row
+  | Rcas009Row
+  | Rcas010Row;

--- a/src/features/common/operationalReports/components/OperationalReportPage.tsx
+++ b/src/features/common/operationalReports/components/OperationalReportPage.tsx
@@ -1,0 +1,409 @@
+import { useState, useCallback } from 'react';
+import { format as dateFnsFormat, parseISO } from 'date-fns';
+import Icon from '@shared/components/Icon';
+import Pagination from '@shared/components/Pagination';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Input from '@shared/components/Input';
+import { useOperationalReport, useReportExport } from '../api/operationalReportsApi';
+import type { BaseReportFilter, SortDir } from '../api/operationalReportsApi';
+import type { ReportConfig, ColumnDef, FilterField } from '../config/reports';
+
+// ─── Value formatter ──────────────────────────────────────────────────────────
+
+function formatCellValue(value: unknown, type: ColumnDef['type']): string {
+  if (value == null) return '—';
+  switch (type) {
+    case 'money':
+      return typeof value === 'number'
+        ? value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+        : String(value);
+    case 'number':
+      return typeof value === 'number'
+        ? value.toLocaleString('en-US', { maximumFractionDigits: 2 })
+        : String(value);
+    case 'int':
+      return typeof value === 'number'
+        ? value.toLocaleString('en-US', { maximumFractionDigits: 0 })
+        : String(value);
+    case 'percent':
+      return typeof value === 'number'
+        ? `${value.toLocaleString('en-US', { maximumFractionDigits: 2 })}%`
+        : String(value);
+    case 'date':
+      try {
+        return dateFnsFormat(parseISO(String(value)), 'dd/MM/yyyy');
+      } catch {
+        return String(value);
+      }
+    case 'datetime':
+      try {
+        return dateFnsFormat(parseISO(String(value)), 'dd/MM/yyyy HH:mm');
+      } catch {
+        return String(value);
+      }
+    default:
+      return String(value);
+  }
+}
+
+// ─── Filter panel ─────────────────────────────────────────────────────────────
+
+interface FilterPanelProps {
+  filters: FilterField[];
+  values: BaseReportFilter;
+  onChange: (patch: Partial<BaseReportFilter>) => void;
+  onReset: () => void;
+}
+
+const FILTER_LABELS: Record<FilterField, string> = {
+  createdFrom: 'Create Date From',
+  createdTo: 'Create Date To',
+  approvedFrom: 'Approved Date From',
+  approvedTo: 'Approved Date To',
+  status: 'Status',
+  bankingSegment: 'Retail/IBG',
+  appraisalCompany: 'Company',
+  internalStaff: 'Internal Staff',
+  channel: 'Channel',
+  reviewType: 'Review Type',
+  stage: 'Stage',
+  customerName: 'Customer',
+  evaluationStatus: 'Eval. Status',
+  payType: 'Pay Type',
+  feeStatus: 'Fee Status',
+  assignType: 'Assign Type',
+};
+
+/** Fields that are date inputs (render as <input type="date">). */
+const DATE_FIELDS = new Set<FilterField>([
+  'createdFrom',
+  'createdTo',
+  'approvedFrom',
+  'approvedTo',
+]);
+
+function FilterPanel({ filters, values, onChange, onReset }: FilterPanelProps) {
+  const hasAny = filters.some(f => Boolean((values as Record<string, unknown>)[f]));
+
+  return (
+    <div className="shrink-0 mb-4 p-4 bg-white rounded-lg border border-gray-200 shadow-sm">
+      <div className="flex flex-wrap items-end gap-3">
+        {filters.map(field => {
+          const val = ((values as Record<string, unknown>)[field] as string) ?? '';
+          const label = FILTER_LABELS[field];
+          const isDate = DATE_FIELDS.has(field);
+
+          return (
+            <div key={field} className="flex flex-col gap-1 min-w-[160px]">
+              <label className="text-xs font-medium text-gray-600">{label}</label>
+              {isDate ? (
+                <input
+                  type="date"
+                  value={val}
+                  onChange={e => onChange({ [field]: e.target.value || undefined })}
+                  className="px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary hover:border-gray-300 transition-colors"
+                />
+              ) : (
+                <Input
+                  value={val}
+                  onChange={e => onChange({ [field]: e.target.value || undefined })}
+                  placeholder={`All ${label}`}
+                  fullWidth={false}
+                  className="min-w-[160px]"
+                />
+              )}
+            </div>
+          );
+        })}
+
+        {hasAny && (
+          <button
+            type="button"
+            onClick={onReset}
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gray-500 border border-gray-200 rounded-lg hover:border-gray-300 hover:text-gray-700 transition-all self-end"
+          >
+            <Icon style="solid" name="xmark" className="size-3.5" />
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Export buttons ───────────────────────────────────────────────────────────
+
+interface ExportButtonsProps {
+  onExport: (format: 'xlsx' | 'csv' | 'pdf') => void;
+  isExporting: boolean;
+}
+
+function ExportButtons({ onExport, isExporting }: ExportButtonsProps) {
+  const btnClass =
+    'inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed';
+  const iconFor = (name: string, color: string) =>
+    isExporting ? (
+      <Icon style="solid" name="spinner" className="size-3.5 animate-spin text-gray-400" />
+    ) : (
+      <Icon style="solid" name={name} className={`size-3.5 ${color}`} />
+    );
+  return (
+    <div className="flex items-center gap-2">
+      <button type="button" disabled={isExporting} onClick={() => onExport('xlsx')} className={btnClass} title="Export to Excel">
+        {iconFor('file-excel', 'text-green-600')}
+        Excel
+      </button>
+      <button type="button" disabled={isExporting} onClick={() => onExport('csv')} className={btnClass} title="Export to CSV">
+        {iconFor('file-csv', 'text-blue-600')}
+        CSV
+      </button>
+      <button type="button" disabled={isExporting} onClick={() => onExport('pdf')} className={btnClass} title="Export to PDF">
+        {iconFor('file-pdf', 'text-red-600')}
+        PDF
+      </button>
+    </div>
+  );
+}
+
+// ─── Sortable th ──────────────────────────────────────────────────────────────
+
+interface SortableThProps {
+  label: string;
+  sortKey?: string;
+  activeSortKey?: string;
+  activeSortDir?: SortDir;
+  onSortChange?: (k: string | undefined, d: SortDir | undefined) => void;
+  className?: string;
+}
+
+function SortableTh({
+  label,
+  sortKey,
+  activeSortKey,
+  activeSortDir,
+  onSortChange,
+  className,
+}: SortableThProps) {
+  const isSortable = Boolean(sortKey && onSortChange);
+  const isActive = isSortable && sortKey === activeSortKey;
+
+  const handleClick = () => {
+    if (!isSortable || !sortKey || !onSortChange) return;
+    if (!isActive) { onSortChange(sortKey, 'asc'); return; }
+    if (activeSortDir === 'asc') { onSortChange(sortKey, 'desc'); return; }
+    onSortChange(undefined, undefined);
+  };
+
+  const baseCls = 'px-4 py-3 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
+
+  if (!isSortable) {
+    return <th className={`${baseCls} ${className ?? ''}`.trim()}>{label}</th>;
+  }
+
+  return (
+    <th
+      className={`${baseCls} ${className ?? ''}`.trim()}
+      aria-sort={isActive ? (activeSortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`inline-flex items-center gap-1 hover:text-gray-700 transition-colors group ${isActive ? 'text-primary' : ''}`}
+      >
+        <span>{label}</span>
+        <Icon
+          style="solid"
+          name={isActive ? (activeSortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort'}
+          className={`size-2.5 ${isActive ? 'text-primary' : 'text-gray-300 group-hover:text-gray-500'}`}
+        />
+      </button>
+    </th>
+  );
+}
+
+// ─── Main page component ──────────────────────────────────────────────────────
+
+interface OperationalReportPageProps {
+  config: ReportConfig;
+}
+
+function OperationalReportPage({ config }: OperationalReportPageProps) {
+  const { slug, title, columns, filters, defaultPageSize = 20 } = config;
+
+  // ── Filter state ─────────────────────────────────────────────────────────────
+  const [filterValues, setFilterValues] = useState<BaseReportFilter>({});
+  const [pageNumber, setPageNumber] = useState(0);
+  const [pageSize, setPageSize] = useState(defaultPageSize);
+  const [sortBy, setSortBy] = useState<string | undefined>();
+  const [sortDir, setSortDir] = useState<SortDir | undefined>();
+
+  const activeFilter: BaseReportFilter = {
+    ...filterValues,
+    pageNumber,
+    pageSize,
+    sortBy,
+    sortDir,
+  };
+
+  const handleFilterChange = useCallback((patch: Partial<BaseReportFilter>) => {
+    setFilterValues(prev => ({ ...prev, ...patch }));
+    setPageNumber(0);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setFilterValues({});
+    setPageNumber(0);
+  }, []);
+
+  const handleSortChange = useCallback((key: string | undefined, dir: SortDir | undefined) => {
+    setSortBy(key);
+    setSortDir(dir);
+    setPageNumber(0);
+  }, []);
+
+  // ── Data ──────────────────────────────────────────────────────────────────────
+  const { data, isLoading, isError, error } = useOperationalReport(slug, activeFilter);
+  const { exportReport, isExporting } = useReportExport(slug, filterValues);
+
+  const rows = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+  const totalPages = Math.ceil(totalCount / pageSize) || 1;
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col min-h-0 gap-4">
+      {/* Header row */}
+      <div className="shrink-0 flex items-center justify-between gap-3">
+        <h1 className="text-lg font-semibold text-gray-800">{title}</h1>
+        <ExportButtons onExport={exportReport} isExporting={isExporting} />
+      </div>
+
+      {/* Filter panel */}
+      {filters.length > 0 && (
+        <FilterPanel
+          filters={filters}
+          values={filterValues}
+          onChange={handleFilterChange}
+          onReset={handleReset}
+        />
+      )}
+
+      {/* Error state */}
+      {isError && (
+        <div className="flex flex-col items-center justify-center h-64 gap-3">
+          <div className="size-12 rounded-full bg-red-50 flex items-center justify-center">
+            <Icon style="solid" name="triangle-exclamation" className="size-5 text-red-500" />
+          </div>
+          <p className="text-sm font-medium text-gray-800">Failed to load report</p>
+          <p className="text-xs text-gray-400">{(error as Error)?.message}</p>
+        </div>
+      )}
+
+      {/* Table */}
+      {!isError && (
+        <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
+          <div className="flex-1 min-h-0 overflow-auto">
+            <table className="w-full min-w-max text-sm">
+              <thead className="sticky top-0 z-20">
+                <tr className="bg-gray-50 border-b border-gray-200">
+                  {columns.map((col, idx) => (
+                    <SortableTh
+                      key={col.key}
+                      label={col.label}
+                      sortKey={col.sortKey ?? toPascalCase(col.field)}
+                      activeSortKey={sortBy}
+                      activeSortDir={sortDir}
+                      onSortChange={handleSortChange}
+                      className={[
+                        col.className ?? '',
+                        idx === 0 ? 'sticky left-0 z-30 shadow-[1px_0_0_0_rgb(229,231,235)]' : '',
+                      ]
+                        .join(' ')
+                        .trim()}
+                    />
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {isLoading ? (
+                  <TableRowSkeleton
+                    columns={columns.map(() => ({ width: 'w-24' }))}
+                    rows={8}
+                  />
+                ) : rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={columns.length} className="py-16">
+                      <div className="flex flex-col items-center justify-center gap-3">
+                        <div className="size-14 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center">
+                          <Icon style="regular" name="inbox" className="size-6 text-gray-300" />
+                        </div>
+                        <div className="text-center">
+                          <p className="text-sm font-semibold text-gray-700">No records</p>
+                          <p className="text-xs text-gray-400 mt-1">
+                            No items match the current filters.
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((row, rowIdx) => (
+                    <tr key={rowIdx} className="hover:bg-gray-50 transition-colors">
+                      {columns.map((col, colIdx) => {
+                        const raw = (row as Record<string, unknown>)[col.field];
+                        const formatted = formatCellValue(raw, col.type);
+                        const isRight =
+                          col.className?.includes('text-right') ||
+                          ['money', 'number', 'int', 'percent'].includes(col.type);
+
+                        return (
+                          <td
+                            key={col.key}
+                            className={[
+                              'px-3 py-1.5 text-xs text-gray-700',
+                              col.className ?? '',
+                              isRight ? 'text-right tabular-nums' : '',
+                              colIdx === 0
+                                ? 'sticky left-0 bg-white shadow-[1px_0_0_0_rgb(229,231,235)] font-medium text-gray-800'
+                                : '',
+                            ]
+                              .join(' ')
+                              .trim()}
+                          >
+                            {formatted}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          <Pagination
+            currentPage={pageNumber}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            pageSize={pageSize}
+            pageSizeOptions={[10, 20, 50, 100]}
+            onPageChange={setPageNumber}
+            onPageSizeChange={size => {
+              setPageSize(size);
+              setPageNumber(0);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OperationalReportPage;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function toPascalCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/features/common/operationalReports/config/reports.ts
+++ b/src/features/common/operationalReports/config/reports.ts
@@ -1,0 +1,290 @@
+// ─── Column value types ───────────────────────────────────────────────────────
+
+/**
+ * The `type` field drives cell formatting:
+ *   money    → right-aligned, thousands separator, 2 dp
+ *   number   → right-aligned, thousands separator
+ *   percent  → appends '%'
+ *   int      → right-aligned integer
+ *   date     → dd/MM/yyyy
+ *   datetime → dd/MM/yyyy HH:mm
+ *   text     → plain string (default)
+ */
+export type ColumnType = 'money' | 'number' | 'percent' | 'int' | 'date' | 'datetime' | 'text';
+
+export interface ColumnDef {
+  key: string;
+  label: string;
+  /** camelCase field name in the API response */
+  field: string;
+  type: ColumnType;
+  /** Optional sort key sent to the server. Defaults to PascalCase of field. */
+  sortKey?: string;
+  className?: string;
+}
+
+// ─── Filter sets ──────────────────────────────────────────────────────────────
+
+/**
+ * Identifies which filter inputs appear on a given report page.
+ * The OperationalReportPage renders only the subset listed here.
+ */
+export type FilterField =
+  | 'createdFrom'
+  | 'createdTo'
+  | 'approvedFrom'
+  | 'approvedTo'
+  | 'status'
+  | 'bankingSegment'
+  | 'appraisalCompany'
+  | 'internalStaff'
+  | 'channel'
+  | 'reviewType'
+  | 'stage'
+  | 'customerName'
+  | 'evaluationStatus'
+  | 'payType'
+  | 'feeStatus'
+  | 'assignType';
+
+// ─── Report config ────────────────────────────────────────────────────────────
+
+export interface ReportConfig {
+  slug: string;
+  title: string;
+  columns: ColumnDef[];
+  filters: FilterField[];
+  /** Default page size. Defaults to 20. rcas010 uses 50. */
+  defaultPageSize?: number;
+}
+
+// ─── Shared OLA column set (rcas003/005/006/007/011/012) ──────────────────────
+
+const OLA_COLUMNS: ColumnDef[] = [
+  { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+  { key: 'customerName', label: 'Customer', field: 'customerName', type: 'text', sortKey: 'CustomerName', className: 'max-w-[160px] truncate' },
+  { key: 'purpose', label: 'Purpose', field: 'purpose', type: 'text' },
+  { key: 'applyLimitAmount', label: 'Apply/Limit', field: 'applyLimitAmount', type: 'money', className: 'text-right' },
+  { key: 'collateralType', label: 'Collateral Type', field: 'collateralType', type: 'text' },
+  { key: 'channel', label: 'Channel', field: 'channel', type: 'text' },
+  { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+  { key: 'internalAppraisalStaff', label: 'Internal Staff', field: 'internalAppraisalStaff', type: 'text' },
+  { key: 'appointmentDate', label: 'Appointment', field: 'appointmentDate', type: 'datetime' },
+  { key: 'assignDate', label: 'Assign', field: 'assignDate', type: 'datetime' },
+  { key: 'receiveDate', label: 'Receive', field: 'receiveDate', type: 'datetime' },
+  { key: 'olaAppraisal', label: 'OLA Appraisal (hrs)', field: 'olaAppraisal', type: 'number', className: 'text-right' },
+  { key: 'olaInternalStaffVerify', label: 'OLA Staff/Verify', field: 'olaInternalStaffVerify', type: 'number', className: 'text-right' },
+  { key: 'olaInternalChecker', label: 'OLA Checker', field: 'olaInternalChecker', type: 'number', className: 'text-right' },
+  { key: 'olaInternalStaffPlusChecker', label: 'OLA Staff+Checker', field: 'olaInternalStaffPlusChecker', type: 'number', className: 'text-right' },
+  { key: 'olaInternalVerify', label: 'OLA Verify', field: 'olaInternalVerify', type: 'number', className: 'text-right' },
+  { key: 'olaApproval', label: 'OLA Approval', field: 'olaApproval', type: 'number', className: 'text-right' },
+  { key: 'appraisalStatus', label: 'Status', field: 'appraisalStatus', type: 'text' },
+];
+
+// rcas003/005/006/007/011/012 share the same filters
+const OLA_FILTERS: FilterField[] = [
+  'createdFrom',
+  'createdTo',
+  'status',
+  'appraisalCompany',
+  'internalStaff',
+  'channel',
+];
+
+// ─── All 12 report configs ────────────────────────────────────────────────────
+
+export const OPERATIONAL_REPORTS: ReportConfig[] = [
+  // ── RCAS001: Appraisal Books ───────────────────────────────────────────────
+  {
+    slug: 'rcas001',
+    title: 'RCAS001 - Appraisal Books',
+    filters: ['createdFrom', 'createdTo', 'status', 'bankingSegment'],
+    columns: [
+      { key: 'appraisalCreateDate', label: 'Create Date', field: 'appraisalCreateDate', type: 'datetime', sortKey: 'AppraisalCreateDate' },
+      { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+      { key: 'customerName', label: 'Customer', field: 'customerName', type: 'text', sortKey: 'CustomerName', className: 'max-w-[160px] truncate' },
+      { key: 'appraisalPurpose', label: 'Purpose', field: 'appraisalPurpose', type: 'text' },
+      { key: 'applyLimitAmount', label: 'Apply/Limit', field: 'applyLimitAmount', type: 'money', className: 'text-right' },
+      { key: 'collateralType', label: 'Collateral Type', field: 'collateralType', type: 'text' },
+      { key: 'approachMethod', label: 'Approach', field: 'approachMethod', type: 'text' },
+      { key: 'appraisalPrice', label: 'Price', field: 'appraisalPrice', type: 'money', className: 'text-right' },
+      { key: 'appraisalStatus', label: 'Status', field: 'appraisalStatus', type: 'text' },
+      { key: 'requestorCode', label: 'Requestor', field: 'requestorCode', type: 'text' },
+      { key: 'requestorDepartment', label: 'Requestor Dept.', field: 'requestorDepartment', type: 'text' },
+      { key: 'bankingSegment', label: 'Retail/IBG', field: 'bankingSegment', type: 'text' },
+      { key: 'internalAppraisalStaff', label: 'Internal Staff', field: 'internalAppraisalStaff', type: 'text' },
+      { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+      { key: 'approveDate', label: 'Approve Date', field: 'approveDate', type: 'datetime', sortKey: 'ApproveDate' },
+    ],
+  },
+
+  // ── RCAS002: Reappraisal Due ───────────────────────────────────────────────
+  {
+    slug: 'rcas002',
+    title: 'RCAS002 - Reappraisal Due',
+    filters: ['reviewType', 'stage', 'customerName'],
+    columns: [
+      { key: 'reviewType', label: 'Review Type', field: 'reviewType', type: 'text' },
+      { key: 'stage', label: 'Stage', field: 'stage', type: 'text' },
+      { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+      { key: 'previousAppraisalNumber', label: 'Previous No.', field: 'previousAppraisalNumber', type: 'text' },
+      { key: 'collateralNumber', label: 'Collateral No.', field: 'collateralNumber', type: 'text' },
+      { key: 'cifNumber', label: 'CIF', field: 'cifNumber', type: 'text' },
+      { key: 'customerName', label: 'Customer', field: 'customerName', type: 'text', sortKey: 'CustomerName', className: 'max-w-[160px] truncate' },
+      { key: 'applyLimitAmount', label: 'Apply/Limit', field: 'applyLimitAmount', type: 'money', className: 'text-right' },
+      { key: 'collateralType', label: 'Collateral Type', field: 'collateralType', type: 'text' },
+      { key: 'titleDeedNumber', label: 'Title Deed', field: 'titleDeedNumber', type: 'text' },
+      { key: 'bankingSegment', label: 'Retail/IBG', field: 'bankingSegment', type: 'text' },
+      { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+      { key: 'internalAppraisalStaff', label: 'Internal Staff', field: 'internalAppraisalStaff', type: 'text' },
+      { key: 'oldAppraisalValue', label: 'Old Value', field: 'oldAppraisalValue', type: 'money', className: 'text-right' },
+      { key: 'pastDueDay', label: 'Past Due Day', field: 'pastDueDay', type: 'int', className: 'text-right' },
+      { key: 'valuationDate', label: 'Valuation Date', field: 'valuationDate', type: 'date' },
+      { key: 'nextValuationDate', label: 'Next Valuation', field: 'nextValuationDate', type: 'date' },
+      { key: 'remainingDays', label: 'Remaining Days', field: 'remainingDays', type: 'int', className: 'text-right' },
+    ],
+  },
+
+  // ── RCAS003: OLA (channel 1) ───────────────────────────────────────────────
+  {
+    slug: 'rcas003',
+    title: 'RCAS003 - OLA Report',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+
+  // ── RCAS004: Inspection <100% ──────────────────────────────────────────────
+  {
+    slug: 'rcas004',
+    title: 'RCAS004 - Inspection Progress (<100%)',
+    filters: ['createdFrom', 'createdTo', 'status'],
+    columns: [
+      { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+      { key: 'customerName', label: 'Customer', field: 'customerName', type: 'text', sortKey: 'CustomerName', className: 'max-w-[160px] truncate' },
+      { key: 'purpose', label: 'Purpose', field: 'purpose', type: 'text' },
+      { key: 'applyLimitAmount', label: 'Apply/Limit', field: 'applyLimitAmount', type: 'money', className: 'text-right' },
+      { key: 'collateralType', label: 'Collateral Type', field: 'collateralType', type: 'text' },
+      { key: 'channel', label: 'Channel', field: 'channel', type: 'text' },
+      { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+      { key: 'internalAppraisalStaff', label: 'Internal Staff', field: 'internalAppraisalStaff', type: 'text' },
+      { key: 'appraisalValue', label: 'Value', field: 'appraisalValue', type: 'money', className: 'text-right' },
+      { key: 'previousAppraisalNumber', label: 'Previous No.', field: 'previousAppraisalNumber', type: 'text' },
+      { key: 'appointmentDate', label: 'Appointment', field: 'appointmentDate', type: 'datetime' },
+      { key: 'appraisalStatus', label: 'Status', field: 'appraisalStatus', type: 'text' },
+      { key: 'progressiveInspectionPct', label: 'Inspection %', field: 'progressiveInspectionPct', type: 'percent', className: 'text-right' },
+    ],
+  },
+
+  // ── RCAS005: OLA (channel 2) ───────────────────────────────────────────────
+  {
+    slug: 'rcas005',
+    title: 'RCAS005 - OLA Report (Ch.2)',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+
+  // ── RCAS006: OLA (channel 3) ───────────────────────────────────────────────
+  {
+    slug: 'rcas006',
+    title: 'RCAS006 - OLA Report (Ch.3)',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+
+  // ── RCAS007: OLA (channel 4) ───────────────────────────────────────────────
+  {
+    slug: 'rcas007',
+    title: 'RCAS007 - OLA Report (Ch.4)',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+
+  // ── RCAS008: Service Quality ───────────────────────────────────────────────
+  {
+    slug: 'rcas008',
+    title: 'RCAS008 - Service Quality Evaluation',
+    filters: ['approvedFrom', 'approvedTo', 'bankingSegment', 'appraisalCompany', 'evaluationStatus'],
+    columns: [
+      { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+      { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+      { key: 'approvedDate', label: 'Approved', field: 'approvedDate', type: 'date', sortKey: 'ApprovedDate' },
+      { key: 'bankingSegment', label: 'Retail/IBG', field: 'bankingSegment', type: 'text' },
+      { key: 'totalScorePct', label: 'Total %', field: 'totalScorePct', type: 'percent', className: 'text-right' },
+      { key: 'scoreReportQuality', label: 'Report Quality', field: 'scoreReportQuality', type: 'int', className: 'text-right' },
+      { key: 'scoreDeliveryTime', label: 'Delivery', field: 'scoreDeliveryTime', type: 'int', className: 'text-right' },
+      { key: 'scorePersonnel', label: 'Personnel', field: 'scorePersonnel', type: 'int', className: 'text-right' },
+      { key: 'scoreResponseTime', label: 'Response', field: 'scoreResponseTime', type: 'int', className: 'text-right' },
+      { key: 'scoreCoordination', label: 'Coordination', field: 'scoreCoordination', type: 'int', className: 'text-right' },
+      { key: 'remark', label: 'Remark', field: 'remark', type: 'text' },
+      { key: 'evaluationStatus', label: 'Eval Status', field: 'evaluationStatus', type: 'text' },
+    ],
+  },
+
+  // ── RCAS009: Fee Summary ───────────────────────────────────────────────────
+  {
+    slug: 'rcas009',
+    title: 'RCAS009 - Fee Summary',
+    filters: ['createdFrom', 'createdTo', 'payType', 'appraisalCompany', 'feeStatus'],
+    columns: [
+      { key: 'appraisalNumber', label: 'Appraisal No.', field: 'appraisalNumber', type: 'text', sortKey: 'AppraisalNumber' },
+      { key: 'customerName', label: 'Customer', field: 'customerName', type: 'text', sortKey: 'CustomerName', className: 'max-w-[160px] truncate' },
+      { key: 'assignType', label: 'Assign Type', field: 'assignType', type: 'text' },
+      { key: 'payType', label: 'Pay Type', field: 'payType', type: 'text' },
+      { key: 'purpose', label: 'Purpose', field: 'purpose', type: 'text' },
+      { key: 'appraisalCreateDate', label: 'Create Date', field: 'appraisalCreateDate', type: 'date', sortKey: 'AppraisalCreateDate' },
+      { key: 'collateralType', label: 'Collateral Type', field: 'collateralType', type: 'text' },
+      { key: 'appraisalStatus', label: 'Status', field: 'appraisalStatus', type: 'text' },
+      { key: 'requestorCode', label: 'Requestor', field: 'requestorCode', type: 'text' },
+      { key: 'requestorDepartment', label: 'Requestor Dept.', field: 'requestorDepartment', type: 'text' },
+      { key: 'bankingSegment', label: 'Retail/IBG', field: 'bankingSegment', type: 'text' },
+      { key: 'appraisalCompany', label: 'Company', field: 'appraisalCompany', type: 'text' },
+      { key: 'internalAppraisalStaff', label: 'Internal Staff', field: 'internalAppraisalStaff', type: 'text' },
+      { key: 'invoiceNumber', label: 'Invoice No.', field: 'invoiceNumber', type: 'text' },
+      { key: 'costCenter', label: 'Cost Center', field: 'costCenter', type: 'text' },
+      { key: 'appraisalFee', label: 'Fee', field: 'appraisalFee', type: 'money', className: 'text-right' },
+      { key: 'vat', label: 'VAT', field: 'vat', type: 'money', className: 'text-right' },
+      { key: 'includeVat', label: 'Incl. VAT', field: 'includeVat', type: 'money', className: 'text-right' },
+      { key: 'feeStatus', label: 'Fee Status', field: 'feeStatus', type: 'text' },
+    ],
+  },
+
+  // ── RCAS010: Bank-Absorbed Fees (aggregate) ────────────────────────────────
+  {
+    slug: 'rcas010',
+    title: 'RCAS010 - Bank-Absorbed Fees',
+    filters: ['createdFrom', 'createdTo', 'channel', 'assignType'],
+    defaultPageSize: 50,
+    columns: [
+      { key: 'channel', label: 'Channel', field: 'channel', type: 'text' },
+      { key: 'assignType', label: 'Assign Type', field: 'assignType', type: 'text' },
+      { key: 'bookCount', label: 'Book Count', field: 'bookCount', type: 'int', className: 'text-right' },
+      { key: 'totalFee', label: 'Total Fee', field: 'totalFee', type: 'money', className: 'text-right' },
+      { key: 'customerPaidCount', label: 'Cust-Paid Count', field: 'customerPaidCount', type: 'int', className: 'text-right' },
+      { key: 'customerPaidFee', label: 'Cust-Paid Fee', field: 'customerPaidFee', type: 'money', className: 'text-right' },
+      { key: 'bankAbsorbCount', label: 'Bank-Absorb Count', field: 'bankAbsorbCount', type: 'int', className: 'text-right' },
+      { key: 'bankAbsorbFee', label: 'Bank-Absorb Fee', field: 'bankAbsorbFee', type: 'money', className: 'text-right' },
+    ],
+  },
+
+  // ── RCAS011: OLA (channel 5) ───────────────────────────────────────────────
+  {
+    slug: 'rcas011',
+    title: 'RCAS011 - OLA Report (Ch.5)',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+
+  // ── RCAS012: OLA (channel 6) ───────────────────────────────────────────────
+  {
+    slug: 'rcas012',
+    title: 'RCAS012 - OLA Report (Ch.6)',
+    filters: OLA_FILTERS,
+    columns: OLA_COLUMNS,
+  },
+];
+
+// ─── Lookup helper ─────────────────────────────────────────────────────────────
+
+export function findReportConfig(slug: string): ReportConfig | undefined {
+  return OPERATIONAL_REPORTS.find(r => r.slug === slug);
+}

--- a/src/features/common/operationalReports/pages/OperationalReportRoute.tsx
+++ b/src/features/common/operationalReports/pages/OperationalReportRoute.tsx
@@ -1,0 +1,42 @@
+import { useParams } from 'react-router-dom';
+import Icon from '@shared/components/Icon';
+import OperationalReportPage from '../components/OperationalReportPage';
+import { findReportConfig } from '../config/reports';
+
+/**
+ * Thin route component mounted at /reports/operational/:slug.
+ * Reads the slug param, looks up the report config, and delegates to
+ * the generic OperationalReportPage.
+ */
+function OperationalReportRoute() {
+  const { slug } = useParams<{ slug: string }>();
+
+  if (!slug) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3">
+        <div className="size-12 rounded-full bg-gray-50 flex items-center justify-center">
+          <Icon style="solid" name="triangle-exclamation" className="size-5 text-gray-400" />
+        </div>
+        <p className="text-sm text-gray-500">No report slug provided.</p>
+      </div>
+    );
+  }
+
+  const config = findReportConfig(slug);
+
+  if (!config) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 gap-3">
+        <div className="size-12 rounded-full bg-gray-50 flex items-center justify-center">
+          <Icon style="solid" name="triangle-exclamation" className="size-5 text-gray-400" />
+        </div>
+        <p className="text-sm font-medium text-gray-700">Report not found</p>
+        <p className="text-xs text-gray-400">No report configured for slug: {slug}</p>
+      </div>
+    );
+  }
+
+  return <OperationalReportPage config={config} />;
+}
+
+export default OperationalReportRoute;

--- a/src/features/common/operationalReports/routes.ts
+++ b/src/features/common/operationalReports/routes.ts
@@ -1,0 +1,26 @@
+/**
+ * Operational Reports route path constants.
+ * Routes live at /reports/operational/:slug where slug matches the report config.
+ * Menu items already exist server-side gated by REPORT_OP_VIEW permission.
+ */
+export const OPERATIONAL_REPORT_PATHS = {
+  root: '/reports/operational',
+  rcas001: '/reports/operational/rcas001',
+  rcas002: '/reports/operational/rcas002',
+  rcas003: '/reports/operational/rcas003',
+  rcas004: '/reports/operational/rcas004',
+  rcas005: '/reports/operational/rcas005',
+  rcas006: '/reports/operational/rcas006',
+  rcas007: '/reports/operational/rcas007',
+  rcas008: '/reports/operational/rcas008',
+  rcas009: '/reports/operational/rcas009',
+  rcas010: '/reports/operational/rcas010',
+  rcas011: '/reports/operational/rcas011',
+  rcas012: '/reports/operational/rcas012',
+} as const;
+
+/**
+ * Permission code used for all operational report pages.
+ * Server-side menu items are already gated by this permission.
+ */
+export const OPERATIONAL_REPORT_PERMISSION = 'REPORT_OP_VIEW' as const;


### PR DESCRIPTION
## Summary
- **New** `features/common/operationalReports/` — api + types, shared `OperationalReportPage`, `OperationalReportRoute`, `config/reports.ts` (12 report configs), `routes.ts`.
- `router.tsx`: single `reports/operational/:slug` route gated by `REPORT_OP_VIEW`, matched to a `ReportConfig` so one route serves all 12 reports.

## Notes
- `router.tsx` here carries **only** the operational-reports import + route (the block-unit-maintenance rename ships in its own PR).

## Test plan
- `/reports/operational/rcas001` renders and is gated by `REPORT_OP_VIEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)