### PR TITLE
Show village/project name above construction summary table

### DIFF
--- a/src/features/appraisal/api/decisionSummary.ts
+++ b/src/features/appraisal/api/decisionSummary.ts
@@ -50,6 +50,7 @@ export interface ConstructionSummaryRow {
 }
 
 export interface ConstructionSummary {
+  village: string | null;
   rows: ConstructionSummaryRow[];
 }
 

--- a/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
+++ b/src/features/appraisal/components/summary/ConstructionSummaryTable.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 interface Props {
   rows: ConstructionSummaryRow[];
+  village?: string | null;
 }
 
 const ROW_CONFIG: Record<
@@ -75,7 +76,7 @@ const ROW_CONFIG: Record<
 
 const DEFAULT_CONFIG = ROW_CONFIG['Previous'];
 
-const ConstructionSummaryTable = ({ rows }: Props) => {
+const ConstructionSummaryTable = ({ rows, village }: Props) => {
   const { t } = useTranslation('appraisal');
 
   const previousRow = rows.find(r => r.label === 'Previous');
@@ -84,6 +85,14 @@ const ConstructionSummaryTable = ({ rows }: Props) => {
 
   return (
     <div className="space-y-4">
+      {village && (
+        <div className="flex items-center gap-2 border-b border-gray-100 pb-3 text-sm text-gray-700">
+          <Icon name="house" style="solid" className="size-3.5 text-gray-400" />
+          <span className="text-gray-500">{t('constructionSummaryTable.villageLabel')}:</span>
+          <span className="font-medium text-gray-800">{village}</span>
+        </div>
+      )}
+
       <ConstructionTimelineBar
         prevValue={previousRow?.buildingValueConstructing ?? 0}
         currentValue={currentRow?.buildingValueConstructing ?? 0}

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -913,7 +913,10 @@ const DecisionSummaryPage = () => {
                   iconColor="yellow"
                   title={t('decisionSummaryPageExtra.constructionSummaryTitle')}
                 >
-                  <ConstructionSummaryTable rows={data.constructionSummary.rows} />
+                  <ConstructionSummaryTable
+                    village={data.constructionSummary.village}
+                    rows={data.constructionSummary.rows}
+                  />
                 </GroupCard>
               )}
 

--- a/src/i18n/locales/en/appraisal.json
+++ b/src/i18n/locales/en/appraisal.json
@@ -1147,6 +1147,7 @@
     "missingFromSurvey": "Missing from survey"
   },
   "constructionSummaryTable": {
+    "villageLabel": "Village / Project",
     "columns": {
       "milestone": "Milestone",
       "totalAppraisalValue": "Total Appraisal Value",

--- a/src/i18n/locales/th/appraisal.json
+++ b/src/i18n/locales/th/appraisal.json
@@ -1147,6 +1147,7 @@
     "missingFromSurvey": "ไม่พบในรังวัด"
   },
   "constructionSummaryTable": {
+    "villageLabel": "ชื่ออาคาร / โครงการ",
     "columns": {
       "milestone": "ช่วงการก่อสร้าง",
       "totalAppraisalValue": "มูลค่าประเมินรวม",

--- a/src/i18n/locales/zh/appraisal.json
+++ b/src/i18n/locales/zh/appraisal.json
@@ -1138,6 +1138,7 @@
     "missingFromSurvey": "勘测中缺失"
   },
   "constructionSummaryTable": {
+    "villageLabel": "楼盘 / 项目",
     "columns": {
       "milestone": "里程碑",
       "totalAppraisalValue": "评估总价值",


### PR DESCRIPTION
## What
Renders the **village / project name** as a separated header line above the Construction Summary timeline/table on the Decision Summary page.

## Changes
- `ConstructionSummary` type gains `village: string | null`.
- `ConstructionSummaryTable` takes a `village` prop and renders a header (house icon + label + value) with `pb-3` + bottom-border separation; hidden when no village.
- `DecisionSummaryPage` passes `constructionSummary.village` through.
- New `constructionSummaryTable.villageLabel` i18n key in en/th/zh.

Pairs with API PR immortalgky/collateral-appraisal-system-api#274 (new `constructionSummary.village` field).

## Verification
Open a CI / Progressive appraisal's Decision Summary where the first L/LB property has a Village set → project name appears above the table; table itself unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmQYBQna3GERaVguFX1L5Y