### PR TITLE
fix(build): resolve recharts react-is chunk-order crash ("setting 'Activity'")

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "zod": "^3.25.75",
     "zustand": "^5.0.5"
   },
+  "pnpm": {
+    "overrides": {
+      "react-is": "^19.0.0"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@playwright/test": "^1.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react-is: ^19.0.0
+
 importers:
 
   .:
@@ -94,7 +97,7 @@ importers:
         version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts:
         specifier: ^3.7.0
-        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(redux@5.0.1)
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -2770,11 +2773,8 @@ packages:
       typescript:
         optional: true
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -2829,7 +2829,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -6181,13 +6181,13 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 17.0.2
+      react-is: 19.2.7
 
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 16.13.1
+      react-is: 19.2.7
 
   proxy-from-env@1.1.0: {}
 
@@ -6234,9 +6234,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       typescript: 5.8.3
 
-  react-is@16.13.1: {}
-
-  react-is@17.0.2: {}
+  react-is@19.2.7: {}
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
     dependencies:
@@ -6277,7 +6275,7 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
-  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       clsx: 2.1.1
@@ -6287,7 +6285,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-is: 17.0.2
+      react-is: 19.2.7
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,11 @@ import { visualizer } from 'rollup-plugin-visualizer';
  */
 function manualChunks(id: string): string | undefined {
   if (!id.includes('node_modules')) return undefined;
-  if (/[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/.test(id))
+  // `react-is` MUST live with React: recharts pulls a CommonJS react-is into the
+  // `charts` chunk otherwise, whose interop wrapper calls back into `react-vendor`
+  // before React's exports are initialized -> "Cannot set properties of undefined
+  // (setting 'Activity')". Co-locating it removes the cross-chunk eval-order cycle.
+  if (/[\\/]node_modules[\\/](react|react-dom|react-is|react-router|react-router-dom|scheduler)[\\/]/.test(id))
     return 'react-vendor';
   if (/[\\/]node_modules[\\/](recharts|d3-|victory-vendor|internmap)/.test(id)) return 'charts';
   if (/[\\/]node_modules[\\/](@xyflow|dagre|@dagrejs|graphlib)/.test(id)) return 'flow';


### PR DESCRIPTION
## Problem

Production builds crash at runtime on chart-heavy routes:

```
Uncaught TypeError: Cannot set properties of undefined (setting 'Activity')
  at react-vendor-*.js   (React's own export assembly: ge.Activity = b, …)
  at charts-*.js          (charts chunk reaching into react-vendor)
```

It was **intermittent across machines** — builds produced on Windows crashed while macOS builds were fine — which is the signature of a latent **cross-chunk evaluation-order cycle**: Rollup's module emission order is influenced by OS filesystem ordering, so only some builds tip into the crash. (`vite dev` never splits chunks, so it only reproduces in production builds.)

## Root cause

Introduced by the vendor code-splitting in `ab5fa6f9`. `recharts` declares `react-is` only as a **peer** dependency, and pnpm mis-resolved that peer to the stale CJS **`react-is@17.0.2`** (hoisted from the dev-only `pretty-format`). That copy got inlined into the `charts` chunk; its CommonJS-interop wrapper calls back into the `react-vendor` chunk **before React's exports finish initializing**, so React's `ge.Activity = …` runs against an undefined exports object.

## Fix

- **`vite.config.ts`** — add `react-is` to the `react-vendor` `manualChunks` rule so it initializes together with React. Removes the cross-chunk back-call entirely → deterministic on any OS.
- **`package.json`** — add `pnpm.overrides` → `"react-is": "^19.0.0"`, aligning react-is with React 19 and deduping the tree to a single copy (`react-is@19.2.7`). A scoped `recharts>react-is` override does **not** work because react-is is a peer (overrides only affect regular deps).

## Verification

- `pnpm install` → recharts now binds `react-is@19.2.7`; one react-is in the tree.
- Clean `vite build` succeeds.
- Chunk inspection of `dist/assets`:
  - `react-is.production` no longer inlined in `charts-*.js` ✓
  - `react-is` now resides in `react-vendor-*.js` ✓
  - `.Activity=` assignment present only in `react-vendor` (1×), absent from `charts` (0×) ✓

> Note: the full `pnpm build` script runs `tsc -b` first, which fails on ~pre-existing TS errors in test/schema files unrelated to this change. The deploy build (`build:sit` = `vite build --mode sit`) skips tsc, matching what was verified here.

**Maintenance:** keep the `react-is` override major aligned with React (bump to `^20` on a React 20 upgrade); no change needed for 19.x minor/patch bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)