### PR TITLE
feat(appraisal): backend-authoritative approval status + warning acknowledgement

### DIFF
--- a/src/features/appraisal/api/decisionSummary.ts
+++ b/src/features/appraisal/api/decisionSummary.ts
@@ -106,6 +106,9 @@ export interface GetApprovalListResponse {
   votesReceived: number;
   quorumMet: boolean;
   majorityMet: boolean;
+  /** Authoritative, voting-mode-aware round status. Use this rather than re-deriving from
+   *  quorumMet/majorityMet (which is not WaitForAll-aware). */
+  status: 'Approved' | 'Returned' | 'Pending';
   members: ApprovalMember[];
   conditions: ApprovalCondition[];
   meetingRef: ApprovalMeetingRef | null;
@@ -170,9 +173,8 @@ export const useSaveDecisionSummary = () => {
  * Get workflow-scoped approval list with polling.
  * GET /api/workflows/instances/{workflowInstanceId}/activities/{activityId}/approval-list
  *
- * Polls every 10s while the approval is still pending (quorum + majority not
- * yet met AND no member has voted `route_back`) so peer votes surface without
- * a manual refresh.
+ * Polls every 10s while the round is still pending (backend-authoritative status),
+ * so peer votes surface without a manual refresh.
  */
 export const useGetApprovalList = (
   workflowInstanceId: string | undefined,
@@ -190,9 +192,8 @@ export const useGetApprovalList = (
     refetchInterval: query => {
       const data = query.state.data;
       if (!data) return false;
-      const routedBack = data.members.some(m => m.vote === 'route_back');
-      const decided = (data.quorumMet && data.majorityMet) || routedBack;
-      return decided ? false : 10_000;
+      // Stop polling once the round has resolved (Approved or Returned); keep polling while Pending.
+      return data.status !== 'Pending' ? false : 10_000;
     },
   });
 };

--- a/src/features/appraisal/api/workflow.ts
+++ b/src/features/appraisal/api/workflow.ts
@@ -78,6 +78,13 @@ export interface StructuredValidationError {
   message: string;
 }
 
+/** Non-blocking warning that requires user acknowledgement before proceeding. */
+export interface StructuredWarning {
+  stepName: string;
+  message: string;
+  ackToken: string;
+}
+
 export interface CompleteActivityResponse {
   workflowInstanceId: string;
   status: string;
@@ -86,6 +93,7 @@ export interface CompleteActivityResponse {
   nextAssignee: string | null;
   isCompleted: boolean;
   validationErrors: StructuredValidationError[] | null;
+  warnings?: StructuredWarning[] | null;
 }
 
 export interface TaskHistoryItem {
@@ -197,6 +205,7 @@ export const useCompleteActivity = () => {
       activityId,
       input,
       nextAssignmentOverrides,
+      acknowledgedWarningTokens,
     }: {
       workflowInstanceId: string;
       activityId: string;
@@ -209,10 +218,11 @@ export const useCompleteActivity = () => {
           overrideReason?: string;
         }
       >;
+      acknowledgedWarningTokens?: string[];
     }): Promise<CompleteActivityResponse> => {
       const { data } = await axios.post(
         `/api/workflows/instances/${workflowInstanceId}/activities/${activityId}/complete`,
-        { input, nextAssignmentOverrides },
+        { input, nextAssignmentOverrides, acknowledgedWarningTokens },
       );
       return data;
     },

--- a/src/features/appraisal/components/ActivityCompletionChecklist.tsx
+++ b/src/features/appraisal/components/ActivityCompletionChecklist.tsx
@@ -2,21 +2,46 @@ import { useTranslation } from 'react-i18next';
 import Icon from '@shared/components/Icon';
 import { useActivityProgressStore } from '../store/activityProgressStore';
 
+interface ActivityCompletionChecklistProps {
+  /**
+   * True while the completion mutation is in flight. Drives whether spinners are
+   * shown: once the request settles, no spinner should linger even if SignalR never
+   * delivered live steps (e.g. the hub was disconnected).
+   */
+  pending?: boolean;
+  /**
+   * True when the SignalR hub isn't connected, so live step-by-step progress won't
+   * arrive. Only affects the submitting message wording.
+   */
+  liveUnavailable?: boolean;
+}
+
 /**
  * Renders the live pipeline step checklist inside the completion ConfirmDialog.
- * Reads from activityProgressStore — no props needed.
+ * Reads from activityProgressStore; props only convey the mutation/hub lifecycle.
  */
-const ActivityCompletionChecklist = () => {
+const ActivityCompletionChecklist = ({
+  pending = false,
+  liveUnavailable = false,
+}: ActivityCompletionChecklistProps) => {
   const { t } = useTranslation('appraisal');
   const steps = useActivityProgressStore(s => s.steps);
   const overall = useActivityProgressStore(s => s.overall);
 
-  // No steps yet — pipeline hasn't sent PipelineStarted (or no steps configured)
+  // No steps yet — pipeline hasn't sent PipelineStarted (or no steps configured).
   if (steps.length === 0) {
+    // Request has settled with no live steps (e.g. SignalR disconnected): don't spin
+    // forever — the error/success result is shown elsewhere.
+    if (!pending) return null;
+
     return (
       <div className="flex items-center justify-center gap-2 rounded-xl border border-gray-100 bg-gray-50 py-5 text-sm text-gray-500">
         <Icon name="spinner" style="solid" className="size-4 shrink-0 animate-spin text-primary" />
-        <span>{t('completionChecklist.submitting')}</span>
+        <span>
+          {liveUnavailable
+            ? t('completionChecklist.submittingNoLive')
+            : t('completionChecklist.submitting')}
+        </span>
       </div>
     );
   }
@@ -38,18 +63,21 @@ const ActivityCompletionChecklist = () => {
       <ul className="space-y-0.5">
         {steps.map(step => {
           const isRunning = step.status === 'running';
+          // A step left 'running' after the request settled (connection dropped
+          // mid-pipeline) must not spin forever — show it as a neutral incomplete marker.
+          const showSpin = isRunning && pending;
           return (
             <li
               key={step.stepName}
               className={`flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors ${
-                isRunning ? 'bg-primary/5' : ''
+                showSpin ? 'bg-primary/5' : ''
               }`}
             >
               <span className="flex size-5 shrink-0 items-center justify-center">
-                {step.status === 'pending' && (
+                {(step.status === 'pending' || (isRunning && !pending)) && (
                   <span className="size-3.5 rounded-full border-2 border-gray-300" />
                 )}
-                {isRunning && (
+                {showSpin && (
                   <Icon name="spinner" style="solid" className="size-4 animate-spin text-primary" />
                 )}
                 {step.status === 'passed' && (
@@ -64,9 +92,9 @@ const ActivityCompletionChecklist = () => {
               </span>
               <span
                 className={`text-sm leading-tight ${
-                  step.status === 'pending'
+                  step.status === 'pending' || (isRunning && !pending)
                     ? 'text-gray-400'
-                    : isRunning
+                    : showSpin
                       ? 'font-medium text-gray-800'
                       : step.status === 'passed'
                         ? 'text-gray-500'

--- a/src/features/appraisal/components/ActivityCompletionErrors.tsx
+++ b/src/features/appraisal/components/ActivityCompletionErrors.tsx
@@ -8,8 +8,20 @@ interface ActivityCompletionErrorsProps {
 }
 
 /**
+ * Split a message into individual requirement lines. The backend often concatenates
+ * several validation sentences into one string (e.g. "Do X. Do Y."); break them on
+ * sentence boundaries so each requirement gets its own line.
+ */
+const toLines = (message: string): string[] =>
+  message
+    .split(/(?<=[.!?])\s+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+/**
  * Renders structured validation errors from a failed activity completion
- * inside an Alert (danger variant). Groups messages by stepName.
+ * inside an Alert (danger variant). Groups messages by stepName and shows each
+ * requirement sentence as its own bulleted line.
  */
 const ActivityCompletionErrors = ({ errors, title }: ActivityCompletionErrorsProps) => {
   const { t } = useTranslation('appraisal');
@@ -25,22 +37,28 @@ const ActivityCompletionErrors = ({ errors, title }: ActivityCompletionErrorsPro
     return acc;
   }, {});
 
+  const showStepName = Object.keys(grouped).length > 1;
+
   return (
     <Alert variant="danger" title={resolvedTitle} className="mt-3 text-left">
-      <ul className="space-y-1 mt-1">
-        {Object.entries(grouped).map(([stepName, messages]) => (
-          <li key={stepName}>
-            {Object.keys(grouped).length > 1 && (
-              <span className="font-medium">{stepName}: </span>
-            )}
-            {messages.map((msg, i) => (
-              <span key={i} className="block">
-                {msg}
-              </span>
-            ))}
-          </li>
-        ))}
-      </ul>
+      <div className="mt-1 space-y-2">
+        {Object.entries(grouped).map(([stepName, messages]) => {
+          const lines = messages.flatMap(toLines);
+          return (
+            <div key={stepName}>
+              {showStepName && <span className="mb-0.5 block font-medium">{stepName}</span>}
+              <ul className="space-y-1">
+                {lines.map((line, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span className="mt-[7px] size-1 shrink-0 rounded-full bg-current opacity-60" />
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
     </Alert>
   );
 };

--- a/src/features/appraisal/components/summary/ApprovalListSection.tsx
+++ b/src/features/appraisal/components/summary/ApprovalListSection.tsx
@@ -12,15 +12,6 @@ import {
   type GetApprovalListResponse,
 } from '../../api/decisionSummary';
 
-/** Client-derived status from quorum/majority/route_back — backend does not emit a status string. */
-type DerivedStatus = 'Approved' | 'Returned' | 'Pending';
-
-const deriveStatus = (data: GetApprovalListResponse): DerivedStatus => {
-  if (data.members.some(m => m.vote === 'route_back')) return 'Returned';
-  if (data.quorumMet && data.majorityMet) return 'Approved';
-  return 'Pending';
-};
-
 // ==================== Presentational Component ====================
 
 interface ApprovalListSectionBaseProps {
@@ -73,7 +64,9 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
     return null;
   }
 
-  const status = deriveStatus(data);
+  // Authoritative, voting-mode-aware status from the backend — never re-derive from quorum/majority
+  // here (that showed "Approved" before a WaitForAll round had actually resolved).
+  const status = data.status;
   const members: ApprovalMember[] = data.members;
   return (
     <FormCard title={t('approvalListSection.title')} icon="users-gear" iconColor="blue">
@@ -104,15 +97,8 @@ const ApprovalListSectionBase = ({ data, isLoading, isError }: ApprovalListSecti
           </div>
         </div>
 
-        {/* Status banner */}
-        {status === 'Approved' && (
-          <div className="flex items-center gap-2 px-4 py-3 bg-emerald-50 border border-emerald-200 rounded-lg">
-            <Icon name="circle-check" style="solid" className="w-5 h-5 text-emerald-500 shrink-0" />
-            <p className="text-sm font-medium text-emerald-700">
-              {t('approvalListSection.approvedBanner')}
-            </p>
-          </div>
-        )}
+        {/* Status banner — Returned only; the "approved" banner was removed (the status chip + the
+            workflow completion already convey approval, and it previously showed prematurely). */}
         {status === 'Returned' && (
           <div className="flex items-center gap-2 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
             <Icon name="rotate-left" style="solid" className="w-5 h-5 text-amber-500 shrink-0" />

--- a/src/features/appraisal/components/summary/VoteDialog.tsx
+++ b/src/features/appraisal/components/summary/VoteDialog.tsx
@@ -3,11 +3,24 @@ import toast from 'react-hot-toast';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
+import Alert from '@/shared/components/Alert';
 import Modal from '@/shared/components/Modal';
 import Button from '@/shared/components/Button';
 import { useAuthStore } from '@/features/auth/store';
-import { useCompleteActivity } from '../../api/workflow';
+import { useCompleteActivity, type StructuredWarning } from '../../api/workflow';
 import { decisionSummaryKeys } from '../../api/decisionSummary';
+
+/**
+ * Splits an admin-authored warning message into individual sentence bullets.
+ * Splits on '. ' (period-space) so single sentences pass through as one bullet.
+ * Re-appends a period to each sentence so each reads as a complete statement.
+ */
+const splitWarningMessage = (message: string): string[] =>
+  message
+    .split(/\.\s+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(s => (s.endsWith('.') ? s : `${s}.`));
 
 const VOTE_OPTIONS = [
   { value: 'approve', label: 'Approve' },
@@ -28,12 +41,13 @@ const VoteDialog = ({ isOpen, onClose, workflowInstanceId, activityId }: VoteDia
   const { t } = useTranslation('appraisal');
   const [selectedVote, setSelectedVote] = useState<VoteValue | null>(null);
   const [comments, setComments] = useState('');
+  const [warnings, setWarnings] = useState<StructuredWarning[]>([]);
   const completeActivity = useCompleteActivity();
   const isPending = completeActivity.isPending;
   const username = useAuthStore(s => s.user?.username);
   const queryClient = useQueryClient();
 
-  const handleSubmit = () => {
+  const submitVote = (acknowledgedWarningTokens?: string[]) => {
     if (!selectedVote || !username) return;
 
     completeActivity.mutate(
@@ -45,9 +59,16 @@ const VoteDialog = ({ isOpen, onClose, workflowInstanceId, activityId }: VoteDia
           decisionTaken: selectedVote,
           comments: comments || undefined,
         },
+        acknowledgedWarningTokens,
       },
       {
         onSuccess: result => {
+          if (result.status === 'WarningsRequireAcknowledgement') {
+            // Non-blocking warnings — keep dialog open and show warning panel
+            setWarnings(result.warnings ?? []);
+            return;
+          }
+
           if (result.status === 'ValidationFailed' || result.status === 'Failed') {
             const errors = result.validationErrors ?? [];
             if (errors.length > 0) {
@@ -65,6 +86,7 @@ const VoteDialog = ({ isOpen, onClose, workflowInstanceId, activityId }: VoteDia
           queryClient.invalidateQueries({
             queryKey: decisionSummaryKeys.approvalList(workflowInstanceId, activityId),
           });
+          setWarnings([]);
           setSelectedVote(null);
           setComments('');
           onClose();
@@ -77,10 +99,16 @@ const VoteDialog = ({ isOpen, onClose, workflowInstanceId, activityId }: VoteDia
     );
   };
 
+  const handleSubmit = () => {
+    setWarnings([]);
+    submitVote();
+  };
+
   const handleClose = () => {
     if (!isPending) {
       setSelectedVote(null);
       setComments('');
+      setWarnings([]);
       onClose();
     }
   };
@@ -124,13 +152,38 @@ const VoteDialog = ({ isOpen, onClose, workflowInstanceId, activityId }: VoteDia
           />
         </div>
 
+        {warnings.length > 0 && (
+          <Alert variant="warning" title={t('decisionSummary.warnings.title')} className="text-left">
+            <ul className="mt-2 space-y-2">
+              {warnings.flatMap((w, wi) =>
+                splitWarningMessage(w.message).map((sentence, si) => (
+                  <li key={`${wi}-${si}`} className="flex items-start gap-2 text-sm text-amber-800">
+                    <span className="mt-[5px] size-1.5 shrink-0 rounded-full bg-amber-500" />
+                    <span>{sentence}</span>
+                  </li>
+                )),
+              )}
+            </ul>
+          </Alert>
+        )}
+
         <div className="flex justify-end gap-3 pt-2">
           <Button variant="ghost" type="button" onClick={handleClose} disabled={isPending}>
             Cancel
           </Button>
-          <Button type="button" onClick={handleSubmit} disabled={!selectedVote || isPending}>
-            {isPending ? 'Submitting...' : 'Submit Vote'}
-          </Button>
+          {warnings.length > 0 ? (
+            <Button
+              type="button"
+              onClick={() => submitVote(warnings.map(w => w.ackToken))}
+              disabled={isPending}
+            >
+              {isPending ? 'Submitting...' : t('decisionSummary.warnings.continueAnyway')}
+            </Button>
+          ) : (
+            <Button type="button" onClick={handleSubmit} disabled={!selectedVote || isPending}>
+              {isPending ? 'Submitting...' : 'Submit Vote'}
+            </Button>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import ActivityCompletionChecklist from '../components/ActivityCompletionChecklist';
 import ActivityCompletionErrors from '../components/ActivityCompletionErrors';
 import { useActivityProgressStore } from '../store/activityProgressStore';
-import type { StructuredValidationError } from '../api/workflow';
+import type { StructuredValidationError, StructuredWarning } from '../api/workflow';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -22,6 +22,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import toast from 'react-hot-toast';
 
+import Alert from '@/shared/components/Alert';
 import Button from '@/shared/components/Button';
 import Icon from '@/shared/components/Icon';
 import { useUnsavedChangesWarning } from '@/shared/hooks/useUnsavedChangesWarning';
@@ -32,6 +33,7 @@ import { FormProvider, FormFields, type FormField } from '@/shared/components/fo
 import { FormReadOnlyContext } from '@/shared/components/form/context';
 
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
+import { useConnectionStatus } from '@/features/notification/hooks/useConnectionStatus';
 import { useGetDecisionSummary, useSaveDecisionSummary } from '../api/decisionSummary';
 import { useCompleteActivity, useGetActivityActions } from '../api/workflow';
 import {
@@ -423,6 +425,20 @@ const SectionReadOnlyWrap = ({
     <>{children}</>
   );
 
+// ==================== Helpers ====================
+
+/**
+ * Splits an admin-authored warning message into individual sentence bullets.
+ * Splits on '. ' (period-space) so single sentences pass through as one bullet.
+ * Re-appends a period to each sentence so each reads as a complete statement.
+ */
+const splitWarningMessage = (message: string): string[] =>
+  message
+    .split(/\.\s+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(s => (s.endsWith('.') ? s : `${s}.`));
+
 // ==================== Page Component ====================
 
 const DecisionSummaryPage = () => {
@@ -456,6 +472,7 @@ const DecisionSummaryPage = () => {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [isHistorySearchOpen, setIsHistorySearchOpen] = useState(false);
   const [failures, setFailures] = useState<StructuredValidationError[]>([]);
+  const [warnings, setWarnings] = useState<StructuredWarning[]>([]);
   const resetProgressStore = useActivityProgressStore(s => s.reset);
 
   // Routing variables from context (for appraisal-initiation refresh)
@@ -469,6 +486,9 @@ const DecisionSummaryPage = () => {
   const { data, isLoading } = useGetDecisionSummary(appraisalId);
   const { mutate: saveSummary, isPending: isSaving } = useSaveDecisionSummary();
   const completeActivity = useCompleteActivity();
+  // SignalR hub status — when not connected, live step progress won't arrive, so the
+  // submitting fallback message is adjusted instead of waiting on step animations.
+  const hubStatus = useConnectionStatus();
   const { data: actionsData } = useGetActivityActions(workflowInstanceId, activityId);
 
   const selectedAction = useMemo(
@@ -583,9 +603,15 @@ const DecisionSummaryPage = () => {
     }
   }, [mapDataToForm, reset]);
 
-  const doCompleteActivity = () => {
-    // Clear previous state before each attempt so a retry shows a fresh checklist
+  const doCompleteActivity = (acknowledgedWarningTokens?: string[]) => {
+    const isAckCall = acknowledgedWarningTokens !== undefined;
+    // On a fresh (non-ack) call, reset all prior feedback.
+    // On an ack re-call, only reset failures so the warning panel stays visible
+    // until the server responds.
     setFailures([]);
+    if (!isAckCall) {
+      setWarnings([]);
+    }
     resetProgressStore();
 
     const targetId = selectedAction?.targetActivityId;
@@ -610,9 +636,15 @@ const DecisionSummaryPage = () => {
           }),
         },
         nextAssignmentOverrides: overrides,
+        acknowledgedWarningTokens,
       },
       {
         onSuccess: result => {
+          if (result.status === 'WarningsRequireAcknowledgement') {
+            // Non-blocking warnings — keep dialog open and show warning panel
+            setWarnings(result.warnings ?? []);
+            return;
+          }
           if (result.status === 'ValidationFailed' || result.status === 'Failed') {
             // Keep dialog open; show structured errors in the panel
             const errs = result.validationErrors ?? [];
@@ -626,6 +658,7 @@ const DecisionSummaryPage = () => {
             return;
           }
           // Success — close dialog and navigate away
+          setWarnings([]);
           setIsConfirmOpen(false);
           toast.success(t('decisionSummary.toasts.submitted'));
           navigate('/tasks');
@@ -1047,6 +1080,7 @@ const DecisionSummaryPage = () => {
         onClose={() => {
           setIsConfirmOpen(false);
           setFailures([]);
+          setWarnings([]);
           resetProgressStore();
         }}
         onConfirm={() => handleSubmit(onSubmit)()}
@@ -1057,17 +1091,64 @@ const DecisionSummaryPage = () => {
         variant="primary"
         isLoading={isSaving || completeActivity.isPending}
         hasError={failures.length > 0}
+        hasWarning={warnings.length > 0 && failures.length === 0}
+        customFooter={
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                setIsConfirmOpen(false);
+                setWarnings([]);
+                resetProgressStore();
+              }}
+              disabled={completeActivity.isPending}
+              className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {t('decisionSummary.confirmDialog.cancel')}
+            </button>
+            <button
+              type="button"
+              onClick={() => doCompleteActivity(warnings.map(w => w.ackToken))}
+              disabled={completeActivity.isPending}
+              className="flex-1 px-4 py-2.5 bg-primary hover:bg-primary/80 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {completeActivity.isPending ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Icon name="spinner" style="solid" className="size-4 animate-spin shrink-0" />
+                  <span className="truncate">{t('decisionSummary.confirmDialog.submitting')}</span>
+                </span>
+              ) : (
+                t('decisionSummary.warnings.continueAnyway')
+              )}
+            </button>
+          </>
+        }
       >
         {failures.length > 0 ? (
           <>
+            {/* Not pending: renders nothing when no live steps arrived (e.g. SignalR
+                disconnected), or the settled/failed checklist when steps did arrive. */}
             <ActivityCompletionChecklist />
             <ActivityCompletionErrors
               errors={failures}
               title={t('decisionSummary.confirmDialog.validationErrorsTitle')}
             />
           </>
+        ) : warnings.length > 0 ? (
+          <Alert variant="warning" title={t('decisionSummary.warnings.title')} className="mt-3 text-left">
+            <ul className="mt-2 space-y-2">
+              {warnings.flatMap((w, wi) =>
+                splitWarningMessage(w.message).map((sentence, si) => (
+                  <li key={`${wi}-${si}`} className="flex items-start gap-2 text-sm text-amber-800">
+                    <span className="mt-[5px] size-1.5 shrink-0 rounded-full bg-amber-500" />
+                    <span>{sentence}</span>
+                  </li>
+                )),
+              )}
+            </ul>
+          </Alert>
         ) : isSaving || completeActivity.isPending ? (
-          <ActivityCompletionChecklist />
+          <ActivityCompletionChecklist pending liveUnavailable={hubStatus !== 'connected'} />
         ) : null}
       </ConfirmDialog>
     </div>

--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -2,6 +2,7 @@
   "completionChecklist": {
     "title": "Validation checks",
     "submitting": "Submitting…",
+    "submittingNoLive": "Submitting… (live updates unavailable)",
     "allPassed": "All checks passed"
   },
   "completionErrors": {
@@ -443,6 +444,10 @@
       "cancel": "Cancel",
       "submitting": "Submitting…",
       "validationErrorsTitle": "Please complete the required fields"
+    },
+    "warnings": {
+      "title": "Review before continuing",
+      "continueAnyway": "Continue anyway"
     },
     "toasts": {
       "saved": "Decision summary saved successfully",
@@ -1142,7 +1147,6 @@
   "approvalListSection": {
     "title": "Committee Approval",
     "notActiveYet": "Committee approval is not active for this appraisal yet.",
-    "approvedBanner": "This appraisal has been approved by the committee.",
     "returnedBanner": "This appraisal has been returned for revision.",
     "conditionsTitle": "Approval Conditions",
     "votesDisplay": "{{received}}/{{total}} votes",

--- a/src/i18n/locales/th/appraisal.json
+++ b/src/i18n/locales/th/appraisal.json
@@ -2,6 +2,7 @@
   "completionChecklist": {
     "title": "การตรวจสอบ",
     "submitting": "กำลังส่ง…",
+    "submittingNoLive": "กำลังส่ง… (ไม่สามารถแสดงความคืบหน้าแบบเรียลไทม์)",
     "allPassed": "ผ่านการตรวจสอบทั้งหมด"
   },
   "completionErrors": {
@@ -446,6 +447,10 @@
       "cancel": "ยกเลิก",
       "submitting": "กำลังส่ง…",
       "validationErrorsTitle": "กรุณากรอกข้อมูลที่จำเป็นให้ครบถ้วน"
+    },
+    "warnings": {
+      "title": "กรุณาตรวจสอบก่อนดำเนินการต่อ",
+      "continueAnyway": "ดำเนินการต่อ"
     },
     "toasts": {
       "saved": "บันทึกสรุปการตัดสินใจสำเร็จ",
@@ -1145,7 +1150,6 @@
   "approvalListSection": {
     "title": "การอนุมัติของคณะกรรมการ",
     "notActiveYet": "การอนุมัติของคณะกรรมการยังไม่เริ่มต้นสำหรับการประเมินนี้",
-    "approvedBanner": "การประเมินนี้ได้รับการอนุมัติจากคณะกรรมการแล้ว",
     "returnedBanner": "การประเมินนี้ถูกส่งกลับเพื่อแก้ไข",
     "conditionsTitle": "เงื่อนไขการอนุมัติ",
     "votesDisplay": "{{received}}/{{total}} คะแนนเสียง",

--- a/src/i18n/locales/zh/appraisal.json
+++ b/src/i18n/locales/zh/appraisal.json
@@ -2,6 +2,7 @@
   "completionChecklist": {
     "title": "验证检查",
     "submitting": "提交中…",
+    "submittingNoLive": "提交中…（实时进度不可用）",
     "allPassed": "所有检查已通过"
   },
   "completionErrors": {
@@ -1145,7 +1146,6 @@
   "approvalListSection": {
     "title": "委员会审批",
     "notActiveYet": "此评估的委员会审批尚未启动。",
-    "approvedBanner": "此评估已获委员会批准。",
     "returnedBanner": "此评估已被退回修改。",
     "conditionsTitle": "审批条件",
     "votesDisplay": "{{received}}/{{total}} 票",

--- a/src/shared/components/ConfirmDialog.tsx
+++ b/src/shared/components/ConfirmDialog.tsx
@@ -30,6 +30,18 @@ interface ConfirmDialogProps {
    * The confirm button keeps its variant colour (so Cancel/retry stay normal).
    */
   hasError?: boolean;
+  /**
+   * When true (and not loading, not hasError), the header shows an amber warning
+   * icon instead of the variant icon. Also replaces the built-in footer buttons
+   * with `customFooter` when provided, so the caller can supply a single
+   * "Continue anyway" primary action without a competing "Submit" button.
+   */
+  hasWarning?: boolean;
+  /**
+   * Replaces the built-in Cancel/Confirm button row when `hasWarning` is true.
+   * Ignored in all other states so existing callers are unaffected.
+   */
+  customFooter?: ReactNode;
   /** Text shown on the confirm button while loading (defaults to "Processing..."). */
   loadingText?: string;
 }
@@ -47,6 +59,8 @@ const ConfirmDialog = ({
   showActivityProgress = false,
   children,
   hasError = false,
+  hasWarning = false,
+  customFooter,
   loadingText,
 }: ConfirmDialogProps) => {
   const progressMessage = useLoadingStore(s => s.message);
@@ -95,13 +109,21 @@ const ConfirmDialog = ({
         <div className="flex flex-col items-center text-center">
           <div
             className={`w-14 h-14 rounded-full flex items-center justify-center mb-4 ${
-              isLoading ? 'bg-primary/10' : hasError ? 'bg-danger/10' : styles.iconBg
+              isLoading
+                ? 'bg-primary/10'
+                : hasError
+                  ? 'bg-danger/10'
+                  : hasWarning
+                    ? 'bg-amber-50'
+                    : styles.iconBg
             }`}
           >
             {isLoading ? (
               <Icon name="spinner" style="solid" className="size-7 text-primary animate-spin" />
             ) : hasError ? (
               <Icon name="triangle-exclamation" style="solid" className="size-7 text-danger" />
+            ) : hasWarning ? (
+              <Icon name="triangle-exclamation" style="solid" className="size-7 text-amber-500" />
             ) : (
               <Icon name={styles.icon} style="solid" className={`size-7 ${styles.iconColor}`} />
             )}
@@ -114,31 +136,35 @@ const ConfirmDialog = ({
               {bodyMessage}
             </p>
           )}
-          <div className="flex gap-3 w-full">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isLoading}
-              className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {cancelText}
-            </button>
-            <button
-              type="button"
-              onClick={handleConfirm}
-              disabled={isLoading}
-              className={`flex-1 px-4 py-2.5 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${styles.confirmBtn}`}
-            >
-              {isLoading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <Icon name="spinner" style="solid" className="size-4 animate-spin shrink-0" />
-                  <span className="truncate">{loadingText ?? 'Processing...'}</span>
-                </span>
-              ) : (
-                confirmText
-              )}
-            </button>
-          </div>
+          {hasWarning && !isLoading && customFooter ? (
+            <div className="flex gap-3 w-full">{customFooter}</div>
+          ) : (
+            <div className="flex gap-3 w-full">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isLoading}
+                className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {cancelText}
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={isLoading}
+                className={`flex-1 px-4 py-2.5 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${styles.confirmBtn}`}
+              >
+                {isLoading ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <Icon name="spinner" style="solid" className="size-4 animate-spin shrink-0" />
+                    <span className="truncate">{loadingText ?? 'Processing...'}</span>
+                  </span>
+                ) : (
+                  confirmText
+                )}
+              </button>
+            </div>
+          )}
         </div>
       </div>
       <div


### PR DESCRIPTION
## Summary
- `decisionSummary`: approval list + polling now driven by backend-authoritative `status` (Approved/Returned/Pending), not re-derived quorum/majority. Removes the now-unused `approvedBanner` i18n string.
- Activity-completion **warning acknowledgement**: `workflow.ts` adds `StructuredWarning` + `acknowledgedWarningTokens`; `ConfirmDialog` gains `hasWarning` / `customFooter` (amber "Continue anyway"); `ActivityCompletionChecklist` / `ActivityCompletionErrors` handle the mutation/hub lifecycle and split concatenated validation sentences.
- `VoteDialog` / `ApprovalListSection` updates.
- i18n: `completionChecklist.submittingNoLive`, `warnings.*` (en/th), `-approvedBanner` (en/th/zh).

## ⚠️ Dependency
`DecisionSummaryPage` imports `useConnectionStatus` (the realtime connection-status hook) which ships in **#185 (feat/realtime-and-async-reports)**. **Merge #185 first** — this branch will not type-check standalone until then. Kept independent off `main` by request.

## Notes
- Pre-existing `DecisionSummaryPage` type errors (unused `*Fields` vars, a `FormField` boolean-toggle mismatch) exist on the combined working tree too and are unrelated to this split.

## Test plan
- Approval list stops polling once Approved/Returned; keeps polling while Pending.
- Completing an activity with a warning shows the amber "Continue anyway" dialog and re-submits with `acknowledgedWarningTokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)