### PR TITLE
feat(task): register int-pma-input PMA activity

### DIFF
--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -306,6 +306,7 @@ const ACTIVITY_SECTION_CONFIG: Record<string, ActivitySectionConfig> = {
   'appraisal-initiation': { sections: [] },
   'appraisal-assignment': { sections: [] },
   'ext-appraisal-assignment': { sections: [] },
+  'int-pma-input': { sections: [] },
   'ext-appraisal-execution': {
     sections: [
       'decisionApproach',

--- a/src/features/task/config/activityConfig.ts
+++ b/src/features/task/config/activityConfig.ts
@@ -91,6 +91,13 @@ const ACTIVITY_CONFIG_MAP: Record<string, ActivityConfig> = {
     icon: 'badge-check',
     allowedRoles: ['Admin', 'IntAdmin', 'IntAppraisalVerifier'],
   },
+  'int-pma-input': {
+    activityId: 'int-pma-input',
+    title: 'PMA Property Input',
+    description: 'Tasks for entering PMA property values before external company assignment',
+    icon: 'file-pen',
+    allowedRoles: ['Admin', 'IntAdmin', 'IntAppraisalStaff'],
+  },
   'pending-approval': {
     activityId: 'pending-approval',
     title: 'Pending Approval',


### PR DESCRIPTION
Frontend pairing for backend PR immortalgky/collateral-appraisal-system-api#257 (one-time PMA input activity).

## Context
The backend adds a new workflow activity `int-pma-input` (assignee `IntAppraisalStaff`) on the PMA branch. Task→screen routing in this app is registered per `activityId`, so the new activity must be registered or it surfaces with no label/role config.

## Changes
- **`src/features/task/config/activityConfig.ts`** — add `int-pma-input` entry (title "PMA Property Input", roles `Admin`/`IntAdmin`/`IntAppraisalStaff`).
- **`src/features/appraisal/pages/DecisionSummaryPage.tsx`** — add `'int-pma-input': { sections: [] }`, consistent with other data-entry activities.

## Behavior
- The task **falls through to the normal appraisal workspace** (no special redirect), exactly like `int-appraisal-execution`.
- The **`property-pma` tab** shows via the existing `appraisal.property-pma` menu condition (`isPma === true`), and `isPma` already comes from the appraisal API. No menu change needed (activity overrides are restrict-only; no override = full role menu).
- Completion uses the generic **Proceed** action returned by the backend `/activities/int-pma-input/actions` endpoint; no hardcoded decision values.

## Out of scope / no change needed
- No routing/`TaskLayout` change (workspace fall-through).
- No new screen — reuses existing `CondoPMAForm` / `LandBuildingPMAForm`.

## Verification
- ESLint clean on `activityConfig.ts`; the lint issues in `DecisionSummaryPage.tsx` are pre-existing (lines 78–163, 898), not from this one-line addition.
- Additions match the existing `ActivityConfig` / `ActivitySectionConfig` shapes.

> Merge alongside backend #257; the backend workflow definition must also be re-imported for the activity to exist at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)