### PR TITLE
feat(appraisal): Cancel Reschedule action on Appointment & Fee

### DIFF
--- a/src/features/appraisal/api/appointment.ts
+++ b/src/features/appraisal/api/appointment.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 import axios from '@shared/api/axiosInstance';
 import type {
   AppointmentDto2Type,
@@ -105,6 +107,44 @@ export const useCancelAppointment = () => {
       queryClient.invalidateQueries({
         queryKey: ['appraisal', variables.appraisalId, 'appointments'],
       });
+    },
+  });
+};
+
+/**
+ * Cancel a pending reschedule (draft state), reverting to the previous date.
+ * PATCH /appraisals/{appraisalId}/appointments/{appointmentId}/cancel-reschedule
+ */
+export const useCancelRescheduleAppointment = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('appraisal');
+
+  return useMutation({
+    mutationFn: async ({
+      appraisalId,
+      appointmentId,
+      ...body
+    }: {
+      appraisalId: string;
+      appointmentId: string;
+      changedBy: string;
+      reason?: string | null;
+    }): Promise<void> => {
+      await axios.patch(
+        `/appraisals/${appraisalId}/appointments/${appointmentId}/cancel-reschedule`,
+        body,
+      );
+    },
+    onSuccess: (_, variables) => {
+      toast.success(t('approval.toasts.rescheduleCancelled'));
+      queryClient.invalidateQueries({ queryKey: ['appraisal', variables.appraisalId, 'appointments'] });
+      queryClient.invalidateQueries({ queryKey: ['appraisal', variables.appraisalId, 'fees'] });
+    },
+    onError: (error: unknown) => {
+      const apiError = error as { apiError?: { detail?: string }; message?: string };
+      const message =
+        apiError?.apiError?.detail ?? apiError?.message ?? t('approval.toasts.rescheduleCancelFailed');
+      toast.error(message);
     },
   });
 };

