### PR TITLE
fix(userManagement): unwrap eligible companies response

### DIFF
--- a/src/features/userManagement/api/companies.ts
+++ b/src/features/userManagement/api/companies.ts
@@ -86,8 +86,8 @@ export const useGetEligibleCompanies = () => {
   return useQuery({
     queryKey: ['eligibleCompanies'],
     queryFn: async (): Promise<EligibleCompany[]> => {
-      const { data } = await axios.get<EligibleCompany[]>('/companies/eligible');
-      return data;
+      const { data } = await axios.get<{ companies: EligibleCompany[] }>('/companies/eligible');
+      return data.companies ?? [];
     },
     staleTime: 30_000,
   });


### PR DESCRIPTION
## Problem

`UserDetailPanel` crashed at render:

```
TypeError: (eligibleCompanies ?? []).map is not a function
```

`GET /companies/eligible` returns a wrapped object `{ companies: [...] }` (C# `GetEligibleCompaniesResult(List<EligibleCompanyDto> Companies)`), but the `useGetEligibleCompanies` hook returned the raw response while typing it as `EligibleCompany[]`. So `eligibleCompanies` was an object, and `.map()` threw into the ErrorBoundary.

## Fix

Unwrap `data.companies ?? []` in the queryFn and correct the `axios.get` generic to the real response shape — mirroring how the appraisal module already consumes the same endpoint (`src/features/appraisal/api/administration.ts`).

`UserDetailPanel` only reads `c.id` / `c.name`, both still present, so no type or component changes were needed.

## Verification

- Open User Management → select a user → the company dropdown renders ("No company" + one option per eligible company) instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)