### PR TITLE
Add weight max and total validation in Sale Adjustment Grid

### DIFF
--- a/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
+++ b/src/features/pricingAnalysis/schemas/saleAdjustmentGridForm.ts
@@ -36,10 +36,12 @@ const SaleAdjustmentGridQualitative = (t: TFunction<'pricingAnalysis'>) =>
 const SaleAdjustmentGridCalculation = (t: TFunction<'pricingAnalysis'>) =>
   z
     .object({
-      weight: z.number({
-        required_error: t('validation.weightRequired'),
-        invalid_type_error: t('validation.weightRequired'),
-      }),
+      weight: z
+        .number({
+          required_error: t('validation.weightRequired'),
+          invalid_type_error: t('validation.weightRequired'),
+        })
+        .max(1, t('validation.weightMax')),
     })
     .passthrough();
 
@@ -93,7 +95,20 @@ export const makeSaleAdjustmentGridDto = (t: TFunction<'pricingAnalysis'>) =>
       /** Qualitative section */
       saleAdjustmentGridQualitatives: z.array(SaleAdjustmentGridQualitative(t)),
       /** Calculation section */
-      saleAdjustmentGridCalculations: z.array(SaleAdjustmentGridCalculation(t)),
+      saleAdjustmentGridCalculations: z.array(SaleAdjustmentGridCalculation(t)).superRefine(
+        (items, ctx) => {
+          const total = items.reduce((sum, item) => sum + (item.weight ?? 0), 0);
+          if (total > 1) {
+            items.forEach((_, i) => {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: t('validation.weightTotalExceeds'),
+                path: [i, 'weight'],
+              });
+            });
+          }
+        },
+      ),
       /** Adjustment Factors (adjust percentage) section */
       saleAdjustmentGridAdjustmentFactors: z.array(SaleAdjustmentGridAdjustmentFactor(t)),
       /** Final value section */

--- a/src/i18n/locales/en/pricingAnalysis.json
+++ b/src/i18n/locales/en/pricingAnalysis.json
@@ -348,6 +348,8 @@
     "depreciationRateRequired": "Depreciation rate is required",
     "factorCodeRequired": "Factor code is required",
     "weightRequired": "Weight is required",
+    "weightMax": "Weight must not exceed 1.0",
+    "weightTotalExceeds": "Total weight across all rows must not exceed 1.0",
     "intensityRequired": "Intensity is required",
     "collateralScoreRequired": "Collateral score is required",
     "surveyScoreRequired": "Survey {{n}}'s score is required",

--- a/src/i18n/locales/th/pricingAnalysis.json
+++ b/src/i18n/locales/th/pricingAnalysis.json
@@ -348,6 +348,8 @@
     "depreciationRateRequired": "กรุณาระบุอัตราค่าเสื่อมราคา",
     "factorCodeRequired": "กรุณาระบุรหัสปัจจัย",
     "weightRequired": "กรุณาระบุน้ำหนัก",
+    "weightMax": "น้ำหนักต้องไม่เกิน 1.0",
+    "weightTotalExceeds": "น้ำหนักรวมทุกแถวต้องไม่เกิน 1.0",
     "intensityRequired": "กรุณาระบุความเข้ม",
     "collateralScoreRequired": "กรุณาระบุคะแนนหลักประกัน",
     "surveyScoreRequired": "กรุณาระบุคะแนนของการสำรวจที่ {{n}}",

--- a/src/i18n/locales/zh/pricingAnalysis.json
+++ b/src/i18n/locales/zh/pricingAnalysis.json
@@ -348,6 +348,8 @@
     "depreciationRateRequired": "Depreciation rate is required",
     "factorCodeRequired": "Factor code is required",
     "weightRequired": "Weight is required",
+    "weightMax": "权重不得超过 1.0",
+    "weightTotalExceeds": "所有行的权重总和不得超过 1.0",
     "intensityRequired": "Intensity is required",
     "collateralScoreRequired": "Collateral score is required",
     "surveyScoreRequired": "Survey {{n}}'s score is required",


### PR DESCRIPTION
Enforce per-row weight <= 1 and ensure sum of weights across calculation rows does not exceed 1. Adds .max(1) on the weight field and a superRefine that aggregates weights and emits a custom issue on each row when the total > 1. Also adds corresponding i18n messages (weightMax, weightTotalExceeds) for en/th/zh.