### PR TITLE
fix(blockProject): align Project Information field limits with FSD (CA-304)

### DIFF
--- a/src/features/blockProject/configs/fields.ts
+++ b/src/features/blockProject/configs/fields.ts
@@ -18,21 +18,22 @@ export const projectInformationFields: FormField[] = [
     name: 'projectName',
     required: true,
     wrapperClassName: 'col-span-8',
-    maxLength: 200,
+    maxLength: 100,
   },
   {
     type: 'textarea',
     label: 'Project Description',
     name: 'projectDescription',
     wrapperClassName: 'col-span-12',
-    maxLength: 500,
+    maxLength: 200,
+    showCharCount: true,
   },
   {
     type: 'text-input',
     label: 'Developer',
     name: 'developer',
     wrapperClassName: 'col-span-6',
-    maxLength: 200,
+    maxLength: 50,
   },
   {
     type: 'text-input',
@@ -211,8 +212,9 @@ export const projectDetailFields: FormField[] = [
     type: 'textarea',
     label: 'Remark',
     name: 'remark',
-    maxLength: 500,
+    maxLength: 4000,
     wrapperClassName: 'col-span-12',
+    showCharCount: true,
   },
 ];
 


### PR DESCRIPTION
## CA-304 — Project Information field limits & char counters

Aligns the Block Project **Project Information** field lengths with the FSD and adds character counters to the text areas.

`src/features/blockProject/configs/fields.ts`:

| Field | maxLength | charCount |
|---|---|---|
| projectName | 200 → **100** | — |
| projectDescription | 500 → **200** | added |
| developer | 200 → **50** | — |
| remark | 500 → **4000** | added |

Char counters use the existing `showCharCount` standard (same as the appraisal screen's text areas).

⚠️ **Reviewer note:** the `remark` change is in the `projectDetailFields` array — please confirm this is the Project Information tab's remark field. Limits (100/200/50/4000) were confirmed verbally; double-check against the FSD if a source-of-truth doc exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