--- a/src/features/appraisal/components/AppointmentInfoCard.tsx
+++ b/src/features/appraisal/components/AppointmentInfoCard.tsx
@@ -8,6 +8,8 @@ interface AppointmentInfoCardProps {
   appointment: AppointmentDto2Type | null;
   onReschedule: () => void;
   onCancel?: () => void;
+  /** Called to discard a pending (draft) reschedule and revert to the previous date */
+  onCancelReschedule?: () => void;
   /** When true, shows "Needs approval" badge on the appointment */
   approvalDraft?: boolean;
   /** When true, shows "Pending approval" badge and disables reschedule */
@@ -26,6 +28,7 @@ export default function AppointmentInfoCard({
   appointment,
   onReschedule,
   onCancel,
+  onCancelReschedule,
   approvalDraft = false,
   approvalSubmitted = false,
   onViewHistory,
@@ -241,16 +244,29 @@ export default function AppointmentInfoCard({
                 <span className="text-sm font-medium">{t('appointment.cancelButton')}</span>
               </button>
             )}
-            <button
-              type="button"
-              onClick={!approvalSubmitted ? onReschedule : undefined}
-              disabled={approvalSubmitted}
-              title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-gray-900"
-            >
-              <Icon name="clock-rotate-left" style="solid" className="w-4 h-4" />
-              <span className="text-sm font-medium">{t('appointment.rescheduleButton')}</span>
-            </button>
+            {approvalDraft && onCancelReschedule ? (
+              <button
+                type="button"
+                onClick={!approvalSubmitted ? onCancelReschedule : undefined}
+                disabled={approvalSubmitted}
+                title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg border border-amber-300 bg-white text-amber-700 hover:bg-amber-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-white"
+              >
+                <Icon name="rotate-left" style="solid" className="w-4 h-4" />
+                <span className="text-sm font-medium">{t('approval.cancelRescheduleButton')}</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={!approvalSubmitted ? onReschedule : undefined}
+                disabled={approvalSubmitted}
+                title={approvalSubmitted ? t('approval.banner.awaiting') : undefined}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-gray-900"
+              >
+                <Icon name="clock-rotate-left" style="solid" className="w-4 h-4" />
+                <span className="text-sm font-medium">{t('appointment.rescheduleButton')}</span>
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/features/appraisal/pages/AppointmentAndFeePage.tsx
+++ b/src/features/appraisal/pages/AppointmentAndFeePage.tsx
@@ -15,6 +15,7 @@ import PaymentInformationSection from '../components/PaymentInformationSection';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import {
   useCancelAppointment,
+  useCancelRescheduleAppointment,
   useCreateAppointment,
   useGetAppointment,
   useRescheduleAppointment,
@@ -73,6 +74,7 @@ export default function AppointmentAndFeePage() {
   const createAppointment = useCreateAppointment();
   const rescheduleAppointment = useRescheduleAppointment();
   const cancelAppointment = useCancelAppointment();
+  const cancelRescheduleAppointment = useCancelRescheduleAppointment();
 
   // Submit-for-approval hook
   const submitApproval = useSubmitFeeAppointmentApproval(appraisalId);
@@ -145,6 +147,15 @@ export default function AppointmentAndFeePage() {
     } catch (error: any) {
       toast.error(error.apiError?.detail || t('appointment.toasts.cancelFailed'));
     }
+  };
+
+  const handleCancelReschedule = () => {
+    if (!appointment) return;
+    cancelRescheduleAppointment.mutate({
+      appraisalId,
+      appointmentId: appointment.id,
+      changedBy: currentUser?.username ?? '',
+    });
   };
 
   const handleApproveFeeItem = async (feeId: string, itemId: string) => {
@@ -330,6 +341,7 @@ export default function AppointmentAndFeePage() {
             appointment={appointment}
             onReschedule={() => !readOnly && setIsRescheduleModalOpen(true)}
             onCancel={() => !readOnly && setIsCancelAppointmentModalOpen(true)}
+            onCancelReschedule={!readOnly ? handleCancelReschedule : undefined}
             approvalDraft={approvalState.draftDateChange}
             approvalSubmitted={approvalState.submittedDateChange}
             onViewHistory={() => setIsHistoryDrawerOpen(true)}

--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -962,6 +962,7 @@
     },
     "submitButton": "Submit for Approval — {{summary}}",
     "submitConfirm": "Submit",
+    "cancelRescheduleButton": "Cancel Reschedule",
     "summary": {
       "dateChange": "1 date change",
       "fees_one": "{{count}} fee",
@@ -969,7 +970,9 @@
     },
     "toasts": {
       "submitted": "Submitted for bank approval",
-      "submitFailed": "Failed to submit for approval"
+      "submitFailed": "Failed to submit for approval",
+      "rescheduleCancelled": "Reschedule cancelled",
+      "rescheduleCancelFailed": "Failed to cancel reschedule"
     }
   },
   "createPage": {

--- a/src/i18n/locales/th/appraisal.json
+++ b/src/i18n/locales/th/appraisal.json
@@ -965,6 +965,7 @@
     },
     "submitButton": "ส่งขออนุมัติ — {{summary}}",
     "submitConfirm": "ส่ง",
+    "cancelRescheduleButton": "ยกเลิกการเลื่อนนัด",
     "summary": {
       "dateChange": "เปลี่ยนวันนัด 1 ครั้ง",
       "fees_one": "{{count}} รายการค่าธรรมเนียม",
@@ -972,7 +973,9 @@
     },
     "toasts": {
       "submitted": "ส่งขออนุมัติจากธนาคารแล้ว",
-      "submitFailed": "ส่งขออนุมัติไม่สำเร็จ"
+      "submitFailed": "ส่งขออนุมัติไม่สำเร็จ",
+      "rescheduleCancelled": "ยกเลิกการเลื่อนนัดแล้ว",
+      "rescheduleCancelFailed": "ไม่สามารถยกเลิกการเลื่อนนัดได้"
     }
   },
   "createPage": {


### PR DESCRIPTION
## Summary
Adds a **Cancel Reschedule** action to the Appointment & Fee screen. When an appointment reschedule is pending bank approval (draft), the **Re-Schedule** button is replaced by a **Cancel Reschedule** button that discards the draft and reverts the appointment to its previous date.

### Changes
- `useCancelRescheduleAppointment` hook → `PATCH /appraisals/{id}/appointments/{id}/cancel-reschedule` (invalidates appointments + fees queries; success/error toasts).
- `AppointmentInfoCard`: swap Re-Schedule → Cancel Reschedule while `approvalDraft` (`requiresApproval && !approvalSubmittedAt`). The whole-appointment Cancel button and the footer Submit-for-Approval button are unchanged.
- `AppointmentAndFeePage`: wires `onCancelReschedule` (passes `appointment.id` + `currentUser.username`), only when not read-only.
- en/th i18n: `approval.cancelRescheduleButton` + toasts.

### Notes
- The button is a true replacement (ternary), not a duplicate; locked behavior preserved when already submitted for review.
- Requires the backend endpoint (`collateral-appraisal-system-api` PR `feature/internal-appointment-fee-approval`).

### Verification
- `tsc` — no new errors (only pre-existing project-wide ones).
- Review: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)