### PR TITLE
map null to cumulativeAdjPeriod field in schema

### DIFF
--- a/src/features/pricingAnalysis/domain/mapSaleAdjustmentGridFormToSubmitSchema.ts
+++ b/src/features/pricingAnalysis/domain/mapSaleAdjustmentGridFormToSubmitSchema.ts
@@ -65,7 +65,7 @@ export function mapSaleAdjustmentGridFormToSubmitSchema({
           !hasOfferingPrice && calc.numberOfYears != null ? Math.trunc(calc.numberOfYears) : null,
         buySellMonth: null,
         adjustedPeriodPct: !hasOfferingPrice ? (calc.sellingPriceAdjustmentYear ?? null) : null,
-        cumulativeAdjPeriod: calc.adjustedValue ?? null,
+        cumulativeAdjPeriod: null,
         landAreaDeficient: calc.landAreaOfDeficient ?? null,
         landAreaDeficientUnit: null,
         landPrice: formAny.landPrice ?? null,


### PR DESCRIPTION
Map null to cumulativeAdjPeriod field in schema because this field will be calculated on server. So, no need to submit this field to server.