### PR TITLE
feat(admin): OAuth client/scope/token + webhook subscription admin screens

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -95,6 +95,10 @@ import IntInvoiceListPage from '@/features/invoice/pages/IntInvoiceListPage';
 import IntInvoiceDetailPage from '@/features/invoice/pages/IntInvoiceDetailPage';
 import IntBulkPaymentPage from '@/features/invoice/pages/IntBulkPaymentPage';
 import WebhookDeliveryListPage from '@features/webhookAdmin/pages/WebhookDeliveryListPage';
+import WebhookSubscriptionListPage from '@features/webhookAdmin/pages/WebhookSubscriptionListPage';
+import OAuthClientListPage from '@features/oauthAdmin/pages/OAuthClientListPage';
+import OAuthScopeListPage from '@features/oauthAdmin/pages/OAuthScopeListPage';
+import OAuthTokenListPage from '@features/oauthAdmin/pages/OAuthTokenListPage';
 import LogViewerPage from '@features/common/logViewer/pages/LogViewerPage';
 import { SupportingDataMaintenanceDetailListPage } from '@/features/supportingDataMaintenance/pages/SupportingDataMaintenanceDetailListPage';
 import ReappraisalListPage from '@/features/reappraisal/pages/ReappraisalListPage';
@@ -362,6 +366,37 @@ export const router = createBrowserRouter([
           { path: 'appointment-approval-rule', element: <AppointmentApprovalRulePage /> },
           { path: 'evaluation-config', element: <EvaluationConfigPage /> },
           { path: 'webhook-deliveries', element: <WebhookDeliveryListPage /> },
+          {
+            path: 'webhook-subscriptions',
+            element: (
+              <RoleProtectedRoute
+                allowedRoles={[]}
+                requiredPermission="WEBHOOK_SUBSCRIPTIONS_MANAGE"
+              />
+            ),
+            children: [{ index: true, element: <WebhookSubscriptionListPage /> }],
+          },
+          {
+            path: 'oauth-clients',
+            element: (
+              <RoleProtectedRoute allowedRoles={[]} requiredPermission="OAUTH_CLIENTS_MANAGE" />
+            ),
+            children: [{ index: true, element: <OAuthClientListPage /> }],
+          },
+          {
+            path: 'oauth-scopes',
+            element: (
+              <RoleProtectedRoute allowedRoles={[]} requiredPermission="OAUTH_SCOPES_MANAGE" />
+            ),
+            children: [{ index: true, element: <OAuthScopeListPage /> }],
+          },
+          {
+            path: 'oauth-tokens',
+            element: (
+              <RoleProtectedRoute allowedRoles={[]} requiredPermission="OAUTH_TOKENS_REVOKE" />
+            ),
+            children: [{ index: true, element: <OAuthTokenListPage /> }],
+          },
           // Menu management — gated by MENU_MANAGE permission
           {
             path: 'menus',

--- a/src/features/oauthAdmin/api/oauthClients.ts
+++ b/src/features/oauthAdmin/api/oauthClients.ts
@@ -1,0 +1,111 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import axios from '@shared/api/axiosInstance';
+import type {
+  CreateClientRequest,
+  CreateClientResponse,
+  OAuthClientDetail,
+  OAuthClientListResult,
+  RotateSecretResponse,
+  UpdateClientRequest,
+} from '../types';
+
+interface ListParams {
+  search?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export const oauthClientKeys = {
+  all: ['oauth-clients'] as const,
+  list: (params: ListParams) => ['oauth-clients', 'list', params] as const,
+  detail: (id: string) => ['oauth-clients', 'detail', id] as const,
+};
+
+export const useGetClients = (params: ListParams = {}) => {
+  return useQuery({
+    queryKey: oauthClientKeys.list(params),
+    queryFn: async (): Promise<OAuthClientListResult> => {
+      const { data } = await axios.get<OAuthClientListResult>('/auth/clients', {
+        params: {
+          search: params.search || undefined,
+          pageNumber: params.pageNumber ?? 1,
+          pageSize: params.pageSize ?? 20,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+export const useGetClient = (id: string | null) => {
+  return useQuery({
+    queryKey: oauthClientKeys.detail(id ?? ''),
+    enabled: !!id,
+    queryFn: async (): Promise<OAuthClientDetail> => {
+      const { data } = await axios.get<OAuthClientDetail>(`/auth/clients/${id}`);
+      return data;
+    },
+  });
+};
+
+export const useCreateClient = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (request: CreateClientRequest): Promise<CreateClientResponse> => {
+      const { data } = await axios.post<CreateClientResponse>('/auth/clients', request);
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: oauthClientKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('clients.toasts.createFailed')),
+  });
+};
+
+export const useUpdateClient = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async ({ id, request }: { id: string; request: UpdateClientRequest }) => {
+      await axios.put(`/auth/clients/${id}`, request);
+    },
+    onSuccess: () => {
+      toast.success(t('clients.toasts.updated'));
+      void queryClient.invalidateQueries({ queryKey: oauthClientKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('clients.toasts.updateFailed')),
+  });
+};
+
+export const useRotateClientSecret = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (id: string): Promise<RotateSecretResponse> => {
+      const { data } = await axios.post<RotateSecretResponse>(`/auth/clients/${id}/secret`);
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: oauthClientKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('clients.toasts.rotateFailed')),
+  });
+};
+
+export const useDeleteClient = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.delete(`/auth/clients/${id}`);
+    },
+    onSuccess: () => {
+      toast.success(t('clients.toasts.deleted'));
+      void queryClient.invalidateQueries({ queryKey: oauthClientKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('clients.toasts.deleteFailed')),
+  });
+};

--- a/src/features/oauthAdmin/api/oauthScopes.ts
+++ b/src/features/oauthAdmin/api/oauthScopes.ts
@@ -1,0 +1,82 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import axios from '@shared/api/axiosInstance';
+import type {
+  CreateScopeRequest,
+  OAuthScopeListResult,
+  UpdateScopeRequest,
+} from '../types';
+
+interface ListParams {
+  search?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export const oauthScopeKeys = {
+  all: ['oauth-scopes'] as const,
+  list: (params: ListParams) => ['oauth-scopes', 'list', params] as const,
+};
+
+export const useGetScopes = (params: ListParams = {}) => {
+  return useQuery({
+    queryKey: oauthScopeKeys.list(params),
+    queryFn: async (): Promise<OAuthScopeListResult> => {
+      const { data } = await axios.get<OAuthScopeListResult>('/auth/scopes', {
+        params: {
+          search: params.search || undefined,
+          pageNumber: params.pageNumber ?? 1,
+          pageSize: params.pageSize ?? 50,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+export const useCreateScope = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (request: CreateScopeRequest) => {
+      const { data } = await axios.post('/auth/scopes', request);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success(t('scopes.toasts.created'));
+      void queryClient.invalidateQueries({ queryKey: oauthScopeKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('scopes.toasts.createFailed')),
+  });
+};
+
+export const useUpdateScope = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async ({ id, request }: { id: string; request: UpdateScopeRequest }) => {
+      await axios.put(`/auth/scopes/${id}`, request);
+    },
+    onSuccess: () => {
+      toast.success(t('scopes.toasts.updated'));
+      void queryClient.invalidateQueries({ queryKey: oauthScopeKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('scopes.toasts.updateFailed')),
+  });
+};
+
+export const useDeleteScope = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.delete(`/auth/scopes/${id}`);
+    },
+    onSuccess: () => {
+      toast.success(t('scopes.toasts.deleted'));
+      void queryClient.invalidateQueries({ queryKey: oauthScopeKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('scopes.toasts.deleteFailed')),
+  });
+};

--- a/src/features/oauthAdmin/api/oauthTokens.ts
+++ b/src/features/oauthAdmin/api/oauthTokens.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import axios from '@shared/api/axiosInstance';
+import type {
+  OAuthAuthorization,
+  OAuthToken,
+  PaginatedResult,
+  TokenViewerParams,
+} from '../types';
+
+export const oauthTokenKeys = {
+  authorizations: (params: TokenViewerParams) => ['oauth-authorizations', params] as const,
+  tokens: (params: TokenViewerParams) => ['oauth-tokens', params] as const,
+};
+
+const toQuery = (params: TokenViewerParams) => ({
+  clientId: params.clientId || undefined,
+  subject: params.subject || undefined,
+  status: params.status || undefined,
+  pageNumber: params.pageNumber ?? 1,
+  pageSize: params.pageSize ?? 20,
+});
+
+export const useGetAuthorizations = (params: TokenViewerParams = {}, enabled = true) => {
+  return useQuery({
+    queryKey: oauthTokenKeys.authorizations(params),
+    enabled,
+    queryFn: async (): Promise<PaginatedResult<OAuthAuthorization>> => {
+      const { data } = await axios.get<PaginatedResult<OAuthAuthorization>>('/auth/authorizations', {
+        params: toQuery(params),
+      });
+      return data;
+    },
+  });
+};
+
+export const useGetTokens = (params: TokenViewerParams = {}, enabled = true) => {
+  return useQuery({
+    queryKey: oauthTokenKeys.tokens(params),
+    enabled,
+    queryFn: async (): Promise<PaginatedResult<OAuthToken>> => {
+      const { data } = await axios.get<PaginatedResult<OAuthToken>>('/auth/tokens', {
+        params: toQuery(params),
+      });
+      return data;
+    },
+  });
+};
+
+export const useRevokeAuthorization = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.post(`/auth/authorizations/${id}/revoke`);
+    },
+    onSuccess: () => {
+      toast.success(t('tokens.revoke.successToast'));
+      void queryClient.invalidateQueries({ queryKey: ['oauth-authorizations'] });
+      void queryClient.invalidateQueries({ queryKey: ['oauth-tokens'] });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('tokens.revoke.errorToast')),
+  });
+};
+
+export const useRevokeToken = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('oauthAdmin');
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.post(`/auth/tokens/${id}/revoke`);
+    },
+    onSuccess: () => {
+      toast.success(t('tokens.revoke.successToast'));
+      void queryClient.invalidateQueries({ queryKey: ['oauth-tokens'] });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('tokens.revoke.errorToast')),
+  });
+};

