### PR TITLE
fix: report job route catch-all, DB-driven report test page & misc fixes

### DIFF
--- a/src/features/appraisal/context/AppraisalContext.tsx
+++ b/src/features/appraisal/context/AppraisalContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, type ReactNode, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { isTerminalStatus } from '@shared/config/navigationTypes';
 import { useMenuStore } from '@features/menuManagement/store';
@@ -93,7 +93,7 @@ export function useAppraisalContextSafe(): AppraisalContextValue | null {
  */
 export function useIsCiAppraisal(): boolean {
   const ctx = useContext(AppraisalContext);
-  return ctx?.appraisal?.appraisalType === 'ConstructionInspection';
+  return ctx?.appraisal?.appraisalType === 'Progressive';
 }
 
 /**

--- a/src/features/common/historySearch/components/MapView.tsx
+++ b/src/features/common/historySearch/components/MapView.tsx
@@ -703,6 +703,22 @@ export function MapView({
     fitToAllPins();
   }, [fitToken, fitToAllPins]);
 
+  // Frame the appraising-collateral/MC pins once they load. On the 360 drawer these
+  // are fetched lazily and often arrive AFTER the one-time sizing fit (which ran with
+  // no pins yet). Without this re-fit the markers are added off-screen and the map
+  // stays on the default center until the drawer is closed and reopened (data cached).
+  // Guarded so it fires once and never fights a later search/fit or user pan.
+  const framedAppraisingRef = useRef(false);
+  useEffect(() => {
+    if (!mapsReady || !mapRef.current) return;
+    const hasAppraising =
+      (appraisingCollateralPins?.length ?? 0) > 0 || (appraisingMcPins?.length ?? 0) > 0;
+    if (hasAppraising && !framedAppraisingRef.current) {
+      framedAppraisingRef.current = true;
+      fitToAllPins();
+    }
+  }, [mapsReady, appraisingCollateralPins, appraisingMcPins, fitToAllPins]);
+
   // Recover from being initialised while the container had no size — e.g. inside a
   // drawer/modal that lays out or animates in after mount. Google Maps renders blank
   // until a resize is triggered, and any fit computed at 0-size is wrong. On the first

--- a/src/features/quotation/api/quotation.ts
+++ b/src/features/quotation/api/quotation.ts
@@ -655,7 +655,7 @@ export const useSendQuotation = (quotationId: string) => {
   return useMutation({
     mutationFn: async (emailData: {
       from: string;
-      to: string;
+      to?: string;
       cc?: string;
       bcc?: string;
       subject: string;

--- a/src/features/reportGeneration/api/reports.ts
+++ b/src/features/reportGeneration/api/reports.ts
@@ -53,6 +53,11 @@ export const reportKeys = {
 // ──────────────────────────────────────────────────────────────────────────────
 // Sync report APIs (existing — kept as-is)
 // ──────────────────────────────────────────────────────────────────────────────
+//
+// NOTE: `entityId` here is a human number, not a Guid — an AppraisalNumber, or a MeetingNo
+// like "12/2567" for Meeting reports. It is interpolated RAW into the path on purpose: the
+// backend route is a catch-all (`/reports/{reportTypeKey}/{*entityId}`) that needs the slash
+// intact. Do NOT encodeURIComponent it — an encoded "%2F" is rejected by ASP.NET in the path.
 
 /**
  * Fetches a report PDF as a Blob (Bearer auth auto-attached by axiosInstance).
@@ -101,13 +106,15 @@ export const getReportDefinitions = async (): Promise<ReportDefinition[]> => {
   return data;
 };
 
-/** POST /reports/{reportTypeKey}/{entityId}/jobs → 202 { jobId } */
+/** POST /reports/{reportTypeKey}/jobs/{entityId} → 202 { jobId }.
+ *  entityId is the trailing catch-all segment (see the raw-interpolation note above) so a
+ *  MeetingNo's slash survives, mirroring the sync GET route. */
 export const enqueueReportJob = async (
   reportTypeKey: string,
   entityId: string,
 ): Promise<{ jobId: string }> => {
   const { data } = await axios.post<{ jobId: string }>(
-    `/reports/${reportTypeKey}/${entityId}/jobs`,
+    `/reports/${reportTypeKey}/jobs/${entityId}`,
   );
   return data;
 };

--- a/src/features/reportGeneration/pages/ReportTestPage.tsx
+++ b/src/features/reportGeneration/pages/ReportTestPage.tsx
@@ -2,23 +2,35 @@ import { useEffect, useRef, useState } from 'react';
 import SectionHeader from '@shared/components/sections/SectionHeader';
 import Icon from '@shared/components/Icon';
 import ReportActionButtons from '../components/ReportActionButtons';
+import { useReportDefinitions } from '../hooks/useReportDefinitions';
 
-const REPORT_TYPES = [
-  { value: 'appointment-quotation-request', label: 'Appointment Quotation Request' },
-  // Unified entry: auto-picks the per-property summary forms and merges them into one PDF
-  // (block-only / construction-only / else land-building + condo + machine).
-  { value: 'appraisal-summary', label: 'Appraisal Summary' },
-  { value: 'external-appraisal-report', label: 'External Appraisal Report' },
-  { value: 'internal-report-construction', label: 'Internal Appraisal Report – Construction' },
-  { value: 'internal-report-block', label: 'Internal Appraisal Report – Block' },
-  { value: 'meeting-invitation', label: 'Meeting Invitation (entity = MeetingId)' },
-  { value: 'meeting-minute', label: 'Meeting Minute (entity = MeetingId)' },
-] as const;
+// The backend resolves the entered number to an entity id: Meeting-category reports use the
+// MeetingNo (e.g. "12/2567"); every other report uses the AppraisalNumber (e.g. "69000042").
 
 const ReportTestPage = () => {
+  // Drive the picker from the DB-backed report registry so it never drifts from the backend.
+  const { definitions, isLoading: isLoadingDefs } = useReportDefinitions();
+
   const [entityId, setEntityId] = useState('');
-  const [reportTypeKey, setReportTypeKey] = useState<string>(REPORT_TYPES[0].value);
+  const [reportTypeKey, setReportTypeKey] = useState<string>('');
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  // Selection defaults to the first definition until the user picks one — derived, not stored,
+  // so there's no effect round-trip or first-render '' mismatch.
+  const effectiveKey = reportTypeKey || definitions[0]?.reportTypeKey || '';
+  const selectedDef = definitions.find(d => d.reportTypeKey === effectiveKey);
+
+  // Meeting-mode comes from the report's Category (authoritative), matching the backend resolver.
+  const meetingMode = selectedDef?.category === 'Meeting';
+  const idLabel = meetingMode ? 'Meeting No.' : 'Appraisal No.';
+  const idPlaceholder = meetingMode ? 'e.g. 12/2567' : 'e.g. 69000042';
+
+  // Switching report type clears the field — a number entered for one category (e.g. a MeetingNo
+  // "12/2567") is meaningless for another and would just 404.
+  const handleReportTypeChange = (key: string) => {
+    setReportTypeKey(key);
+    setEntityId('');
+  };
 
   // Keep a ref to the current object URL so the cleanup effect always revokes
   // the most-recent one, even if state has already changed.
@@ -58,26 +70,27 @@ const ReportTestPage = () => {
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">Report Type</label>
             <select
-              value={reportTypeKey}
-              onChange={e => setReportTypeKey(e.target.value)}
-              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              value={effectiveKey}
+              onChange={e => handleReportTypeChange(e.target.value)}
+              disabled={isLoadingDefs || definitions.length === 0}
+              className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:bg-gray-50 disabled:text-gray-400"
             >
-              {REPORT_TYPES.map(rt => (
-                <option key={rt.value} value={rt.value}>
-                  {rt.label}
+              {definitions.map(rt => (
+                <option key={rt.reportTypeKey} value={rt.reportTypeKey}>
+                  {rt.displayNameEn || rt.reportTypeKey}
                 </option>
               ))}
             </select>
           </div>
 
-          {/* Appraisal ID */}
+          {/* Appraisal / Meeting number */}
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Appraisal ID</label>
+            <label className="block text-xs font-medium text-gray-600 mb-1">{idLabel}</label>
             <input
               type="text"
               value={entityId}
               onChange={e => setEntityId(e.target.value)}
-              placeholder="e.g. 01969f4a-0000-7000-0000-000000000001"
+              placeholder={idPlaceholder}
               className="w-full text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
             />
           </div>
@@ -86,9 +99,9 @@ const ReportTestPage = () => {
         {/* Mode-aware actions — reads generationMode from /reports/definitions and routes
             Sync → open inline, Async → enqueue a background job (realtime + polling + bell). */}
         <div className="flex items-center gap-2 mt-4">
-          {entityId.trim() ? (
+          {entityId.trim() && effectiveKey ? (
             <ReportActionButtons
-              reportTypeKey={reportTypeKey}
+              reportTypeKey={effectiveKey}
               entityId={entityId.trim()}
               onSyncBlobReady={(_blob, url) => {
                 if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
@@ -97,7 +110,7 @@ const ReportTestPage = () => {
               }}
             />
           ) : (
-            <p className="text-xs text-gray-400">Enter an Appraisal ID to view or generate.</p>
+            <p className="text-xs text-gray-400">Enter {meetingMode ? 'a Meeting No.' : 'an Appraisal No.'} to view or generate.</p>
           )}
 
           {objectUrl && (

--- a/src/shared/components/inputs/Autocomplete.tsx
+++ b/src/shared/components/inputs/Autocomplete.tsx
@@ -35,6 +35,8 @@ interface AutocompleteProps {
   /** Called whenever the raw input text changes. Use to drive external search queries. */
   onInputChange?: (text: string) => void;
   ariaLabel?: string;
+  /** Width (and any extra) classes for the dropdown panel. Defaults to a fixed `w-56`; pass `w-full` to match the input. */
+  menuClassName?: string;
 }
 
 function Autocomplete({
@@ -48,6 +50,7 @@ function Autocomplete({
   filterItems,
   onInputChange,
   ariaLabel,
+  menuClassName = 'w-56',
 }: AutocompleteProps) {
   const listId = useId();
   const [inputText, setInputText] = useState('');
@@ -196,7 +199,7 @@ function Autocomplete({
         <ul
           id={listId}
           role="listbox"
-          className="absolute z-50 mt-1 w-56 max-h-52 overflow-auto bg-white border border-gray-200 rounded-lg shadow-lg text-sm"
+          className={`absolute z-50 mt-1 ${menuClassName} max-h-52 overflow-auto bg-white border border-gray-200 rounded-lg shadow-lg text-sm`}
         >
           {isLoading && visibleItems.length === 0 ? (
             <li role="option" aria-selected={false} className="px-3 py-2 text-gray-400 italic">

--- a/src/shared/utils/validationUtils.ts
+++ b/src/shared/utils/validationUtils.ts
@@ -12,16 +12,6 @@ export function isValidEmail(email: string): boolean {
 }
 
 /**
- * Check if a password meets complexity requirements
- * @param password Password to validate
- */
-export function isValidPassword(password: string): boolean {
-  // At least 8 characters, one uppercase, one lowercase, one number
-  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
-  return passwordRegex.test(password);
-}
-
-/**
  * Check if a phone number is valid
  * @param phone Phone number to validate
  */


### PR DESCRIPTION
## Summary

- **reports**: move `entityId` to the trailing catch-all segment (`/reports/{key}/jobs/{entityId}`) so a MeetingNo's slash (e.g. `12/2567`) survives; document the raw-interpolation contract (never `encodeURIComponent` the entityId)
- **report test page**: drive the report picker from the DB-backed report registry (`useReportDefinitions`) instead of a hardcoded list; label/placeholder switch between "Appraisal No." and "Meeting No." based on the report's category; switching report type clears the entered number
- **map view (360 drawer)**: re-fit the map once when appraising-collateral/MC pins load lazily after the initial sizing fit, guarded so it never fights later fits or user panning
- **appraisal context**: `useIsCiAppraisal` now matches `appraisalType === 'Progressive'` — the actual backend value — instead of `'ConstructionInspection'`
- **quotation**: make `to` optional in the send-quotation payload
- **autocomplete**: add `menuClassName` prop (default `w-56`); fixes `PermissionSelect`'s existing `menuClassName="w-full"` usage merged in #196
- **validation utils**: drop unused `isValidPassword` (superseded by the server-driven password policy)

## Test plan

- [ ] Generate a Meeting report (sync + async job) with a MeetingNo containing a slash, e.g. `12/2567`
- [ ] Generate a non-meeting report with an AppraisalNumber; verify picker is populated from the registry
- [ ] Open the 360 drawer map and confirm appraising pins are framed when they load
- [ ] Verify a Progressive appraisal shows the CI-specific pages/behavior gated by `useIsCiAppraisal`
- [ ] `tsc --noEmit` error count unchanged vs. main (pre-existing errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)