### PR TITLE
fix(blockReappraisal): prevent Unit List table collapse on short screens

### DIFF
--- a/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
+++ b/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
@@ -338,7 +338,7 @@ function BlockReappraisalDetailPage() {
   const isCondo = detail.projectType === 'Condo';
 
   return (
-    <div className="flex flex-col h-full min-h-0 min-w-0 gap-4">
+    <div className="flex flex-col min-h-full min-w-0 gap-4">
       {/* ── Page header ── */}
       <div className="shrink-0 flex items-start justify-between gap-4">
         <div className="flex items-center gap-3">
@@ -441,7 +441,7 @@ function BlockReappraisalDetailPage() {
       </section>
 
       {/* ── Units table (read-only) ── */}
-      <section className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
+      <section className="flex-1 min-h-[24rem] bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
         <div className="shrink-0 px-4 py-3 border-b border-gray-100 flex items-center justify-between">
           <h3 className="text-xs font-semibold text-gray-700">{t('detail.units.title')}</h3>
           <span className="text-xs text-gray-400 tabular-nums">
@@ -451,7 +451,7 @@ function BlockReappraisalDetailPage() {
 
         <div className="flex-1 min-h-0 overflow-auto">
           {detail.structure.units.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-32 gap-2">
+            <div className="flex flex-col items-center justify-center h-full gap-2">
               <Icon style="regular" name="folder-open" className="size-8 text-gray-300" />
               <p className="text-xs text-gray-400">{t('detail.units.empty')}</p>
             </div>


### PR DESCRIPTION
## Problem
On the Block Reappraisal detail page, the bottom **Unit List** table collapsed to near-zero height (too small / mostly hidden) on short-height screens. On tall screens it worked fine.

**Root cause:** the page root used `h-full`, locking it to exactly the scrollable outlet's viewport height. The three `shrink-0` cards above (header, summary, overview chart) consumed their natural height, so the `flex-1` units `<section>` got only the leftover space — which approaches zero on short screens. The outlet's existing `overflow-y-auto` never engaged because `h-full` forbade the page from growing past the viewport.

## Fix
`src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx` — three className tokens:

| Element | Before | After |
|---|---|---|
| Page root | `h-full min-h-0` | `min-h-full` |
| Units `<section>` | `min-h-0` | `min-h-[24rem]` |
| Empty-state block | `h-32` | `h-full` |

- **`min-h-full`** lets the page grow past the viewport on short screens (engaging the outlet's existing scroll) while still pinning to viewport height on tall screens (so `flex-1` keeps distributing space). `min-h-0` dropped — same CSS property, would conflict.
- **`min-h-[24rem]`** (384px) gives the table a hard floor so it can't collapse. On tall screens `flex-1` exceeds this, so the floor never binds.
- **`h-full`** empty-state centers within the floored section instead of clinging to the top.

## Behavior
- **Tall screen:** unchanged — cards fixed at top, table fills remaining space with internal sticky-header scroll.
- **Short screen:** table keeps a usable 384px height; the whole page scrolls via the outlet.

## Testing
1. `npm run dev`, open the Block Reappraisal detail page (e.g. IDEO / Land & Building, Old Appraisal No. 69000139).
2. Short window (~700px tall): table is visible, page scrolls to reach it.
3. Tall/maximized window: table fills space, sticky header works, cards stay fixed.
4. Both project types (Condo → `CondoUnitsTable`, Land & Building → `LandBuildingUnitsTable`).

CSS-only; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)