--- a/src/features/oauthAdmin/components/OAuthClientFormModal.tsx
+++ b/src/features/oauthAdmin/components/OAuthClientFormModal.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from '@shared/components/Modal';
+import Button from '@shared/components/Button';
+import { useCreateClient, useGetClient, useUpdateClient } from '../api/oauthClients';
+import { GRANT_TYPES, type ClientType, type CreateClientResponse, type GrantType } from '../types';
+import { splitLines, splitList } from '../utils/textParse';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** OpenIddict id when editing; null when registering a new client. */
+  editId: string | null;
+  /** Fired after a successful create so the parent can reveal the one-time secret. */
+  onCreated: (response: CreateClientResponse) => void;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary';
+
+const OAuthClientFormModal = ({ isOpen, onClose, editId, onCreated }: Props) => {
+  const { t } = useTranslation('oauthAdmin');
+  const isEdit = editId !== null;
+
+  const { data: detail } = useGetClient(isEdit ? editId : null);
+
+  const [displayName, setDisplayName] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [clientType, setClientType] = useState<ClientType>('confidential');
+  const [grantTypes, setGrantTypes] = useState<GrantType[]>(['authorization_code']);
+  const [scopes, setScopes] = useState('');
+  const [redirectUris, setRedirectUris] = useState('');
+  const [postLogoutRedirectUris, setPostLogoutRedirectUris] = useState('');
+
+  const createMutation = useCreateClient();
+  const updateMutation = useUpdateClient();
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (isEdit && detail) {
+      setDisplayName(detail.displayName);
+      setClientId(detail.clientId);
+      setClientType(detail.clientType);
+      setGrantTypes(detail.grantTypes as GrantType[]);
+      setScopes(detail.scopes.join(' '));
+      setRedirectUris(detail.redirectUris.join('\n'));
+      setPostLogoutRedirectUris(detail.postLogoutRedirectUris.join('\n'));
+    } else {
+      // Create mode, OR edit mode while the target client's detail is still loading — clear the
+      // form so a previously-edited client's values can never linger and be submitted.
+      setDisplayName('');
+      setClientId('');
+      setClientType('confidential');
+      setGrantTypes(['authorization_code']);
+      setScopes('');
+      setRedirectUris('');
+      setPostLogoutRedirectUris('');
+    }
+    // Key on detail?.id, not the detail object: this populates once when the client's detail first
+    // loads (and re-runs when the edited id changes), but a later background refetch of the same
+    // client won't re-fire and overwrite the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, isEdit, editId, detail?.id]);
+
+  const toggleGrant = (grant: GrantType) => {
+    setGrantTypes(prev =>
+      prev.includes(grant) ? prev.filter(g => g !== grant) : [...prev, grant],
+    );
+  };
+
+  const handleSubmit = () => {
+    const common = {
+      displayName,
+      redirectUris: splitLines(redirectUris),
+      postLogoutRedirectUris: splitLines(postLogoutRedirectUris),
+      grantTypes,
+      scopes: splitList(scopes),
+    };
+
+    if (isEdit) {
+      updateMutation.mutate({ id: editId, request: common }, { onSuccess: onClose });
+    } else {
+      createMutation.mutate(
+        { ...common, clientId: clientId.trim() || undefined, clientType },
+        {
+          onSuccess: response => {
+            onClose();
+            onCreated(response);
+          },
+        },
+      );
+    }
+  };
+
+  const requiresRedirect = grantTypes.includes('authorization_code');
+  const canSubmit =
+    displayName.trim() !== '' &&
+    grantTypes.length > 0 &&
+    (!requiresRedirect || splitLines(redirectUris).length > 0);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isEdit ? t('clients.form.editTitle') : t('clients.form.createTitle')}
+      size="lg"
+    >
+      <div className="px-6 py-5 space-y-4 max-h-[70vh] overflow-y-auto">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.displayName')}
+          </label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.clientId')}
+          </label>
+          <input
+            type="text"
+            value={clientId}
+            disabled={isEdit}
+            onChange={e => setClientId(e.target.value)}
+            className={`${inputClass} ${isEdit ? 'bg-gray-50 text-gray-500' : ''}`}
+          />
+          {!isEdit && (
+            <p className="mt-1 text-xs text-gray-400">{t('clients.form.clientIdHint')}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.clientType')}
+          </label>
+          {isEdit ? (
+            <div className={`${inputClass} bg-gray-50 text-gray-500`}>
+              {t(`clients.type.${clientType}` as const)}
+            </div>
+          ) : (
+            <div className="flex gap-4">
+              {(['confidential', 'public'] as ClientType[]).map(type => (
+                <label key={type} className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="radio"
+                    name="clientType"
+                    checked={clientType === type}
+                    onChange={() => setClientType(type)}
+                  />
+                  {t(`clients.type.${type}` as const)}
+                </label>
+              ))}
+            </div>
+          )}
+          {!isEdit && (
+            <p className="mt-1 text-xs text-gray-400">
+              {clientType === 'public'
+                ? t('clients.form.clientTypePublicHint')
+                : t('clients.form.clientTypeConfidentialHint')}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.grantTypes')}
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {GRANT_TYPES.map(grant => (
+              <label key={grant} className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={grantTypes.includes(grant)}
+                  onChange={() => toggleGrant(grant)}
+                />
+                {t(`clients.grant.${grant}` as const)}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.scopes')}
+          </label>
+          <input
+            type="text"
+            value={scopes}
+            onChange={e => setScopes(e.target.value)}
+            placeholder="profile email appraisal.read"
+            className={`${inputClass} font-mono`}
+          />
+          <p className="mt-1 text-xs text-gray-400">{t('clients.form.scopesHint')}</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.redirectUris')}
+          </label>
+          <textarea
+            value={redirectUris}
+            onChange={e => setRedirectUris(e.target.value)}
+            rows={2}
+            placeholder="https://app.example.com/callback"
+            className={`${inputClass} font-mono`}
+          />
+          <p className="mt-1 text-xs text-gray-400">{t('clients.form.redirectUrisHint')}</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('clients.form.postLogoutRedirectUris')}
+          </label>
+          <textarea
+            value={postLogoutRedirectUris}
+            onChange={e => setPostLogoutRedirectUris(e.target.value)}
+            rows={2}
+            className={`${inputClass} font-mono`}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
+        <Button variant="secondary" onClick={onClose} disabled={isPending}>
+          {t('clients.form.cancel')}
+        </Button>
+        <Button onClick={handleSubmit} disabled={!canSubmit || isPending}>
+          {isEdit ? t('clients.form.save') : t('clients.form.create')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default OAuthClientFormModal;

--- a/src/features/oauthAdmin/components/OAuthScopeFormModal.tsx
+++ b/src/features/oauthAdmin/components/OAuthScopeFormModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from '@shared/components/Modal';
+import Button from '@shared/components/Button';
+import { useCreateScope, useUpdateScope } from '../api/oauthScopes';
+import { splitList } from '../utils/textParse';
+import type { OAuthScope } from '../types';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  scope: OAuthScope | null;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary';
+
+const OAuthScopeFormModal = ({ isOpen, onClose, scope }: Props) => {
+  const { t } = useTranslation('oauthAdmin');
+  const isEdit = scope !== null;
+
+  const [name, setName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [resources, setResources] = useState('');
+
+  const createMutation = useCreateScope();
+  const updateMutation = useUpdateScope();
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setName(scope?.name ?? '');
+    setDisplayName(scope?.displayName ?? '');
+    setDescription(scope?.description ?? '');
+    setResources(scope?.resources.join(' ') ?? '');
+  }, [isOpen, scope]);
+
+  const handleSubmit = () => {
+    if (isEdit) {
+      updateMutation.mutate(
+        {
+          id: scope!.id,
+          request: {
+            displayName: displayName || undefined,
+            description: description || undefined,
+            resources: splitList(resources),
+          },
+        },
+        { onSuccess: onClose },
+      );
+    } else {
+      createMutation.mutate(
+        {
+          name: name.trim(),
+          displayName: displayName || undefined,
+          description: description || undefined,
+          resources: splitList(resources),
+        },
+        { onSuccess: onClose },
+      );
+    }
+  };
+
+  const canSubmit = isEdit || name.trim() !== '';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isEdit ? t('scopes.form.editTitle') : t('scopes.form.createTitle')}
+      size="md"
+    >
+      <div className="px-6 py-5 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('scopes.form.name')}
+          </label>
+          <input
+            type="text"
+            value={name}
+            disabled={isEdit}
+            onChange={e => setName(e.target.value)}
+            placeholder="appraisal.read"
+            className={`${inputClass} font-mono ${isEdit ? 'bg-gray-50 text-gray-500' : ''}`}
+          />
+          <p className="mt-1 text-xs text-gray-400">{t('scopes.form.nameHint')}</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('scopes.form.displayName')}
+          </label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('scopes.form.description')}
+          </label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={2}
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('scopes.form.resources')}
+          </label>
+          <input
+            type="text"
+            value={resources}
+            onChange={e => setResources(e.target.value)}
+            className={`${inputClass} font-mono`}
+          />
+          <p className="mt-1 text-xs text-gray-400">{t('scopes.form.resourcesHint')}</p>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
+        <Button variant="secondary" onClick={onClose} disabled={isPending}>
+          {t('scopes.form.cancel')}
+        </Button>
+        <Button onClick={handleSubmit} disabled={!canSubmit || isPending}>
+          {isEdit ? t('scopes.form.save') : t('scopes.form.create')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default OAuthScopeFormModal;

--- a/src/features/oauthAdmin/components/SecretRevealModal.tsx
+++ b/src/features/oauthAdmin/components/SecretRevealModal.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from '@shared/components/Modal';
+import Button from '@shared/components/Button';
+import Icon from '@shared/components/Icon';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  clientId: string;
+  secret: string;
+  /** Whether this secret came from a create or a rotate, to pick the right copy. */
+  variant: 'created' | 'rotated';
+}
+
+/**
+ * One-time display of a freshly minted client secret. The secret is never retrievable again,
+ * so the modal hides the header close (X) and leads with a copy affordance and a warning.
+ * (Backdrop/Esc still dismiss, per the shared Modal — the warning makes the stakes clear.)
+ */
+const SecretRevealModal = ({ isOpen, onClose, clientId, secret, variant }: Props) => {
+  const { t } = useTranslation('oauthAdmin');
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(secret);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('clients.secret.title')} size="md" showCloseButton={false}>
+      <div className="px-6 py-5 space-y-4">
+        <div className="flex items-start gap-3 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
+          <Icon name="triangle-exclamation" style="solid" className="size-5 text-amber-500 mt-0.5" />
+          <p className="text-sm text-amber-800">
+            {variant === 'created'
+              ? t('clients.secret.createdIntro')
+              : t('clients.secret.rotatedIntro')}
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">
+            {t('clients.secret.clientId')}
+          </label>
+          <div className="font-mono text-sm text-gray-800 bg-gray-50 rounded-lg px-3 py-2 break-all">
+            {clientId}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">
+            {t('clients.secret.secret')}
+          </label>
+          <div className="flex items-stretch gap-2">
+            <div className="flex-1 font-mono text-sm text-gray-800 bg-gray-50 rounded-lg px-3 py-2 break-all">
+              {secret}
+            </div>
+            <button
+              type="button"
+              onClick={copy}
+              className="shrink-0 px-3 rounded-lg border border-gray-200 text-sm text-gray-600 hover:bg-gray-50 transition-colors"
+            >
+              <Icon name={copied ? 'check' : 'copy'} style="regular" className="size-4 mr-1" />
+              {copied ? t('clients.secret.copied') : t('clients.secret.copy')}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end px-6 py-4 border-t border-gray-200">
+        <Button onClick={onClose}>{t('clients.secret.done')}</Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default SecretRevealModal;

--- a/src/features/oauthAdmin/pages/OAuthClientListPage.tsx
+++ b/src/features/oauthAdmin/pages/OAuthClientListPage.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Pagination from '@shared/components/Pagination';
+import DataErrorState from '@shared/components/DataErrorState';
+import { useGetClients, useRotateClientSecret, useDeleteClient } from '../api/oauthClients';
+import OAuthClientFormModal from '../components/OAuthClientFormModal';
+import SecretRevealModal from '../components/SecretRevealModal';
+import type { CreateClientResponse, OAuthClientListItem } from '../types';
+
+const PAGE_SIZE = 20;
+const SKELETON_COLUMNS = [
+  { width: 'w-32' },
+  { width: 'w-40' },
+  { width: 'w-20' },
+  { width: 'w-40' },
+  { width: 'w-40' },
+  { width: 'w-24' },
+];
+
+const OAuthClientListPage = () => {
+  const { t } = useTranslation('oauthAdmin');
+
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<OAuthClientListItem | null>(null);
+  const [rotateTarget, setRotateTarget] = useState<OAuthClientListItem | null>(null);
+  const [revealed, setRevealed] = useState<{
+    clientId: string;
+    secret: string;
+    variant: 'created' | 'rotated';
+  } | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchInput);
+      setPageIndex(0);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const { data, isLoading, isError, refetch } = useGetClients({
+    search: debouncedSearch || undefined,
+    pageNumber: pageIndex + 1,
+    pageSize: PAGE_SIZE,
+  });
+
+  const rotateMutation = useRotateClientSecret();
+  const deleteMutation = useDeleteClient();
+
+  const clients = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+
+  const openCreate = () => {
+    setEditId(null);
+    setShowForm(true);
+  };
+  const openEdit = (client: OAuthClientListItem) => {
+    setEditId(client.id);
+    setShowForm(true);
+  };
+
+  const handleCreated = (response: CreateClientResponse) => {
+    if (response.clientSecret) {
+      setRevealed({ clientId: response.clientId, secret: response.clientSecret, variant: 'created' });
+    }
+  };
+
+  const handleRotateConfirm = () => {
+    if (!rotateTarget) return;
+    rotateMutation.mutate(rotateTarget.id, {
+      onSuccess: response => {
+        setRotateTarget(null);
+        setRevealed({ clientId: response.clientId, secret: response.clientSecret, variant: 'rotated' });
+      },
+      onError: () => setRotateTarget(null),
+    });
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+      onError: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-start justify-between">
+        <SectionHeader
+          title={t('clients.page.title')}
+          subtitle={t('clients.page.subtitle')}
+          icon="key"
+          iconColor="blue"
+        />
+        <Button onClick={openCreate}>
+          <Icon name="plus" style="regular" className="size-4 mr-1.5" />
+          {t('clients.actions.add')}
+        </Button>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm mt-4">
+        <div className="flex flex-wrap items-center gap-3 px-4 pt-4 pb-2">
+          <div className="relative min-w-64">
+            <Icon
+              name="magnifying-glass"
+              style="regular"
+              className="size-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              type="text"
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              placeholder={t('clients.filters.searchPlaceholder')}
+              className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              {t('clients.filters.clear')}
+            </button>
+          )}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.displayName')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.clientId')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.type')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.grantTypes')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.scopes')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('clients.columns.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <TableRowSkeleton columns={SKELETON_COLUMNS} rows={5} />
+              ) : isError ? (
+                <tr>
+                  <td colSpan={6} className="py-4">
+                    <DataErrorState variant="inline" title={t('clients.loadFailed')} onRetry={refetch} />
+                  </td>
+                </tr>
+              ) : clients.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="text-center py-12 text-gray-400 text-sm">
+                    <Icon name="key" style="regular" className="size-8 mx-auto mb-2 opacity-40" />
+                    <p>{t('clients.emptyState')}</p>
+                  </td>
+                </tr>
+              ) : (
+                clients.map(client => (
+                  <tr key={client.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 font-medium text-gray-900">
+                      <div className="flex items-center gap-2">
+                        {client.displayName}
+                        {client.isSystem && (
+                          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 text-gray-500 uppercase tracking-wide">
+                            {t('clients.badges.system')}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 font-mono text-xs">{client.clientId}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          client.clientType === 'confidential'
+                            ? 'bg-indigo-50 text-indigo-700'
+                            : 'bg-sky-50 text-sky-700'
+                        }`}
+                      >
+                        {t(`clients.type.${client.clientType}` as const)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">
+                      {client.grantTypes.join(', ') || '—'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs max-w-xs">
+                      <span className="block truncate" title={client.scopes.join(' ')}>
+                        {client.scopes.join(', ') || '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => openEdit(client)}
+                          className="p-1.5 text-gray-400 hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
+                          title={t('clients.actions.edit')}
+                        >
+                          <Icon name="pen" style="regular" className="size-4" />
+                        </button>
+                        {client.hasSecret && (
+                          <button
+                            type="button"
+                            onClick={() => setRotateTarget(client)}
+                            className="p-1.5 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors"
+                            title={t('clients.actions.rotateSecret')}
+                          >
+                            <Icon name="rotate" style="regular" className="size-4" />
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => setDeleteTarget(client)}
+                          disabled={client.isSystem}
+                          className="p-1.5 text-gray-400 hover:text-danger hover:bg-danger/5 rounded-lg transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+                          title={t('clients.actions.delete')}
+                        >
+                          <Icon name="trash" style="regular" className="size-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {!isLoading && totalCount > 0 && (
+          <Pagination
+            currentPage={pageIndex}
+            totalPages={Math.ceil(totalCount / PAGE_SIZE)}
+            totalCount={totalCount}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPageIndex}
+            showPageSizeSelector={false}
+          />
+        )}
+      </div>
+
+      <OAuthClientFormModal
+        isOpen={showForm}
+        onClose={() => setShowForm(false)}
+        editId={editId}
+        onCreated={handleCreated}
+      />
+
+      {revealed && (
+        <SecretRevealModal
+          isOpen={!!revealed}
+          onClose={() => setRevealed(null)}
+          clientId={revealed.clientId}
+          secret={revealed.secret}
+          variant={revealed.variant}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={!!rotateTarget}
+        onClose={() => setRotateTarget(null)}
+        onConfirm={handleRotateConfirm}
+        title={t('clients.secret.rotateConfirmTitle')}
+        message={t('clients.secret.rotateConfirmMessage')}
+        confirmText={t('clients.secret.rotateConfirmButton')}
+        cancelText={t('clients.delete.cancelButton')}
+        variant="warning"
+        isLoading={rotateMutation.isPending}
+      />
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title={t('clients.delete.confirmTitle')}
+        message={t('clients.delete.confirmMessage')}
+        confirmText={t('clients.delete.confirmButton')}
+        cancelText={t('clients.delete.cancelButton')}
+        variant="danger"
+        isLoading={deleteMutation.isPending}
+      />
+    </div>
+  );
+};
+
+export default OAuthClientListPage;

--- a/src/features/oauthAdmin/pages/OAuthScopeListPage.tsx
+++ b/src/features/oauthAdmin/pages/OAuthScopeListPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Pagination from '@shared/components/Pagination';
+import DataErrorState from '@shared/components/DataErrorState';
+import { useGetScopes, useDeleteScope } from '../api/oauthScopes';
+import OAuthScopeFormModal from '../components/OAuthScopeFormModal';
+import type { OAuthScope } from '../types';
+
+const PAGE_SIZE = 50;
+const SKELETON_COLUMNS = [{ width: 'w-32' }, { width: 'w-40' }, { width: 'w-64' }, { width: 'w-24' }];
+
+const OAuthScopeListPage = () => {
+  const { t } = useTranslation('oauthAdmin');
+
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editTarget, setEditTarget] = useState<OAuthScope | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<OAuthScope | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchInput);
+      setPageIndex(0);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const { data, isLoading, isError, refetch } = useGetScopes({
+    search: debouncedSearch || undefined,
+    pageNumber: pageIndex + 1,
+    pageSize: PAGE_SIZE,
+  });
+
+  const deleteMutation = useDeleteScope();
+
+  const scopes = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+
+  const openCreate = () => {
+    setEditTarget(null);
+    setShowForm(true);
+  };
+  const openEdit = (scope: OAuthScope) => {
+    setEditTarget(scope);
+    setShowForm(true);
+  };
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+      onError: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-start justify-between">
+        <SectionHeader
+          title={t('scopes.page.title')}
+          subtitle={t('scopes.page.subtitle')}
+          icon="shield-halved"
+          iconColor="blue"
+        />
+        <Button onClick={openCreate}>
+          <Icon name="plus" style="regular" className="size-4 mr-1.5" />
+          {t('scopes.actions.add')}
+        </Button>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm mt-4">
+        <div className="flex flex-wrap items-center gap-3 px-4 pt-4 pb-2">
+          <div className="relative min-w-64">
+            <Icon
+              name="magnifying-glass"
+              style="regular"
+              className="size-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              type="text"
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              placeholder={t('scopes.filters.searchPlaceholder')}
+              className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              {t('scopes.filters.clear')}
+            </button>
+          )}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('scopes.columns.name')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('scopes.columns.displayName')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('scopes.columns.description')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('scopes.columns.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <TableRowSkeleton columns={SKELETON_COLUMNS} rows={5} />
+              ) : isError ? (
+                <tr>
+                  <td colSpan={4} className="py-4">
+                    <DataErrorState variant="inline" title={t('scopes.loadFailed')} onRetry={refetch} />
+                  </td>
+                </tr>
+              ) : scopes.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="text-center py-12 text-gray-400 text-sm">
+                    <Icon name="shield-halved" style="regular" className="size-8 mx-auto mb-2 opacity-40" />
+                    <p>{t('scopes.emptyState')}</p>
+                  </td>
+                </tr>
+              ) : (
+                scopes.map(scope => (
+                  <tr key={scope.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 font-mono text-xs text-gray-900">{scope.name}</td>
+                    <td className="px-4 py-3 text-gray-700">{scope.displayName || '—'}</td>
+                    <td className="px-4 py-3 text-gray-500 max-w-md">
+                      <span className="block truncate" title={scope.description ?? ''}>
+                        {scope.description || '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => openEdit(scope)}
+                          className="p-1.5 text-gray-400 hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
+                          title={t('scopes.actions.edit')}
+                        >
+                          <Icon name="pen" style="regular" className="size-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setDeleteTarget(scope)}
+                          className="p-1.5 text-gray-400 hover:text-danger hover:bg-danger/5 rounded-lg transition-colors"
+                          title={t('scopes.actions.delete')}
+                        >
+                          <Icon name="trash" style="regular" className="size-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {!isLoading && totalCount > 0 && (
+          <Pagination
+            currentPage={pageIndex}
+            totalPages={Math.ceil(totalCount / PAGE_SIZE)}
+            totalCount={totalCount}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPageIndex}
+            showPageSizeSelector={false}
+          />
+        )}
+      </div>
+
+      <OAuthScopeFormModal isOpen={showForm} onClose={() => setShowForm(false)} scope={editTarget} />
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title={t('scopes.delete.confirmTitle')}
+        message={t('scopes.delete.confirmMessage')}
+        confirmText={t('scopes.delete.confirmButton')}
+        cancelText={t('scopes.delete.cancelButton')}
+        variant="danger"
+        isLoading={deleteMutation.isPending}
+      />
+    </div>
+  );
+};
+
+export default OAuthScopeListPage;

--- a/src/features/oauthAdmin/pages/OAuthTokenListPage.tsx
+++ b/src/features/oauthAdmin/pages/OAuthTokenListPage.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Icon from '@shared/components/Icon';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Pagination from '@shared/components/Pagination';
+import DataErrorState from '@shared/components/DataErrorState';
+import {
+  useGetAuthorizations,
+  useGetTokens,
+  useRevokeAuthorization,
+  useRevokeToken,
+} from '../api/oauthTokens';
+
+const PAGE_SIZE = 20;
+const STATUS_OPTIONS = ['valid', 'revoked', 'redeemed', 'inactive'];
+
+type Tab = 'authorizations' | 'tokens';
+
+const statusBadgeClass = (status: string | null): string => {
+  switch ((status ?? '').toLowerCase()) {
+    case 'valid':
+      return 'bg-emerald-50 text-emerald-700';
+    case 'revoked':
+      return 'bg-danger/10 text-danger';
+    default:
+      return 'bg-gray-100 text-gray-500';
+  }
+};
+
+const OAuthTokenListPage = () => {
+  const { t } = useTranslation('oauthAdmin');
+
+  const [tab, setTab] = useState<Tab>('authorizations');
+  const [clientIdInput, setClientIdInput] = useState('');
+  const [subjectInput, setSubjectInput] = useState('');
+  const [debounced, setDebounced] = useState({ clientId: '', subject: '' });
+  const [status, setStatus] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const [revokeTarget, setRevokeTarget] = useState<{ id: string; kind: Tab } | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounced({ clientId: clientIdInput, subject: subjectInput });
+      setPageIndex(0);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [clientIdInput, subjectInput]);
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [status, tab]);
+
+  const params = {
+    clientId: debounced.clientId || undefined,
+    subject: debounced.subject || undefined,
+    status: status || undefined,
+    pageNumber: pageIndex + 1,
+    pageSize: PAGE_SIZE,
+  };
+
+  // Only the active tab's query fires — the inactive one is disabled so it issues no request.
+  const authorizationsQuery = useGetAuthorizations(params, tab === 'authorizations');
+  const tokensQuery = useGetTokens(params, tab === 'tokens');
+  const active = tab === 'authorizations' ? authorizationsQuery : tokensQuery;
+
+  const revokeAuthorization = useRevokeAuthorization();
+  const revokeToken = useRevokeToken();
+  const revokePending = revokeAuthorization.isPending || revokeToken.isPending;
+
+  const totalCount = active.data?.count ?? 0;
+
+  const handleRevokeConfirm = () => {
+    if (!revokeTarget) return;
+    const mutation = revokeTarget.kind === 'authorizations' ? revokeAuthorization : revokeToken;
+    mutation.mutate(revokeTarget.id, {
+      onSuccess: () => setRevokeTarget(null),
+      onError: () => setRevokeTarget(null),
+    });
+  };
+
+  const clearFilters = () => {
+    setClientIdInput('');
+    setSubjectInput('');
+    setStatus('');
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8">
+      <SectionHeader
+        title={t('tokens.page.title')}
+        subtitle={t('tokens.page.subtitle')}
+        icon="ticket"
+        iconColor="blue"
+      />
+
+      {/* Tabs */}
+      <div className="flex gap-1 mt-4 border-b border-gray-200">
+        {(['authorizations', 'tokens'] as Tab[]).map(key => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTab(key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              tab === key
+                ? 'border-primary text-primary'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {t(`tokens.tabs.${key}` as const)}
+          </button>
+        ))}
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm mt-4">
+        {/* Filters */}
+        <div className="flex flex-wrap items-center gap-3 px-4 pt-4 pb-2">
+          <input
+            type="text"
+            value={clientIdInput}
+            onChange={e => setClientIdInput(e.target.value)}
+            placeholder={t('tokens.filters.clientIdPlaceholder')}
+            className="px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary min-w-48"
+          />
+          <input
+            type="text"
+            value={subjectInput}
+            onChange={e => setSubjectInput(e.target.value)}
+            placeholder={t('tokens.filters.subjectPlaceholder')}
+            className="px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary min-w-48"
+          />
+          <select
+            value={status}
+            onChange={e => setStatus(e.target.value)}
+            className="px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary bg-white"
+          >
+            <option value="">{t('tokens.filters.allStatuses')}</option>
+            {STATUS_OPTIONS.map(s => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          {(clientIdInput || subjectInput || status) && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              {t('tokens.filters.clear')}
+            </button>
+          )}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.subject')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.clientId')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.status')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.type')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {tab === 'authorizations' ? t('tokens.columns.scopes') : t('tokens.columns.expires')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.created')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('tokens.columns.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {active.isLoading ? (
+                <TableRowSkeleton
+                  columns={[
+                    { width: 'w-32' },
+                    { width: 'w-20' },
+                    { width: 'w-16' },
+                    { width: 'w-20' },
+                    { width: 'w-32' },
+                    { width: 'w-32' },
+                    { width: 'w-16' },
+                  ]}
+                  rows={5}
+                />
+              ) : active.isError ? (
+                <tr>
+                  <td colSpan={7} className="py-4">
+                    <DataErrorState
+                      variant="inline"
+                      title={t('tokens.loadFailed')}
+                      onRetry={active.refetch}
+                    />
+                  </td>
+                </tr>
+              ) : (active.data?.items.length ?? 0) === 0 ? (
+                <tr>
+                  <td colSpan={7} className="text-center py-12 text-gray-400 text-sm">
+                    <Icon name="ticket" style="regular" className="size-8 mx-auto mb-2 opacity-40" />
+                    <p>
+                      {tab === 'authorizations'
+                        ? t('tokens.emptyAuthorizations')
+                        : t('tokens.emptyTokens')}
+                    </p>
+                  </td>
+                </tr>
+              ) : tab === 'authorizations' ? (
+                authorizationsQuery.data?.items.map(item => (
+                  <tr key={item.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 text-gray-700">{item.subject ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-600 font-mono text-xs">{item.clientId ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusBadgeClass(item.status)}`}
+                      >
+                        {item.status ?? '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">{item.type ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-500 text-xs max-w-xs">
+                      <span className="block truncate" title={item.scopes.join(' ')}>
+                        {item.scopes.join(', ') || '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs whitespace-nowrap">
+                      {item.creationDate ? new Date(item.creationDate).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => setRevokeTarget({ id: item.id, kind: 'authorizations' })}
+                        className="p-1.5 text-gray-400 hover:text-danger hover:bg-danger/5 rounded-lg transition-colors"
+                        title={t('tokens.actions.revoke')}
+                      >
+                        <Icon name="ban" style="regular" className="size-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                tokensQuery.data?.items.map(item => (
+                  <tr key={item.id} className="border-b border-gray-50 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 text-gray-700">{item.subject ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-600 font-mono text-xs">{item.clientId ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusBadgeClass(item.status)}`}
+                      >
+                        {item.status ?? '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">{item.type ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-500 text-xs whitespace-nowrap">
+                      {item.expirationDate ? new Date(item.expirationDate).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs whitespace-nowrap">
+                      {item.creationDate ? new Date(item.creationDate).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => setRevokeTarget({ id: item.id, kind: 'tokens' })}
+                        className="p-1.5 text-gray-400 hover:text-danger hover:bg-danger/5 rounded-lg transition-colors"
+                        title={t('tokens.actions.revoke')}
+                      >
+                        <Icon name="ban" style="regular" className="size-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {!active.isLoading && totalCount > 0 && (
+          <Pagination
+            currentPage={pageIndex}
+            totalPages={Math.ceil(totalCount / PAGE_SIZE)}
+            totalCount={totalCount}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPageIndex}
+            showPageSizeSelector={false}
+          />
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={!!revokeTarget}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={handleRevokeConfirm}
+        title={t('tokens.revoke.confirmTitle')}
+        message={
+          revokeTarget?.kind === 'authorizations'
+            ? t('tokens.revoke.confirmMessageAuthorization')
+            : t('tokens.revoke.confirmMessageToken')
+        }
+        confirmText={t('tokens.revoke.confirmButton')}
+        cancelText={t('tokens.revoke.cancelButton')}
+        variant="danger"
+        isLoading={revokePending}
+      />
+    </div>
+  );
+};
+
+export default OAuthTokenListPage;

--- a/src/features/oauthAdmin/types/index.ts
+++ b/src/features/oauthAdmin/types/index.ts
@@ -1,0 +1,124 @@
+// ─── OAuth Clients ────────────────────────────────────────────────────────────
+
+export type ClientType = 'public' | 'confidential';
+
+export const GRANT_TYPES = [
+  'authorization_code',
+  'client_credentials',
+  'password',
+  'refresh_token',
+] as const;
+export type GrantType = (typeof GRANT_TYPES)[number];
+
+export interface OAuthClientListItem {
+  id: string;
+  clientId: string;
+  displayName: string;
+  clientType: ClientType;
+  grantTypes: string[];
+  scopes: string[];
+  hasSecret: boolean;
+  /** Seeded core clients (spa/los/cls) cannot be deleted. */
+  isSystem: boolean;
+}
+
+export interface OAuthClientDetail extends OAuthClientListItem {
+  redirectUris: string[];
+  postLogoutRedirectUris: string[];
+}
+
+export interface OAuthClientListResult {
+  items: OAuthClientListItem[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface CreateClientRequest {
+  clientId?: string;
+  displayName: string;
+  clientType: ClientType;
+  redirectUris: string[];
+  postLogoutRedirectUris: string[];
+  grantTypes: string[];
+  scopes: string[];
+}
+
+export type UpdateClientRequest = Omit<CreateClientRequest, 'clientId' | 'clientType'>;
+
+/** Returned once on create — the only time the secret is ever visible. */
+export interface CreateClientResponse {
+  id: string;
+  clientId: string;
+  clientSecret: string | null;
+}
+
+export interface RotateSecretResponse {
+  clientId: string;
+  clientSecret: string;
+}
+
+// ─── OAuth Scopes ─────────────────────────────────────────────────────────────
+
+export interface OAuthScope {
+  id: string;
+  name: string;
+  displayName: string | null;
+  description: string | null;
+  resources: string[];
+}
+
+export interface OAuthScopeListResult {
+  items: OAuthScope[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface CreateScopeRequest {
+  name: string;
+  displayName?: string;
+  description?: string;
+  resources: string[];
+}
+
+export type UpdateScopeRequest = Omit<CreateScopeRequest, 'name'>;
+
+// ─── OAuth Authorizations & Tokens ─────────────────────────────────────────────
+
+export interface OAuthAuthorization {
+  id: string;
+  subject: string | null;
+  status: string | null;
+  type: string | null;
+  applicationId: string | null;
+  clientId: string | null;
+  scopes: string[];
+  creationDate: string | null;
+}
+
+export interface OAuthToken {
+  id: string;
+  subject: string | null;
+  status: string | null;
+  type: string | null;
+  applicationId: string | null;
+  clientId: string | null;
+  creationDate: string | null;
+  expirationDate: string | null;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface TokenViewerParams {
+  clientId?: string;
+  subject?: string;
+  status?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}

--- a/src/features/oauthAdmin/utils/textParse.ts
+++ b/src/features/oauthAdmin/utils/textParse.ts
@@ -1,0 +1,13 @@
+/** Splits a space-or-comma separated string into a trimmed, non-empty list (scopes, resources). */
+export const splitList = (value: string): string[] =>
+  value
+    .split(/[\s,]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+/** Splits a newline-separated string into a trimmed, non-empty list (redirect URIs). */
+export const splitLines = (value: string): string[] =>
+  value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);

--- a/src/features/webhookAdmin/api/webhookSubscriptions.ts
+++ b/src/features/webhookAdmin/api/webhookSubscriptions.ts
@@ -1,0 +1,102 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import axios from '@shared/api/axiosInstance';
+import type {
+  CreateWebhookSubscriptionRequest,
+  GetWebhookSubscriptionsParams,
+  UpdateWebhookSubscriptionRequest,
+  WebhookSubscriptionListResult,
+} from '../types';
+
+export const webhookSubscriptionKeys = {
+  all: ['webhook-subscriptions'] as const,
+  list: (params: GetWebhookSubscriptionsParams) =>
+    ['webhook-subscriptions', 'list', params] as const,
+};
+
+export const useGetWebhookSubscriptions = (params: GetWebhookSubscriptionsParams = {}) => {
+  return useQuery({
+    queryKey: webhookSubscriptionKeys.list(params),
+    queryFn: async (): Promise<WebhookSubscriptionListResult> => {
+      const { data } = await axios.get<WebhookSubscriptionListResult>('/webhook-subscriptions', {
+        params: {
+          pageNumber: params.pageNumber ?? 1,
+          pageSize: params.pageSize ?? 20,
+          systemCode: params.systemCode || undefined,
+          isActive: params.isActive,
+        },
+      });
+      return data;
+    },
+  });
+};
+
+export const useCreateWebhookSubscription = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('webhookAdmin');
+  return useMutation({
+    mutationFn: async (request: CreateWebhookSubscriptionRequest) => {
+      const { data } = await axios.post('/webhook-subscriptions', request);
+      return data;
+    },
+    onSuccess: () => {
+      toast.success(t('subscriptions.toasts.created'));
+      void queryClient.invalidateQueries({ queryKey: webhookSubscriptionKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('subscriptions.toasts.createFailed')),
+  });
+};
+
+export const useUpdateWebhookSubscription = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('webhookAdmin');
+  return useMutation({
+    mutationFn: async ({
+      id,
+      request,
+    }: {
+      id: string;
+      request: UpdateWebhookSubscriptionRequest;
+    }) => {
+      await axios.put(`/webhook-subscriptions/${id}`, request);
+    },
+    onSuccess: () => {
+      toast.success(t('subscriptions.toasts.updated'));
+      void queryClient.invalidateQueries({ queryKey: webhookSubscriptionKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('subscriptions.toasts.updateFailed')),
+  });
+};
+
+export const useToggleWebhookSubscription = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('webhookAdmin');
+  return useMutation({
+    mutationFn: async ({ id, isActive }: { id: string; isActive: boolean }) => {
+      await axios.post(`/webhook-subscriptions/${id}/${isActive ? 'activate' : 'deactivate'}`);
+    },
+    onSuccess: (_data, { isActive }) => {
+      toast.success(
+        isActive ? t('subscriptions.toasts.activated') : t('subscriptions.toasts.deactivated'),
+      );
+      void queryClient.invalidateQueries({ queryKey: webhookSubscriptionKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('subscriptions.toasts.toggleFailed')),
+  });
+};
+
+export const useDeleteWebhookSubscription = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('webhookAdmin');
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await axios.delete(`/webhook-subscriptions/${id}`);
+    },
+    onSuccess: () => {
+      toast.success(t('subscriptions.toasts.deleted'));
+      void queryClient.invalidateQueries({ queryKey: webhookSubscriptionKeys.all });
+    },
+    onError: (err: any) => toast.error(err?.apiError?.detail ?? t('subscriptions.toasts.deleteFailed')),
+  });
+};

--- a/src/features/webhookAdmin/components/WebhookSubscriptionFormModal.tsx
+++ b/src/features/webhookAdmin/components/WebhookSubscriptionFormModal.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from '@shared/components/Modal';
+import Button from '@shared/components/Button';
+import {
+  useCreateWebhookSubscription,
+  useUpdateWebhookSubscription,
+} from '../api/webhookSubscriptions';
+import type { WebhookSubscription } from '../types';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** When provided, the modal is in edit mode; otherwise create mode. */
+  subscription: WebhookSubscription | null;
+}
+
+const inputClass =
+  'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary';
+
+const WebhookSubscriptionFormModal = ({ isOpen, onClose, subscription }: Props) => {
+  const { t } = useTranslation('webhookAdmin');
+  const isEdit = subscription !== null;
+
+  const [systemCode, setSystemCode] = useState('');
+  const [callbackUrl, setCallbackUrl] = useState('');
+  const [secretKey, setSecretKey] = useState('');
+  // In edit mode the existing secret stays unless the admin opts to replace it.
+  const [replaceSecret, setReplaceSecret] = useState(false);
+
+  const createMutation = useCreateWebhookSubscription();
+  const updateMutation = useUpdateWebhookSubscription();
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  // Reset the form whenever the modal opens for a different target.
+  useEffect(() => {
+    if (!isOpen) return;
+    setSystemCode(subscription?.systemCode ?? '');
+    setCallbackUrl(subscription?.callbackUrl ?? '');
+    setSecretKey('');
+    setReplaceSecret(false);
+    // Key on subscription?.id, not the object: a background refetch of the list passes a new object
+    // with the same id and must not re-fire this effect and wipe the user's in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, subscription?.id]);
+
+  const handleSubmit = () => {
+    if (isEdit) {
+      updateMutation.mutate(
+        {
+          id: subscription!.id,
+          request: {
+            callbackUrl,
+            secretKey: replaceSecret && secretKey ? secretKey : undefined,
+          },
+        },
+        { onSuccess: onClose },
+      );
+    } else {
+      createMutation.mutate(
+        { systemCode, callbackUrl, secretKey },
+        { onSuccess: onClose },
+      );
+    }
+  };
+
+  const canSubmit = isEdit
+    ? callbackUrl.trim() !== '' && (!replaceSecret || secretKey.trim() !== '')
+    : systemCode.trim() !== '' && callbackUrl.trim() !== '' && secretKey.trim() !== '';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isEdit ? t('subscriptions.form.editTitle') : t('subscriptions.form.createTitle')}
+      size="md"
+    >
+      <div className="px-6 py-5 space-y-4">
+        {/* System code */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('subscriptions.form.systemCode')}
+          </label>
+          <input
+            type="text"
+            value={systemCode}
+            disabled={isEdit}
+            onChange={e => setSystemCode(e.target.value)}
+            placeholder={t('subscriptions.form.systemCodePlaceholder')}
+            className={`${inputClass} ${isEdit ? 'bg-gray-50 text-gray-500' : ''}`}
+          />
+          {isEdit && (
+            <p className="mt-1 text-xs text-gray-400">{t('subscriptions.form.systemCodeLocked')}</p>
+          )}
+        </div>
+
+        {/* Callback URL */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('subscriptions.form.callbackUrl')}
+          </label>
+          <input
+            type="url"
+            value={callbackUrl}
+            onChange={e => setCallbackUrl(e.target.value)}
+            placeholder="https://example.com/webhooks/cas"
+            className={inputClass}
+          />
+        </div>
+
+        {/* Secret key */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {t('subscriptions.form.secretKey')}
+          </label>
+
+          {isEdit && !replaceSecret ? (
+            <div className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2">
+              <span className="text-sm text-gray-500 font-mono">
+                ••••{subscription?.secretLast4 ?? '____'}
+              </span>
+              <button
+                type="button"
+                onClick={() => setReplaceSecret(true)}
+                className="text-xs text-primary hover:underline"
+              >
+                {t('subscriptions.form.replaceSecret')}
+              </button>
+            </div>
+          ) : (
+            <input
+              type="text"
+              value={secretKey}
+              onChange={e => setSecretKey(e.target.value)}
+              placeholder={t('subscriptions.form.secretKeyPlaceholder')}
+              className={`${inputClass} font-mono`}
+            />
+          )}
+          <p className="mt-1 text-xs text-gray-400">{t('subscriptions.form.secretKeyHint')}</p>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 px-6 py-4 border-t border-gray-200">
+        <Button variant="secondary" onClick={onClose} disabled={isPending}>
+          {t('subscriptions.form.cancel')}
+        </Button>
+        <Button onClick={handleSubmit} disabled={!canSubmit || isPending}>
+          {isEdit ? t('subscriptions.form.save') : t('subscriptions.form.create')}
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default WebhookSubscriptionFormModal;

--- a/src/features/webhookAdmin/pages/WebhookSubscriptionListPage.tsx
+++ b/src/features/webhookAdmin/pages/WebhookSubscriptionListPage.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SectionHeader from '@shared/components/sections/SectionHeader';
+import Icon from '@shared/components/Icon';
+import Button from '@shared/components/Button';
+import ConfirmDialog from '@shared/components/ConfirmDialog';
+import { TableRowSkeleton } from '@shared/components/Skeleton';
+import Pagination from '@shared/components/Pagination';
+import DataErrorState from '@shared/components/DataErrorState';
+import {
+  useGetWebhookSubscriptions,
+  useToggleWebhookSubscription,
+  useDeleteWebhookSubscription,
+} from '../api/webhookSubscriptions';
+import WebhookSubscriptionFormModal from '../components/WebhookSubscriptionFormModal';
+import type { WebhookSubscription } from '../types';
+
+const PAGE_SIZE = 20;
+
+const TABLE_SKELETON_COLUMNS = [
+  { width: 'w-24' },
+  { width: 'w-64' },
+  { width: 'w-16' },
+  { width: 'w-20' },
+  { width: 'w-32' },
+  { width: 'w-24' },
+];
+
+type ActiveFilter = '' | 'true' | 'false';
+
+const WebhookSubscriptionListPage = () => {
+  const { t } = useTranslation('webhookAdmin');
+
+  const [systemCodeInput, setSystemCodeInput] = useState('');
+  const [debouncedSystemCode, setDebouncedSystemCode] = useState('');
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>('');
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const [formTarget, setFormTarget] = useState<WebhookSubscription | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<WebhookSubscription | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSystemCode(systemCodeInput);
+      setPageIndex(0);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [systemCodeInput]);
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [activeFilter]);
+
+  const { data, isLoading, isError, refetch } = useGetWebhookSubscriptions({
+    pageNumber: pageIndex + 1,
+    pageSize: PAGE_SIZE,
+    systemCode: debouncedSystemCode || undefined,
+    isActive: activeFilter === '' ? undefined : activeFilter === 'true',
+  });
+
+  const toggleMutation = useToggleWebhookSubscription();
+  const deleteMutation = useDeleteWebhookSubscription();
+
+  const subscriptions = data?.items ?? [];
+  const totalCount = data?.count ?? 0;
+
+  const openCreate = () => {
+    setFormTarget(null);
+    setShowForm(true);
+  };
+
+  const openEdit = (subscription: WebhookSubscription) => {
+    setFormTarget(subscription);
+    setShowForm(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+      onError: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-start justify-between">
+        <SectionHeader
+          title={t('subscriptions.page.title')}
+          subtitle={t('subscriptions.page.subtitle')}
+          icon="satellite-dish"
+          iconColor="blue"
+        />
+        <Button onClick={openCreate}>
+          <Icon name="plus" style="regular" className="size-4 mr-1.5" />
+          {t('subscriptions.actions.add')}
+        </Button>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm mt-4">
+        {/* Filters */}
+        <div className="flex flex-wrap items-center gap-3 px-4 pt-4 pb-2">
+          <div className="relative min-w-48">
+            <Icon
+              name="magnifying-glass"
+              style="regular"
+              className="size-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              type="text"
+              value={systemCodeInput}
+              onChange={e => setSystemCodeInput(e.target.value)}
+              placeholder={t('subscriptions.filters.systemCodePlaceholder')}
+              className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+            />
+          </div>
+
+          <select
+            value={activeFilter}
+            onChange={e => setActiveFilter(e.target.value as ActiveFilter)}
+            className="px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary bg-white"
+          >
+            <option value="">{t('subscriptions.filters.statusAll')}</option>
+            <option value="true">{t('subscriptions.filters.statusActive')}</option>
+            <option value="false">{t('subscriptions.filters.statusInactive')}</option>
+          </select>
+
+          {(systemCodeInput || activeFilter) && (
+            <button
+              type="button"
+              onClick={() => {
+                setSystemCodeInput('');
+                setActiveFilter('');
+              }}
+              className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              {t('subscriptions.filters.clear')}
+            </button>
+          )}
+        </div>
+
+        {/* Table */}
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.systemCode')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.callbackUrl')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.active')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.secret')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.lastDelivery')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  {t('subscriptions.columns.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <TableRowSkeleton columns={TABLE_SKELETON_COLUMNS} rows={5} />
+              ) : isError ? (
+                <tr>
+                  <td colSpan={6} className="py-4">
+                    <DataErrorState
+                      variant="inline"
+                      title={t('subscriptions.loadFailed')}
+                      onRetry={refetch}
+                    />
+                  </td>
+                </tr>
+              ) : subscriptions.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="text-center py-12 text-gray-400 text-sm">
+                    <Icon name="plug" style="regular" className="size-8 mx-auto mb-2 opacity-40" />
+                    <p>{t('subscriptions.emptyState')}</p>
+                  </td>
+                </tr>
+              ) : (
+                subscriptions.map(sub => (
+                  <tr
+                    key={sub.id}
+                    className="border-b border-gray-50 hover:bg-gray-50 transition-colors"
+                  >
+                    <td className="px-4 py-3 font-medium text-gray-900">{sub.systemCode}</td>
+                    <td className="px-4 py-3 text-gray-600 max-w-xs">
+                      <span className="block truncate" title={sub.callbackUrl}>
+                        {sub.callbackUrl}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          sub.isActive
+                            ? 'bg-emerald-50 text-emerald-700'
+                            : 'bg-gray-100 text-gray-500'
+                        }`}
+                      >
+                        {sub.isActive ? t('subscriptions.active.yes') : t('subscriptions.active.no')}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 font-mono text-xs">
+                      ••••{sub.secretLast4 ?? '____'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
+                      {sub.lastDeliveryAt ? (
+                        new Date(sub.lastDeliveryAt).toLocaleString()
+                      ) : (
+                        <span className="text-gray-300">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => openEdit(sub)}
+                          className="p-1.5 text-gray-400 hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
+                          title={t('subscriptions.actions.edit')}
+                        >
+                          <Icon name="pen" style="regular" className="size-4" />
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() =>
+                            toggleMutation.mutate({ id: sub.id, isActive: !sub.isActive })
+                          }
+                          disabled={toggleMutation.isPending}
+                          className="p-1.5 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors"
+                          title={
+                            sub.isActive
+                              ? t('subscriptions.actions.deactivate')
+                              : t('subscriptions.actions.activate')
+                          }
+                        >
+                          <Icon
+                            name={sub.isActive ? 'toggle-on' : 'toggle-off'}
+                            style="regular"
+                            className="size-4"
+                          />
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => setDeleteTarget(sub)}
+                          className="p-1.5 text-gray-400 hover:text-danger hover:bg-danger/5 rounded-lg transition-colors"
+                          title={t('subscriptions.actions.delete')}
+                        >
+                          <Icon name="trash" style="regular" className="size-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {!isLoading && totalCount > 0 && (
+          <Pagination
+            currentPage={pageIndex}
+            totalPages={Math.ceil(totalCount / PAGE_SIZE)}
+            totalCount={totalCount}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPageIndex}
+            showPageSizeSelector={false}
+          />
+        )}
+      </div>
+
+      <WebhookSubscriptionFormModal
+        isOpen={showForm}
+        onClose={() => setShowForm(false)}
+        subscription={formTarget}
+      />
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title={t('subscriptions.delete.confirmTitle')}
+        message={t('subscriptions.delete.confirmMessage')}
+        confirmText={t('subscriptions.delete.confirmButton')}
+        cancelText={t('subscriptions.delete.cancelButton')}
+        variant="danger"
+        isLoading={deleteMutation.isPending}
+      />
+    </div>
+  );
+};
+
+export default WebhookSubscriptionListPage;

--- a/src/features/webhookAdmin/types/index.ts
+++ b/src/features/webhookAdmin/types/index.ts
@@ -36,3 +36,42 @@ export interface GetWebhookDeliveriesParams extends WebhookDeliveryFilters {
   pageNumber?: number;
   pageSize?: number;
 }
+
+// ─── Webhook Subscriptions ────────────────────────────────────────────────────
+
+export interface WebhookSubscription {
+  id: string;
+  systemCode: string;
+  callbackUrl: string;
+  isActive: boolean;
+  /** Last 4 chars of the shared HMAC secret — the full secret is never returned. */
+  secretLast4: string | null;
+  lastDeliveryAt: string | null;
+  createdAt: string | null;
+}
+
+export interface WebhookSubscriptionListResult {
+  items: WebhookSubscription[];
+  count: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface GetWebhookSubscriptionsParams {
+  pageNumber?: number;
+  pageSize?: number;
+  systemCode?: string;
+  isActive?: boolean;
+}
+
+export interface CreateWebhookSubscriptionRequest {
+  systemCode: string;
+  callbackUrl: string;
+  secretKey: string;
+}
+
+export interface UpdateWebhookSubscriptionRequest {
+  callbackUrl: string;
+  /** Only sent when replacing the shared secret; omitted leaves it unchanged. */
+  secretKey?: string;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -6,6 +6,7 @@ import { useLocaleStore } from '@shared/store';
 import enCommon from './locales/en/common.json';
 import enNav from './locales/en/nav.json';
 import enWebhookAdmin from './locales/en/webhookAdmin.json';
+import enOauthAdmin from './locales/en/oauthAdmin.json';
 import enInvoice from './locales/en/invoice.json';
 import enServiceQualityEvaluation from './locales/en/serviceQualityEvaluation.json';
 import enMonitoring from './locales/en/monitoring.json';
@@ -100,6 +101,7 @@ export const resources = {
     common: enCommon,
     nav: enNav,
     webhookAdmin: enWebhookAdmin,
+    oauthAdmin: enOauthAdmin,
     invoice: enInvoice,
     serviceQualityEvaluation: enServiceQualityEvaluation,
     monitoring: enMonitoring,

--- a/src/i18n/locales/en/oauthAdmin.json
+++ b/src/i18n/locales/en/oauthAdmin.json
@@ -1,0 +1,183 @@
+{
+  "clients": {
+    "page": {
+      "title": "OAuth Clients",
+      "subtitle": "Register and configure OAuth / OpenID Connect client applications"
+    },
+    "columns": {
+      "displayName": "Name",
+      "clientId": "Client ID",
+      "type": "Type",
+      "grantTypes": "Grant Types",
+      "scopes": "Scopes",
+      "actions": "Actions"
+    },
+    "type": {
+      "public": "Public",
+      "confidential": "Confidential"
+    },
+    "badges": {
+      "system": "System"
+    },
+    "filters": {
+      "searchPlaceholder": "Search by name or client ID...",
+      "clear": "Clear"
+    },
+    "actions": {
+      "add": "Register Client",
+      "edit": "Edit",
+      "rotateSecret": "Rotate secret",
+      "delete": "Delete"
+    },
+    "form": {
+      "createTitle": "Register OAuth Client",
+      "editTitle": "Edit OAuth Client",
+      "displayName": "Display Name",
+      "clientId": "Client ID",
+      "clientIdHint": "Leave blank to generate automatically.",
+      "clientType": "Client Type",
+      "clientTypePublicHint": "Public clients (e.g. SPA) use PKCE and have no secret.",
+      "clientTypeConfidentialHint": "Confidential clients receive a generated secret.",
+      "grantTypes": "Grant Types",
+      "scopes": "Scopes",
+      "scopesHint": "Space- or comma-separated scope names (e.g. profile email appraisal.read).",
+      "redirectUris": "Redirect URIs",
+      "redirectUrisHint": "One per line. Required for the authorization_code flow.",
+      "postLogoutRedirectUris": "Post-Logout Redirect URIs",
+      "cancel": "Cancel",
+      "create": "Register",
+      "save": "Save"
+    },
+    "grant": {
+      "authorization_code": "Authorization Code",
+      "client_credentials": "Client Credentials",
+      "password": "Password",
+      "refresh_token": "Refresh Token"
+    },
+    "secret": {
+      "title": "Client Secret",
+      "createdIntro": "The client was registered. Copy the secret now — it will not be shown again.",
+      "rotatedIntro": "A new secret was generated. Copy it now — it will not be shown again.",
+      "clientId": "Client ID",
+      "secret": "Client Secret",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "done": "Done",
+      "rotateConfirmTitle": "Rotate Client Secret",
+      "rotateConfirmMessage": "The current secret will stop working immediately. Any integration using it must be updated. Continue?",
+      "rotateConfirmButton": "Rotate"
+    },
+    "delete": {
+      "confirmTitle": "Delete OAuth Client",
+      "confirmMessage": "This client and its authorizations will be removed. Applications using it will no longer be able to authenticate. Continue?",
+      "confirmButton": "Delete",
+      "cancelButton": "Cancel"
+    },
+    "toasts": {
+      "created": "OAuth client registered",
+      "updated": "OAuth client updated",
+      "deleted": "OAuth client deleted",
+      "createFailed": "Failed to register client",
+      "updateFailed": "Failed to update client",
+      "deleteFailed": "Failed to delete client",
+      "rotateFailed": "Failed to rotate secret"
+    },
+    "emptyState": "No OAuth clients found",
+    "loadFailed": "Failed to load OAuth clients"
+  },
+  "scopes": {
+    "page": {
+      "title": "OAuth Scopes",
+      "subtitle": "Define the API resources that clients can request"
+    },
+    "columns": {
+      "name": "Name",
+      "displayName": "Display Name",
+      "description": "Description",
+      "resources": "Resources",
+      "actions": "Actions"
+    },
+    "filters": {
+      "searchPlaceholder": "Search scopes...",
+      "clear": "Clear"
+    },
+    "actions": {
+      "add": "Add Scope",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "form": {
+      "createTitle": "Add OAuth Scope",
+      "editTitle": "Edit OAuth Scope",
+      "name": "Name",
+      "nameHint": "Unique scope identifier (e.g. appraisal.read). Cannot be changed after creation.",
+      "displayName": "Display Name",
+      "description": "Description",
+      "resources": "Resources",
+      "resourcesHint": "Space- or comma-separated API resource identifiers.",
+      "cancel": "Cancel",
+      "create": "Create",
+      "save": "Save"
+    },
+    "delete": {
+      "confirmTitle": "Delete Scope",
+      "confirmMessage": "This scope will be permanently removed. Clients requesting it will be rejected. Continue?",
+      "confirmButton": "Delete",
+      "cancelButton": "Cancel"
+    },
+    "toasts": {
+      "created": "Scope created",
+      "updated": "Scope updated",
+      "deleted": "Scope deleted",
+      "createFailed": "Failed to create scope",
+      "updateFailed": "Failed to update scope",
+      "deleteFailed": "Failed to delete scope"
+    },
+    "emptyState": "No scopes found",
+    "loadFailed": "Failed to load scopes"
+  },
+  "tokens": {
+    "page": {
+      "title": "OAuth Authorizations & Tokens",
+      "subtitle": "View and revoke active grants and tokens"
+    },
+    "tabs": {
+      "authorizations": "Authorizations",
+      "tokens": "Tokens"
+    },
+    "filters": {
+      "clientId": "Client ID",
+      "clientIdPlaceholder": "Filter by client ID...",
+      "subject": "Subject",
+      "subjectPlaceholder": "Filter by subject...",
+      "status": "Status",
+      "allStatuses": "All statuses",
+      "clear": "Clear filters"
+    },
+    "columns": {
+      "subject": "Subject",
+      "clientId": "Client",
+      "status": "Status",
+      "type": "Type",
+      "scopes": "Scopes",
+      "created": "Created",
+      "expires": "Expires",
+      "actions": "Actions"
+    },
+    "actions": {
+      "revoke": "Revoke"
+    },
+    "revoke": {
+      "confirmTitle": "Revoke",
+      "confirmMessageAuthorization": "Revoking this authorization will also revoke its tokens. Continue?",
+      "confirmMessageToken": "This token will be revoked immediately. Continue?",
+      "confirmButton": "Revoke",
+      "cancelButton": "Cancel",
+      "successToast": "Revoked",
+      "errorToast": "Failed to revoke"
+    },
+    "emptyAuthorizations": "No authorizations found",
+    "emptyTokens": "No tokens found",
+    "loadFailed": "Failed to load"
+  }
+}

--- a/src/i18n/locales/en/webhookAdmin.json
+++ b/src/i18n/locales/en/webhookAdmin.json
@@ -49,5 +49,71 @@
     "noPayload": "No payload"
   },
   "emptyState": "No webhook deliveries found",
-  "loadFailed": "Failed to load webhook deliveries"
+  "loadFailed": "Failed to load webhook deliveries",
+  "subscriptions": {
+    "page": {
+      "title": "Webhook Subscriptions",
+      "subtitle": "Configure the external systems that receive outbound webhook events"
+    },
+    "columns": {
+      "systemCode": "System Code",
+      "callbackUrl": "Callback URL",
+      "active": "Active",
+      "secret": "Secret",
+      "lastDelivery": "Last Delivery",
+      "actions": "Actions"
+    },
+    "filters": {
+      "systemCodePlaceholder": "Filter by system code...",
+      "statusAll": "All",
+      "statusActive": "Active only",
+      "statusInactive": "Inactive only",
+      "clear": "Clear filters"
+    },
+    "actions": {
+      "add": "Add Subscription",
+      "edit": "Edit",
+      "activate": "Activate",
+      "deactivate": "Deactivate",
+      "delete": "Delete"
+    },
+    "active": {
+      "yes": "Active",
+      "no": "Inactive"
+    },
+    "form": {
+      "createTitle": "Add Webhook Subscription",
+      "editTitle": "Edit Webhook Subscription",
+      "systemCode": "System Code",
+      "systemCodePlaceholder": "e.g. LOS, CLS",
+      "systemCodeLocked": "System code cannot be changed after creation.",
+      "callbackUrl": "Callback URL",
+      "secretKey": "Signing Secret",
+      "secretKeyPlaceholder": "Shared HMAC secret from the receiving system",
+      "secretKeyHint": "Shared HMAC-SHA256 secret used to sign outbound payloads. Coordinated with the receiving system.",
+      "replaceSecret": "Replace secret",
+      "cancel": "Cancel",
+      "create": "Create",
+      "save": "Save"
+    },
+    "delete": {
+      "confirmTitle": "Delete Subscription",
+      "confirmMessage": "This subscription will be permanently removed. Subscriptions with delivery history cannot be deleted — deactivate them instead.",
+      "confirmButton": "Delete",
+      "cancelButton": "Cancel"
+    },
+    "toasts": {
+      "created": "Webhook subscription created",
+      "updated": "Webhook subscription updated",
+      "activated": "Subscription activated",
+      "deactivated": "Subscription deactivated",
+      "deleted": "Subscription deleted",
+      "createFailed": "Failed to create subscription",
+      "updateFailed": "Failed to update subscription",
+      "toggleFailed": "Failed to change subscription status",
+      "deleteFailed": "Failed to delete subscription"
+    },
+    "emptyState": "No webhook subscriptions configured",
+    "loadFailed": "Failed to load webhook subscriptions"
+  }
 }


### PR DESCRIPTION
## What
Admin UI for the OAuth/webhook configuration backend (`immortalgky/collateral-appraisal-system-api#258`).

- **`oauthAdmin`** feature: OAuth client list with register / edit / rotate-secret / delete and a one-time `SecretRevealModal` (copy-once); OAuth scope CRUD; an Authorizations | Tokens viewer with revoke + client/subject/status filters.
- **`webhookAdmin`** extended: webhook **subscriptions** list + create/edit/activate/deactivate/delete. The HMAC `SecretKey` is shared with the receiving system → paste-only, shown masked (`••••last4`) with a "Replace secret" action.
- Routes under `/admin` (`oauth-clients`, `oauth-scopes`, `oauth-tokens`, `webhook-subscriptions`), each `RoleProtectedRoute`-gated to the matching permission. English i18n added (`oauthAdmin.json` + webhook subscription keys); th/zh fall back to en until translated.

## Notes
- **Depends on backend #258** — merge/deploy that first (the screens call its endpoints).
- The screens appear once the user is granted the new permissions; menu entries auto-seed from the backend.
- `tsc` clean for all new files (the repo has a pre-existing error baseline unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
