### PR TITLE
fix(admin): correct route permission codes and company response unwrapping

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -330,22 +330,22 @@ export const router = createBrowserRouter([
           { path: 'users', element: <UserProfilePage /> },
           {
             path: 'teams',
-            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanManageTeams" />,
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="TEAM_MANAGE" />,
             children: [{ index: true, element: <TeamListPage /> }],
           },
           {
             path: 'audit-logs',
-            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanViewAuthAudit" />,
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="AUTH_AUDIT_VIEW" />,
             children: [{ index: true, element: <AuditLogPage /> }],
           },
           {
             path: 'companies',
-            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanManageCompanies" />,
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="COMPANY_MANAGE" />,
             children: [{ index: true, element: <CompanyListPage /> }],
           },
           {
             path: 'access-report',
-            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="CanViewAuthAudit" />,
+            element: <RoleProtectedRoute allowedRoles={[]} requiredPermission="AUTH_AUDIT_VIEW" />,
             children: [{ index: true, element: <AccessReportPage /> }],
           },
           { path: 'committees', element: <CommitteeAdminPage /> },

--- a/src/features/userManagement/api/companies.ts
+++ b/src/features/userManagement/api/companies.ts
@@ -32,8 +32,8 @@ export const useGetAdminCompanyById = (id: string | null) => {
   return useQuery({
     queryKey: [QUERY_KEY, id],
     queryFn: async (): Promise<Company> => {
-      const { data } = await axios.get<Company>(`/companies/${id}`);
-      return data;
+      const { data } = await axios.get<{ company: Company }>(`/companies/${id}`);
+      return data.company;
     },
     enabled: !!id,
   });

--- a/src/features/userManagement/pages/CompanyListPage.tsx
+++ b/src/features/userManagement/pages/CompanyListPage.tsx
@@ -31,7 +31,7 @@ const CompanyListPage = () => {
     pageSize: 50,
   });
 
-  const companies = data?.items ?? [];
+  const companies = data?.companies ?? [];
   const createCompany = useCreateAdminCompany();
 
   const handleOpenCreate = () => {

--- a/src/features/userManagement/types/index.ts
+++ b/src/features/userManagement/types/index.ts
@@ -425,10 +425,7 @@ export interface CompanyListItem {
 }
 
 export interface CompanyListResult {
-  items: CompanyListItem[];
-  totalCount: number;
-  pageNumber: number;
-  pageSize: number;
+  companies: CompanyListItem[];
 }
 
 export interface GetCompaniesParams {


### PR DESCRIPTION
## Problems

### 1. Admin menu items redirect to `/`
`RoleProtectedRoute` checks `user.permissions.includes(requiredPermission)`, and `user.permissions` (from `/auth/me`) holds backend permission **codes** (`TEAM_MANAGE`, `AUTH_AUDIT_VIEW`, `COMPANY_MANAGE`). But the **Teams / Audit Log / Access Report / Companies** routes passed the ASP.NET **policy names** (`CanManageTeams`, `CanViewAuthAudit`, `CanManageCompanies`) as `requiredPermission`. The menu item showed (backend filters the sidebar by the real `ViewPermissionCode`) but clicking always redirected to `/`.

### 2. Company list & detail render empty
The backend wraps responses: `GET /companies` → `{ companies: [...] }` and `GET /companies/{id}` → `{ company: {...} }`. The hooks expected `{ items }` and a bare `Company`, so `data?.items`/`data` were `undefined` → blank list and all-`—` detail fields.

## Changes

- `router.tsx` — use real permission codes for the four admin routes.
- `types/index.ts` — `CompanyListResult` → `{ companies: CompanyListItem[] }` (dropped unused pagination fields; the endpoint isn't paginated and the page has no pager).
- `CompanyListPage.tsx` — `data?.items` → `data?.companies`.
- `api/companies.ts` — detail hook unwraps `data.company` (matching the existing `/companies/eligible` → `data.companies` convention).

## Companion PR

Backend `COMPANY_MANAGE` seed + endpoint gating: immortalgky/collateral-appraisal-system-api#241

## Verification

1. Log in as Admin → Teams / Audit Log / Access Report / Companies open instead of redirecting.
2. Companies list shows rows; selecting a company populates the detail panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)