### PR TITLE
CA-273 Use tableTitle i18n key for invited companies

### DIFF
--- a/src/features/quotation/components/InvitedCompaniesTable.tsx
+++ b/src/features/quotation/components/InvitedCompaniesTable.tsx
@@ -18,7 +18,7 @@ const InvitedCompaniesTable = ({ companies, companyQuotations }: InvitedCompanie
           <Icon name="building" style="solid" className="size-3.5 text-teal-600" />
         </div>
         <h2 className="text-sm font-semibold text-gray-700">
-          {t('invitedCompanies.title')} ({companies.length})
+          {t('invitedCompanies.tableTitle')} ({companies.length})
         </h2>
       </div>
 

--- a/src/i18n/locales/en/quotation.json
+++ b/src/i18n/locales/en/quotation.json
@@ -406,6 +406,7 @@
   },
   "invitedCompanies": {
     "title": "Invited Companies",
+    "tableTitle": "External Appraisal Company Listing",
     "totalLabel": "{{count}} total",
     "pending": "Pending"
   },


### PR DESCRIPTION
Replace translation key in InvitedCompaniesTable from invitedCompanies.title to invitedCompanies.tableTitle to display a more specific label. Added invitedCompanies.tableTitle = "External Appraisal Company Listing" to en/quotation.json; the original title key is left intact.