### PR TITLE
Add market reference button to DCF income inputs

### DIFF
--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModalRenderer.tsx
@@ -54,7 +54,15 @@ export function DiscountedCashFlowModalRenderer({
     }
     // Method 02
     case 'specifiedRoomIncomeBySeasonalRates':
-      return <MethodSpecifiedRoomIncomeBySeasonalRatesModal {...props} />;
+      return (
+        <MethodSpecifiedRoomIncomeBySeasonalRatesModal
+          {...props}
+          incomeAnalysisId={incomeAnalysisId}
+          hostMethodId={hostMethodId}
+          marketSurveys={marketSurveys}
+          ensureIncomeAnalysisId={ensureIncomeAnalysisId}
+        />
+      );
     // Method 03
     case 'specifiedRoomIncomeWithGrowth':
       return <MethodSpecifiedRoomIncomeWithGrowthModal {...props} />;
@@ -63,7 +71,15 @@ export function DiscountedCashFlowModalRenderer({
       return <MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal {...props} />;
     // Method 05
     case 'specifiedRentalIncomePerMonth':
-      return <MethodSpecifiedRentalIncomePerMonthModal {...props} />;
+      return (
+        <MethodSpecifiedRentalIncomePerMonthModal
+          {...props}
+          incomeAnalysisId={incomeAnalysisId}
+          hostMethodId={hostMethodId}
+          marketSurveys={marketSurveys}
+          ensureIncomeAnalysisId={ensureIncomeAnalysisId}
+        />
+      );
     // Method 06
     case 'specifiedRentalIncomePerSquareMeter':
       return <MethodSpecifiedRentalIncomePerSquareMeterModal {...props} />;

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
@@ -1,23 +1,42 @@
 import { Icon } from '@/shared/components';
 import { RHFInputCell } from '../../table/RHFInputCell';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameters';
+import { PricingAnalysisSubjectType } from '@/features/pricingAnalysis/api/references';
+import { MarketReferenceButton } from '../../MarketReferenceButton';
+import type { MarketComparableDetailType } from '@/features/pricingAnalysis/schemas';
+import type { TemplateDtoType } from '@/shared/schemas/v1';
 
 interface MethodSpecifiedRentalIncomePerMonthModalProps {
   name: string;
   isReadOnly?: boolean;
   getOuterFormValues: UseFormGetValues<any>;
+  incomeAnalysisId?: string;
+  hostMethodId?: string;
+  marketSurveys?: MarketComparableDetailType[];
+  templateList?: TemplateDtoType[] | undefined;
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }
 export function MethodSpecifiedRentalIncomePerMonthModal({
   name = '',
   isReadOnly,
   getOuterFormValues,
+  incomeAnalysisId,
+  hostMethodId,
+  marketSurveys,
+  templateList,
+  ensureIncomeAnalysisId,
 }: MethodSpecifiedRentalIncomePerMonthModalProps) {
+  // Local state to cache the id obtained by ensureIncomeAnalysisId so the
+  // button can function before the first save.
+  const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
+
   const {
     getValues,
+    setValue,
     formState: { errors },
   } = useFormContext();
   const { fields, append, remove } = useFieldArray({ name: `${name}.roomDetails` });
@@ -170,12 +189,64 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                       </div>
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
-                      <RHFInputCell
-                        fieldName={`${name}.roomDetails.${index}.roomIncome`}
-                        inputType="number"
-                        disabled={isReadOnly}
-                        number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
-                      />
+                      {(() => {
+                        const roomType = getValues(`${name}.roomDetails.${index}.roomType`);
+                        const roomOther = getValues(`${name}.roomDetails.${index}.roomTypeOther`);
+                        const roomCode = String(roomType ?? '');
+                        const anchorRefKey =
+                          roomCode === '99' && roomOther ? String(roomOther) : roomCode;
+                        // The effective anchorId: already-saved id wins; fall back to locally ensured.
+                        // Read from ref for latest value without stale closure inside onBeforeOpen.
+                        const effectiveId = incomeAnalysisId ?? ensuredId;
+                        const refButton = !isReadOnly ? (
+                          <MarketReferenceButton
+                            compact
+                            label="WQS"
+                            subjectType={PricingAnalysisSubjectType.RoomIncomeRef}
+                            // Pass the live value; after onBeforeOpen resolves the state update
+                            // will have re-rendered with the new id, and the modal reads anchorId
+                            // from the prop at open time.
+                            anchorId={effectiveId ?? ''}
+                            anchorRefKey={anchorRefKey}
+                            hostMethodId={hostMethodId}
+                            marketSurveys={marketSurveys ?? []}
+                            templateList={templateList}
+                            currentAnchorLabel={anchorRefKey}
+                            onApplyValue={v =>
+                              setValue(`${name}.roomDetails.${index}.roomIncome`, v, {
+                                shouldDirty: true,
+                              })
+                            }
+                            onBeforeOpen={
+                              effectiveId
+                                ? undefined
+                                : async () => {
+                                    const id = await ensureIncomeAnalysisId?.();
+                                    if (id) {
+                                      setEnsuredId(id);
+                                    }
+                                    // Throw to abort open if still no id (save failed, toast shown)
+                                    if (!id) throw new Error('no-id');
+                                  }
+                            }
+                            className="pointer-events-auto shrink-0"
+                          />
+                        ) : null;
+                        return (
+                          <RHFInputCell
+                            fieldName={`${name}.roomDetails.${index}.roomIncome`}
+                            inputType="number"
+                            disabled={isReadOnly}
+                            number={{
+                              decimalPlaces: 2,
+                              maxIntegerDigits: 15,
+                              allowNegative: false,
+                            }}
+                            rightIcon={refButton}
+                            inputClassName={refButton ? '!pr-14' : undefined}
+                          />
+                        );
+                      })()}
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">
                       <RHFInputCell

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import {
   useForm,
   FormProvider,
@@ -14,6 +14,10 @@ import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toNumber } from '../../../domain/calculation';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
 import clsx from 'clsx';
+import { MarketReferenceButton } from '../../MarketReferenceButton';
+import { PricingAnalysisSubjectType } from '@/features/pricingAnalysis/api/references';
+import type { MarketComparableDetailType } from '@/features/pricingAnalysis/schemas';
+import type { TemplateDtoType } from '@/shared/schemas/v1';
 
 type SeasonRateInput = {
   seasonId: string;
@@ -97,11 +101,24 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
   name,
   isReadOnly,
   getOuterFormValues,
+  incomeAnalysisId,
+  hostMethodId,
+  marketSurveys,
+  templateList,
+  ensureIncomeAnalysisId,
 }: {
   name: string;
   isReadOnly?: boolean;
   getOuterFormValues: UseFormGetValues<any>;
+  incomeAnalysisId?: string;
+  hostMethodId?: string;
+  marketSurveys?: MarketComparableDetailType[];
+  templateList?: TemplateDtoType[] | undefined;
+  ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }) {
+  // Local state to cache the id obtained by ensureIncomeAnalysisId so the
+  // button can function before the first save.
+  const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
   const {
     control,
     getValues,
@@ -326,16 +343,70 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                       return (
                         <Fragment key={`${field.id}-${seasonIndex}`}>
                           <td className="border-b border-gray-300 p-1">
-                            <RHFInputCell
-                              fieldName={`${name}.roomDetails.${rowIndex}.seasons.${seasonIndex}.roomIncome`}
-                              inputType="number"
-                              disabled={isReadOnly}
-                              number={{
-                                decimalPlaces: 2,
-                                maxIntegerDigits: 15,
-                                allowNegative: false,
-                              }}
-                            />
+                            {(() => {
+                              const roomType = getValues(
+                                `${name}.roomDetails.${rowIndex}.roomType`,
+                              );
+                              const roomOther = getValues(
+                                `${name}.roomDetails.${rowIndex}.roomTypeOther`,
+                              );
+                              const roomCode = String(roomType ?? '');
+                              const anchorRefKey =
+                                roomCode === '99' && roomOther ? String(roomOther) : roomCode;
+                              const effectiveId = incomeAnalysisId ?? ensuredId;
+                              const refButton = !isReadOnly ? (
+                                <MarketReferenceButton
+                                  compact
+                                  label="WQS"
+                                  subjectType={PricingAnalysisSubjectType.RoomIncomeRef}
+                                  // Pass the live value; after onBeforeOpen resolves the state update
+                                  // will have re-rendered with the new id, and the modal reads anchorId
+                                  // from the prop at open time.
+                                  anchorId={effectiveId ?? ''}
+                                  anchorRefKey={anchorRefKey}
+                                  hostMethodId={hostMethodId}
+                                  marketSurveys={marketSurveys ?? []}
+                                  templateList={templateList}
+                                  currentAnchorLabel={anchorRefKey}
+                                  onApplyValue={v =>
+                                    setValue(
+                                      `${name}.roomDetails.${rowIndex}.seasons.${seasonIndex}.roomIncome`,
+                                      v,
+                                      {
+                                        shouldDirty: true,
+                                      },
+                                    )
+                                  }
+                                  onBeforeOpen={
+                                    effectiveId
+                                      ? undefined
+                                      : async () => {
+                                          const id = await ensureIncomeAnalysisId?.();
+                                          if (id) {
+                                            setEnsuredId(id);
+                                          }
+                                          // Throw to abort open if still no id (save failed, toast shown)
+                                          if (!id) throw new Error('no-id');
+                                        }
+                                  }
+                                  className="pointer-events-auto shrink-0"
+                                />
+                              ) : null;
+                              return (
+                                <RHFInputCell
+                                  fieldName={`${name}.roomDetails.${rowIndex}.seasons.${seasonIndex}.roomIncome`}
+                                  inputType="number"
+                                  disabled={isReadOnly}
+                                  number={{
+                                    decimalPlaces: 2,
+                                    maxIntegerDigits: 15,
+                                    allowNegative: false,
+                                  }}
+                                  rightIcon={refButton}
+                                  inputClassName={refButton ? '!pr-14' : undefined}
+                                />
+                              );
+                            })()}
                           </td>
                           <td className="border-b border-gray-300 p-1">
                             <RHFInputCell


### PR DESCRIPTION
Enable users to reference market survey data when entering room and rental income values in DCF analysis methods. Added MarketReferenceButton integration to MethodSpecifiedRentalIncomePerMonthModal and MethodSpecifiedRoomIncomeBySeasonalRatesModal with local state caching to support referencing before initial save.