### PR TITLE
chore: priority radio-code casing + menu view-permission-prefix

### DIFF
--- a/src/features/menuManagement/components/MenuItemForm.tsx
+++ b/src/features/menuManagement/components/MenuItemForm.tsx
@@ -66,6 +66,7 @@ export interface MenuItemFormValues {
   iconColor: string | null;
   sortOrder: number;
   viewPermissionCode: string;
+  viewPermissionPrefix: string | null;
   editPermissionCode: string | null;
   translations: { languageCode: string; label: string }[];
 }
@@ -106,6 +107,7 @@ export function MenuItemForm({
     parent: `${fieldId}-parent`,
     path: `${fieldId}-path`,
     sortOrder: `${fieldId}-sortOrder`,
+    viewPermissionPrefix: `${fieldId}-viewPermissionPrefix`,
     labelInput: (lang: string) => `${fieldId}-label-${lang}`,
   };
 
@@ -119,6 +121,7 @@ export function MenuItemForm({
     iconColor: initial?.iconColor ?? null,
     sortOrder: initial?.sortOrder ?? 10,
     viewPermissionCode: initial?.viewPermissionCode ?? '',
+    viewPermissionPrefix: initial?.viewPermissionPrefix ?? null,
     editPermissionCode: initial?.editPermissionCode ?? null,
     translations: LANGS.map(lang => ({
       languageCode: lang,
@@ -137,9 +140,12 @@ export function MenuItemForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // PermissionSelect wraps a non-native Autocomplete, so the View permission's
-    // required-ness isn't enforced by the browser — guard it here.
-    if (!values.viewPermissionCode.trim()) {
+    // PermissionSelect wraps a non-native Autocomplete, so this isn't enforced by the
+    // browser — guard it here. At least one of viewPermissionCode / viewPermissionPrefix
+    // must be set (e.g. Monitoring uses only a prefix, with no discrete code).
+    const hasViewCode = values.viewPermissionCode.trim() !== '';
+    const hasViewPrefix = (values.viewPermissionPrefix ?? '').trim() !== '';
+    if (!hasViewCode && !hasViewPrefix) {
       setViewError(true);
       return;
     }
@@ -210,13 +216,14 @@ export function MenuItemForm({
           <p className="text-xs text-gray-400 mt-1">{t('form.pathHint')}</p>
         </div>
 
-        {/* View Permission — composite control */}
+        {/* View Permission — composite control. At least one of View Permission /
+            View Permission Prefix is required (see viewPermissionPrefix below). */}
         <div role="group" aria-labelledby={`${fieldId}-view-perm-label`}>
           <span
             id={`${fieldId}-view-perm-label`}
             className="block text-sm font-medium text-gray-700 mb-1"
           >
-            {t('form.viewPermission')} <span className="text-red-500">*</span>
+            {t('form.viewPermission')}
           </span>
           <PermissionSelect
             value={values.viewPermissionCode}
@@ -228,6 +235,23 @@ export function MenuItemForm({
           {viewError && (
             <p className="text-xs text-red-500 mt-1">{t('form.viewPermissionRequired')}</p>
           )}
+        </div>
+
+        {/* View Permission Prefix — plain text field, not an autocomplete. e.g.
+            "MONITORING:" grants view access to every permission with that prefix. */}
+        <div>
+          <TextInput
+            id={ids.viewPermissionPrefix}
+            label={t('form.viewPermissionPrefix')}
+            value={values.viewPermissionPrefix ?? ''}
+            onChange={e => {
+              const prefix = e.target.value || null;
+              setValues(v => ({ ...v, viewPermissionPrefix: prefix }));
+              if (prefix) setViewError(false);
+            }}
+            placeholder={t('form.viewPermissionPrefixPlaceholder')}
+          />
+          <p className="text-xs text-gray-400 mt-1">{t('form.viewPermissionPrefixHint')}</p>
         </div>
 
         {/* Edit Permission — composite control */}

--- a/src/features/menuManagement/components/MenuItemForm.tsx
+++ b/src/features/menuManagement/components/MenuItemForm.tsx
@@ -247,7 +247,7 @@ export function MenuItemForm({
             onChange={e => {
               const prefix = e.target.value || null;
               setValues(v => ({ ...v, viewPermissionPrefix: prefix }));
-              if (prefix) setViewError(false);
+              if (prefix?.trim()) setViewError(false);
             }}
             placeholder={t('form.viewPermissionPrefixPlaceholder')}
           />

--- a/src/features/menuManagement/components/MenuTreePreviewPane.tsx
+++ b/src/features/menuManagement/components/MenuTreePreviewPane.tsx
@@ -28,7 +28,11 @@ function buildVisible(
   out: PreviewNode[],
 ) {
   nodes.forEach(item => {
-    const canView = roleCodes ? roleCodes.has(item.viewPermissionCode) : true;
+    const canView = roleCodes
+      ? roleCodes.has(item.viewPermissionCode) ||
+        (!!item.viewPermissionPrefix &&
+          [...roleCodes].some(code => code.startsWith(item.viewPermissionPrefix!)))
+      : true;
     if (!canView) return; // parent hidden → whole subtree unreachable
     const canEdit = roleCodes
       ? !item.editPermissionCode || roleCodes.has(item.editPermissionCode)

--- a/src/features/menuManagement/pages/MenuEditPage.tsx
+++ b/src/features/menuManagement/pages/MenuEditPage.tsx
@@ -55,6 +55,7 @@ export default function MenuEditPage() {
         iconColor: values.iconColor,
         sortOrder: values.sortOrder,
         viewPermissionCode: values.viewPermissionCode,
+        viewPermissionPrefix: values.viewPermissionPrefix || null,
         editPermissionCode: values.editPermissionCode,
         translations: values.translations.filter(tr => tr.label.trim() !== ''),
       };
@@ -70,6 +71,7 @@ export default function MenuEditPage() {
         iconColor: values.iconColor,
         sortOrder: values.sortOrder,
         viewPermissionCode: values.viewPermissionCode,
+        viewPermissionPrefix: values.viewPermissionPrefix || null,
         editPermissionCode: values.editPermissionCode,
         translations: values.translations.filter(tr => tr.label.trim() !== ''),
       };

--- a/src/features/menuManagement/pages/MenuEditPage.tsx
+++ b/src/features/menuManagement/pages/MenuEditPage.tsx
@@ -55,7 +55,7 @@ export default function MenuEditPage() {
         iconColor: values.iconColor,
         sortOrder: values.sortOrder,
         viewPermissionCode: values.viewPermissionCode,
-        viewPermissionPrefix: values.viewPermissionPrefix || null,
+        viewPermissionPrefix: values.viewPermissionPrefix?.trim() || null,
         editPermissionCode: values.editPermissionCode,
         translations: values.translations.filter(tr => tr.label.trim() !== ''),
       };
@@ -71,7 +71,7 @@ export default function MenuEditPage() {
         iconColor: values.iconColor,
         sortOrder: values.sortOrder,
         viewPermissionCode: values.viewPermissionCode,
-        viewPermissionPrefix: values.viewPermissionPrefix || null,
+        viewPermissionPrefix: values.viewPermissionPrefix?.trim() || null,
         editPermissionCode: values.editPermissionCode,
         translations: values.translations.filter(tr => tr.label.trim() !== ''),
       };

--- a/src/features/menuManagement/types.ts
+++ b/src/features/menuManagement/types.ts
@@ -35,6 +35,7 @@ export interface MenuItemAdminDto extends Omit<MenuTreeNode, 'children'> {
   scope: MenuScope;
   parentId: string | null;
   viewPermissionCode: string;
+  viewPermissionPrefix: string | null;
   editPermissionCode: string | null;
   isSystem: boolean;
   translations: MenuItemTranslationDto[];
@@ -57,6 +58,7 @@ export interface CreateMenuItemRequest {
   iconColor: string | null;
   sortOrder: number;
   viewPermissionCode: string;
+  viewPermissionPrefix: string | null;
   editPermissionCode: string | null;
   translations: MenuItemTranslationDto[];
 }

--- a/src/features/request/configs/fields.ts
+++ b/src/features/request/configs/fields.ts
@@ -39,8 +39,8 @@ export function makeRequestFields(t: TFunction<'request'>): FormField[] {
       label: t('fields.priority'),
       name: 'priority',
       options: [
-        { name: 'normal', label: t('fields.priorityNormal') },
-        { name: 'high', label: t('fields.priorityHigh') },
+        { name: 'Normal', label: t('fields.priorityNormal') },
+        { name: 'High', label: t('fields.priorityHigh') },
       ],
       wrapperClassName: 'col-span-2',
     },
@@ -1749,8 +1749,8 @@ export const requestFields: FormField[] = [
     label: _st('Priority'),
     name: 'priority',
     options: [
-      { name: 'normal', label: 'Normal' },
-      { name: 'high', label: 'High' },
+      { name: 'Normal', label: 'Normal' },
+      { name: 'High', label: 'High' },
     ],
     wrapperClassName: 'col-span-2',
   },

--- a/src/features/request/utils/mappers.ts
+++ b/src/features/request/utils/mappers.ts
@@ -12,7 +12,9 @@ export const mapRequestResponseToForm = (
   return {
     purpose: response.purpose ?? '',
     channel: response.channel ?? '',
-    priority: response.priority ?? 'Normal',
+    // Normalize legacy lower-case values (older responses / persisted drafts) to the
+    // Title-case radio option values so the priority field stays selected.
+    priority: response.priority?.toLowerCase() === 'high' ? 'High' : 'Normal',
     isPma: response.isPma ?? false,
     creator: response.creator ?? { userId: '', username: '' },
     // GET /requests/{id} returns RequestorDetailDto (employeeId + full snapshot, no GUID).

--- a/src/features/request/utils/mappers.ts
+++ b/src/features/request/utils/mappers.ts
@@ -12,7 +12,7 @@ export const mapRequestResponseToForm = (
   return {
     purpose: response.purpose ?? '',
     channel: response.channel ?? '',
-    priority: response.priority ?? 'normal',
+    priority: response.priority ?? 'Normal',
     isPma: response.isPma ?? false,
     creator: response.creator ?? { userId: '', username: '' },
     // GET /requests/{id} returns RequestorDetailDto (employeeId + full snapshot, no GUID).

--- a/src/i18n/locales/en/menuManagement.json
+++ b/src/i18n/locales/en/menuManagement.json
@@ -59,6 +59,9 @@
     "iconColorNone": "No color",
     "sortOrder": "Sort Order",
     "viewPermission": "View Permission",
+    "viewPermissionPrefix": "View Permission Prefix",
+    "viewPermissionPrefixPlaceholder": "e.g. MONITORING:",
+    "viewPermissionPrefixHint": "Grants view access to every permission starting with this prefix. Required if View Permission is empty.",
     "editPermission": "Edit Permission",
     "labels": "Labels",
     "labelPlaceholderEn": "English label (required)",
@@ -66,7 +69,7 @@
     "labelAriaInput": "{{lang}} label",
     "submit": "Save",
     "submitting": "Saving...",
-    "viewPermissionRequired": "View permission is required"
+    "viewPermissionRequired": "Provide a view permission or a permission prefix."
   },
   "colors": {
     "Blue": "Blue",

--- a/src/i18n/locales/th/menuManagement.json
+++ b/src/i18n/locales/th/menuManagement.json
@@ -59,6 +59,9 @@
     "iconColorNone": "ไม่มีสี",
     "sortOrder": "ลำดับการเรียง",
     "viewPermission": "สิทธิ์ดู",
+    "viewPermissionPrefix": "คำนำหน้าสิทธิ์ดู",
+    "viewPermissionPrefixPlaceholder": "เช่น MONITORING:",
+    "viewPermissionPrefixHint": "ให้สิทธิ์ดูแก่สิทธิ์ทั้งหมดที่ขึ้นต้นด้วยคำนำหน้านี้ จำเป็นหากไม่ได้ระบุสิทธิ์ดู",
     "editPermission": "สิทธิ์แก้ไข",
     "labels": "ป้ายกำกับ",
     "labelPlaceholderEn": "ป้ายกำกับภาษาอังกฤษ (จำเป็น)",
@@ -66,7 +69,7 @@
     "labelAriaInput": "ป้ายกำกับ {{lang}}",
     "submit": "บันทึก",
     "submitting": "กำลังบันทึก...",
-    "viewPermissionRequired": "จำเป็นต้องระบุสิทธิ์การดู"
+    "viewPermissionRequired": "โปรดระบุสิทธิ์ดูหรือคำนำหน้าสิทธิ์"
   },
   "colors": {
     "Blue": "น้ำเงิน",

--- a/src/i18n/locales/zh/menuManagement.json
+++ b/src/i18n/locales/zh/menuManagement.json
@@ -59,6 +59,9 @@
     "iconColorNone": "No color",
     "sortOrder": "Sort Order",
     "viewPermission": "View Permission",
+    "viewPermissionPrefix": "View Permission Prefix",
+    "viewPermissionPrefixPlaceholder": "e.g. MONITORING:",
+    "viewPermissionPrefixHint": "Grants view access to every permission starting with this prefix. Required if View Permission is empty.",
     "editPermission": "Edit Permission",
     "labels": "Labels",
     "labelPlaceholderEn": "English label (required)",
@@ -66,7 +69,7 @@
     "labelAriaInput": "{{lang}} label",
     "submit": "Save",
     "submitting": "Saving...",
-    "viewPermissionRequired": "View permission is required"
+    "viewPermissionRequired": "Provide a view permission or a permission prefix."
   },
   "colors": {
     "Blue": "Blue",


### PR DESCRIPTION
Frontend side of two standalone efforts mapping to **no CA ticket**. Pairs with the api repo `chore/misc-refactors` PR.

## Contents
- **Priority casing** — request priority radio codes `normal/high` → `Normal/High` and default mapper `'normal'` → `'Normal'`, matching the backend Priority value-object refactor.
- **Menu `viewPermissionPrefix`** — new form input + types + i18n; view-permission no longer hard-required when a prefix is set.

## Notes
- ⚠️ Not CA-396 (Cancel button) — that fix remains unimplemented.
- `vite build` clean; no new `tsc` errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpPDZpdFipoSk8ev5QQXF