### PR TITLE
CA-272 Change 'Companies Invited' to 'Invited Companies'

### DIFF
--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -311,7 +311,7 @@
     "closes": "Closes",
     "hoursRemaining": "{{n}}h remaining",
     "stats": {
-      "companiesInvited": "Companies Invited",
+      "companiesInvited": "Invited Companies",
       "responses": "Responses",
       "appraisals": "Appraisals",
       "cutOffTime": "Cut Off Time"
@@ -343,7 +343,7 @@
     },
     "editDraft": {
       "appraisalCount": "{{n}} (use Add / Remove to change appraisals)",
-      "companiesInvited": "Companies Invited",
+      "companiesInvited": "Invited Companies",
       "eligibleFor": "eligible for",
       "companySearchPlaceholder": "Search company name...",
       "noEligibleCompanies": "No eligible companies for this segment",

--- a/src/i18n/locales/en/quotation.json
+++ b/src/i18n/locales/en/quotation.json
@@ -456,7 +456,7 @@
   "shared": {
     "hoursRemaining": "{{n}}h remaining",
     "cutOff": "Cut-off",
-    "companiesInvited": "Companies Invited",
+    "companiesInvited": "Invited Companies",
     "responses": "Responses",
     "appraisals": "Appraisals",
     "invited": "Invited",


### PR DESCRIPTION
Update EN locale strings to use 'Invited Companies' instead of 'Companies Invited' for the companiesInvited key in src/i18n/locales/en/appraisal.json (stats, editDraft) and src/i18n/locales/en/quotation.json (shared). Pure i18n wording change for consistency; no functional changes.