### PR TITLE
feat(meeting): email composer attachments + meeting documents UI; Cc/Bcc

### DIFF
--- a/src/features/meeting/api/meetings.ts
+++ b/src/features/meeting/api/meetings.ts
@@ -18,9 +18,12 @@ import type {
   CreateAcknowledgementQueueItemRequest,
   CreateMeetingRequest,
   CreateMeetingResponse,
+  GenerateMeetingDocumentRequest,
   GetMeetingQueueParams,
   GetMeetingsParams,
+  LinkMeetingDocumentRequest,
   MeetingDetailDto,
+  MeetingDocumentDto,
   MeetingListItemDto,
   MeetingQueueItemDto,
   PaginatedResult,
@@ -32,6 +35,11 @@ import type {
 } from './types';
 
 // ==================== Query Keys ====================
+
+export const meetingDocumentKeys = {
+  all: ['meetingDocuments'] as const,
+  byMeeting: (meetingId: string) => ['meetingDocuments', meetingId] as const,
+};
 
 export const meetingKeys = {
   all: ['meetings'] as const,
@@ -238,13 +246,17 @@ export const useSendInvitation = () => {
       id,
       from,
       to,
+      cc,
+      bcc,
       subject,
       content,
       attachments,
     }: {
       id: string;
       from: string;
-      to: string;
+      to?: string;
+      cc?: string;
+      bcc?: string;
       subject: string;
       content?: string;
       attachments?: string[];
@@ -252,6 +264,8 @@ export const useSendInvitation = () => {
       const { data } = await axios.post(`/meetings/${id}/send-invitation`, {
         from,
         to,
+        cc,
+        bcc,
         subject,
         content,
         attachments,
@@ -389,6 +403,88 @@ export const useCreateAcknowledgementQueueItem = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: meetingKeys.queueAll });
+    },
+  });
+};
+
+// ==================== Meeting Document Hooks ====================
+
+/** GET /meetings/{id}/documents */
+export const useGetMeetingDocuments = (meetingId: string | undefined) => {
+  return useQuery({
+    queryKey: meetingDocumentKeys.byMeeting(meetingId ?? ''),
+    queryFn: async (): Promise<MeetingDocumentDto[]> => {
+      const { data } = await axios.get(`/meetings/${meetingId}/documents`);
+      return data;
+    },
+    enabled: !!meetingId,
+  });
+};
+
+/** POST /meetings/{id}/documents/generate */
+export const useGenerateMeetingDocument = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      meetingId,
+      body,
+    }: {
+      meetingId: string;
+      body: GenerateMeetingDocumentRequest;
+    }): Promise<MeetingDocumentDto> => {
+      const { data } = await axios.post(`/meetings/${meetingId}/documents/generate`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: meetingDocumentKeys.byMeeting(variables.meetingId),
+      });
+    },
+  });
+};
+
+/** POST /meetings/{id}/documents */
+export const useLinkMeetingDocument = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      meetingId,
+      body,
+    }: {
+      meetingId: string;
+      body: LinkMeetingDocumentRequest;
+    }): Promise<MeetingDocumentDto> => {
+      const { data } = await axios.post(`/meetings/${meetingId}/documents`, body);
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: meetingDocumentKeys.byMeeting(variables.meetingId),
+      });
+    },
+  });
+};
+
+/** DELETE /meetings/{id}/documents/{documentId} */
+export const useRemoveMeetingDocument = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      meetingId,
+      documentId,
+    }: {
+      meetingId: string;
+      documentId: string;
+    }) => {
+      await axios.delete(`/meetings/${meetingId}/documents/${documentId}`);
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: meetingDocumentKeys.byMeeting(variables.meetingId),
+      });
     },
   });
 };

--- a/src/features/meeting/api/types.ts
+++ b/src/features/meeting/api/types.ts
@@ -223,6 +223,33 @@ export interface CancelMeetingRequest {
   reason: string;
 }
 
+// ==================== Meeting Documents ====================
+
+export type MeetingDocumentType = 'Invitation' | 'Minute' | 'Upload';
+export type MeetingDocumentSource = 'Generated' | 'Uploaded';
+
+export interface MeetingDocumentDto {
+  id: string;
+  documentId: string;
+  fileName: string;
+  documentType: MeetingDocumentType;
+  source: MeetingDocumentSource;
+  // API serializes with WhenWritingNull — these may be absent. Use nullish.
+  createdBy?: string | null;
+  createdAt?: string | null;
+  fileSizeBytes?: number | null;
+  mimeType?: string | null;
+}
+
+export interface GenerateMeetingDocumentRequest {
+  documentType: 'Invitation' | 'Minute';
+}
+
+export interface LinkMeetingDocumentRequest {
+  documentId: string;
+  fileName: string;
+}
+
 // ==================== Query params ====================
 
 export interface GetMeetingsParams {

--- a/src/features/meeting/components/DocumentPickerModal.tsx
+++ b/src/features/meeting/components/DocumentPickerModal.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/shared/components/Modal';
+import Button from '@/shared/components/Button';
+import Icon from '@/shared/components/Icon';
+import FileInput from '@/shared/components/inputs/FileInput';
+import { useGetMeetingDocuments } from '../api/meetings';
+import { useMeetingDocumentUpload } from '../hooks/useMeetingDocumentUpload';
+import type { MeetingDocumentDto } from '../api/types';
+
+export interface PickedDocument {
+  id: string;
+  name: string;
+}
+
+interface DocumentPickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  meetingId: string;
+  /** Initially selected document ids */
+  selectedIds?: string[];
+  onConfirm: (selected: PickedDocument[]) => void;
+}
+
+const DocumentPickerModal = ({
+  isOpen,
+  onClose,
+  meetingId,
+  selectedIds = [],
+  onConfirm,
+}: DocumentPickerModalProps) => {
+  const { t } = useTranslation('meeting');
+  const { data: documents = [], isLoading } = useGetMeetingDocuments(isOpen ? meetingId : undefined);
+  const { uploading, uploadAndLink } = useMeetingDocumentUpload(meetingId);
+
+  const [checked, setChecked] = useState<Set<string>>(() => new Set(selectedIds));
+
+  useEffect(() => {
+    if (isOpen) setChecked(new Set(selectedIds));
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleToggle = (docId: string) => {
+    setChecked(prev => {
+      const next = new Set(prev);
+      if (next.has(docId)) next.delete(docId);
+      else next.add(docId);
+      return next;
+    });
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const linked = await uploadAndLink(e);
+    if (linked) {
+      // auto-select the newly uploaded document
+      setChecked(prev => new Set([...prev, linked.documentId]));
+    }
+  };
+
+  const handleConfirm = () => {
+    const picked = documents
+      .filter((d: MeetingDocumentDto) => checked.has(d.documentId))
+      .map((d: MeetingDocumentDto) => ({ id: d.documentId, name: d.fileName }));
+    onConfirm(picked);
+    onClose();
+  };
+
+  const isBusy = uploading;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('documents.pickerTitle')} size="md">
+      <div className="flex flex-col gap-3">
+        {/* Upload new */}
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">{t('documents.pickerHint')}</p>
+          <FileInput
+            accept=".pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg"
+            onChange={handleFileChange}
+            disabled={isBusy}
+            multiple={false}
+          >
+            {(isDragging) => (
+              <span
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border rounded-md transition-colors font-medium
+                  ${isDragging ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-300 hover:bg-gray-50 text-gray-700'}
+                  ${isBusy ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+              >
+                {uploading ? (
+                  <Icon name="spinner" style="solid" className="size-3.5 animate-spin" />
+                ) : (
+                  <Icon name="arrow-up-from-bracket" style="solid" className="size-3.5" />
+                )}
+                {t('documents.uploadNew')}
+              </span>
+            )}
+          </FileInput>
+        </div>
+
+        {/* Document list */}
+        <div className="border border-gray-200 rounded-md overflow-hidden max-h-72 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8 text-gray-400">
+              <Icon name="spinner" style="solid" className="size-4 animate-spin mr-2" />
+              <span className="text-sm">{t('documents.loading')}</span>
+            </div>
+          ) : documents.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-gray-400 gap-2">
+              <Icon name="file" style="regular" className="size-6" />
+              <span className="text-sm">{t('documents.empty')}</span>
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {documents.map((doc: MeetingDocumentDto) => (
+                <li key={doc.id}>
+                  <label className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={checked.has(doc.documentId)}
+                      onChange={() => handleToggle(doc.documentId)}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <Icon name="file" style="regular" className="size-4 text-gray-400 shrink-0" />
+                    <span className="text-sm text-gray-900 flex-1 truncate">{doc.fileName}</span>
+                    <span className="text-xs text-gray-400 shrink-0">{doc.documentType}</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="text-xs text-gray-400">
+          {t('documents.pickerSelected', { count: checked.size })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-2 border-t border-gray-100">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            {t('buttons.cancel')}
+          </Button>
+          <Button size="sm" onClick={handleConfirm} disabled={isBusy}>
+            {t('documents.pickerConfirm')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DocumentPickerModal;

--- a/src/features/meeting/components/MeetingDocumentsDialog.tsx
+++ b/src/features/meeting/components/MeetingDocumentsDialog.tsx
@@ -1,0 +1,206 @@
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/shared/components/Modal';
+import Button from '@/shared/components/Button';
+import Icon from '@/shared/components/Icon';
+import FileInput from '@/shared/components/inputs/FileInput';
+import { useDownloadDocument } from '@/features/request/api/documents';
+import {
+  useGetMeetingDocuments,
+  useGenerateMeetingDocument,
+  useRemoveMeetingDocument,
+} from '../api/meetings';
+import { useMeetingDocumentUpload } from '../hooks/useMeetingDocumentUpload';
+import type { MeetingDocumentDto } from '../api/types';
+
+interface MeetingDocumentsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  meetingId: string;
+}
+
+const MeetingDocumentsDialog = ({ isOpen, onClose, meetingId }: MeetingDocumentsDialogProps) => {
+  const { t } = useTranslation('meeting');
+  const { data: documents = [], isLoading } = useGetMeetingDocuments(isOpen ? meetingId : undefined);
+  const generate = useGenerateMeetingDocument();
+  const removeDocument = useRemoveMeetingDocument();
+  const download = useDownloadDocument();
+  const { uploading, uploadAndLink } = useMeetingDocumentUpload(meetingId);
+
+  const handleDownload = (doc: MeetingDocumentDto) => {
+    download.mutate(doc.documentId, {
+      onSuccess: ({ blob, fileName }) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileName ?? doc.fileName;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+      onError: () => toast.error(t('documents.downloadFailed')),
+    });
+  };
+
+  const handleRemove = (doc: MeetingDocumentDto) => {
+    removeDocument.mutate(
+      { meetingId, documentId: doc.documentId },
+      {
+        onSuccess: () => toast.success(t('documents.removed')),
+        onError: () => toast.error(t('documents.removeFailed')),
+      },
+    );
+  };
+
+  const handleGenerate = (documentType: 'Invitation' | 'Minute') => {
+    generate.mutate(
+      { meetingId, body: { documentType } },
+      {
+        onSuccess: () => toast.success(t('documents.generated')),
+        onError: () => toast.error(t('documents.generateFailed')),
+      },
+    );
+  };
+
+  const isBusy = generate.isPending || uploading;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('documents.title')} size="lg">
+      <div className="flex flex-col gap-4">
+        {/* Generate buttons */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-gray-600">{t('documents.generate')}:</span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isBusy}
+            isLoading={generate.isPending && generate.variables?.body.documentType === 'Invitation'}
+            onClick={() => handleGenerate('Invitation')}
+          >
+            <Icon name="file-pdf" style="solid" className="size-3.5 mr-1.5" />
+            {t('documents.invitation')}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isBusy}
+            isLoading={generate.isPending && generate.variables?.body.documentType === 'Minute'}
+            onClick={() => handleGenerate('Minute')}
+          >
+            <Icon name="file-lines" style="solid" className="size-3.5 mr-1.5" />
+            {t('documents.minutes')}
+          </Button>
+
+          <div className="ml-auto">
+            <FileInput
+              accept=".pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg"
+              onChange={uploadAndLink}
+              disabled={isBusy}
+              multiple={false}
+            >
+              {(isDragging) => (
+                <span
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border rounded-md transition-colors font-medium
+                    ${isDragging ? 'border-blue-400 bg-blue-50 text-blue-700' : 'border-gray-300 hover:bg-gray-50 text-gray-700'}
+                    ${isBusy ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                >
+                  {uploading ? (
+                    <Icon name="spinner" style="solid" className="size-3.5 animate-spin" />
+                  ) : (
+                    <Icon name="arrow-up-from-bracket" style="solid" className="size-3.5" />
+                  )}
+                  {t('documents.uploadNew')}
+                </span>
+              )}
+            </FileInput>
+          </div>
+        </div>
+
+        {/* Document list */}
+        <div className="border border-gray-200 rounded-md overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-10 text-gray-400">
+              <Icon name="spinner" style="solid" className="size-5 animate-spin mr-2" />
+              <span className="text-sm">{t('documents.loading')}</span>
+            </div>
+          ) : documents.length === 0 ? (
+            <div className="flex items-center justify-center py-10 text-gray-400">
+              <Icon name="file" style="regular" className="size-5 mr-2" />
+              <span className="text-sm">{t('documents.empty')}</span>
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-600">
+                    {t('documents.colFileName')}
+                  </th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-600">
+                    {t('documents.colType')}
+                  </th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-600">
+                    {t('documents.colSource')}
+                  </th>
+                  <th className="px-4 py-2.5 text-right font-medium text-gray-600">
+                    {t('documents.colActions')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {documents.map(doc => (
+                  <tr key={doc.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-2.5">
+                      <span className="font-medium text-gray-900 truncate max-w-[200px] block">
+                        {doc.fileName}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600">
+                      {doc.documentType}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                          ${doc.source === 'Generated' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700'}`}
+                      >
+                        {doc.source}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center justify-end gap-1.5">
+                        <button
+                          type="button"
+                          onClick={() => handleDownload(doc)}
+                          className="p-1.5 text-gray-400 hover:text-blue-600 rounded transition-colors"
+                          title={t('documents.download')}
+                        >
+                          <Icon name="arrow-down-to-bracket" style="solid" className="size-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(doc)}
+                          disabled={removeDocument.isPending}
+                          className="p-1.5 text-gray-400 hover:text-red-600 rounded transition-colors disabled:opacity-40"
+                          title={t('documents.remove')}
+                        >
+                          <Icon name="trash" style="solid" className="size-3.5" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="flex justify-end pt-1 border-t border-gray-100">
+          <Button variant="ghost" onClick={onClose}>
+            {t('buttons.cancel')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default MeetingDocumentsDialog;

--- a/src/features/meeting/components/SendInvitationDialog.tsx
+++ b/src/features/meeting/components/SendInvitationDialog.tsx
@@ -58,7 +58,7 @@ const SendInvitationDialog = ({
     to: memberEmails ?? 'committee@lhbank.com',
     subject: `ขอเรียนเชิญคณะกรรมการฯ เข้าร่วมประชุมมติ คณะกรรมการกำหนดราคาประเมินหลักประกัน ครั้งที่ ${meetingNo} ในวัน ${date} เวลา ${time}`,
     content: `เรียน คณะกรรมการกำหนดราคาประเมินหลักประกัน\n\n    ขอเรียนเชิญคณะกรรมการฯ เข้าร่วมประชุมมติและกรรมการกำหนดราคาประเมินหลักประกัน\nครั้งที่ ${meetingNo} ในวัน ${date} เวลา ${time} ณ ห้องประชุม ${room}\nหรือหากมีการเปลี่ยนแปลงจะแจ้งอีกครั้งภายหลังค่ะ\n\nจึงเรียนมาเพื่อโปรดทราบ\n${currentUser ? `${currentUser.firstName} ${currentUser.lastName}` : ''}`,
-    attachments: ['Agenda Meeting'],
+    attachments: [],
   };
 
   const handleSubmit = (values: EmailFormValues) => {
@@ -67,6 +67,8 @@ const SendInvitationDialog = ({
         id: meetingId,
         from: values.from,
         to: values.to,
+        cc: values.cc,
+        bcc: values.bcc,
         subject: values.subject,
         content: values.content,
         attachments: values.attachments,
@@ -98,7 +100,9 @@ const SendInvitationDialog = ({
       onClose={onClose}
       title={isResend ? t('dialogs.resendInvitation') : t('dialogs.newEmail')}
       showAttachments={true}
-      showCc={false}
+      attachmentPicker={{ meetingId }}
+      showCc={true}
+      showBcc={true}
       subjectLabel={t('fields.subjectLabel')}
       defaultValues={defaultValues}
       isPending={sendInvitation.isPending}

--- a/src/features/meeting/hooks/useMeetingDocumentUpload.ts
+++ b/src/features/meeting/hooks/useMeetingDocumentUpload.ts
@@ -1,0 +1,81 @@
+import { useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+import { createUploadSession, useUploadDocument } from '@/features/request/api/documents';
+import { useLinkMeetingDocument } from '../api/meetings';
+import type { MeetingDocumentDto } from '../api/types';
+
+export const MEETING_DOCUMENT_TYPE = 'MEETING';
+export const MEETING_DOCUMENT_CATEGORY = 'meeting';
+
+export interface UseMeetingDocumentUploadResult {
+  uploading: boolean;
+  uploadAndLink: (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => Promise<MeetingDocumentDto | null>;
+}
+
+/**
+ * Encapsulates the upload-session + upload + link flow for meeting documents.
+ * The session is created lazily on first upload and reused for subsequent ones.
+ *
+ * Returns `uploading` state and an `uploadAndLink` handler that:
+ *  1. Resets the file input immediately (so re-selecting the same file fires onChange)
+ *  2. Creates/reuses an upload session
+ *  3. Uploads the file
+ *  4. Links it to the meeting
+ *  5. Shows success/failure toasts
+ *  6. Returns the linked MeetingDocumentDto on success, or null on failure
+ */
+export const useMeetingDocumentUpload = (
+  meetingId: string,
+): UseMeetingDocumentUploadResult => {
+  const { t } = useTranslation('meeting');
+  const upload = useUploadDocument();
+  const linkDocument = useLinkMeetingDocument();
+
+  const sessionIdRef = useRef<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const getOrCreateSession = async (): Promise<string> => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+    const { sessionId } = await createUploadSession();
+    sessionIdRef.current = sessionId;
+    return sessionId;
+  };
+
+  const uploadAndLink = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<MeetingDocumentDto | null> => {
+    const file = e.target.files?.[0];
+    // Reset the input so re-selecting the SAME file (e.g. to retry after a failed upload)
+    // still fires onChange.
+    e.target.value = '';
+    if (!file) return null;
+
+    setUploading(true);
+    try {
+      const sessionId = await getOrCreateSession();
+      const result = await upload.mutateAsync({
+        uploadSessionId: sessionId,
+        file,
+        documentType: MEETING_DOCUMENT_TYPE,
+        documentCategory: MEETING_DOCUMENT_CATEGORY,
+      });
+      const linked = await linkDocument.mutateAsync({
+        meetingId,
+        body: { documentId: result.documentId, fileName: result.fileName },
+      });
+      toast.success(t('documents.uploaded'));
+      return linked;
+    } catch {
+      toast.error(t('documents.uploadFailed'));
+      return null;
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return { uploading, uploadAndLink };
+};

--- a/src/features/meeting/pages/MeetingDetailPage.tsx
+++ b/src/features/meeting/pages/MeetingDetailPage.tsx
@@ -21,6 +21,7 @@ import AddItemsDialog from '../components/AddItemsDialog';
 import AgendaForm from '../components/AgendaForm';
 import CancelMeetingDialog from '../components/CancelMeetingDialog';
 import CutOffReviewDialog from '../components/CutOffReviewDialog';
+import MeetingDocumentsDialog from '../components/MeetingDocumentsDialog';
 import MeetingFormDialog from '../components/MeetingFormDialog';
 import MeetingItemsGrouped from '../components/MeetingItemsGrouped';
 import MeetingMembersTable from '../components/MeetingMembersTable';
@@ -58,6 +59,7 @@ const MeetingDetailPage = () => {
   const resendInvitationDialog = useDisclosure();
   const cancelDialog = useDisclosure();
   const addItemsDialog = useDisclosure();
+  const documentsDialog = useDisclosure();
 
   if (isLoading || !meeting) {
     return (
@@ -132,6 +134,11 @@ const MeetingDetailPage = () => {
                 {t('buttons.resendInvitation')}
               </Button>
             )}
+
+            <Button variant="ghost" size="sm" type="button" onClick={documentsDialog.onOpen}>
+              <Icon name="folder-open" style="solid" className="size-3.5 mr-1.5" />
+              {t('buttons.documents')}
+            </Button>
 
             {CANCEL_ELIGIBLE.has(status) && (
               <Button variant="danger" size="sm" type="button" onClick={cancelDialog.onOpen}>
@@ -335,6 +342,12 @@ const MeetingDetailPage = () => {
       <AddItemsDialog
         isOpen={addItemsDialog.isOpen}
         onClose={addItemsDialog.onClose}
+        meetingId={meeting.id}
+      />
+
+      <MeetingDocumentsDialog
+        isOpen={documentsDialog.isOpen}
+        onClose={documentsDialog.onClose}
         meetingId={meeting.id}
       />
     </div>

--- a/src/features/quotation/pages/QuotationSelectionPage.tsx
+++ b/src/features/quotation/pages/QuotationSelectionPage.tsx
@@ -277,7 +277,7 @@ const QuotationSelectionPage = () => {
 
   const handleSendConfirm = (emailData: {
     from: string;
-    to: string;
+    to?: string;
     cc?: string;
     bcc?: string;
     subject: string;

--- a/src/i18n/locales/en/meeting.json
+++ b/src/i18n/locales/en/meeting.json
@@ -70,7 +70,8 @@
     "cancelMeeting": "Cancel Meeting",
     "confirmCutOff": "Confirm Cut-Off",
     "addMemberSubmit": "Add Member",
-    "cancelMemberAdd": "Cancel"
+    "cancelMemberAdd": "Cancel",
+    "documents": "Documents"
   },
   "actions": {
     "cutOff": "Cut Off",
@@ -292,5 +293,31 @@
   },
   "confirm": {
     "removeMember": "Remove {{name}} from this meeting?"
+  },
+  "documents": {
+    "title": "Meeting Documents",
+    "generate": "Generate",
+    "invitation": "Invitation",
+    "minutes": "Minutes",
+    "uploadNew": "Upload new",
+    "loading": "Loading documents...",
+    "empty": "No documents yet",
+    "colFileName": "File Name",
+    "colType": "Type",
+    "colSource": "Source",
+    "colActions": "Actions",
+    "download": "Download",
+    "remove": "Remove",
+    "generated": "Document generated",
+    "generateFailed": "Failed to generate document",
+    "uploaded": "File uploaded and linked",
+    "uploadFailed": "Failed to upload file",
+    "downloadFailed": "Failed to download file",
+    "removed": "Document removed",
+    "removeFailed": "Failed to remove document",
+    "pickerTitle": "Select Attachments",
+    "pickerHint": "Select documents to attach to the email",
+    "pickerSelected": "{{count}} selected",
+    "pickerConfirm": "Confirm"
   }
 }

--- a/src/i18n/locales/th/meeting.json
+++ b/src/i18n/locales/th/meeting.json
@@ -70,7 +70,8 @@
     "cancelMeeting": "ยกเลิกการประชุม",
     "confirmCutOff": "ยืนยันการปิดรับ",
     "addMemberSubmit": "เพิ่มกรรมการ",
-    "cancelMemberAdd": "ยกเลิก"
+    "cancelMemberAdd": "ยกเลิก",
+    "documents": "เอกสาร"
   },
   "actions": {
     "cutOff": "ปิดรับ",
@@ -292,5 +293,31 @@
   },
   "confirm": {
     "removeMember": "นำ {{name}} ออกจากการประชุมนี้?"
+  },
+  "documents": {
+    "title": "เอกสารการประชุม",
+    "generate": "สร้าง",
+    "invitation": "หนังสือเชิญ",
+    "minutes": "รายงานการประชุม",
+    "uploadNew": "อัปโหลดใหม่",
+    "loading": "กำลังโหลดเอกสาร...",
+    "empty": "ยังไม่มีเอกสาร",
+    "colFileName": "ชื่อไฟล์",
+    "colType": "ประเภท",
+    "colSource": "แหล่งที่มา",
+    "colActions": "การดำเนินการ",
+    "download": "ดาวน์โหลด",
+    "remove": "นำออก",
+    "generated": "สร้างเอกสารแล้ว",
+    "generateFailed": "ไม่สามารถสร้างเอกสารได้",
+    "uploaded": "อัปโหลดและเชื่อมโยงไฟล์แล้ว",
+    "uploadFailed": "ไม่สามารถอัปโหลดไฟล์ได้",
+    "downloadFailed": "ไม่สามารถดาวน์โหลดไฟล์ได้",
+    "removed": "นำเอกสารออกแล้ว",
+    "removeFailed": "ไม่สามารถนำเอกสารออกได้",
+    "pickerTitle": "เลือกไฟล์แนบ",
+    "pickerHint": "เลือกเอกสารเพื่อแนบในอีเมล",
+    "pickerSelected": "เลือก {{count}} รายการ",
+    "pickerConfirm": "ยืนยัน"
   }
 }

--- a/src/i18n/locales/zh/meeting.json
+++ b/src/i18n/locales/zh/meeting.json
@@ -70,7 +70,8 @@
     "cancelMeeting": "取消会议",
     "confirmCutOff": "确认截止",
     "addMemberSubmit": "添加委员",
-    "cancelMemberAdd": "取消"
+    "cancelMemberAdd": "取消",
+    "documents": "文件"
   },
   "actions": {
     "cutOff": "截止",
@@ -292,5 +293,31 @@
   },
   "confirm": {
     "removeMember": "将 {{name}} 从本次会议中移除？"
+  },
+  "documents": {
+    "title": "会议文件",
+    "generate": "生成",
+    "invitation": "邀请函",
+    "minutes": "会议纪要",
+    "uploadNew": "上传新文件",
+    "loading": "正在加载文件...",
+    "empty": "暂无文件",
+    "colFileName": "文件名",
+    "colType": "类型",
+    "colSource": "来源",
+    "colActions": "操作",
+    "download": "下载",
+    "remove": "移除",
+    "generated": "文件已生成",
+    "generateFailed": "生成文件失败",
+    "uploaded": "文件已上传并关联",
+    "uploadFailed": "上传文件失败",
+    "downloadFailed": "下载文件失败",
+    "removed": "文件已移除",
+    "removeFailed": "移除文件失败",
+    "pickerTitle": "选择附件",
+    "pickerHint": "选择要附在邮件中的文件",
+    "pickerSelected": "已选 {{count}} 项",
+    "pickerConfirm": "确认"
   }
 }

--- a/src/shared/components/EmailCompositionModal.tsx
+++ b/src/shared/components/EmailCompositionModal.tsx
@@ -3,7 +3,21 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Modal from './Modal';
 import Button from './Button';
+import Icon from './Icon';
 import { emailFormSchema, type EmailFormValues } from '@/shared/schemas/email';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
+import DocumentPickerModal from '@/features/meeting/components/DocumentPickerModal';
+import type { PickedDocument } from '@/features/meeting/components/DocumentPickerModal';
+
+/**
+ * When provided, replaces the free-text attachment chip input with a document
+ * picker sourced from the given meeting's document library. Quotation flows that
+ * use `showAttachments={false}` are unaffected — this prop is only consulted
+ * when `showAttachments` is also true.
+ */
+interface AttachmentPickerConfig {
+  meetingId: string;
+}
 
 interface EmailCompositionModalProps {
   isOpen: boolean;
@@ -13,6 +27,8 @@ interface EmailCompositionModalProps {
   showCc?: boolean;
   showBcc?: boolean;
   showAttachments?: boolean;
+  /** When set, replaces the free-text input with a document picker for the given meeting. */
+  attachmentPicker?: AttachmentPickerConfig;
   subjectLabel?: string;
   isPending?: boolean;
   onSubmit: (values: EmailFormValues) => void;
@@ -29,6 +45,7 @@ const EmailCompositionModal = ({
   showCc = false,
   showBcc = false,
   showAttachments = false,
+  attachmentPicker,
   subjectLabel = 'Subject',
   isPending = false,
   onSubmit,
@@ -58,6 +75,10 @@ const EmailCompositionModal = ({
   const [attachmentInput, setAttachmentInput] = useState('');
   const attachmentInputRef = useRef<HTMLInputElement>(null);
 
+  // Single source of truth for picker mode: docs the user has selected
+  const [pickedDocs, setPickedDocs] = useState<PickedDocument[]>([]);
+  const pickerDisclosure = useDisclosure();
+
   useEffect(() => {
     if (isOpen) {
       reset({
@@ -71,6 +92,7 @@ const EmailCompositionModal = ({
         ...defaultValues,
       });
       setAttachmentInput('');
+      setPickedDocs([]);
     }
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -96,6 +118,17 @@ const EmailCompositionModal = ({
       'attachments',
       attachments.filter((_: string, i: number) => i !== index),
     );
+  };
+
+  const handlePickerConfirm = (picked: PickedDocument[]) => {
+    setPickedDocs(picked);
+    setValue('attachments', picked.map(p => p.id));
+  };
+
+  const handleRemovePickedAttachment = (id: string) => {
+    const next = pickedDocs.filter(d => d.id !== id);
+    setPickedDocs(next);
+    setValue('attachments', next.map(d => d.id));
   };
 
   const handleClose = () => {
@@ -182,33 +215,73 @@ const EmailCompositionModal = ({
                 Attachments
               </label>
               <div className="flex-1">
-                <div className="flex flex-wrap items-center gap-1.5 min-h-[38px] border border-gray-300 rounded-md px-3 py-1.5 focus-within:ring-2 focus-within:ring-blue-500">
-                  {attachments.map((chip: string, i: number) => (
-                    <span
-                      key={i}
-                      className="bg-blue-100 text-blue-800 rounded-full px-3 py-0.5 text-sm flex items-center gap-1"
+                {attachmentPicker ? (
+                  /* ── Picker mode: document IDs + locked auto-PDF chip ── */
+                  <div className="flex flex-col gap-2">
+                    <div className="flex flex-wrap gap-1.5 min-h-[38px]">
+                      {/* Locked chip — auto-attached invitation PDF (display-only, NOT in submitted attachments) */}
+                      <span className="bg-gray-100 text-gray-500 border border-gray-300 rounded-full px-3 py-0.5 text-sm flex items-center gap-1.5 cursor-default select-none">
+                        <Icon name="lock" style="solid" className="size-3 text-gray-400" />
+                        Meeting Invitation (PDF)
+                      </span>
+                      {/* User-picked document chips — sourced from pickedDocs (single source of truth) */}
+                      {pickedDocs.map((doc) => (
+                        <span
+                          key={doc.id}
+                          className="bg-blue-100 text-blue-800 rounded-full px-3 py-0.5 text-sm flex items-center gap-1"
+                        >
+                          <Icon name="file" style="regular" className="size-3" />
+                          {doc.name}
+                          <button
+                            type="button"
+                            onClick={() => handleRemovePickedAttachment(doc.id)}
+                            className="ml-0.5 text-blue-600 hover:text-blue-800 leading-none"
+                            aria-label={`Remove ${doc.name}`}
+                          >
+                            &times;
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={pickerDisclosure.onOpen}
+                      className="self-start inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 transition-colors"
                     >
-                      {chip}
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveAttachment(i)}
-                        className="ml-0.5 text-blue-600 hover:text-blue-800 leading-none"
-                        aria-label={`Remove ${chip}`}
+                      <Icon name="paperclip" style="solid" className="size-3.5" />
+                      Add attachment
+                    </button>
+                  </div>
+                ) : (
+                  /* ── Free-text chip mode (original behavior) ── */
+                  <div className="flex flex-wrap items-center gap-1.5 min-h-[38px] border border-gray-300 rounded-md px-3 py-1.5 focus-within:ring-2 focus-within:ring-blue-500">
+                    {attachments.map((chip: string, i: number) => (
+                      <span
+                        key={i}
+                        className="bg-blue-100 text-blue-800 rounded-full px-3 py-0.5 text-sm flex items-center gap-1"
                       >
-                        &times;
-                      </button>
-                    </span>
-                  ))}
-                  <input
-                    ref={attachmentInputRef}
-                    type="text"
-                    value={attachmentInput}
-                    onChange={e => setAttachmentInput(e.target.value)}
-                    onKeyDown={handleAttachmentKeyDown}
-                    placeholder={attachments.length === 0 ? 'Type and press Enter to add' : ''}
-                    className="flex-1 min-w-[120px] text-sm outline-none bg-transparent py-0.5"
-                  />
-                </div>
+                        {chip}
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveAttachment(i)}
+                          className="ml-0.5 text-blue-600 hover:text-blue-800 leading-none"
+                          aria-label={`Remove ${chip}`}
+                        >
+                          &times;
+                        </button>
+                      </span>
+                    ))}
+                    <input
+                      ref={attachmentInputRef}
+                      type="text"
+                      value={attachmentInput}
+                      onChange={e => setAttachmentInput(e.target.value)}
+                      onKeyDown={handleAttachmentKeyDown}
+                      placeholder={attachments.length === 0 ? 'Type and press Enter to add' : ''}
+                      className="flex-1 min-w-[120px] text-sm outline-none bg-transparent py-0.5"
+                    />
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -251,6 +324,16 @@ const EmailCompositionModal = ({
           </Button>
         </div>
       </form>
+      {/* Document picker (only in picker mode) */}
+      {attachmentPicker && (
+        <DocumentPickerModal
+          isOpen={pickerDisclosure.isOpen}
+          onClose={pickerDisclosure.onClose}
+          meetingId={attachmentPicker.meetingId}
+          selectedIds={pickedDocs.map(d => d.id)}
+          onConfirm={handlePickerConfirm}
+        />
+      )}
     </Modal>
   );
 };

--- a/src/shared/schemas/email.ts
+++ b/src/shared/schemas/email.ts
@@ -1,36 +1,48 @@
 import { z } from 'zod';
 
-const containsAt = (v: string) =>
+// Split on ',' or ';' to match the backend's ParseAddresses, and require EACH part to look
+// like an email. The previous check only required a '@' somewhere in the whole string, so
+// "a@b.com, bad" passed the FE and then threw server-side at MailboxAddress.Parse.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const validAddresses = (v: string) =>
   v
-    .split(',')
+    .split(/[,;]/)
     .map(s => s.trim())
     .filter(Boolean)
-    .every(s => s.includes('@'));
+    .every(s => EMAIL_RE.test(s));
 
-export const emailFormSchema = z.object({
-  from: z
-    .string()
-    .min(1, 'Required')
-    .max(500)
-    .refine(containsAt, { message: 'From must contain valid email address(es)' }),
-  to: z
-    .string()
-    .min(1, 'Required')
-    .max(500)
-    .refine(containsAt, { message: 'To must contain valid email address(es)' }),
-  cc: z
-    .string()
-    .max(500)
-    .refine(v => !v || containsAt(v), { message: 'CC must contain valid email address(es)' })
-    .optional(),
-  bcc: z
-    .string()
-    .max(500)
-    .refine(v => !v || containsAt(v), { message: 'BCC must contain valid email address(es)' })
-    .optional(),
-  subject: z.string().min(1, 'Required').max(500),
-  content: z.string().max(4000).optional(),
-  attachments: z.array(z.string().max(200)).max(10).optional(),
-});
+export const emailFormSchema = z
+  .object({
+    from: z
+      .string()
+      .min(1, 'Required')
+      .max(500)
+      .refine(validAddresses, { message: 'From must contain valid email address(es)' }),
+    to: z
+      .string()
+      .max(500)
+      .refine(v => !v || validAddresses(v), { message: 'To must contain valid email address(es)' })
+      .optional(),
+    cc: z
+      .string()
+      .max(500)
+      .refine(v => !v || validAddresses(v), { message: 'CC must contain valid email address(es)' })
+      .optional(),
+    bcc: z
+      .string()
+      .max(500)
+      .refine(v => !v || validAddresses(v), { message: 'BCC must contain valid email address(es)' })
+      .optional(),
+    subject: z.string().min(1, 'Required').max(500),
+    content: z.string().max(4000).optional(),
+    attachments: z.array(z.string().max(200)).max(10).optional(),
+  })
+  .refine(
+    data => !!(data.to?.trim() || data.cc?.trim() || data.bcc?.trim()),
+    {
+      message: 'At least one recipient (To, Cc, or Bcc) is required.',
+      path: ['to'],
+    },
+  );
 
 export type EmailFormValues = z.infer<typeof emailFormSchema>;


### PR DESCRIPTION
Frontend for the bank email feature.

## What
- **EmailCompositionModal**: attachments are now a real document **picker** (yields Document IDs) plus a locked, display-only "Meeting Invitation (PDF)" chip for the auto-attached invitation. Optional **To** with **Cc/Bcc**; per-address validation (split on `,`/`;`).
- **Meeting Documents** dialog (from the meeting detail toolbar): generate Invitation/Minutes, upload, list, download, remove.
- Reusable `DocumentPickerModal` + `useMeetingDocumentUpload` hook.
- `SendInvitationDialog` wired to the picker; quotation send **To** made optional.
- i18n: meeting `documents` namespace (en/th/zh).

## Pairs with
Backend PR in collateral-appraisal-system-api (bank SMTP email + meeting documents).

## Notes
- `tsc` is not a clean gate in this repo (~450 pre-existing errors); changed files introduce no new type errors.
- Reviewed across multiple passes during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)