### PR TITLE
feat(dashboard): widgets + task-list SLA chip + date-picker/chunk-load/ops-report fixes

### DIFF
--- a/src/app/AppraisalLayout.tsx
+++ b/src/app/AppraisalLayout.tsx
@@ -41,11 +41,11 @@ function resolveReturnPath(appraisalId: string, locationState: unknown): string 
     if (stored) {
       const parsed = JSON.parse(stored);
       if (parsed.appraisalId?.toLowerCase() === appraisalId?.toLowerCase()) {
-        return parsed.returnPath ?? '/appraisals/search';
+        return parsed.returnPath ?? '/appraisals/list';
       }
     }
   } catch { /* ignore */ }
-  return '/appraisals/search';
+  return '/appraisals/list';
 }
 
 const userNavigation = [

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter, Navigate, useParams, useSearchParams } from 'react-router-dom';
 import Layout from './Layout';
 import AppraisalLayout from './AppraisalLayout';
-import { lazy } from 'react';
+import { lazyWithRetry as lazy } from '@shared/utils/lazyWithRetry';
 // Eager — structural shell, route guards, read-only wrappers, and helpers that
 // must be available immediately (no spinner on the critical path).
 import LoginPage from '@features/auth/pages/LoginPage';

--- a/src/features/appraisal/components/tabs/DocumentChecklistTab.tsx
+++ b/src/features/appraisal/components/tabs/DocumentChecklistTab.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { lazyWithRetry } from '@shared/utils/lazyWithRetry';
 import Icon from '@shared/components/Icon';
 import Button from '@shared/components/Button';
 import ConfirmDialog from '@shared/components/ConfirmDialog';
@@ -33,7 +34,7 @@ import type { AnnotationResult } from '@shared/components/ImageAnnotationEditor'
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import DataErrorState from '@/shared/components/DataErrorState';
 
-const ImageAnnotationEditor = lazy(
+const ImageAnnotationEditor = lazyWithRetry(
   () => import('@shared/components/ImageAnnotationEditor/ImageAnnotationEditor'),
 );
 

--- a/src/features/appraisal/configs/fields.ts
+++ b/src/features/appraisal/configs/fields.ts
@@ -2534,6 +2534,30 @@ export const pmaField: FormField[] = [
 export const landAndBuildingPMAFields: FormField[] = [
   {
     type: 'text-input',
+    label: 'Title Number',
+    name: 'titleNumber',
+    wrapperClassName: 'col-span-3',
+    required: true,
+    maxLength: 200,
+  },
+  {
+    type: 'text-input',
+    label: 'Book Number',
+    name: 'bookNumber',
+    wrapperClassName: 'col-span-3',
+    required: true,
+    maxLength: 10,
+  },
+  {
+    type: 'text-input',
+    label: 'Page Number',
+    name: 'pageNumber',
+    wrapperClassName: 'col-span-3',
+    required: true,
+    maxLength: 10,
+  },
+  {
+    type: 'text-input',
     label: 'Rawang',
     name: 'rawang',
     wrapperClassName: 'col-span-3',
@@ -2542,7 +2566,7 @@ export const landAndBuildingPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Land No.',
+    label: 'Land Number',
     name: 'landNumber',
     wrapperClassName: 'col-span-3',
     required: true,
@@ -2550,33 +2574,9 @@ export const landAndBuildingPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Survey No.',
+    label: 'Survey Number',
     name: 'surveyNumber',
     wrapperClassName: 'col-span-3',
-    required: true,
-    maxLength: 10,
-  },
-  {
-    type: 'text-input',
-    label: 'Title Deed No.',
-    name: 'titleNumber',
-    wrapperClassName: 'col-span-3',
-    required: true,
-    maxLength: 200,
-  },
-  {
-    type: 'text-input',
-    label: 'Book No.',
-    name: 'bookNumber',
-    wrapperClassName: 'col-span-1',
-    required: true,
-    maxLength: 10,
-  },
-  {
-    type: 'text-input',
-    label: 'Page No.',
-    name: 'pageNumber',
-    wrapperClassName: 'col-span-1',
     required: true,
     maxLength: 10,
   },
@@ -2601,7 +2601,7 @@ export const landAndBuildingPMAFields: FormField[] = [
   },
   {
     type: 'number-input',
-    label: 'Wa',
+    label: 'Sq.Wa',
     name: 'areaSquareWa',
     wrapperClassName: 'col-span-1',
     required: true,
@@ -2645,7 +2645,7 @@ export const landAndBuildingPMAFields: FormField[] = [
 export const condoPMAFields: FormField[] = [
   {
     type: 'text-input',
-    label: 'Construction on Title Deed No.',
+    label: 'Construction on Title Deed Number',
     name: 'builtOnTitleNumber',
     wrapperClassName: 'col-span-6',
     required: true,
@@ -2653,7 +2653,7 @@ export const condoPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Condominium Registration No.',
+    label: 'Condominium Registration Number',
     name: 'condoRegistrationNumber',
     wrapperClassName: 'col-span-3',
     required: true,
@@ -2661,15 +2661,7 @@ export const condoPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Condominium Name.',
-    name: 'condoName',
-    wrapperClassName: 'col-span-6',
-    required: true,
-    maxLength: 100,
-  },
-  {
-    type: 'text-input',
-    label: 'Room No.',
+    label: 'Room Number',
     name: 'roomNumber',
     wrapperClassName: 'col-span-1',
     required: true,
@@ -2677,7 +2669,7 @@ export const condoPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Floor No.',
+    label: 'Floor Number',
     name: 'floorNumber',
     wrapperClassName: 'col-span-1',
     required: true,
@@ -2685,11 +2677,19 @@ export const condoPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Building No.',
+    label: 'Building Number',
     name: 'buildingNumber',
     wrapperClassName: 'col-span-1',
     required: true,
     maxLength: 30,
+  },
+  {
+    type: 'text-input',
+    label: 'Condominium Name',
+    name: 'condoName',
+    wrapperClassName: 'col-span-6',
+    required: true,
+    maxLength: 100,
   },
   {
     type: 'location-selector',

--- a/src/features/appraisal/utils/mappers.ts
+++ b/src/features/appraisal/utils/mappers.ts
@@ -212,6 +212,9 @@ export const mapBuildingPropertyResponseToForm = (
 export const mapCondoPropertyResponseToForm = (
   response: GetCondoPropertyResponseType,
 ): createCondoFormType => {
+  const addressLookup = response.subDistrict
+    ? findAddressBySubDistrictCode(response.subDistrict)
+    : undefined;
   return {
     ownerName: response.ownerName ?? '',
 
@@ -229,8 +232,11 @@ export const mapCondoPropertyResponseToForm = (
     longitude: response.longitude ?? 0,
 
     subDistrict: response.subDistrict ?? '',
+    subDistrictName: addressLookup?.subDistrictName ?? '',
     district: response.district ?? '',
+    districtName: addressLookup?.districtName ?? '',
     province: response.province ?? '',
+    provinceName: addressLookup?.provinceName ?? '',
     landOffice: response.landOffice ?? '',
 
     isOwnerVerified: response.isOwnerVerified ?? false,

--- a/src/features/common/operationalReports/components/OperationalReportPage.tsx
+++ b/src/features/common/operationalReports/components/OperationalReportPage.tsx
@@ -4,6 +4,8 @@ import Icon from '@shared/components/Icon';
 import Pagination from '@shared/components/Pagination';
 import { TableRowSkeleton } from '@shared/components/Skeleton';
 import Input from '@shared/components/Input';
+import Autocomplete from '@shared/components/inputs/Autocomplete';
+import { APPRAISAL_STATUS_FILTER_OPTIONS } from '@shared/constants/appraisalStatus';
 import { useDebounce } from '@shared/hooks/useDebounce';
 import { useOperationalReport, useReportExport } from '../api/operationalReportsApi';
 import type { BaseReportFilter, SortDir } from '../api/operationalReportsApi';
@@ -84,6 +86,15 @@ const DATE_FIELDS = new Set<FilterField>([
   'approvedTo',
 ]);
 
+/**
+ * Fields that render as a searchable dropdown bound to a fixed option list.
+ * `evaluationStatus`/`feeStatus` intentionally stay free text — they use
+ * different domains and have no shared option list yet.
+ */
+const OPTION_FIELDS: Partial<Record<FilterField, { value: string; label: string }[]>> = {
+  status: APPRAISAL_STATUS_FILTER_OPTIONS,
+};
+
 function FilterPanel({ filters, values, onChange, onReset }: FilterPanelProps) {
   const hasAny = filters.some(f => Boolean((values as Record<string, unknown>)[f]));
 
@@ -94,11 +105,24 @@ function FilterPanel({ filters, values, onChange, onReset }: FilterPanelProps) {
           const val = ((values as Record<string, unknown>)[field] as string) ?? '';
           const label = FILTER_LABELS[field];
           const isDate = DATE_FIELDS.has(field);
+          const options = OPTION_FIELDS[field];
 
           return (
             <div key={field} className="flex flex-col gap-1 min-w-[160px]">
               <label className="text-xs font-medium text-gray-600">{label}</label>
-              {isDate ? (
+              {options ? (
+                <Autocomplete
+                  items={options}
+                  value={val}
+                  onChange={v => onChange({ [field]: v || undefined })}
+                  displayText={options.find(o => o.value === val)?.label}
+                  placeholder={`All ${label}`}
+                  showAllOnFocus
+                  menuClassName="w-full"
+                  filterItems={(item, text) =>
+                    item.label.toLowerCase().includes(text.toLowerCase())}
+                />
+              ) : isDate ? (
                 <input
                   type="date"
                   value={val}

--- a/src/features/common/operationalReports/pages/OperationalReportRoute.tsx
+++ b/src/features/common/operationalReports/pages/OperationalReportRoute.tsx
@@ -36,7 +36,7 @@ function OperationalReportRoute() {
     );
   }
 
-  return <OperationalReportPage config={config} />;
+  return <OperationalReportPage key={config.slug} config={config} />;
 }
 
 export default OperationalReportRoute;

--- a/src/features/dashboard/api/dashboardApi.ts
+++ b/src/features/dashboard/api/dashboardApi.ts
@@ -23,10 +23,18 @@ export const dashboardApi = {
     return data;
   },
 
-  getAppraisalCounts: async (period = 'monthly', from?: string, to?: string) => {
+  getAppraisalCounts: async (
+    period = 'monthly',
+    from?: string,
+    to?: string,
+    groupByType?: boolean,
+    bankingSegment?: string,
+  ) => {
     const params = new URLSearchParams({ period });
     if (from) params.set('from', from);
     if (to) params.set('to', to);
+    if (groupByType) params.set('groupByType', 'true');
+    if (bankingSegment) params.set('bankingSegment', bankingSegment);
     const { data } = await axios.get<AppraisalCountsResponse>(
       `/dashboard/appraisal-counts?${params}`,
     );

--- a/src/features/dashboard/api/hooks.ts
+++ b/src/features/dashboard/api/hooks.ts
@@ -19,6 +19,8 @@ export type AppraisalCountsFilters = {
   period?: string;
   from?: string;
   to?: string;
+  groupByType?: boolean;
+  bankingSegment?: string;
 };
 
 export type AppraisalStatusSummaryFilters = {
@@ -63,11 +65,19 @@ export const useTaskSummary = (filters: TaskSummaryFilters = {}) => {
   });
 };
 
-export const useAppraisalCounts = (period = 'monthly', from?: string, to?: string) => {
+export const useAppraisalCounts = (
+  period = 'monthly',
+  from?: string,
+  to?: string,
+  groupByType?: boolean,
+  bankingSegment?: string,
+  options: { enabled?: boolean } = {},
+) => {
   return useQuery({
-    queryKey: dashboardKeys.appraisalCounts({ period, from, to }),
-    queryFn: () => dashboardApi.getAppraisalCounts(period, from, to),
+    queryKey: dashboardKeys.appraisalCounts({ period, from, to, groupByType, bankingSegment }),
+    queryFn: () => dashboardApi.getAppraisalCounts(period, from, to, groupByType, bankingSegment),
     staleTime: DASHBOARD_STALE_TIME,
+    enabled: options.enabled ?? true,
   });
 };
 

--- a/src/features/dashboard/api/types.ts
+++ b/src/features/dashboard/api/types.ts
@@ -9,6 +9,9 @@ export type TaskSummaryResponse = {
 
 export type AppraisalCountItem = {
   period: string | null;
+  // Only present when the request is made with groupByType=true; one item per
+  // (period, appraisalType) pair. Null/absent in the default overview response.
+  appraisalType?: string | null;
   createdCount: number;
   completedCount: number;
 };
@@ -43,6 +46,8 @@ export type CompanyAppraisalSummaryItem = {
   companyName: string;
   assignedCount: number;
   completedCount: number;
+  overdueCount: number;
+  inProgressCount: number;
 };
 
 export type CompanyAppraisalSummaryResponse = {
@@ -105,4 +110,5 @@ export type QuotationTaskSummaryResponse = {
   pendingQuotationCreation: number;
   waitingCompanySubmission: number;
   waitingRmSelection: number;
+  pendingApprovals: number;
 };

--- a/src/features/dashboard/components/ChartTooltip.tsx
+++ b/src/features/dashboard/components/ChartTooltip.tsx
@@ -1,0 +1,41 @@
+// Shared card-style tooltip for dashboard charts. Iterates the hovered series so it
+// works for any line/bar chart (fixed or dynamic series). Matches the look used by
+// ExternalTaskSummaryWidget's tooltip for a consistent dashboard style.
+type ChartTooltipEntry = {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  stroke?: string;
+};
+
+type ChartTooltipProps = {
+  active?: boolean;
+  payload?: ChartTooltipEntry[];
+  label?: string | number;
+};
+
+export default function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm px-3 py-2 text-xs min-w-[160px]">
+      {label != null && label !== '' && (
+        <p className="font-semibold text-gray-800 mb-1.5">{label}</p>
+      )}
+      <div className="space-y-1">
+        {payload.map((entry, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <span
+              className="inline-block w-2 h-2 rounded-full shrink-0"
+              style={{ backgroundColor: entry.color ?? entry.stroke ?? '#9ca3af' }}
+            />
+            <span className="text-gray-600">{entry.name}</span>
+            <span className="ml-auto font-medium text-gray-800 tabular-nums">
+              {typeof entry.value === 'number' ? entry.value.toLocaleString() : entry.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/dashboard/components/ExternalTaskSummaryWidget.tsx
+++ b/src/features/dashboard/components/ExternalTaskSummaryWidget.tsx
@@ -6,11 +6,12 @@ import {
   ResponsiveContainer,
   BarChart,
   Bar,
+  Cell,
+  LabelList,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
 } from 'recharts';
 
 import { formatDistanceToNow } from 'date-fns';
@@ -36,6 +37,7 @@ type ExternalTaskSettings = {
   from?: string;
   to?: string;
   companyId?: string;
+  hidden?: string[]; // segment keys toggled off via the legend
 };
 
 const EMPTY_SETTINGS: ExternalTaskSettings = Object.freeze({}) as ExternalTaskSettings;
@@ -44,8 +46,79 @@ type Row = {
   companyId: string;
   name: string;
   assigned: number;
+  overdue: number;
+  inProgress: number;
   completed: number;
 };
+
+// Backend fallback label for an AssigneeCompanyId with no auth.Companies match
+// (COALESCE(..., N'(pending)') in the summary query).
+const PENDING = '(pending)';
+
+const SEGMENT_COLORS = {
+  overdue: '#ef4444',
+  inProgress: '#3b82f6',
+  completed: '#10b981',
+} as const;
+
+type SeriesKey = 'overdue' | 'inProgress' | 'completed';
+
+// Render/legend order. `bar` is the (possibly zeroed-when-hidden) key the chart plots.
+const SERIES = [
+  { key: 'overdue', bar: 'barOverdue', color: SEGMENT_COLORS.overdue, labelKey: 'externalSummary.chart.overdue' },
+  { key: 'inProgress', bar: 'barInProgress', color: SEGMENT_COLORS.inProgress, labelKey: 'externalSummary.chart.inProgress' },
+  { key: 'completed', bar: 'barCompleted', color: SEGMENT_COLORS.completed, labelKey: 'externalSummary.chart.completed' },
+] as const;
+
+// Row augmented with per-segment bar values (0 when that series is hidden) and their sum.
+type ChartRow = Row & {
+  barOverdue: number;
+  barInProgress: number;
+  barCompleted: number;
+  visible: number;
+};
+
+type SummaryTooltipProps = {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartRow }>;
+};
+
+function SummaryTooltip({ active, payload }: SummaryTooltipProps) {
+  const { t } = useTranslation('dashboard');
+  if (!active || !payload?.length) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+
+  // Only the currently-visible (non-hidden, non-zero) segments; total matches the bar.
+  const segments = [
+    { color: SEGMENT_COLORS.overdue, label: t('externalSummary.chart.overdue'), value: row.barOverdue },
+    { color: SEGMENT_COLORS.inProgress, label: t('externalSummary.chart.inProgress'), value: row.barInProgress },
+    { color: SEGMENT_COLORS.completed, label: t('externalSummary.chart.completed'), value: row.barCompleted },
+  ].filter(s => s.value > 0);
+  const pct = row.visible > 0 ? Math.round((row.barCompleted / row.visible) * 100) : 0;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm px-3 py-2 text-xs min-w-[168px]">
+      <p className="font-semibold text-gray-800 mb-1.5">{row.name}</p>
+      <div className="space-y-1">
+        {segments.map(s => (
+          <div key={s.label} className="flex items-center gap-2">
+            <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: s.color }} />
+            <span className="text-gray-600">{s.label}</span>
+            <span className="ml-auto font-medium text-gray-800 tabular-nums">{s.value}</span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-1.5 pt-1.5 border-t border-gray-100 flex items-center gap-2">
+        <span className="text-gray-600">{t('externalSummary.chart.assigned')}</span>
+        <span className="ml-auto font-semibold text-gray-800 tabular-nums">{row.visible}</span>
+      </div>
+      {row.barCompleted > 0 && (
+        <p className="text-gray-400 mt-0.5">{t('externalSummary.chart.delivered', { pct })}</p>
+      )}
+    </div>
+  );
+}
 
 function ExternalTaskSummaryWidget() {
   const { t } = useTranslation('dashboard');
@@ -92,21 +165,73 @@ function ExternalTaskSummaryWidget() {
     ? formatDistanceToNow(dataUpdatedAt, { addSuffix: false })
     : null;
 
-  const allRows: Row[] = useMemo(() => {
+  // Named companies (sorted by volume). Companies the backend couldn't resolve
+  // (name === PENDING) are excluded here and rolled up into a single Unknown row below.
+  const namedRows: Row[] = useMemo(() => {
     return (data?.items ?? [])
+      .filter(item => item.companyName && item.companyName !== PENDING)
       .map(item => ({
         companyId: item.companyId,
-        name: item.companyName || 'Unknown',
+        name: item.companyName,
+        // buckets are mutually exclusive and sum to assigned (server-computed live)
         assigned: item.assignedCount,
+        overdue: item.overdueCount,
+        inProgress: item.inProgressCount,
         completed: item.completedCount,
       }))
-      .sort((a, b) => b.assigned + b.completed - (a.assigned + a.completed));
+      .sort((a, b) => b.assigned - a.assigned);
   }, [data]);
 
-  const rows = useMemo(
-    () => (settings.companyId ? allRows.filter(r => r.companyId === settings.companyId) : allRows),
-    [allRows, settings.companyId],
-  );
+  // One de-emphasized aggregate row (companyId '' = sentinel: non-clickable, greyed).
+  const allRows: Row[] = useMemo(() => {
+    const pending = (data?.items ?? []).filter(
+      item => !item.companyName || item.companyName === PENDING,
+    );
+    if (pending.length === 0) return namedRows;
+    const unknown: Row = {
+      companyId: '',
+      name: t('externalSummary.unknownCompany', { count: pending.length }),
+      assigned: pending.reduce((s, i) => s + i.assignedCount, 0),
+      overdue: pending.reduce((s, i) => s + i.overdueCount, 0),
+      inProgress: pending.reduce((s, i) => s + i.inProgressCount, 0),
+      completed: pending.reduce((s, i) => s + i.completedCount, 0),
+    };
+    return [...namedRows, unknown];
+  }, [data, namedRows, t]);
+
+  const hidden = useMemo(() => new Set(settings.hidden ?? []), [settings.hidden]);
+
+  const toggleSeries = (key: SeriesKey) => {
+    const next = new Set(hidden);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    updateSettings(WIDGET_ID, { hidden: Array.from(next) } as ExternalTaskSettings);
+  };
+
+  // Zero out hidden segments, then sort by the visible sum (desc) so the ranking follows
+  // whatever series are currently shown. The Unknown aggregate stays pinned to the bottom.
+  const rows: ChartRow[] = useMemo(() => {
+    const filtered = settings.companyId
+      ? allRows.filter(r => r.companyId === settings.companyId)
+      : allRows;
+    return filtered
+      .map(r => {
+        const barOverdue = hidden.has('overdue') ? 0 : r.overdue;
+        const barInProgress = hidden.has('inProgress') ? 0 : r.inProgress;
+        const barCompleted = hidden.has('completed') ? 0 : r.completed;
+        return {
+          ...r,
+          barOverdue,
+          barInProgress,
+          barCompleted,
+          visible: barOverdue + barInProgress + barCompleted,
+        };
+      })
+      .sort((a, b) => {
+        if (!a.companyId !== !b.companyId) return a.companyId ? -1 : 1;
+        return b.visible - a.visible;
+      });
+  }, [allRows, settings.companyId, hidden]);
 
   const handlePeriodChange = (key: PeriodPresetKey, custom?: { from: Date; to: Date }) => {
     updateSettings(WIDGET_ID, {
@@ -148,13 +273,13 @@ function ExternalTaskSummaryWidget() {
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
           <div className="flex flex-col gap-1 min-w-0">
             <div className="flex items-center gap-3">
-              <h3 className="font-semibold text-gray-800 truncate">{t('externalSummary.title')}</h3>
+              <h3 className="font-semibold text-gray-800">{t('externalSummary.title')}</h3>
               <PeriodSelect value={presetKey} custom={customRange} onChange={handlePeriodChange} />
             </div>
             <WidgetDateRangeBadge from={range.from} to={range.to} />
           </div>
           <div className="flex items-center gap-2">
-            {allRows.length > 0 && (
+            {namedRows.length > 0 && (
               <select
                 value={settings.companyId ?? ''}
                 onChange={e =>
@@ -164,7 +289,7 @@ function ExternalTaskSummaryWidget() {
                 aria-label={t('externalSummary.aria.filterByCompany')}
               >
                 <option value="">{t('externalSummary.allCompanies')}</option>
-                {allRows.map(r => (
+                {namedRows.map(r => (
                   <option key={r.companyId} value={r.companyId}>
                     {r.name}
                   </option>
@@ -245,7 +370,7 @@ function ExternalTaskSummaryWidget() {
                 <BarChart
                   data={rows}
                   layout="vertical"
-                  margin={{ top: 4, right: 24, left: 8, bottom: 0 }}
+                  margin={{ top: 4, right: 40, left: 0, bottom: 0 }}
                   barCategoryGap={8}
                 >
                   <CartesianGrid horizontal={false} stroke="#f3f4f6" />
@@ -258,42 +383,110 @@ function ExternalTaskSummaryWidget() {
                   <YAxis
                     type="category"
                     dataKey="name"
-                    width={140}
+                    width={118}
                     tick={{ fontSize: 12, fill: '#4b5563' }}
                     axisLine={false}
                     tickLine={false}
                   />
-                  <Tooltip
-                    cursor={{ fill: 'rgba(0,0,0,0.03)' }}
-                    contentStyle={{
-                      borderRadius: 8,
-                      border: '1px solid #e5e7eb',
-                      fontSize: 12,
-                    }}
-                  />
-                  <Legend iconType="circle" wrapperStyle={{ fontSize: 12, paddingTop: 8 }} />
+                  <Tooltip cursor={{ fill: 'rgba(0,0,0,0.03)' }} content={<SummaryTooltip />} />
+                  {/* Single stack whose total length == the visible sum. Segments are
+                      mutually exclusive; overdue anchors at the axis origin so every company
+                      shares a baseline, then in-progress, then completed. Hidden series are
+                      zeroed (bar* keys). The Unknown aggregate (companyId '') is greyed via
+                      per-row Cell opacity and is not clickable. `completed` carries the total
+                      label at the stack's right end (minPointSize keeps the cap present even
+                      when its value is 0; the cap is made invisible in that case). */}
                   <Bar
-                    dataKey="assigned"
-                    name={t('externalSummary.chart.assigned')}
-                    fill="#3b82f6"
+                    dataKey="barOverdue"
+                    stackId="assigned"
+                    fill={SEGMENT_COLORS.overdue}
                     cursor="pointer"
                     onClick={data => {
-                      const row = (data as { payload?: Row }).payload;
-                      if (row) drillDown(row.companyId);
+                      const row = (data as { payload?: ChartRow }).payload;
+                      if (row?.companyId) drillDown(row.companyId);
                     }}
-                  />
+                  >
+                    {rows.map(r => (
+                      <Cell
+                        key={r.companyId || r.name}
+                        fill={SEGMENT_COLORS.overdue}
+                        fillOpacity={r.companyId ? 1 : 0.35}
+                      />
+                    ))}
+                  </Bar>
                   <Bar
-                    dataKey="completed"
-                    name={t('externalSummary.chart.completed')}
-                    fill="#10b981"
+                    dataKey="barInProgress"
+                    stackId="assigned"
+                    fill={SEGMENT_COLORS.inProgress}
                     cursor="pointer"
                     onClick={data => {
-                      const row = (data as { payload?: Row }).payload;
-                      if (row) drillDown(row.companyId);
+                      const row = (data as { payload?: ChartRow }).payload;
+                      if (row?.companyId) drillDown(row.companyId);
                     }}
-                  />
+                  >
+                    {rows.map(r => (
+                      <Cell
+                        key={r.companyId || r.name}
+                        fill={SEGMENT_COLORS.inProgress}
+                        fillOpacity={r.companyId ? 1 : 0.35}
+                      />
+                    ))}
+                  </Bar>
+                  <Bar
+                    dataKey="barCompleted"
+                    stackId="assigned"
+                    fill={SEGMENT_COLORS.completed}
+                    cursor="pointer"
+                    minPointSize={2}
+                    onClick={data => {
+                      const row = (data as { payload?: ChartRow }).payload;
+                      if (row?.companyId) drillDown(row.companyId);
+                    }}
+                  >
+                    {rows.map(r => (
+                      <Cell
+                        key={r.companyId || r.name}
+                        fill={SEGMENT_COLORS.completed}
+                        fillOpacity={r.barCompleted === 0 ? 0 : r.companyId ? 1 : 0.35}
+                      />
+                    ))}
+                    <LabelList
+                      dataKey="visible"
+                      position="right"
+                      style={{ fontSize: 11, fill: '#6b7280', fontWeight: 600 }}
+                    />
+                  </Bar>
                 </BarChart>
               </ResponsiveContainer>
+
+              {/* Clickable legend — toggle a series off to drop it from the bars and
+                  re-rank companies by the remaining (visible) total. */}
+              <div className="flex items-center justify-center gap-4 pt-3 flex-wrap">
+                {SERIES.map(s => {
+                  const isHidden = hidden.has(s.key);
+                  return (
+                    <button
+                      key={s.key}
+                      type="button"
+                      onClick={() => toggleSeries(s.key)}
+                      aria-pressed={!isHidden}
+                      aria-label={t('externalSummary.aria.toggleSeries', { label: t(s.labelKey) })}
+                      className="flex items-center gap-1.5 text-xs"
+                    >
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full"
+                        style={{
+                          backgroundColor: isHidden ? 'transparent' : s.color,
+                          boxShadow: `inset 0 0 0 2px ${s.color}`,
+                        }}
+                      />
+                      <span className={isHidden ? 'text-gray-400 line-through' : 'text-gray-600'}>
+                        {t(s.labelKey)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
             </>
           )}
         </div>

--- a/src/features/dashboard/components/ExternalTaskSummaryWidget.tsx
+++ b/src/features/dashboard/components/ExternalTaskSummaryWidget.tsx
@@ -252,6 +252,7 @@ function ExternalTaskSummaryWidget() {
       from: undefined,
       to: undefined,
       companyId: undefined,
+      hidden: undefined, // restore legend series toggled off, so reset is a true default view
     });
     setMenuOpen(false);
   };

--- a/src/features/dashboard/components/ProgressSummaryWidget.tsx
+++ b/src/features/dashboard/components/ProgressSummaryWidget.tsx
@@ -9,6 +9,7 @@ import Icon from '@shared/components/Icon';
 import { Skeleton } from '@shared/components/Skeleton';
 import WidgetWrapper from './WidgetWrapper';
 import PeriodSelect from './PeriodSelect';
+import SegmentSelect from './SegmentSelect';
 import WidgetError from './WidgetError';
 import WidgetDateRangeBadge from './WidgetDateRangeBadge';
 import { useAppraisalStatusSummary, type AppraisalStatusSummaryFilters } from '../api';
@@ -284,16 +285,13 @@ function ProgressSummaryWidget() {
                         className="text-sm border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                     </label>
-                    <label className="flex flex-col gap-1 text-xs text-gray-500">
+                    <div className="flex flex-col gap-1 text-xs text-gray-500">
                       {t('progressSummary.filters.bankingSegment')}
-                      <input
-                        type="text"
-                        value={bankingInput}
-                        onChange={e => setBankingInput(e.target.value)}
-                        placeholder={t('progressSummary.filters.bankingPlaceholder')}
-                        className="text-sm border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      <SegmentSelect
+                        value={bankingInput || undefined}
+                        onChange={seg => setBankingInput(seg ?? '')}
                       />
-                    </label>
+                    </div>
                     <div className="flex items-center justify-between gap-2 pt-1">
                       <label className="inline-flex items-center gap-2 text-xs text-gray-600">
                         <input

--- a/src/features/dashboard/components/QuotationTaskSummaryWidget.tsx
+++ b/src/features/dashboard/components/QuotationTaskSummaryWidget.tsx
@@ -77,13 +77,13 @@ function QuotationTaskSummaryWidget() {
         {isError ? (
           <WidgetError message={t('quotationSummary.error')} onRetry={() => refetch()} />
         ) : isLoading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {Array.from({ length: 3 }).map((_, i) => (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
               <KpiCardSkeleton key={i} />
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <KpiCard
               label={t('quotationSummary.pendingCreation')}
               count={data?.pendingQuotationCreation ?? 0}
@@ -113,6 +113,16 @@ function QuotationTaskSummaryWidget() {
               cardBg="bg-white"
               openListLabel={t('quotationSummary.openList')}
               onClick={() => navigate('/quotations?status=PendingRmSelection')}
+            />
+            <KpiCard
+              label={t('quotationSummary.pendingApprovals')}
+              count={data?.pendingApprovals ?? 0}
+              icon="file-circle-check"
+              iconColor="text-amber-500"
+              iconBg="bg-amber-50"
+              cardBg="bg-white"
+              openListLabel={t('quotationSummary.openList')}
+              onClick={() => navigate('/tasks?activityId=fee-appointment-approval')}
             />
           </div>
         )}

--- a/src/features/dashboard/components/SegmentSelect.tsx
+++ b/src/features/dashboard/components/SegmentSelect.tsx
@@ -65,7 +65,7 @@ function SegmentSelect({ value, onChange }: SegmentSelectProps) {
                   type="button"
                   onClick={() => select(seg)}
                   className={`w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 ${
-                    value === seg ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
+                    known === seg ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
                   }`}
                 >
                   {t(`segment.${seg}`)}

--- a/src/features/dashboard/components/SegmentSelect.tsx
+++ b/src/features/dashboard/components/SegmentSelect.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '@shared/components/Icon';
+
+// Canonical banking segments. NULL/blank segments are treated as IBG server-side.
+const SEGMENTS = ['Retail', 'IBG'] as const;
+
+type SegmentSelectProps = {
+  value?: string; // undefined = all segments
+  onChange: (segment?: string) => void;
+};
+
+function SegmentSelect({ value, onChange }: SegmentSelectProps) {
+  const { t } = useTranslation('dashboard');
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const select = (segment?: string) => {
+    onChange(segment);
+    setOpen(false);
+  };
+
+  // Resolve case-insensitively to a known segment (handles stale/lowercase persisted
+  // values); fall back to the raw value rather than leaking a missing i18n key.
+  const known = SEGMENTS.find(s => s.toLowerCase() === value?.toLowerCase());
+  const label = !value ? t('segment.all') : known ? t(`segment.${known}`) : value;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="inline-flex items-center gap-1 text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        <span>{label}</span>
+        <Icon name="chevron-down" style="solid" className="size-3 text-gray-400" />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 z-20 mt-1 w-40 rounded-lg border border-gray-200 bg-white shadow-lg p-2">
+          <ul className="text-sm">
+            <li>
+              <button
+                type="button"
+                onClick={() => select(undefined)}
+                className={`w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 ${
+                  !value ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
+                }`}
+              >
+                {t('segment.all')}
+              </button>
+            </li>
+            {SEGMENTS.map(seg => (
+              <li key={seg}>
+                <button
+                  type="button"
+                  onClick={() => select(seg)}
+                  className={`w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 ${
+                    value === seg ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
+                  }`}
+                >
+                  {t(`segment.${seg}`)}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SegmentSelect;

--- a/src/features/dashboard/components/TotalAppraisalsWidget.tsx
+++ b/src/features/dashboard/components/TotalAppraisalsWidget.tsx
@@ -26,6 +26,8 @@ import Modal from '@shared/components/Modal';
 import { Skeleton } from '@shared/components/Skeleton';
 import WidgetWrapper from './WidgetWrapper';
 import PeriodSelect from './PeriodSelect';
+import SegmentSelect from './SegmentSelect';
+import ChartTooltip from './ChartTooltip';
 import WidgetError from './WidgetError';
 import WidgetDateRangeBadge from './WidgetDateRangeBadge';
 import { formatDistanceToNow } from 'date-fns';
@@ -49,15 +51,49 @@ type DataPoint = {
   bucketTo: string;
 };
 
+type WidgetMode = 'overview' | 'byType';
+type MetricKey = 'created' | 'completed';
+
 type TotalAppraisalsSettings = {
   period?: PeriodPresetKey;
   from?: string;
   to?: string;
+  mode?: WidgetMode;
+  metric?: MetricKey;
+  bankingSegment?: string;
+  hidden?: string[]; // series keys toggled off via the legend
 };
 
 const WIDGET_ID = 'total-appraisals';
 
 const EMPTY_SETTINGS: TotalAppraisalsSettings = Object.freeze({}) as TotalAppraisalsSettings;
+
+// Known appraisal types get a stable order + color and a translated label.
+// Must match the backend AppraisalType values (Modules/Appraisal .../AppraisalTypes.cs).
+// The actual set plotted is derived from the API response (see typeKeys) so any
+// extra/legacy value still shows (as an "extra" series) rather than being silently
+// dropped — otherwise the by-type totals would not reconcile with overview.
+const APPRAISAL_TYPES = ['New', 'ReAppraisal', 'Progressive', 'PreAppraisal'] as const;
+type AppraisalTypeKey = (typeof APPRAISAL_TYPES)[number];
+const TYPE_COLORS: Record<AppraisalTypeKey, string> = {
+  New: '#3b82f6',
+  ReAppraisal: '#10b981',
+  Progressive: '#f59e0b',
+  PreAppraisal: '#8b5cf6',
+};
+// Colors for any type not in APPRAISAL_TYPES (assigned by position).
+const EXTRA_TYPE_COLORS = ['#ec4899', '#14b8a6', '#a855f7', '#f97316', '#64748b'];
+
+const isKnownType = (type: string): type is AppraisalTypeKey =>
+  (APPRAISAL_TYPES as readonly string[]).includes(type);
+
+type ByTypePoint = {
+  key: string;
+  label: string;
+  bucketFrom: string;
+  bucketTo: string;
+  counts: Record<string, number>;
+};
 
 const getBackendPeriod = (granularity: 'day' | 'week' | 'month'): string =>
   granularity === 'day' ? 'daily' : granularity === 'week' ? 'daily' : 'monthly';
@@ -151,11 +187,38 @@ function TotalAppraisalsWidget() {
     [presetKey, today, customRange],
   );
   const apiPeriod = getBackendPeriod(range.granularity);
+  const mode: WidgetMode = settings.mode ?? 'overview';
+  const metric: MetricKey = settings.metric ?? 'created';
+  const bankingSegment = settings.bankingSegment;
+  const isByType = mode === 'byType';
 
-  const current = useAppraisalCounts(apiPeriod, toIsoDate(range.from), toIsoDate(range.to));
-  const prior = useAppraisalCounts(apiPeriod, toIsoDate(range.prevFrom), toIsoDate(range.prevTo));
-  const updatedLabel = current.dataUpdatedAt
-    ? formatDistanceToNow(current.dataUpdatedAt, { addSuffix: false })
+  const current = useAppraisalCounts(
+    apiPeriod,
+    toIsoDate(range.from),
+    toIsoDate(range.to),
+    false,
+    bankingSegment,
+    { enabled: !isByType },
+  );
+  const prior = useAppraisalCounts(
+    apiPeriod,
+    toIsoDate(range.prevFrom),
+    toIsoDate(range.prevTo),
+    false,
+    bankingSegment,
+    { enabled: !isByType },
+  );
+  const byType = useAppraisalCounts(
+    apiPeriod,
+    toIsoDate(range.from),
+    toIsoDate(range.to),
+    true,
+    bankingSegment,
+    { enabled: isByType },
+  );
+  const activeUpdatedAt = isByType ? byType.dataUpdatedAt : current.dataUpdatedAt;
+  const updatedLabel = activeUpdatedAt
+    ? formatDistanceToNow(activeUpdatedAt, { addSuffix: false })
     : null;
 
   const data: DataPoint[] = useMemo(() => {
@@ -238,8 +301,113 @@ function TotalAppraisalsWidget() {
     [totals.created, range.from, range.to, today],
   );
 
-  const isLoading = current.isLoading || prior.isLoading;
-  const isError = current.isError || prior.isError;
+  // Series to plot: the four known types (stable order) plus any extra/legacy
+  // AppraisalType returned by the API, so by-type totals always reconcile with
+  // overview instead of silently dropping unknown values.
+  const typeKeys = useMemo(() => {
+    const extra: string[] = [];
+    for (const item of byType.data?.items ?? []) {
+      const type = item.appraisalType;
+      if (type && !isKnownType(type) && !extra.includes(type)) extra.push(type);
+    }
+    extra.sort();
+    return [...APPRAISAL_TYPES, ...extra];
+  }, [byType.data]);
+
+  const byTypeData: ByTypePoint[] = useMemo(() => {
+    const buckets = buildBuckets(range.from, range.to, range.granularity);
+    const map = new Map<string, Record<string, number>>();
+    for (const item of byType.data?.items ?? []) {
+      if (!item.period || !item.appraisalType) continue;
+      const d = parseApiPeriod(item.period);
+      if (!d) continue;
+      const k = bucketKeyForDate(d, range.granularity);
+      const row = map.get(k) ?? {};
+      const value = metric === 'created' ? item.createdCount : item.completedCount;
+      row[item.appraisalType] = (row[item.appraisalType] ?? 0) + value;
+      map.set(k, row);
+    }
+    return buckets.map(b => {
+      const row = map.get(b.key) ?? {};
+      const counts: Record<string, number> = {};
+      for (const type of typeKeys) counts[type] = row[type] ?? 0;
+      return {
+        key: b.key,
+        label: b.label,
+        bucketFrom: toIsoDate(b.bucketFrom),
+        bucketTo: toIsoDate(b.bucketTo),
+        counts,
+      };
+    });
+  }, [byType.data, range, metric, typeKeys]);
+
+  const byTypeTotals = useMemo(() => {
+    const totals: Record<string, number> = Object.fromEntries(typeKeys.map(type => [type, 0]));
+    for (const point of byTypeData) {
+      for (const type of typeKeys) totals[type] += point.counts[type];
+    }
+    return totals;
+  }, [byTypeData, typeKeys]);
+
+  const typeColor = (type: string, idx: number): string =>
+    isKnownType(type) ? TYPE_COLORS[type] : EXTRA_TYPE_COLORS[idx % EXTRA_TYPE_COLORS.length];
+  const typeLabel = (type: string): string =>
+    isKnownType(type) ? t(`totalAppraisals.types.${type}`) : type;
+
+  // Legend-driven series hiding. Overview and by-type use distinct, stable keys
+  // (prevCreated/created/completed vs. appraisal-type names) so one persisted set serves both.
+  const hidden = useMemo(() => new Set(settings.hidden ?? []), [settings.hidden]);
+  const toggleSeries = (key: string) => {
+    const next = new Set(hidden);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    updateSettings(WIDGET_ID, { hidden: Array.from(next) } as TotalAppraisalsSettings);
+  };
+
+  const overviewSeries = [
+    { key: 'prevCreated', color: '#f59e0b', label: t('totalAppraisals.chart.prevPeriod') },
+    { key: 'created', color: '#3b82f6', label: t('totalAppraisals.chart.created') },
+    { key: 'completed', color: '#10b981', label: t('totalAppraisals.chart.completed') },
+  ];
+  const byTypeSeries = typeKeys.map((type, idx) => ({
+    key: type,
+    color: typeColor(type, idx),
+    label: typeLabel(type),
+  }));
+
+  // Clickable legend (recharts `content`) — stays inside the chart so it also shows in
+  // the expanded modal; items remain visible when hidden so they can be toggled back.
+  const renderLineLegend = (series: { key: string; color: string; label: string }[]) => (
+    <div className="flex items-center justify-center gap-4 pt-2 flex-wrap">
+      {series.map(s => {
+        const isHidden = hidden.has(s.key);
+        return (
+          <button
+            key={s.key}
+            type="button"
+            onClick={() => toggleSeries(s.key)}
+            aria-pressed={!isHidden}
+            aria-label={t('totalAppraisals.aria.toggleSeries', { label: s.label })}
+            className="flex items-center gap-1.5 text-xs"
+          >
+            <span
+              className="inline-block w-2.5 h-2.5 rounded-full"
+              style={{
+                backgroundColor: isHidden ? 'transparent' : s.color,
+                boxShadow: `inset 0 0 0 2px ${s.color}`,
+              }}
+            />
+            <span className={isHidden ? 'text-gray-400 line-through' : 'text-gray-600'}>
+              {s.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const isLoading = isByType ? byType.isLoading : current.isLoading || prior.isLoading;
+  const isError = isByType ? byType.isError : current.isError || prior.isError;
 
   const handlePeriodChange = (key: PeriodPresetKey, custom?: { from: Date; to: Date }) => {
     updateSettings(WIDGET_ID, {
@@ -255,19 +423,40 @@ function TotalAppraisalsWidget() {
   };
 
   const handleReset = () => {
-    updateSettings(WIDGET_ID, { period: undefined, from: undefined, to: undefined });
+    updateSettings(WIDGET_ID, {
+      period: undefined,
+      from: undefined,
+      to: undefined,
+      mode: undefined,
+      metric: undefined,
+      bankingSegment: undefined,
+    });
     setMenuOpen(false);
+  };
+
+  const handleModeChange = (next: WidgetMode) => {
+    updateSettings(WIDGET_ID, { mode: next } as TotalAppraisalsSettings);
+  };
+
+  const handleMetricChange = (next: MetricKey) => {
+    updateSettings(WIDGET_ID, { metric: next } as TotalAppraisalsSettings);
+  };
+
+  const handleSegmentChange = (segment?: string) => {
+    updateSettings(WIDGET_ID, { bankingSegment: segment } as TotalAppraisalsSettings);
+  };
+
+  const navigateToBucket = (bucketFrom?: string, bucketTo?: string) => {
+    if (!bucketFrom || !bucketTo) return;
+    const params = new URLSearchParams({ createdFrom: bucketFrom, createdTo: bucketTo });
+    // Close expand modal before navigating so it doesn't sit open behind the new route.
+    setExpanded(false);
+    navigate(`/appraisals/list?${params}`);
   };
 
   const handleDotClick = (point: DataPoint | undefined) => {
     if (!point) return;
-    const params = new URLSearchParams({
-      createdFrom: point.bucketFrom,
-      createdTo: point.bucketTo,
-    });
-    // Close expand modal before navigating so it doesn't sit open behind the new route.
-    setExpanded(false);
-    navigate(`/appraisals/list?${params}`);
+    navigateToBucket(point.bucketFrom, point.bucketTo);
   };
 
   const renderKpi = (
@@ -321,15 +510,8 @@ function TotalAppraisalsWidget() {
           tickLine={false}
           width={40}
         />
-        <Tooltip
-          cursor={{ stroke: '#e5e7eb' }}
-          contentStyle={{
-            borderRadius: 8,
-            border: '1px solid #e5e7eb',
-            fontSize: 12,
-          }}
-        />
-        <Legend iconType="circle" wrapperStyle={{ fontSize: 12, paddingTop: 8 }} />
+        <Tooltip cursor={{ stroke: '#e5e7eb' }} content={<ChartTooltip />} />
+        <Legend content={() => renderLineLegend(overviewSeries)} />
         <Line
           type="monotone"
           dataKey="prevCreated"
@@ -339,6 +521,7 @@ function TotalAppraisalsWidget() {
           strokeDasharray="4 4"
           dot={false}
           activeDot={false}
+          hide={hidden.has('prevCreated')}
         />
         <Line
           type="monotone"
@@ -348,6 +531,7 @@ function TotalAppraisalsWidget() {
           strokeWidth={2.5}
           dot={{ r: 3, fill: '#3b82f6' }}
           activeDot={{ r: 5, cursor: 'pointer' }}
+          hide={hidden.has('created')}
         />
         <Line
           type="monotone"
@@ -357,7 +541,48 @@ function TotalAppraisalsWidget() {
           strokeWidth={2.5}
           dot={{ r: 3, fill: '#10b981' }}
           activeDot={{ r: 5, cursor: 'pointer' }}
+          hide={hidden.has('completed')}
         />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+
+  const byTypeChartContent = (
+    <ResponsiveContainer width="100%" height="100%">
+      <ComposedChart
+        data={byTypeData}
+        margin={{ top: 10, right: 12, left: -16, bottom: 0 }}
+        onClick={state => {
+          const idx = state?.activeIndex;
+          if (typeof idx === 'number' && byTypeData[idx]) {
+            const p = byTypeData[idx];
+            navigateToBucket(p.bucketFrom, p.bucketTo);
+          }
+        }}
+      >
+        <CartesianGrid stroke="#f3f4f6" vertical={false} />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: '#9ca3af' }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} width={40} />
+        <Tooltip cursor={{ stroke: '#e5e7eb' }} content={<ChartTooltip />} />
+        <Legend content={() => renderLineLegend(byTypeSeries)} />
+        {typeKeys.map((type, idx) => (
+          <Line
+            key={type}
+            type="monotone"
+            dataKey={(p: ByTypePoint) => p.counts[type]}
+            name={typeLabel(type)}
+            stroke={typeColor(type, idx)}
+            strokeWidth={2}
+            dot={{ r: 2, fill: typeColor(type, idx) }}
+            activeDot={{ r: 5, cursor: 'pointer' }}
+            hide={hidden.has(type)}
+          />
+        ))}
       </ComposedChart>
     </ResponsiveContainer>
   );
@@ -368,9 +593,44 @@ function TotalAppraisalsWidget() {
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
           <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap">
               <h3 className="font-semibold text-gray-800">{t('totalAppraisals.title')}</h3>
               <PeriodSelect value={presetKey} custom={customRange} onChange={handlePeriodChange} />
+              <SegmentSelect value={bankingSegment} onChange={handleSegmentChange} />
+              <div className="inline-flex rounded-lg border border-gray-200 p-0.5 text-xs">
+                {(['overview', 'byType'] as const).map(m => (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => handleModeChange(m)}
+                    className={`px-2 py-1 rounded-md transition-colors ${
+                      mode === m
+                        ? 'bg-gray-100 text-gray-800 font-medium'
+                        : 'text-gray-500 hover:text-gray-700'
+                    }`}
+                  >
+                    {t(`totalAppraisals.mode.${m}`)}
+                  </button>
+                ))}
+              </div>
+              {isByType && (
+                <div className="inline-flex rounded-lg border border-gray-200 p-0.5 text-xs">
+                  {(['created', 'completed'] as const).map(mk => (
+                    <button
+                      key={mk}
+                      type="button"
+                      onClick={() => handleMetricChange(mk)}
+                      className={`px-2 py-1 rounded-md transition-colors ${
+                        metric === mk
+                          ? 'bg-gray-100 text-gray-800 font-medium'
+                          : 'text-gray-500 hover:text-gray-700'
+                      }`}
+                    >
+                      {t(`totalAppraisals.metric.${mk}`)}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
             <WidgetDateRangeBadge from={range.from} to={range.to} />
           </div>
@@ -445,24 +705,41 @@ function TotalAppraisalsWidget() {
             </div>
           ) : (
             <>
-              <div className="grid grid-cols-3 gap-4 mb-4">
-                {renderKpi(
-                  t('totalAppraisals.kpi.created'),
-                  totals.created.toLocaleString(),
-                  totals.createdYoY,
-                )}
-                {renderKpi(
-                  t('totalAppraisals.kpi.completed'),
-                  totals.completed.toLocaleString(),
-                  totals.completedYoY,
-                )}
-                {renderKpi(
-                  t('totalAppraisals.kpi.completionRate'),
-                  `${totals.completionRate.toFixed(1)}%`,
-                  totals.completionRateDeltaPp,
-                  true,
-                )}
-              </div>
+              {isByType ? (
+                <div className="flex flex-wrap gap-x-6 gap-y-2 mb-4">
+                  {typeKeys.map((type, idx) => (
+                    <div key={type} className="flex items-center gap-2">
+                      <span
+                        className="size-2.5 rounded-full"
+                        style={{ backgroundColor: typeColor(type, idx) }}
+                      />
+                      <span className="text-xs text-gray-500">{typeLabel(type)}</span>
+                      <span className="text-sm font-semibold text-gray-800 tabular-nums">
+                        {byTypeTotals[type].toLocaleString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="grid grid-cols-3 gap-4 mb-4">
+                  {renderKpi(
+                    t('totalAppraisals.kpi.created'),
+                    totals.created.toLocaleString(),
+                    totals.createdYoY,
+                  )}
+                  {renderKpi(
+                    t('totalAppraisals.kpi.completed'),
+                    totals.completed.toLocaleString(),
+                    totals.completedYoY,
+                  )}
+                  {renderKpi(
+                    t('totalAppraisals.kpi.completionRate'),
+                    `${totals.completionRate.toFixed(1)}%`,
+                    totals.completionRateDeltaPp,
+                    true,
+                  )}
+                </div>
+              )}
 
               {pace.isFutureRange && totals.created > 0 && (
                 <div className="mb-3 flex items-center gap-2 text-xs text-gray-500">
@@ -494,7 +771,15 @@ function TotalAppraisalsWidget() {
               )}
 
               <div className="h-56">
-                {data.every(d => d.created === 0 && d.completed === 0) ? (
+                {isByType ? (
+                  byTypeData.every(p => typeKeys.every(type => p.counts[type] === 0)) ? (
+                    <div className="h-full flex items-center justify-center text-sm text-gray-400">
+                      {t('totalAppraisals.noData')}
+                    </div>
+                  ) : (
+                    byTypeChartContent
+                  )
+                ) : data.every(d => d.created === 0 && d.completed === 0) ? (
                   <div className="h-full flex items-center justify-center text-sm text-gray-400">
                     {t('totalAppraisals.noData')}
                   </div>
@@ -514,39 +799,66 @@ function TotalAppraisalsWidget() {
         size="2xl"
       >
         <div className="space-y-4">
-          <div className="h-80">{chartContent}</div>
+          <div className="h-80">{isByType ? byTypeChartContent : chartContent}</div>
           <div className="overflow-auto max-h-72 border border-gray-100 rounded-lg">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
-                <tr>
-                  <th className="px-3 py-2 text-left">{t('totalAppraisals.table.period')}</th>
-                  <th className="px-3 py-2 text-right">{t('totalAppraisals.table.created')}</th>
-                  <th className="px-3 py-2 text-right">{t('totalAppraisals.table.completed')}</th>
-                  <th className="px-3 py-2 text-right">
-                    {t('totalAppraisals.table.completionPct')}
-                  </th>
-                  <th className="px-3 py-2 text-right">{t('totalAppraisals.table.prior')}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {data.map(d => {
-                  const rate = d.created > 0 ? (d.completed / d.created) * 100 : 0;
-                  return (
-                    <tr key={d.key} className="hover:bg-gray-50">
-                      <td className="px-3 py-2 text-gray-700">{d.label}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{d.created}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{d.completed}</td>
-                      <td className="px-3 py-2 text-right tabular-nums text-gray-500">
-                        {rate.toFixed(1)}%
-                      </td>
-                      <td className="px-3 py-2 text-right tabular-nums text-gray-400">
-                        {d.prevCreated}
-                      </td>
+            {isByType ? (
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
+                  <tr>
+                    <th className="px-3 py-2 text-left">{t('totalAppraisals.table.period')}</th>
+                    {typeKeys.map(type => (
+                      <th key={type} className="px-3 py-2 text-right">
+                        {typeLabel(type)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {byTypeData.map(p => (
+                    <tr key={p.key} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 text-gray-700">{p.label}</td>
+                      {typeKeys.map(type => (
+                        <td key={type} className="px-3 py-2 text-right tabular-nums">
+                          {p.counts[type]}
+                        </td>
+                      ))}
                     </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
+                  <tr>
+                    <th className="px-3 py-2 text-left">{t('totalAppraisals.table.period')}</th>
+                    <th className="px-3 py-2 text-right">{t('totalAppraisals.table.created')}</th>
+                    <th className="px-3 py-2 text-right">{t('totalAppraisals.table.completed')}</th>
+                    <th className="px-3 py-2 text-right">
+                      {t('totalAppraisals.table.completionPct')}
+                    </th>
+                    <th className="px-3 py-2 text-right">{t('totalAppraisals.table.prior')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {data.map(d => {
+                    const rate = d.created > 0 ? (d.completed / d.created) * 100 : 0;
+                    return (
+                      <tr key={d.key} className="hover:bg-gray-50">
+                        <td className="px-3 py-2 text-gray-700">{d.label}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{d.created}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{d.completed}</td>
+                        <td className="px-3 py-2 text-right tabular-nums text-gray-500">
+                          {rate.toFixed(1)}%
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums text-gray-400">
+                          {d.prevCreated}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
           </div>
           <p className="text-xs text-gray-500">
             {t('totalAppraisals.table.period')}: {format(range.from, 'd MMM yyyy')} –{' '}

--- a/src/features/dashboard/components/TotalAppraisalsWidget.tsx
+++ b/src/features/dashboard/components/TotalAppraisalsWidget.tsx
@@ -430,6 +430,7 @@ function TotalAppraisalsWidget() {
       mode: undefined,
       metric: undefined,
       bankingSegment: undefined,
+      hidden: undefined, // restore legend series toggled off, so reset is a true default view
     });
     setMenuOpen(false);
   };

--- a/src/features/dashboard/pages/CalendarPage.tsx
+++ b/src/features/dashboard/pages/CalendarPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { createPortal } from 'react-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   format,
@@ -15,12 +16,14 @@ import Icon from '@shared/components/Icon';
 import { Skeleton } from '@shared/components/Skeleton';
 import { useCalendarEvents } from '../api/hooks';
 import { useDashboardStore } from '../store';
-import type { CalendarItem, CalendarItemType, CalendarLinkEntityType } from '../api/types';
+import type {
+  CalendarDay,
+  CalendarItem,
+  CalendarItemType,
+  CalendarLinkEntityType,
+} from '../api/types';
 import { toIsoDate } from '../utils/periodPresets';
 import WidgetDateRangeBadge from '../components/WidgetDateRangeBadge';
-
-const THIS_YEAR = new Date().getFullYear();
-const YEAR_OPTIONS = Array.from({ length: 11 }, (_, i) => THIS_YEAR - 5 + i);
 
 type VisualCategory = 'meeting' | 'sla' | 'task';
 
@@ -58,19 +61,31 @@ function buildEntityUrl(entityType: CalendarLinkEntityType, entityId: string): s
 
 const dateKeyOf = (d: Date) => format(d, 'yyyy-MM-dd');
 
+// Navigate to a calendar entity while passing the calendar page as `returnPath`,
+// so the appraisal read-only shell's Exit button returns here instead of the
+// hardcoded /appraisals/search fallback.
+function useEntityNavigate() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  return (entityType: CalendarLinkEntityType, entityId: string) => {
+    const returnPath = location.pathname + location.search;
+    navigate(buildEntityUrl(entityType, entityId), { state: { returnPath } });
+  };
+}
+
 type EventItemProps = {
   item: CalendarItem;
   categoryLabel: (cat: VisualCategory) => string;
 };
 
 function EventItem({ item, categoryLabel }: EventItemProps) {
-  const navigate = useNavigate();
+  const goToEntity = useEntityNavigate();
   const cat = categoryOf(item);
   return (
     <button
       type="button"
       title={`${categoryLabel(cat)}${item.time ? ` at ${item.time.slice(0, 5)}` : ''}${item.appraisalNumber ? ` · ${item.appraisalNumber}` : ''} — ${item.title}`}
-      onClick={() => navigate(buildEntityUrl(item.linkEntityType, item.linkEntityId))}
+      onClick={() => goToEntity(item.linkEntityType, item.linkEntityId)}
       className={`w-full text-left text-[11px] leading-tight px-1.5 py-0.5 rounded border truncate ${CATEGORY_TEXT_CLASS[cat]} hover:brightness-95`}
     >
       {item.time && <span className="font-medium mr-1">{item.time.slice(0, 5)}</span>}
@@ -93,7 +108,7 @@ type DayViewProps = {
 };
 
 function DayView({ date, eventMap, isLoading, noEventsLabel, categoryLabel }: DayViewProps) {
-  const navigate = useNavigate();
+  const goToEntity = useEntityNavigate();
   const items = eventMap.get(dateKeyOf(date)) ?? [];
 
   return (
@@ -123,7 +138,7 @@ function DayView({ date, eventMap, isLoading, noEventsLabel, categoryLabel }: Da
                 <li key={i}>
                   <button
                     type="button"
-                    onClick={() => navigate(buildEntityUrl(item.linkEntityType, item.linkEntityId))}
+                    onClick={() => goToEntity(item.linkEntityType, item.linkEntityId)}
                     className="w-full flex items-start gap-3 p-3 rounded-xl border border-gray-100 hover:border-gray-200 hover:bg-gray-50 text-left transition-colors"
                   >
                     <span
@@ -242,6 +257,8 @@ type MonthViewProps = {
   today: Date;
   dayLabels: string[];
   categoryLabel: (cat: VisualCategory) => string;
+  eventsCountLabel: (n: number) => string;
+  closeLabel: string;
 };
 
 function MonthView({
@@ -251,8 +268,30 @@ function MonthView({
   today,
   dayLabels,
   categoryLabel,
+  eventsCountLabel,
+  closeLabel,
 }: MonthViewProps) {
-  const navigate = useNavigate();
+  const goToEntity = useEntityNavigate();
+  const [dayPopover, setDayPopover] = useState<{
+    date: Date;
+    items: CalendarItem[];
+    rect: DOMRect;
+  } | null>(null);
+
+  const openDay = (date: Date, dayItems: CalendarItem[], rect: DOMRect) => {
+    if (dayItems.length === 0) return;
+    setDayPopover({ date, items: dayItems, rect });
+  };
+
+  // Close the day popover on Escape.
+  useEffect(() => {
+    if (!dayPopover) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDayPopover(null);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [dayPopover]);
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
   const firstOfMonth = startOfMonth(currentDate);
@@ -283,7 +322,7 @@ function MonthView({
           </div>
         ))}
       </div>
-      <div className="flex-1 grid grid-cols-7 grid-rows-6 gap-1 min-h-0">
+      <div className="flex-1 grid grid-cols-7 auto-rows-[minmax(7rem,1fr)] gap-1 min-h-0 overflow-y-auto">
         {gridCells.map((cell, idx) => {
           const key = dateKeyOf(cell.date);
           const items = cell.inMonth ? (eventMap.get(key) ?? []) : [];
@@ -313,47 +352,489 @@ function MonthView({
                   <span className="text-[10px] text-gray-400 tabular-nums">{items.length}</span>
                 )}
               </div>
-              <div className="flex-1 px-1 pb-1 flex flex-col gap-0.5 overflow-hidden">
-                {isLoading && cell.inMonth ? (
-                  <>
-                    <Skeleton variant="rounded" height={14} />
-                    <Skeleton variant="rounded" height={14} />
-                  </>
-                ) : (
-                  visible.map((item, i) => {
-                    const cat = categoryOf(item);
-                    return (
-                      <button
-                        key={i}
-                        type="button"
-                        title={`${categoryLabel(cat)}${item.time ? ` at ${item.time.slice(0, 5)}` : ''}${item.appraisalNumber ? ` · ${item.appraisalNumber}` : ''} — ${item.title}`}
-                        onClick={() =>
-                          navigate(buildEntityUrl(item.linkEntityType, item.linkEntityId))
-                        }
-                        className={`text-left text-[11px] leading-tight px-1.5 py-0.5 rounded border truncate ${CATEGORY_TEXT_CLASS[cat]} hover:brightness-95`}
-                      >
-                        {item.time && (
-                          <span className="font-medium mr-1">{item.time.slice(0, 5)}</span>
-                        )}
-                        {item.appraisalNumber && (
-                          <span className="font-semibold mr-1 tabular-nums">
-                            {item.appraisalNumber}
+              <div className="flex-1 px-1 pb-1 flex flex-col gap-0.5 min-h-0">
+                <div className="flex-1 flex flex-col gap-0.5 overflow-hidden min-h-0">
+                  {isLoading && cell.inMonth ? (
+                    <>
+                      <Skeleton variant="rounded" height={14} />
+                      <Skeleton variant="rounded" height={14} />
+                    </>
+                  ) : (
+                    visible.map((item, i) => {
+                      const cat = categoryOf(item);
+                      return (
+                        <button
+                          key={i}
+                          type="button"
+                          title={`${categoryLabel(cat)}${item.time ? ` at ${item.time.slice(0, 5)}` : ''}${item.appraisalNumber ? ` · ${item.appraisalNumber}` : ''} — ${item.title}`}
+                          onClick={e => {
+                            e.stopPropagation();
+                            goToEntity(item.linkEntityType, item.linkEntityId);
+                          }}
+                          className={`shrink-0 text-left text-[11px] leading-tight px-1.5 py-0.5 rounded border truncate ${CATEGORY_TEXT_CLASS[cat]} hover:brightness-95`}
+                        >
+                          {item.time && (
+                            <span className="font-medium mr-1">{item.time.slice(0, 5)}</span>
+                          )}
+                          <span className="font-semibold tabular-nums">
+                            {item.appraisalNumber ?? item.title}
                           </span>
-                        )}
-                        {item.title}
-                      </button>
-                    );
-                  })
-                )}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
                 {hidden > 0 && (
-                  <span className="text-[10px] text-gray-400 px-1">+{hidden} more</span>
+                  <button
+                    type="button"
+                    onClick={e =>
+                      openDay(cell.date, items, e.currentTarget.getBoundingClientRect())
+                    }
+                    className="shrink-0 text-left text-[10px] text-gray-500 px-1 pt-0.5 font-medium hover:text-gray-700"
+                  >
+                    +{hidden} more
+                  </button>
                 )}
               </div>
             </div>
           );
         })}
       </div>
+
+      {dayPopover &&
+        createPortal(
+          <>
+            <div
+              className="fixed inset-0 z-40"
+              onClick={() => setDayPopover(null)}
+              aria-hidden="true"
+            />
+            <div
+              role="dialog"
+              className="fixed z-50 w-64 max-h-80 flex flex-col bg-white rounded-xl shadow-xl border border-gray-200 overflow-hidden"
+              style={{
+                left: Math.max(8, Math.min(dayPopover.rect.left, window.innerWidth - 256 - 8)),
+                top: Math.max(8, Math.min(dayPopover.rect.top, window.innerHeight - 320 - 8)),
+              }}
+            >
+              <div className="shrink-0 px-3 py-2 border-b border-gray-100 flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs font-semibold text-gray-800">
+                    {format(dayPopover.date, 'EEEE, d MMM yyyy')}
+                  </p>
+                  <p className="text-[11px] text-gray-400">
+                    {eventsCountLabel(dayPopover.items.length)}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setDayPopover(null)}
+                  aria-label={closeLabel}
+                  className="shrink-0 -mr-1 size-6 flex items-center justify-center rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                >
+                  <Icon name="xmark" style="solid" className="size-3" />
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto p-1.5 space-y-0.5">
+                {dayPopover.items.map((item, i) => {
+                  const cat = categoryOf(item);
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => {
+                        setDayPopover(null);
+                        goToEntity(item.linkEntityType, item.linkEntityId);
+                      }}
+                      className="w-full flex items-start gap-2 p-2 rounded-lg hover:bg-gray-50 text-left transition-colors group"
+                    >
+                      <span
+                        className={`mt-1 size-2 rounded-full shrink-0 ${CATEGORY_DOT_CLASS[cat]}`}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-gray-800 truncate">
+                          {item.appraisalNumber && (
+                            <span className="font-semibold tabular-nums mr-1">
+                              {item.appraisalNumber}
+                            </span>
+                          )}
+                          {item.title}
+                        </p>
+                        <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
+                          <span>{categoryLabel(cat)}</span>
+                          {item.time && (
+                            <>
+                              <span className="text-gray-300">·</span>
+                              <span>{item.time.slice(0, 5)}</span>
+                            </>
+                          )}
+                        </p>
+                      </div>
+                      <Icon
+                        name="arrow-right"
+                        style="solid"
+                        className="size-3 text-gray-300 mt-1 shrink-0 group-hover:text-gray-500"
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </>,
+          document.body,
+        )}
     </>
+  );
+}
+
+// ── Next 7 days panel ─────────────────────────────────────────────────────────
+
+type NextSevenDaysPanelProps = {
+  today: Date;
+  days: CalendarDay[];
+  isLoading: boolean;
+  categoryLabel: (cat: VisualCategory) => string;
+  title: string;
+  eventsCountLabel: (n: number) => string;
+  todayLabel: string;
+  emptyLabel: string;
+};
+
+function NextSevenDaysPanel({
+  today,
+  days,
+  isLoading,
+  categoryLabel,
+  title,
+  eventsCountLabel,
+  todayLabel,
+  emptyLabel,
+}: NextSevenDaysPanelProps) {
+  const goToEntity = useEntityNavigate();
+  const withEvents = days.filter(d => d.items.length > 0);
+  const total = withEvents.reduce((sum, d) => sum + d.items.length, 0);
+
+  return (
+    <aside className="hidden lg:flex flex-col w-80 shrink-0 bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="shrink-0 px-5 pt-5 pb-3 flex items-center justify-between border-b border-gray-50">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        {!isLoading && <span className="text-xs text-gray-400">{eventsCountLabel(total)}</span>}
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} variant="rounded" height={40} />
+            ))}
+          </div>
+        ) : total === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-2 text-center">
+            <div className="size-12 rounded-full bg-gray-50 border border-gray-100 flex items-center justify-center">
+              <Icon name="calendar-check" style="regular" className="size-5 text-gray-300" />
+            </div>
+            <p className="text-sm text-gray-400">{emptyLabel}</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {withEvents.map(day => {
+              const date = new Date(day.date);
+              const isToday = isSameDay(date, today);
+              return (
+                <div key={day.date}>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide mb-1.5">
+                    <span className={isToday ? 'text-blue-600' : 'text-gray-500'}>
+                      {isToday ? todayLabel : format(date, 'EEE, d MMM')}
+                    </span>
+                    {!isToday && (
+                      <span className="text-gray-300 font-normal"> {format(date, 'yyyy')}</span>
+                    )}
+                  </p>
+                  <ul className="space-y-1">
+                    {day.items.map((item, i) => {
+                      const cat = categoryOf(item);
+                      return (
+                        <li key={i}>
+                          <button
+                            type="button"
+                            onClick={() => goToEntity(item.linkEntityType, item.linkEntityId)}
+                            className="w-full flex items-start gap-2.5 p-2 rounded-lg hover:bg-gray-50 text-left transition-colors group"
+                          >
+                            <span
+                              className={`mt-1 size-2 rounded-full shrink-0 ${CATEGORY_DOT_CLASS[cat]}`}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm text-gray-800 truncate">
+                                {item.appraisalNumber && (
+                                  <span className="font-semibold tabular-nums mr-1">
+                                    {item.appraisalNumber}
+                                  </span>
+                                )}
+                                {item.title}
+                              </p>
+                              <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
+                                <span>{categoryLabel(cat)}</span>
+                                {item.time && (
+                                  <>
+                                    <span className="text-gray-300">·</span>
+                                    <span>{item.time.slice(0, 5)}</span>
+                                  </>
+                                )}
+                              </p>
+                            </div>
+                            <Icon
+                              name="arrow-right"
+                              style="solid"
+                              className="size-3 text-gray-300 mt-1 shrink-0 group-hover:text-gray-500"
+                            />
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+// ── Date picker (MS Teams-style dual pane) ───────────────────────────────────
+
+// Build a Monday-first 6-week grid (leading/trailing days from adjacent months).
+function buildMiniGrid(viewDate: Date): Date[] {
+  const first = startOfMonth(viewDate);
+  const firstWeekday = (first.getDay() + 6) % 7;
+  const cells: Date[] = [];
+  for (let i = firstWeekday; i > 0; i--) cells.push(addDays(first, -i));
+  const daysInMonth = endOfMonth(viewDate).getDate();
+  for (let i = 0; i < daysInMonth; i++) cells.push(addDays(first, i));
+  while (cells.length % 7 !== 0) cells.push(addDays(cells[cells.length - 1], 1));
+  return cells;
+}
+
+type TeamsDatePickerProps = {
+  mode: 'day' | 'week' | 'month';
+  selected: Date;
+  today: Date;
+  dayLabels: string[]; // Monday-first; first letter is shown
+  months: string[]; // full month names (left-pane header)
+  monthsShort: string[]; // short month names (right-pane grid)
+  onSelect: (d: Date) => void; // final pick — updates the date and closes the popover
+  onNavigate: (d: Date) => void; // live navigation (Month mode) — updates without closing
+  todayLabel: string;
+  prevAria: string;
+  nextAria: string;
+};
+
+// A two-pane picker like MS Teams: a day grid on the left (hidden in Month mode)
+// and a year + month quick-jump on the right. Picking a month in Month mode
+// commits immediately; in Day/Week mode it just navigates the left grid.
+function TeamsDatePicker({
+  mode,
+  selected,
+  today,
+  dayLabels,
+  months,
+  monthsShort,
+  onSelect,
+  onNavigate,
+  todayLabel,
+  prevAria,
+  nextAria,
+}: TeamsDatePickerProps) {
+  const [viewDate, setViewDate] = useState(() => startOfMonth(selected));
+  const cells = useMemo(() => buildMiniGrid(viewDate), [viewDate]);
+  const viewMonth = viewDate.getMonth();
+  const viewYear = viewDate.getFullYear();
+  const showDays = mode !== 'month';
+
+  // Move the visible view. In Month mode this also updates the calendar live, so a
+  // year/month change takes effect immediately without needing a second month click.
+  const goToView = (d: Date) => {
+    setViewDate(d);
+    if (mode === 'month') onNavigate(d);
+  };
+
+  // Right pane can flip to a 12-year grid when the year header is clicked.
+  const [yearGridOpen, setYearGridOpen] = useState(false);
+  const [yearBase, setYearBase] = useState(() => viewYear - 6);
+  const openYearGrid = () => {
+    setYearBase(viewYear - 6);
+    setYearGridOpen(v => !v);
+  };
+
+  // In Week mode the whole week of the selected date is highlighted as a band.
+  const selWeekStart = startOfWeek(selected, { weekStartsOn: 1 });
+  const selWeekEnd = endOfWeek(selected, { weekStartsOn: 1 });
+
+  const arrowBtn =
+    'size-6 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600';
+
+  return (
+    <div className="flex">
+      {showDays && (
+        <div className="w-60 p-3 border-r border-gray-100">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-semibold text-gray-800">
+              {months[viewMonth]} {viewYear}
+            </span>
+            <div className="flex items-center gap-0.5">
+              <button
+                type="button"
+                aria-label={prevAria}
+                onClick={() => setViewDate(new Date(viewYear, viewMonth - 1, 1))}
+                className={arrowBtn}
+              >
+                <Icon name="chevron-up" style="solid" className="size-3" />
+              </button>
+              <button
+                type="button"
+                aria-label={nextAria}
+                onClick={() => setViewDate(new Date(viewYear, viewMonth + 1, 1))}
+                className={arrowBtn}
+              >
+                <Icon name="chevron-down" style="solid" className="size-3" />
+              </button>
+            </div>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 mb-1">
+            {dayLabels.map((d, i) => (
+              <div key={i} className="text-center text-[11px] font-medium text-gray-400">
+                {d.charAt(0)}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-0.5">
+            {cells.map((d, i) => {
+              const inMonth = d.getMonth() === viewMonth;
+              const isToday = isSameDay(d, today);
+              const inWeekBand = mode === 'week' && d >= selWeekStart && d <= selWeekEnd;
+              const isSel = mode === 'day' && isSameDay(d, selected);
+
+              let cls: string;
+              if (isSel) cls = 'bg-blue-600 text-white font-semibold';
+              else if (inWeekBand && isToday) cls = 'bg-blue-600 text-white font-semibold';
+              else if (inWeekBand) cls = 'bg-blue-100 text-blue-700';
+              else if (isToday)
+                cls = 'ring-1 ring-blue-500 text-blue-600 font-semibold hover:bg-blue-50';
+              else if (inMonth) cls = 'text-gray-700 hover:bg-gray-100';
+              else cls = 'text-gray-300 hover:bg-gray-50';
+
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => onSelect(d)}
+                  className={`h-8 rounded-lg text-sm flex items-center justify-center ${cls}`}
+                >
+                  {d.getDate()}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="w-56 p-3 flex flex-col">
+        <div className="flex items-center justify-between mb-3">
+          <button
+            type="button"
+            onClick={openYearGrid}
+            className="text-sm font-semibold text-gray-800 hover:text-blue-600 rounded px-1 -ml-1"
+          >
+            {yearGridOpen ? `${yearBase}–${yearBase + 11}` : viewYear}
+          </button>
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              aria-label={prevAria}
+              onClick={() =>
+                yearGridOpen
+                  ? setYearBase(b => b - 12)
+                  : goToView(new Date(viewYear - 1, viewMonth, 1))
+              }
+              className={arrowBtn}
+            >
+              <Icon name="chevron-up" style="solid" className="size-3" />
+            </button>
+            <button
+              type="button"
+              aria-label={nextAria}
+              onClick={() =>
+                yearGridOpen
+                  ? setYearBase(b => b + 12)
+                  : goToView(new Date(viewYear + 1, viewMonth, 1))
+              }
+              className={arrowBtn}
+            >
+              <Icon name="chevron-down" style="solid" className="size-3" />
+            </button>
+          </div>
+        </div>
+        {yearGridOpen ? (
+          <div className="grid grid-cols-4 gap-x-1 gap-y-3">
+            {Array.from({ length: 12 }, (_, k) => yearBase + k).map(y => (
+              <button
+                key={y}
+                type="button"
+                onClick={() => {
+                  goToView(new Date(y, viewMonth, 1));
+                  setYearGridOpen(false);
+                }}
+                className={`h-9 rounded-lg text-sm flex items-center justify-center ${
+                  y === viewYear
+                    ? 'bg-blue-600 text-white font-semibold'
+                    : 'text-gray-700 hover:bg-gray-100'
+                }`}
+              >
+                {y}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-4 gap-x-1 gap-y-3">
+            {monthsShort.map((m, mi) => {
+              // Highlight the month currently shown by the left grid so it follows navigation.
+              const isViewMonth = mi === viewMonth;
+              return (
+                <button
+                  key={mi}
+                  type="button"
+                  onClick={() =>
+                    mode === 'month'
+                      ? onSelect(new Date(viewYear, mi, 1))
+                      : goToView(new Date(viewYear, mi, 1))
+                  }
+                  className={`h-9 rounded-lg text-sm flex items-center justify-center ${
+                    isViewMonth
+                      ? 'bg-blue-600 text-white font-semibold'
+                      : 'text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  {m}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <div className="mt-auto pt-3 text-right">
+          <button
+            type="button"
+            onClick={() =>
+              onSelect(
+                mode === 'month' ? new Date(today.getFullYear(), today.getMonth(), 1) : today,
+              )
+            }
+            className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+          >
+            {todayLabel}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -365,6 +846,8 @@ function CalendarPage() {
   const [topicFilter, setTopicFilter] = useState<CalendarItemType[]>([]);
   const [topicOpen, setTopicOpen] = useState(false);
   const topicRef = useRef<HTMLDivElement>(null);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
+  const datePickerRef = useRef<HTMLDivElement>(null);
 
   const today = useMemo(() => new Date(), []);
 
@@ -390,6 +873,12 @@ function CalendarPage() {
   const MONTHS = Array.from({ length: 12 }, (_, i) =>
     t(
       `calendar.months.${i}` as `calendar.months.${0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11}`,
+    ),
+  );
+
+  const MONTHS_SHORT = Array.from({ length: 12 }, (_, i) =>
+    t(
+      `calendar.monthsShort.${i}` as `calendar.monthsShort.${0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11}`,
     ),
   );
 
@@ -419,9 +908,32 @@ function CalendarPage() {
     return () => document.removeEventListener('mousedown', handler);
   }, [topicOpen]);
 
+  useEffect(() => {
+    if (!datePickerOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (datePickerRef.current && !datePickerRef.current.contains(e.target as Node))
+        setDatePickerOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [datePickerOpen]);
+
   // Derive from/to based on view mode
   const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 });
   const weekEnd = endOfWeek(currentDate, { weekStartsOn: 1 });
+
+  // Trigger label adapts to the active view: full date / week range / month + year.
+  const pickerLabel = (() => {
+    if (viewMode === 'day') return `${MONTHS[month]} ${currentDate.getDate()}, ${year}`;
+    if (viewMode === 'month') return `${MONTHS[month]} ${year}`;
+    const s = weekStart;
+    const e = weekEnd;
+    if (s.getMonth() === e.getMonth())
+      return `${MONTHS[s.getMonth()]} ${s.getDate()}–${e.getDate()}, ${s.getFullYear()}`;
+    if (s.getFullYear() === e.getFullYear())
+      return `${MONTHS_SHORT[s.getMonth()]} ${s.getDate()} – ${MONTHS_SHORT[e.getMonth()]} ${e.getDate()}, ${s.getFullYear()}`;
+    return `${MONTHS_SHORT[s.getMonth()]} ${s.getDate()}, ${s.getFullYear()} – ${MONTHS_SHORT[e.getMonth()]} ${e.getDate()}, ${e.getFullYear()}`;
+  })();
 
   const { from, to } = useMemo(() => {
     if (viewMode === 'day') {
@@ -443,6 +955,19 @@ function CalendarPage() {
     for (const d of data?.items ?? []) map.set(d.date, d.items);
     return map;
   }, [data]);
+
+  // "Next 7 days" sidebar (Month view only) — a rolling window from today, driven
+  // by the same hook and honouring the active Topics filter.
+  const upcomingRange = useMemo(
+    () => ({ from: toIsoDate(today), to: toIsoDate(addDays(today, 6)) }),
+    [today],
+  );
+  const { data: upcomingData, isLoading: upcomingLoading } = useCalendarEvents({
+    from: upcomingRange.from,
+    to: upcomingRange.to,
+    types: activeTypes,
+  });
+  const upcomingDays: CalendarDay[] = upcomingData?.items ?? [];
 
   const goToday = () => setCurrentDate(new Date());
 
@@ -522,36 +1047,37 @@ function CalendarPage() {
             <Icon name="chevron-left" style="solid" className="size-4" />
           </button>
 
-          {/* Month/year jump picker */}
-          <div className="flex items-center gap-1.5">
-            <select
-              value={month}
-              onChange={e =>
-                setCurrentDate(new Date(year, Number(e.target.value), currentDate.getDate()))
-              }
-              className="text-sm font-semibold text-gray-800 border border-gray-200 rounded-lg px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
-              aria-label={t('calendar.aria.selectMonth')}
+          {/* Date picker (MS Teams-style dual pane), adapts per view */}
+          <div ref={datePickerRef} className="relative">
+            <button
+              type="button"
+              onClick={() => setDatePickerOpen(o => !o)}
+              className="inline-flex items-center gap-2 text-sm font-semibold text-gray-800 border border-gray-200 rounded-lg px-3 py-1.5 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label={t('calendar.aria.selectDate')}
             >
-              {MONTHS.map((m, i) => (
-                <option key={i} value={i}>
-                  {m}
-                </option>
-              ))}
-            </select>
-            <select
-              value={year}
-              onChange={e =>
-                setCurrentDate(new Date(Number(e.target.value), month, currentDate.getDate()))
-              }
-              className="text-sm font-semibold text-gray-800 border border-gray-200 rounded-lg px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
-              aria-label={t('calendar.aria.selectYear')}
-            >
-              {YEAR_OPTIONS.map(y => (
-                <option key={y} value={y}>
-                  {y}
-                </option>
-              ))}
-            </select>
+              {pickerLabel}
+              <Icon name="chevron-down" style="solid" className="size-3 text-gray-400" />
+            </button>
+            {datePickerOpen && (
+              <div className="absolute left-0 z-20 mt-1 rounded-lg border border-gray-200 bg-white shadow-xl">
+                <TeamsDatePicker
+                  mode={viewMode}
+                  selected={currentDate}
+                  today={today}
+                  dayLabels={DAYS}
+                  months={MONTHS}
+                  monthsShort={MONTHS_SHORT}
+                  todayLabel={t('calendarPage.today')}
+                  onSelect={d => {
+                    setCurrentDate(d);
+                    setDatePickerOpen(false);
+                  }}
+                  onNavigate={d => setCurrentDate(d)}
+                  prevAria={t('calendar.aria.previous')}
+                  nextAria={t('calendar.aria.next')}
+                />
+              </div>
+            )}
           </div>
 
           <button
@@ -627,58 +1153,75 @@ function CalendarPage() {
           </button>
         </div>
       ) : (
-        <div className="flex-1 min-h-0 bg-white rounded-2xl shadow-sm border border-gray-100 p-5 flex flex-col">
-          {viewMode === 'day' && (
-            <DayView
-              date={currentDate}
-              eventMap={eventMap}
-              isLoading={isLoading}
-              noEventsLabel={t('calendarPage.noEventsForDay')}
-              categoryLabel={cat => CATEGORY_LABEL[cat]}
-            />
-          )}
-          {viewMode === 'week' && (
-            <WeekView
-              weekStart={weekStart}
-              eventMap={eventMap}
-              isLoading={isLoading}
-              today={today}
-              dayLabels={DAYS}
-              categoryLabel={cat => CATEGORY_LABEL[cat]}
-            />
-          )}
-          {viewMode === 'month' && (
-            <MonthView
-              currentDate={currentDate}
-              eventMap={eventMap}
-              isLoading={isLoading}
-              today={today}
-              dayLabels={DAYS}
-              categoryLabel={cat => CATEGORY_LABEL[cat]}
-            />
-          )}
+        <div className="flex-1 min-h-0 flex gap-4">
+          <div className="flex-1 min-h-0 bg-white rounded-2xl shadow-sm border border-gray-100 p-5 flex flex-col">
+            {viewMode === 'day' && (
+              <DayView
+                date={currentDate}
+                eventMap={eventMap}
+                isLoading={isLoading}
+                noEventsLabel={t('calendarPage.noEventsForDay')}
+                categoryLabel={cat => CATEGORY_LABEL[cat]}
+              />
+            )}
+            {viewMode === 'week' && (
+              <WeekView
+                weekStart={weekStart}
+                eventMap={eventMap}
+                isLoading={isLoading}
+                today={today}
+                dayLabels={DAYS}
+                categoryLabel={cat => CATEGORY_LABEL[cat]}
+              />
+            )}
+            {viewMode === 'month' && (
+              <MonthView
+                currentDate={currentDate}
+                eventMap={eventMap}
+                isLoading={isLoading}
+                today={today}
+                dayLabels={DAYS}
+                categoryLabel={cat => CATEGORY_LABEL[cat]}
+                eventsCountLabel={n => t('calendarPage.eventsCount', { count: n })}
+                closeLabel={t('calendarPage.close')}
+              />
+            )}
 
-          {/* Legend */}
-          <div className="mt-3 flex items-center gap-4 shrink-0 flex-wrap">
-            <div className="flex items-center gap-1.5">
-              <span className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.meeting}`} />
-              <span className="text-xs text-gray-500">{t('calendar.legend.meeting')}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="inline-flex items-center -space-x-1">
-                <span
-                  className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.task} ring-1 ring-white`}
-                />
-                <span
-                  className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.sla} ring-1 ring-white`}
-                />
-              </span>
-              <span className="text-xs text-gray-500">
-                {t('calendar.legend.taskDue')}{' '}
-                <span className="text-gray-400">({t('calendar.legend.slaCritical')})</span>
-              </span>
+            {/* Legend */}
+            <div className="mt-3 flex items-center gap-4 shrink-0 flex-wrap">
+              <div className="flex items-center gap-1.5">
+                <span className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.meeting}`} />
+                <span className="text-xs text-gray-500">{t('calendar.legend.meeting')}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="inline-flex items-center -space-x-1">
+                  <span
+                    className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.task} ring-1 ring-white`}
+                  />
+                  <span
+                    className={`w-2.5 h-2.5 rounded-full ${CATEGORY_DOT_CLASS.sla} ring-1 ring-white`}
+                  />
+                </span>
+                <span className="text-xs text-gray-500">
+                  {t('calendar.legend.taskDue')}{' '}
+                  <span className="text-gray-400">({t('calendar.legend.slaCritical')})</span>
+                </span>
+              </div>
             </div>
           </div>
+
+          {viewMode === 'month' && (
+            <NextSevenDaysPanel
+              today={today}
+              days={upcomingDays}
+              isLoading={upcomingLoading}
+              categoryLabel={cat => CATEGORY_LABEL[cat]}
+              title={t('calendarPage.next7Days')}
+              eventsCountLabel={n => t('calendarPage.eventsCount', { count: n })}
+              todayLabel={t('calendarPage.todayGroupLabel')}
+              emptyLabel={t('calendarPage.noUpcoming')}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/features/dashboard/pages/CalendarPage.tsx
+++ b/src/features/dashboard/pages/CalendarPage.tsx
@@ -411,6 +411,8 @@ function MonthView({
             />
             <div
               role="dialog"
+              aria-modal="true"
+              aria-labelledby="day-popover-title"
               className="fixed z-50 w-64 max-h-80 flex flex-col bg-white rounded-xl shadow-xl border border-gray-200 overflow-hidden"
               style={{
                 left: Math.max(8, Math.min(dayPopover.rect.left, window.innerWidth - 256 - 8)),
@@ -419,7 +421,7 @@ function MonthView({
             >
               <div className="shrink-0 px-3 py-2 border-b border-gray-100 flex items-start justify-between gap-2">
                 <div>
-                  <p className="text-xs font-semibold text-gray-800">
+                  <p id="day-popover-title" className="text-xs font-semibold text-gray-800">
                     {format(dayPopover.date, 'EEEE, d MMM yyyy')}
                   </p>
                   <p className="text-[11px] text-gray-400">

--- a/src/features/dashboard/store.ts
+++ b/src/features/dashboard/store.ts
@@ -33,10 +33,14 @@ type DashboardStore = {
 
 // Merge persisted widgets with DEFAULT_WIDGETS to include any new widgets
 const mergeWidgets = (persistedWidgets: Widget[]): Widget[] => {
-  const existingIds = new Set(persistedWidgets.map(w => w.id));
+  // Drop any persisted widget whose type is no longer known (e.g. a removed
+  // widget type). Otherwise WIDGET_CONFIGS[type] lookups below (and in
+  // canPlaceInSidebar) would be undefined and crash the dashboard.
+  const knownWidgets = persistedWidgets.filter(w => WIDGET_CONFIGS[w.type]);
+  const existingIds = new Set(knownWidgets.map(w => w.id));
   const newWidgets = DEFAULT_WIDGETS.filter(w => !existingIds.has(w.id));
   // Ensure all widgets have position and settings fields
-  const updatedWidgets = persistedWidgets.map(w => ({
+  const updatedWidgets = knownWidgets.map(w => ({
     ...w,
     position: w.position || (canPlaceInSidebar(w.type) ? 'sidebar' : 'main'),
     settings: w.settings ?? {},

--- a/src/features/task/components/ActivityTaskTable.tsx
+++ b/src/features/task/components/ActivityTaskTable.tsx
@@ -10,7 +10,7 @@ import PoolTaskListPage from '../pages/PoolTaskListPage';
 import { useGetTaskCounts, useGetTasks, useGetTasksForKanban } from '../api';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import type { GroupByField, Task, TaskFilterParams, TaskListResponse } from '../types';
-import { columnDefs, getActivityColumnConfig, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
+import { columnDefs, getActivityColumnConfig, DEFAULT_CONFIG, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
 import Icon from '@/shared/components/Icon';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
@@ -100,6 +100,11 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
     'task-columns-' + activityId,
     columnConfig,
   );
+
+  // Pool tab column layout — own key so it persists independently, dropdown rendered
+  // inline in the pool toolbar (parity with the personal tab).
+  const poolCols = useColumnVisibility('task-columns-pool', DEFAULT_CONFIG);
+  const poolWidths = useColumnWidths('task-columns-pool', DEFAULT_CONFIG);
 
   const tableRef = useRef<HTMLTableElement>(null);
 
@@ -366,6 +371,18 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
                 </span>
               )}
             </button>
+
+            {/* Columns */}
+            <div className="mb-2">
+              <ColumnVisibilityDropdown
+                orderedColumns={poolCols.orderedColumns}
+                hidden={poolCols.hidden}
+                alwaysVisible={poolCols.alwaysVisible}
+                onToggle={poolCols.toggleColumn}
+                onReorder={poolCols.reorderColumns}
+                onReset={() => { poolCols.resetToDefault(); poolWidths.resetWidths(); }}
+              />
+            </div>
           </>
         )}
 
@@ -527,6 +544,9 @@ export function ActivityTaskTable({ activityId, title, description }: ActivityTa
             activityId={activityId}
             externalSearch={debouncedPoolSearch}
             externalFilters={poolFilters}
+            visibleColumns={poolCols.visibleColumns}
+            colWidths={poolWidths.widths}
+            onColWidthChange={poolWidths.setWidth}
           />
         </>
       )}

--- a/src/features/task/config/columnDefs.tsx
+++ b/src/features/task/config/columnDefs.tsx
@@ -11,15 +11,6 @@ import { DateCell } from '@features/common/monitoring/components/DateCell';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-const formatDate = (dateString?: string | null): string => {
-  if (!dateString) return '-';
-  try {
-    return format(new Date(dateString), 'dd/MM/yyyy');
-  } catch {
-    return dateString;
-  }
-};
-
 const AVATAR_COLORS = [
   'bg-blue-100 text-blue-700',
   'bg-emerald-100 text-emerald-700',
@@ -64,39 +55,65 @@ function PersonCell({ name }: { name: string | null | undefined }) {
 function DueDateCell({
   dateString,
   slaStatus,
+  slaDurationHours,
 }: {
   dateString: string | null | undefined;
   slaStatus: string | null;
+  slaDurationHours?: number | null;
 }) {
-  if (!dateString) return <>-</>;
+  // Independent of dateString: an appointment-anchored task can have a known
+  // SLA budget before a due date is computed.
+  const durationChip =
+    slaDurationHours != null ? (
+      <span className="text-xs text-gray-400 mt-0.5">{slaDurationHours}h</span>
+    ) : null;
+
+  if (!dateString) {
+    if (!durationChip) return <>-</>;
+    return (
+      <div className="flex flex-col">
+        <span>-</span>
+        {durationChip}
+      </div>
+    );
+  }
   try {
     const formatted = format(new Date(dateString), 'dd/MM/yyyy');
     // Drive icon/color from the backend slaStatus so this cell agrees with the
     // SLA Status badge and the row tint (proportional 75%-of-window rule), rather
     // than a fixed client-side day threshold.
     const bucket = bucketForSlaStatus(slaStatus);
+    let dateLine: ReactNode;
     if (bucket === 'breached')
-      return (
+      dateLine = (
         <span className="inline-flex items-center gap-1 text-red-600 font-medium text-sm">
           <Icon style="solid" name="circle-exclamation" className="size-3 flex-shrink-0" />
           {formatted}
         </span>
       );
-    if (bucket === 'atRisk')
-      return (
+    else if (bucket === 'atRisk')
+      dateLine = (
         <span className="inline-flex items-center gap-1 text-amber-600 font-medium text-sm">
           <Icon style="solid" name="clock" className="size-3 flex-shrink-0" />
           {formatted}
         </span>
       );
-    if (bucket === 'healthy')
-      return (
+    else if (bucket === 'healthy')
+      dateLine = (
         <span className="inline-flex items-center gap-1 text-emerald-600 font-medium text-sm">
           <Icon style="solid" name="circle-check" className="size-3 flex-shrink-0" />
           {formatted}
         </span>
       );
-    return <>{formatted}</>;
+    else dateLine = <>{formatted}</>;
+
+    if (!durationChip) return dateLine;
+    return (
+      <div className="flex flex-col">
+        {dateLine}
+        {durationChip}
+      </div>
+    );
   } catch {
     return <>{dateString}</>;
   }
@@ -124,21 +141,6 @@ function HoursCell({
     else cls = 'text-emerald-600';
   }
   return <span className={`text-sm ${cls}`}>{label}</span>;
-}
-
-function AppointmentCell({ dateString }: { dateString: string | null | undefined }) {
-  if (!dateString) return <>-</>;
-  try {
-    const date = new Date(dateString);
-    return (
-      <div className="flex items-center gap-1.5 min-w-0">
-        <Icon style="regular" name="calendar" className="size-3 text-gray-400 flex-shrink-0" />
-        <span className="text-sm">{format(date, 'dd/MM/yyyy HH:mm')}</span>
-      </div>
-    );
-  } catch {
-    return <>{dateString}</>;
-  }
 }
 
 // ── Column definitions ─────────────────────────────────────────────────────
@@ -247,13 +249,13 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
     label: 'Appointment Date',
     sortField: 'appointmentDateTime',
     width: 150,
-    render: task => <AppointmentCell dateString={task.appointmentDateTime} />,
+    render: task => <DateCell value={task.appointmentDateTime} withTime withAgo />,
   },
   requestedAt: {
     label: 'Requested At',
     sortField: 'RequestedAt',
-    width: 140,
-    render: task => formatDate(task.requestedAt),
+    width: 150,
+    render: task => <DateCell value={task.requestedAt} withTime withAgo />,
   },
   requestedBy: {
     label: 'Requested By',
@@ -261,16 +263,15 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
     render: task => <PersonCell name={task.requestedByName ?? task.requestedBy} />,
   },
   reportReceivedAt: {
-    label: 'Report Received At',
-    sortField: 'ReportReceivedAt',
+    label: 'Report Received Date',
     width: 150,
-    render: task => formatDate(task.reportReceivedAt),
+    render: task => <DateCell value={task.reportReceivedAt} withTime withAgo />,
   },
   requestReceivedDate: {
     label: 'Request Received Date',
     sortField: 'requestReceivedDate',
     width: 150,
-    render: task => <AppointmentCell dateString={task.requestReceivedDate} />,
+    render: task => <DateCell value={task.requestReceivedDate} withTime withAgo />,
   },
   internalFollowupStaff: {
     label: 'Internal Followup Staff',
@@ -306,7 +307,13 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
     label: 'SLA Due',
     sortField: 'dueAt',
     width: 140,
-    render: task => <DueDateCell dateString={task.dueAt} slaStatus={task.slaStatus} />,
+    render: task => (
+      <DueDateCell
+        dateString={task.dueAt}
+        slaStatus={task.slaStatus}
+        slaDurationHours={task.slaDurationHours}
+      />
+    ),
   },
   elapsedHours: {
     label: 'Elapsed (hrs)',
@@ -361,7 +368,6 @@ const DEFAULT_COLUMNS: ColumnKey[] = [
   'reportReceivedAt',
   'internalFollowupStaff',
   'appraiser',
-  'requestReceivedDate',
   'assignedDate',
   'movement',
   'dueAt',

--- a/src/features/task/config/columnDefs.tsx
+++ b/src/features/task/config/columnDefs.tsx
@@ -264,6 +264,7 @@ export const columnDefs: Record<ColumnKey, ColumnDef> = {
   },
   reportReceivedAt: {
     label: 'Report Received Date',
+    sortField: 'ReportReceivedAt',
     width: 150,
     render: task => <DateCell value={task.reportReceivedAt} withTime withAgo />,
   },

--- a/src/features/task/pages/PoolTaskListPage.tsx
+++ b/src/features/task/pages/PoolTaskListPage.tsx
@@ -402,17 +402,22 @@ function PoolTaskListPage({
               )}
             </button>
 
-            <ColumnVisibilityDropdown
-              orderedColumns={internalCols.orderedColumns}
-              hidden={internalCols.hidden}
-              alwaysVisible={internalCols.alwaysVisible}
-              onToggle={internalCols.toggleColumn}
-              onReorder={internalCols.reorderColumns}
-              onReset={() => {
-                internalCols.resetToDefault();
-                internalWidths.resetWidths();
-              }}
-            />
+            {/* Only render our own column dropdown when the layout is unmanaged. When embedded
+                (TaskListingPage/ActivityTaskTable) the columns are controlled via props and the
+                parent owns the dropdown — rendering it here would duplicate a non-functional one. */}
+            {propVisibleColumns === undefined && (
+              <ColumnVisibilityDropdown
+                orderedColumns={internalCols.orderedColumns}
+                hidden={internalCols.hidden}
+                alwaysVisible={internalCols.alwaysVisible}
+                onToggle={internalCols.toggleColumn}
+                onReorder={internalCols.reorderColumns}
+                onReset={() => {
+                  internalCols.resetToDefault();
+                  internalWidths.resetWidths();
+                }}
+              />
+            )}
           </div>
 
           {activeFilterChips.length > 0 && (

--- a/src/features/task/pages/PoolTaskListPage.tsx
+++ b/src/features/task/pages/PoolTaskListPage.tsx
@@ -14,28 +14,16 @@ import { useWorkflowHub } from '../hooks/useWorkflowHub';
 import Icon from '@/shared/components/Icon';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
-import { columnDefs, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
+import { columnDefs, DEFAULT_CONFIG, MIN_COLUMN_WIDTH, MAX_AUTOFIT_WIDTH } from '../config/columnDefs';
 import type { ColumnKey } from '../config/columnDefs';
 import { useColumnWidths } from '../hooks/useColumnWidths';
+import { useColumnVisibility } from '../hooks/useColumnVisibility';
 import { ColumnResizeHandle } from '../components/ColumnResizeHandle';
+import { ColumnVisibilityDropdown } from '../components/ColumnVisibilityDropdown';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import { TaskFilterDialog } from '../components/TaskFilterDialog';
 
 type SortDirection = 'asc' | 'desc';
-
-const POOL_COLUMNS = [
-  'appraisalNumber',
-  'customerName',
-  'taskType',
-  'purpose',
-  'propertyType',
-  'status',
-  'assignedDate',
-  'dueAt',
-  'slaStatus',
-  'movement',
-  'priority',
-] as const;
 
 const FILTER_LABELS: Record<keyof TaskFilterParams, string> = {
   appraisalNumber: 'Appraisal No.',
@@ -112,9 +100,23 @@ interface PoolTaskListPageProps {
   externalSearch?: string;
   externalFilters?: TaskFilterParams;
   onCountChange?: (count: number) => void;
+  // Column layout — supplied by the parent so the columns dropdown can live inline in
+  // the parent toolbar (single shared source). Falls back to internal state when the
+  // page is rendered standalone (uncontrolled).
+  visibleColumns?: ColumnKey[];
+  colWidths?: Record<string, number>;
+  onColWidthChange?: (key: ColumnKey, px: number) => void;
 }
 
-function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCountChange }: PoolTaskListPageProps) {
+function PoolTaskListPage({
+  activityId,
+  externalSearch,
+  externalFilters,
+  onCountChange,
+  visibleColumns: propVisibleColumns,
+  colWidths: propColWidths,
+  onColWidthChange,
+}: PoolTaskListPageProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const currentUsername = useAuthStore(s => s.user?.username);
@@ -167,20 +169,22 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCount
   const pendingTaskIdRef = useRef<string | null>(null);
   const [openMenuTaskId, setOpenMenuTaskId] = useState<string | null>(null);
 
-  // Column widths
-  const poolColumnConfig = useMemo(
-    () => ({ columns: [...POOL_COLUMNS] as ColumnKey[], stickyColumn: 'appraisalNumber' as const }),
-    [],
-  );
-  const { widths: colWidths, setWidth: setColWidth } = useColumnWidths(
-    'task-columns-pool',
-    poolColumnConfig,
-  );
+  // Column visibility / order (show-hide + drag reorder), persisted per-tab.
+  // Same DEFAULT_CONFIG as My Task so default headers match; own storage key so
+  // customization stays independent. When a parent controls the layout (embedded
+  // in the task listing / activity toolbar), it owns this state and passes the
+  // resolved values in as props — these internal hooks are the standalone fallback.
+  const internalCols = useColumnVisibility('task-columns-pool', DEFAULT_CONFIG);
+  const internalWidths = useColumnWidths('task-columns-pool', DEFAULT_CONFIG);
+
+  const visibleColumns = propVisibleColumns ?? internalCols.visibleColumns;
+  const colWidths = propColWidths ?? internalWidths.widths;
+  const setColWidth = onColWidthChange ?? internalWidths.setWidth;
   const tableRef = useRef<HTMLTableElement>(null);
   const ACTIONS_COL_WIDTH = 40; // w-10 = 2.5rem = 40px
   const totalTableWidth = useMemo(
-    () => POOL_COLUMNS.reduce((sum, k) => sum + colWidths[k], 0) + ACTIONS_COL_WIDTH,
-    [colWidths],
+    () => visibleColumns.reduce((sum, k) => sum + colWidths[k], 0) + ACTIONS_COL_WIDTH,
+    [visibleColumns, colWidths],
   );
   const getAutoFitWidth = useCallback(
     (_key: string, colIndex: number): (() => number | null) =>
@@ -397,6 +401,18 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCount
                 </span>
               )}
             </button>
+
+            <ColumnVisibilityDropdown
+              orderedColumns={internalCols.orderedColumns}
+              hidden={internalCols.hidden}
+              alwaysVisible={internalCols.alwaysVisible}
+              onToggle={internalCols.toggleColumn}
+              onReorder={internalCols.reorderColumns}
+              onReset={() => {
+                internalCols.resetToDefault();
+                internalWidths.resetWidths();
+              }}
+            />
           </div>
 
           {activeFilterChips.length > 0 && (
@@ -442,19 +458,19 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCount
             style={{ width: totalTableWidth }}
           >
             <colgroup>
-              {POOL_COLUMNS.map(key => (
+              {visibleColumns.map(key => (
                 <col key={key} style={{ width: colWidths[key] }} />
               ))}
               <col style={{ width: ACTIONS_COL_WIDTH }} />
             </colgroup>
             <thead className="sticky top-0 z-20">
               <tr className="bg-gray-50 border-b border-gray-200">
-                {POOL_COLUMNS.map((key, colIndex) => {
+                {visibleColumns.map((key, colIndex) => {
                   const col = columnDefs[key];
                   const isActive = sortField === col.sortField;
                   const base =
                     'relative px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap select-none bg-gray-50';
-                  const isSticky = key === 'appraisalNumber';
+                  const isSticky = key === DEFAULT_CONFIG.stickyColumn;
                   const thClass = isSticky
                     ? `${base} sticky left-0 z-30 cursor-pointer hover:text-gray-600 after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
                     : col.sortField
@@ -487,10 +503,10 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCount
             </thead>
             <tbody className="divide-y divide-gray-100">
               {isLoading ? (
-                <TableRowSkeleton columns={POOL_COLUMNS.map(() => ({ width: 'w-24' }))} rows={8} />
+                <TableRowSkeleton columns={visibleColumns.map(() => ({ width: 'w-24' }))} rows={8} />
               ) : tasks.length === 0 ? (
                 <tr>
-                  <td colSpan={POOL_COLUMNS.length + 2} className="py-24">
+                  <td colSpan={visibleColumns.length + 2} className="py-24">
                     <div className="flex flex-col items-center gap-4">
                       <div className="size-16 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center">
                         <Icon style="regular" name="inbox" className="size-7 text-gray-300" />
@@ -537,9 +553,9 @@ function PoolTaskListPage({ activityId, externalSearch, externalFilters, onCount
                             : `hover:bg-gray-50 ${getRowVariantClasses(bucketForSlaStatus(task.slaStatus))}`
                       }`}
                     >
-                      {POOL_COLUMNS.map(key => {
+                      {visibleColumns.map(key => {
                         const col = columnDefs[key];
-                        const isSticky = key === 'appraisalNumber';
+                        const isSticky = key === DEFAULT_CONFIG.stickyColumn;
                         const tdClass = isSticky
                           ? `${isLockedBySelf ? 'bg-blue-50' : isLockedByOther ? 'bg-amber-50' : 'bg-white group-hover:bg-gray-50'} transition-colors sticky left-0 z-10 px-3 py-1.5 overflow-hidden whitespace-nowrap after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-gray-200`
                           : (col.tdClassName ?? 'px-3 py-1.5 text-gray-600 text-xs overflow-hidden whitespace-nowrap');

--- a/src/features/task/pages/TaskListingPage.tsx
+++ b/src/features/task/pages/TaskListingPage.tsx
@@ -114,6 +114,11 @@ function TaskListingPage() {
     DEFAULT_CONFIG,
   );
 
+  // Pool tab column layout — its own key so it persists independently of My Task, but
+  // the dropdown renders inline in the pool toolbar (parity with the personal tab).
+  const poolCols = useColumnVisibility('task-columns-pool', DEFAULT_CONFIG);
+  const poolWidths = useColumnWidths('task-columns-pool', DEFAULT_CONFIG);
+
   const tableRef = useRef<HTMLTableElement>(null);
 
   const ACTIONS_COL_WIDTH = 32; // w-8 = 2rem = 32px
@@ -434,6 +439,18 @@ function TaskListingPage() {
                 </span>
               )}
             </button>
+
+            {/* Columns */}
+            <div className="mb-2">
+              <ColumnVisibilityDropdown
+                orderedColumns={poolCols.orderedColumns}
+                hidden={poolCols.hidden}
+                alwaysVisible={poolCols.alwaysVisible}
+                onToggle={poolCols.toggleColumn}
+                onReorder={poolCols.reorderColumns}
+                onReset={() => { poolCols.resetToDefault(); poolWidths.resetWidths(); }}
+              />
+            </div>
           </>
         )}
 
@@ -596,6 +613,9 @@ function TaskListingPage() {
             externalSearch={debouncedPoolSearch}
             externalFilters={poolFilters}
             onCountChange={setPoolTotalCount}
+            visibleColumns={poolCols.visibleColumns}
+            colWidths={poolWidths.widths}
+            onColWidthChange={poolWidths.setWidth}
           />
         </>
       )}

--- a/src/features/task/types/index.ts
+++ b/src/features/task/types/index.ts
@@ -116,6 +116,7 @@ export interface Task {
   priority: string | null;
   dueAt: string | null;
   slaStatus: string | null;
+  slaDurationHours: number | null;
   elapsedHours: number | null;
   remainingHours: number | null;
   // New fields added to backend DTO

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -46,6 +46,11 @@
     "customTo": "To",
     "apply": "Apply"
   },
+  "segment": {
+    "all": "All Segments",
+    "Retail": "Retail",
+    "IBG": "IBG"
+  },
   "taskSummary": {
     "title": "Task Summary",
     "notStarted": "Not Started",
@@ -98,6 +103,20 @@
       "created": "Created",
       "completed": "Completed"
     },
+    "mode": {
+      "overview": "Overview",
+      "byType": "By Type"
+    },
+    "metric": {
+      "created": "Created",
+      "completed": "Completed"
+    },
+    "types": {
+      "New": "New",
+      "ReAppraisal": "Re-Appraisal",
+      "Progressive": "Progressive",
+      "PreAppraisal": "Pre-Appraisal"
+    },
     "table": {
       "period": "Period",
       "created": "Created",
@@ -108,7 +127,8 @@
     "rangeInfo": "Range: {{from}} – {{to}} · {{buckets}} bucket{{bucketPlural}} · {{days}} days",
     "aria": {
       "expand": "Expand widget",
-      "menu": "Widget menu"
+      "menu": "Widget menu",
+      "toggleSeries": "Toggle {{label}}"
     },
     "menu": {
       "refresh": "Refresh",
@@ -180,13 +200,18 @@
     "clickBarHint": "Click a bar to view that company's appraisals",
     "clearCompanyFilter": "Clear company filter",
     "noData": "No company data for this period",
+    "unknownCompany": "Unknown ({{count}})",
     "chart": {
       "assigned": "Assigned",
-      "completed": "Completed"
+      "overdue": "Overdue",
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "delivered": "{{pct}}% delivered"
     },
     "aria": {
       "filterByCompany": "Filter by company",
-      "menu": "Widget menu"
+      "menu": "Widget menu",
+      "toggleSeries": "Toggle {{label}}"
     },
     "menu": {
       "refresh": "Refresh",
@@ -195,12 +220,13 @@
     "error": "Unable to load company summary"
   },
   "quotationSummary": {
-    "title": "Quotation Task Summary",
+    "title": "Admin Worklist",
     "pendingCreation": "Pending Quotation Creation",
     "waitingSubmission": "Waiting Company Submission",
     "waitingRm": "Waiting RM Selection",
+    "pendingApprovals": "Pending Fee/Reschedule Approvals",
     "openList": "Open list",
-    "error": "Unable to load quotation task summary"
+    "error": "Unable to load admin worklist"
   },
   "calendar": {
     "title": "Calendar",
@@ -224,6 +250,7 @@
       "filterByTopic": "Filter by topic",
       "selectMonth": "Select month",
       "selectYear": "Select year",
+      "selectDate": "Select date",
       "previous": "Previous",
       "next": "Next"
     },
@@ -280,7 +307,12 @@
     "today": "Today",
     "topicsLabel": "Topics",
     "noEventsForDay": "No events for this day.",
-    "error": "Unable to load calendar events"
+    "error": "Unable to load calendar events",
+    "next7Days": "Next 7 days",
+    "eventsCount": "{{count}} events",
+    "todayGroupLabel": "Today",
+    "noUpcoming": "No upcoming events",
+    "close": "Close"
   },
   "reminders": {
     "title": "Reminders",
@@ -346,8 +378,8 @@
       "description": "Bar chart of external appraisals"
     },
     "quotationTaskSummary": {
-      "title": "Quotation Task Summary",
-      "description": "Track quotation pipeline stages for intAdmin"
+      "title": "Admin Worklist",
+      "description": "Admin worklist: quotation pipeline and pending approvals"
     },
     "calendar": {
       "title": "Calendar",

--- a/src/i18n/locales/th/dashboard.json
+++ b/src/i18n/locales/th/dashboard.json
@@ -46,6 +46,11 @@
     "customTo": "ถึง",
     "apply": "นำไปใช้"
   },
+  "segment": {
+    "all": "ทุกกลุ่มธุรกิจ",
+    "Retail": "รายย่อย",
+    "IBG": "IBG"
+  },
   "taskSummary": {
     "title": "สรุปงาน",
     "notStarted": "ยังไม่เริ่ม",
@@ -98,6 +103,20 @@
       "created": "สร้างแล้ว",
       "completed": "เสร็จสิ้น"
     },
+    "mode": {
+      "overview": "ภาพรวม",
+      "byType": "ตามประเภท"
+    },
+    "metric": {
+      "created": "สร้างแล้ว",
+      "completed": "เสร็จสิ้น"
+    },
+    "types": {
+      "New": "รายใหม่",
+      "ReAppraisal": "ประเมินใหม่",
+      "Progressive": "ตามความคืบหน้า",
+      "PreAppraisal": "ประเมินเบื้องต้น"
+    },
     "table": {
       "period": "งวด",
       "created": "สร้างแล้ว",
@@ -108,7 +127,8 @@
     "rangeInfo": "ช่วง: {{from}} – {{to}} · {{buckets}} ช่วง{{bucketPlural}} · {{days}} วัน",
     "aria": {
       "expand": "ขยายวิดเจ็ต",
-      "menu": "เมนูวิดเจ็ต"
+      "menu": "เมนูวิดเจ็ต",
+      "toggleSeries": "สลับ {{label}}"
     },
     "menu": {
       "refresh": "รีเฟรช",
@@ -180,13 +200,18 @@
     "clickBarHint": "คลิกแถบเพื่อดูการประเมินของบริษัทนั้น",
     "clearCompanyFilter": "ล้างตัวกรองบริษัท",
     "noData": "ไม่มีข้อมูลบริษัทสำหรับช่วงนี้",
+    "unknownCompany": "ไม่ทราบบริษัท ({{count}})",
     "chart": {
       "assigned": "มอบหมายแล้ว",
-      "completed": "เสร็จสิ้น"
+      "overdue": "เกินกำหนด",
+      "inProgress": "กำลังดำเนินการ",
+      "completed": "เสร็จสิ้น",
+      "delivered": "ส่งแล้ว {{pct}}%"
     },
     "aria": {
       "filterByCompany": "กรองตามบริษัท",
-      "menu": "เมนูวิดเจ็ต"
+      "menu": "เมนูวิดเจ็ต",
+      "toggleSeries": "สลับ {{label}}"
     },
     "menu": {
       "refresh": "รีเฟรช",
@@ -195,12 +220,13 @@
     "error": "ไม่สามารถโหลดสรุปบริษัทได้"
   },
   "quotationSummary": {
-    "title": "สรุปงานใบเสนอราคา",
+    "title": "รายการงานผู้ดูแลระบบ",
     "pendingCreation": "รอสร้างใบเสนอราคา",
     "waitingSubmission": "รอบริษัทส่งเอกสาร",
     "waitingRm": "รอ RM เลือก",
+    "pendingApprovals": "รออนุมัติค่าบริการ/เลื่อนนัด",
     "openList": "เปิดรายการ",
-    "error": "ไม่สามารถโหลดสรุปงานใบเสนอราคาได้"
+    "error": "ไม่สามารถโหลดรายการงานผู้ดูแลระบบได้"
   },
   "calendar": {
     "title": "ปฏิทิน",
@@ -224,6 +250,7 @@
       "filterByTopic": "กรองตามหัวข้อ",
       "selectMonth": "เลือกเดือน",
       "selectYear": "เลือกปี",
+      "selectDate": "เลือกวันที่",
       "previous": "ก่อนหน้า",
       "next": "ถัดไป"
     },
@@ -280,7 +307,12 @@
     "today": "วันนี้",
     "topicsLabel": "หัวข้อ",
     "noEventsForDay": "ไม่มีกิจกรรมสำหรับวันนี้",
-    "error": "ไม่สามารถโหลดกิจกรรมปฏิทินได้"
+    "error": "ไม่สามารถโหลดกิจกรรมปฏิทินได้",
+    "next7Days": "7 วันข้างหน้า",
+    "eventsCount": "{{count}} กิจกรรม",
+    "todayGroupLabel": "วันนี้",
+    "noUpcoming": "ไม่มีกิจกรรมที่กำลังจะมาถึง",
+    "close": "ปิด"
   },
   "reminders": {
     "title": "การแจ้งเตือน",
@@ -346,8 +378,8 @@
       "description": "กราฟแท่งของการประเมินภายนอก"
     },
     "quotationTaskSummary": {
-      "title": "สรุปงานใบเสนอราคา",
-      "description": "ติดตามขั้นตอนใบเสนอราคาสำหรับ intAdmin"
+      "title": "รายการงานผู้ดูแลระบบ",
+      "description": "รายการงานผู้ดูแลระบบ: ขั้นตอนใบเสนอราคาและรายการรออนุมัติ"
     },
     "calendar": {
       "title": "ปฏิทิน",

--- a/src/i18n/locales/zh/dashboard.json
+++ b/src/i18n/locales/zh/dashboard.json
@@ -46,6 +46,11 @@
     "customTo": "至",
     "apply": "应用"
   },
+  "segment": {
+    "all": "全部业务板块",
+    "Retail": "零售",
+    "IBG": "IBG"
+  },
   "taskSummary": {
     "title": "任务摘要",
     "notStarted": "未开始",
@@ -98,6 +103,20 @@
       "created": "已创建",
       "completed": "已完成"
     },
+    "mode": {
+      "overview": "总览",
+      "byType": "按类型"
+    },
+    "metric": {
+      "created": "已创建",
+      "completed": "已完成"
+    },
+    "types": {
+      "New": "新估",
+      "ReAppraisal": "重新估价",
+      "Progressive": "分阶段",
+      "PreAppraisal": "预估价"
+    },
     "table": {
       "period": "周期",
       "created": "已创建",
@@ -108,7 +127,8 @@
     "rangeInfo": "范围：{{from}} – {{to}} · {{buckets}} 个周期{{bucketPlural}} · {{days}} 天",
     "aria": {
       "expand": "展开小部件",
-      "menu": "小部件菜单"
+      "menu": "小部件菜单",
+      "toggleSeries": "切换{{label}}"
     },
     "menu": {
       "refresh": "刷新",
@@ -180,13 +200,18 @@
     "clickBarHint": "点击条形图查看该公司的评估",
     "clearCompanyFilter": "清除公司筛选",
     "noData": "该期间没有公司数据",
+    "unknownCompany": "未知公司（{{count}}）",
     "chart": {
       "assigned": "已分配",
-      "completed": "已完成"
+      "overdue": "已逾期",
+      "inProgress": "进行中",
+      "completed": "已完成",
+      "delivered": "已交付 {{pct}}%"
     },
     "aria": {
       "filterByCompany": "按公司筛选",
-      "menu": "小部件菜单"
+      "menu": "小部件菜单",
+      "toggleSeries": "切换{{label}}"
     },
     "menu": {
       "refresh": "刷新",
@@ -195,12 +220,13 @@
     "error": "无法加载公司摘要"
   },
   "quotationSummary": {
-    "title": "报价任务摘要",
+    "title": "管理员工作列表",
     "pendingCreation": "待创建报价",
     "waitingSubmission": "等待公司提交",
     "waitingRm": "等待RM选择",
+    "pendingApprovals": "待审批费用/改期",
     "openList": "打开列表",
-    "error": "无法加载报价任务摘要"
+    "error": "无法加载管理员工作列表"
   },
   "calendar": {
     "title": "日历",
@@ -224,6 +250,7 @@
       "filterByTopic": "按主题筛选",
       "selectMonth": "选择月份",
       "selectYear": "选择年份",
+      "selectDate": "选择日期",
       "previous": "上一个",
       "next": "下一个"
     },
@@ -280,7 +307,12 @@
     "today": "今天",
     "topicsLabel": "主题",
     "noEventsForDay": "本日没有活动。",
-    "error": "无法加载日历事件"
+    "error": "无法加载日历事件",
+    "next7Days": "未来7天",
+    "eventsCount": "{{count}} 个事件",
+    "todayGroupLabel": "今天",
+    "noUpcoming": "没有即将到来的事件",
+    "close": "关闭"
   },
   "reminders": {
     "title": "提醒",
@@ -346,8 +378,8 @@
       "description": "外部评估条形图"
     },
     "quotationTaskSummary": {
-      "title": "报价任务摘要",
-      "description": "跟踪 intAdmin 的报价流程阶段"
+      "title": "管理员工作列表",
+      "description": "管理员工作列表：报价流程和待审批事项"
     },
     "calendar": {
       "title": "日历",

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react';
 import { Link } from 'react-router-dom';
 import Icon from './Icon';
+import { isChunkLoadError } from '@shared/utils/lazyWithRetry';
 
 type ErrorBoundaryProps = {
   children: ReactNode;
@@ -32,6 +33,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
         return this.props.fallback;
       }
 
+      // A failed dynamic import that survived lazyWithRetry's retry-and-reload almost
+      // always means the app was redeployed and this tab still points at old chunk
+      // hashes. Show an update-oriented message rather than a scary generic error.
+      const isChunkError = isChunkLoadError(this.state.error);
+
       return (
         <div className="min-h-[60vh] flex items-center justify-center">
           <div className="text-center">
@@ -40,10 +46,12 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             </div>
             <p className="text-base font-semibold text-error">Error</p>
             <h1 className="mt-2 text-3xl font-bold tracking-tight text-base-content sm:text-5xl">
-              Something went wrong
+              {isChunkError ? 'A new version is available' : 'Something went wrong'}
             </h1>
             <p className="mt-4 text-base text-base-content/60 max-w-md mx-auto">
-              An unexpected error occurred. Please try refreshing the page or go back to the home page.
+              {isChunkError
+                ? 'The app was updated while this page was open. Please refresh to load the latest version.'
+                : 'An unexpected error occurred. Please try refreshing the page or go back to the home page.'}
             </p>
             {this.state.error && (
               <div className="mt-4 p-4 bg-error/10 rounded-lg max-w-lg mx-auto">

--- a/src/shared/components/ImageAnnotationEditor/index.ts
+++ b/src/shared/components/ImageAnnotationEditor/index.ts
@@ -1,7 +1,7 @@
-import { lazy } from 'react';
+import { lazyWithRetry } from '@shared/utils/lazyWithRetry';
 
 export type { AnnotationResult, ImageAnnotationEditorProps } from './types';
 
-const ImageAnnotationEditor = lazy(() => import('./ImageAnnotationEditor'));
+const ImageAnnotationEditor = lazyWithRetry(() => import('./ImageAnnotationEditor'));
 
 export default ImageAnnotationEditor;

--- a/src/shared/components/inputs/CalendarNavHeader.tsx
+++ b/src/shared/components/inputs/CalendarNavHeader.tsx
@@ -1,0 +1,102 @@
+import clsx from 'clsx';
+
+interface CalendarNavHeaderProps {
+  /** Rendered title, e.g. "July 2026" */
+  label: string;
+  /** Step to the previous month (up chevron) */
+  onPrev: () => void;
+  /** Step to the next month (down chevron) */
+  onNext: () => void;
+  /** When provided, the title becomes a button that toggles the month/year panel */
+  onToggle?: () => void;
+  /** Whether the month/year panel is currently open (rotates the caret) */
+  expanded?: boolean;
+  prevAriaLabel?: string;
+  nextAriaLabel?: string;
+  className?: string;
+}
+
+// Clickable "MMMM yyyy" title + vertical up/down month steppers.
+// Shared by the date pickers (RDP caption replacement) and the dashboard widget.
+export function CalendarNavHeader({
+  label,
+  onPrev,
+  onNext,
+  onToggle,
+  expanded = false,
+  prevAriaLabel = 'Previous month',
+  nextAriaLabel = 'Next month',
+  className,
+}: CalendarNavHeaderProps) {
+  const Title = onToggle ? 'button' : 'span';
+  return (
+    <div className={clsx('flex items-center justify-between', className)}>
+      <Title
+        type={onToggle ? 'button' : undefined}
+        onClick={onToggle}
+        aria-expanded={onToggle ? expanded : undefined}
+        className={clsx(
+          'flex items-center gap-1 text-sm font-semibold text-gray-800 rounded px-1 -mx-1 py-0.5',
+          onToggle &&
+            'cursor-pointer hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200',
+        )}
+      >
+        <span>{label}</span>
+        {onToggle && (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            className={clsx('text-gray-400 transition-transform', expanded && 'rotate-180')}
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        )}
+      </Title>
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          onClick={onPrev}
+          aria-label={prevAriaLabel}
+          className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+          >
+            <path d="M18 15l-6-6-6 6" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          aria-label={nextAriaLabel}
+          className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CalendarNavHeader;

--- a/src/shared/components/inputs/DatePickerInput.tsx
+++ b/src/shared/components/inputs/DatePickerInput.tsx
@@ -1,35 +1,48 @@
 import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { DayPicker, type DropdownProps } from 'react-day-picker';
+import { DayPicker } from 'react-day-picker';
 import { format, formatISO, isValid, parse } from 'date-fns';
 import clsx from 'clsx';
 import 'react-day-picker/style.css';
 import { useFormReadOnly } from '../form/context';
 import { buildDisabledMatcher, validateDateConstraints } from './dateConstraints';
-import { ScrollableSelect } from './ScrollableSelect';
+import { CalendarNavHeader } from './CalendarNavHeader';
+import { MonthYearPanel } from './MonthYearPanel';
 
-function CompactRdpDropdown(props: DropdownProps) {
-  const { options = [], value, onChange, 'aria-label': ariaLabel } = props;
-  return (
-    <ScrollableSelect
-      ariaLabel={ariaLabel}
-      variant="ghost"
-      value={String(value ?? '')}
-      options={options.map(o => ({
-        value: String(o.value),
-        label: o.label,
-        disabled: o.disabled,
-      }))}
-      onChange={next => {
-        if (!onChange) return;
-        const synthetic = {
-          target: { value: next },
-        } as React.ChangeEvent<HTMLSelectElement>;
-        onChange(synthetic);
-      }}
-      maxHeightClass="max-h-48"
-    />
-  );
-}
+const MONTH_LABELS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+// Hide RDP's built-in month caption — we render our own CalendarNavHeader above the grid.
+const HiddenCaption = () => <></>;
+
+// Compact react-day-picker sizing. These vars MUST live on the DayPicker root: v9's
+// stylesheet declares `.rdp-root { --rdp-day-width: 44px }`, so the same vars set on an
+// ancestor never win. An inline style on the root beats that class rule.
+const CALENDAR_RDP_STYLE = {
+  '--rdp-day-width': '1.75rem',
+  '--rdp-day-height': '1.75rem',
+  '--rdp-day_button-width': '1.75rem',
+  '--rdp-day_button-height': '1.75rem',
+  '--rdp-day_button-border-radius': '0.25rem',
+  '--rdp-weekday-padding': '0',
+  '--rdp-weekday-opacity': '0.6',
+  '--rdp-font-family': 'inherit',
+  '--rdp-accent-color': 'var(--color-primary)',
+} as React.CSSProperties;
+
+// Single-letter weekday headers (M T W T F S S) to match the design.
+const formatNarrowWeekday = (date: Date) => date.toLocaleDateString('en-US', { weekday: 'narrow' });
 
 interface DatePickerInputProps {
   label?: string;
@@ -93,6 +106,7 @@ const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>(
     const [isOpen, setIsOpen] = useState(false);
     const [inputValue, setInputValue] = useState('');
     const [month, setMonth] = useState(new Date());
+    const [showMonths, setShowMonths] = useState(false);
     const [position, setPosition] = useState<'bottom' | 'top'>('bottom');
     const [align, setAlign] = useState<'left' | 'right'>('left');
     const [constraintError, setConstraintError] = useState<string | null>(null);
@@ -166,7 +180,7 @@ const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>(
         // Horizontal flip: a left-aligned calendar overflows to the right and can be
         // clipped by a scrollable/narrow container (e.g. a search panel). When there
         // isn't room on the right, anchor to the input's right edge so it expands left.
-        const calendarWidth = 300; // approximate width of calendar
+        const calendarWidth = 460; // calendar + month/year panel when expanded
         const spaceRight = window.innerWidth - rect.left;
         if (spaceRight < calendarWidth && rect.right > calendarWidth) {
           setAlign('right');
@@ -263,6 +277,7 @@ const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>(
 
     const handleInputClick = () => {
       if (!isDisabled) {
+        setShowMonths(false);
         setIsOpen(true);
       }
     };
@@ -348,37 +363,55 @@ const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>(
               position === 'bottom' ? 'mt-1' : 'bottom-full mb-1',
               align === 'right' ? 'right-0' : 'left-0',
             )}
-            style={
-              {
-                '--rdp-day-width': '1.75rem',
-                '--rdp-day-height': '1.75rem',
-                '--rdp-day_button-width': '1.75rem',
-                '--rdp-day_button-height': '1.75rem',
-                '--rdp-day_button-border-radius': '0.25rem',
-                '--rdp-weekday-padding': '0',
-                '--rdp-nav_button-width': '1.5rem',
-                '--rdp-nav_button-height': '1.5rem',
-                '--rdp-month_caption-font': '600 0.8125rem/1 inherit',
-                '--rdp-weekday-opacity': '0.6',
-                '--rdp-font-family': 'inherit',
-              } as React.CSSProperties
-            }
           >
-            <DayPicker
-              className="react-day-picker p-2 text-xs"
-              captionLayout="dropdown"
-              mode="single"
-              navLayout="around"
-              selected={selectedDate}
-              onSelect={handleDaySelect}
-              month={month}
-              onMonthChange={setMonth}
-              showOutsideDays
-              reverseYears
-              endMonth={new Date(new Date().getFullYear() + 100, 12, 0)}
-              disabled={disabledMatcher}
-              components={{ Dropdown: CompactRdpDropdown }}
-            />
+            <div className="flex">
+              <div className="p-2">
+                <CalendarNavHeader
+                  label={format(month, 'MMMM yyyy')}
+                  onPrev={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1))}
+                  onNext={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1))}
+                  onToggle={() => setShowMonths(s => !s)}
+                  expanded={showMonths}
+                  className="mb-1 px-1"
+                />
+                <DayPicker
+                  className="react-day-picker text-xs"
+                  style={CALENDAR_RDP_STYLE}
+                  weekStartsOn={1}
+                  formatters={{ formatWeekdayName: formatNarrowWeekday }}
+                  mode="single"
+                  hideNavigation
+                  selected={selectedDate}
+                  onSelect={handleDaySelect}
+                  month={month}
+                  onMonthChange={setMonth}
+                  showOutsideDays
+                  disabled={disabledMatcher}
+                  components={{ MonthCaption: HiddenCaption }}
+                />
+              </div>
+              {showMonths && (
+                <div className="w-44 p-2 pl-3 border-l border-gray-200">
+                  <MonthYearPanel
+                    year={month.getFullYear()}
+                    selectedMonth={month.getMonth()}
+                    monthLabels={MONTH_LABELS_SHORT}
+                    onSelectMonth={m => {
+                      setMonth(new Date(month.getFullYear(), m, 1));
+                      setShowMonths(false);
+                    }}
+                    onStepYear={delta =>
+                      setMonth(new Date(month.getFullYear() + delta, month.getMonth(), 1))
+                    }
+                    onSelectYear={y => setMonth(new Date(y, month.getMonth(), 1))}
+                    onToday={() => {
+                      setMonth(new Date());
+                      setShowMonths(false);
+                    }}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         )}
 

--- a/src/shared/components/inputs/DateTimePickerInput.tsx
+++ b/src/shared/components/inputs/DateTimePickerInput.tsx
@@ -1,11 +1,49 @@
 import { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { DayPicker, type DropdownProps } from 'react-day-picker';
+import { DayPicker } from 'react-day-picker';
 import { format, formatISO, isValid, parse, setHours, setMinutes } from 'date-fns';
 import clsx from 'clsx';
 import 'react-day-picker/style.css';
 import { useFormReadOnly } from '../form/context';
 import { buildDisabledMatcher, validateDateConstraints } from './dateConstraints';
 import { ScrollableSelect } from './ScrollableSelect';
+import { CalendarNavHeader } from './CalendarNavHeader';
+import { MonthYearPanel } from './MonthYearPanel';
+
+const MONTH_LABELS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+// Hide RDP's built-in month caption — we render our own CalendarNavHeader above the grid.
+const HiddenCaption = () => <></>;
+
+// Compact react-day-picker sizing. These vars MUST live on the DayPicker root: v9's
+// stylesheet declares `.rdp-root { --rdp-day-width: 44px }`, so the same vars set on an
+// ancestor never win. An inline style on the root beats that class rule.
+const CALENDAR_RDP_STYLE = {
+  '--rdp-day-width': '1.75rem',
+  '--rdp-day-height': '1.75rem',
+  '--rdp-day_button-width': '1.75rem',
+  '--rdp-day_button-height': '1.75rem',
+  '--rdp-day_button-border-radius': '0.25rem',
+  '--rdp-weekday-padding': '0',
+  '--rdp-weekday-opacity': '0.6',
+  '--rdp-font-family': 'inherit',
+  '--rdp-accent-color': 'var(--color-primary)',
+} as React.CSSProperties;
+
+// Single-letter weekday headers (M T W T F S S) to match the design.
+const formatNarrowWeekday = (date: Date) => date.toLocaleDateString('en-US', { weekday: 'narrow' });
 
 interface DateTimePickerInputProps {
   label?: string;
@@ -84,33 +122,6 @@ function TimeInput24({ value, onChange, id, className }: TimeInput24Props) {
   );
 }
 
-// Custom react-day-picker Dropdown — replaces native <select> so the year/month
-// list is scrollable with a fixed max height. Uses the ghost variant so both
-// Month and Year render as matching caption-style labels.
-function CompactRdpDropdown(props: DropdownProps) {
-  const { options = [], value, onChange, 'aria-label': ariaLabel } = props;
-  return (
-    <ScrollableSelect
-      ariaLabel={ariaLabel}
-      variant="ghost"
-      value={String(value ?? '')}
-      options={options.map(o => ({
-        value: String(o.value),
-        label: o.label,
-        disabled: o.disabled,
-      }))}
-      onChange={next => {
-        if (!onChange) return;
-        const synthetic = {
-          target: { value: next },
-        } as React.ChangeEvent<HTMLSelectElement>;
-        onChange(synthetic);
-      }}
-      maxHeightClass="max-h-48"
-    />
-  );
-}
-
 const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerInputProps>(
   (
     {
@@ -144,6 +155,7 @@ const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerInputProp
     const [isOpen, setIsOpen] = useState(false);
     const [inputValue, setInputValue] = useState('');
     const [month, setMonth] = useState(new Date());
+    const [showMonths, setShowMonths] = useState(false);
     const [timeValue, setTimeValue] = useState('00:00');
     const [position, setPosition] = useState<'bottom' | 'top'>('bottom');
     const [constraintError, setConstraintError] = useState<string | null>(null);
@@ -323,6 +335,7 @@ const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerInputProp
 
     const handleInputClick = () => {
       if (!isDisabled) {
+        setShowMonths(false);
         setIsOpen(true);
       }
     };
@@ -412,38 +425,55 @@ const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerInputProp
               'absolute z-[100] bg-base-100 rounded-box shadow-lg border border-gray-200',
               position === 'bottom' ? 'mt-1' : 'bottom-full mb-1',
             )}
-            style={
-              {
-                // Compact react-day-picker (defaults are 44px cells / rem-based fonts)
-                '--rdp-day-width': '1.75rem',
-                '--rdp-day-height': '1.75rem',
-                '--rdp-day_button-width': '1.75rem',
-                '--rdp-day_button-height': '1.75rem',
-                '--rdp-day_button-border-radius': '0.25rem',
-                '--rdp-weekday-padding': '0',
-                '--rdp-nav_button-width': '1.5rem',
-                '--rdp-nav_button-height': '1.5rem',
-                '--rdp-month_caption-font': '600 0.8125rem/1 inherit',
-                '--rdp-weekday-opacity': '0.6',
-                '--rdp-font-family': 'inherit',
-              } as React.CSSProperties
-            }
           >
-            <DayPicker
-              className="react-day-picker p-2 text-xs"
-              captionLayout="dropdown"
-              mode="single"
-              navLayout="around"
-              selected={selectedDate}
-              onSelect={handleDaySelect}
-              month={month}
-              onMonthChange={setMonth}
-              showOutsideDays
-              reverseYears
-              endMonth={new Date(new Date().getFullYear() + 100, 12, 0)}
-              disabled={disabledMatcher}
-              components={{ Dropdown: CompactRdpDropdown }}
-            />
+            <div className="flex">
+              <div className="p-2">
+                <CalendarNavHeader
+                  label={format(month, 'MMMM yyyy')}
+                  onPrev={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1))}
+                  onNext={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1))}
+                  onToggle={() => setShowMonths(s => !s)}
+                  expanded={showMonths}
+                  className="mb-1 px-1"
+                />
+                <DayPicker
+                  className="react-day-picker text-xs"
+                  style={CALENDAR_RDP_STYLE}
+                  weekStartsOn={1}
+                  formatters={{ formatWeekdayName: formatNarrowWeekday }}
+                  mode="single"
+                  hideNavigation
+                  selected={selectedDate}
+                  onSelect={handleDaySelect}
+                  month={month}
+                  onMonthChange={setMonth}
+                  showOutsideDays
+                  disabled={disabledMatcher}
+                  components={{ MonthCaption: HiddenCaption }}
+                />
+              </div>
+              {showMonths && (
+                <div className="w-44 p-2 pl-3 border-l border-gray-200">
+                  <MonthYearPanel
+                    year={month.getFullYear()}
+                    selectedMonth={month.getMonth()}
+                    monthLabels={MONTH_LABELS_SHORT}
+                    onSelectMonth={m => {
+                      setMonth(new Date(month.getFullYear(), m, 1));
+                      setShowMonths(false);
+                    }}
+                    onStepYear={delta =>
+                      setMonth(new Date(month.getFullYear() + delta, month.getMonth(), 1))
+                    }
+                    onSelectYear={y => setMonth(new Date(y, month.getMonth(), 1))}
+                    onToday={() => {
+                      setMonth(new Date());
+                      setShowMonths(false);
+                    }}
+                  />
+                </div>
+              )}
+            </div>
 
             {/* Time + Done footer */}
             <div className="px-2 pb-2 pt-2 border-t border-gray-200">

--- a/src/shared/components/inputs/MonthYearPanel.tsx
+++ b/src/shared/components/inputs/MonthYearPanel.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+
+interface MonthYearPanelProps {
+  /** Year shown in the panel header */
+  year: number;
+  /** Highlighted month (0-11) or null */
+  selectedMonth: number | null;
+  /** Pick a month (0-11) */
+  onSelectMonth: (month: number) => void;
+  /** Step the year by delta (-1 / +1) via the header chevrons */
+  onStepYear: (delta: number) => void;
+  /** Pick an absolute year from the year grid (falls back to onStepYear if omitted) */
+  onSelectYear?: (year: number) => void;
+  /** Jump back to today */
+  onToday: () => void;
+  /** 12 short month labels (Jan..Dec), localizable */
+  monthLabels: string[];
+  todayLabel?: string;
+  prevYearAriaLabel?: string;
+  nextYearAriaLabel?: string;
+  /** Optionally grey-out months fully outside the allowed range */
+  isMonthDisabled?: (month: number) => boolean;
+  className?: string;
+}
+
+// The mock's right-hand panel. Two levels:
+//  - month grid (default): year header + up/down steppers, a 4-col Jan-Dec grid.
+//  - year grid: clicking the year flips to a 12-year grid (header shows the range,
+//    chevrons page by 12), mirroring the calendar page. Picking a year returns to
+//    the month grid. Selection uses the same primary color as the day-grid selection.
+export function MonthYearPanel({
+  year,
+  selectedMonth,
+  onSelectMonth,
+  onStepYear,
+  onSelectYear,
+  onToday,
+  monthLabels,
+  todayLabel = 'Today',
+  prevYearAriaLabel = 'Previous year',
+  nextYearAriaLabel = 'Next year',
+  isMonthDisabled,
+  className,
+}: MonthYearPanelProps) {
+  const [yearGridOpen, setYearGridOpen] = useState(false);
+  const [yearBase, setYearBase] = useState(year - 6);
+
+  const toggleYearGrid = () => {
+    setYearBase(year - 6);
+    setYearGridOpen(open => !open);
+  };
+
+  const selectYear = (y: number) => {
+    if (onSelectYear) onSelectYear(y);
+    else onStepYear(y - year);
+    setYearGridOpen(false);
+  };
+
+  return (
+    <div className={clsx('flex flex-col', className)}>
+      <div className="flex items-center justify-between mb-2">
+        <button
+          type="button"
+          onClick={toggleYearGrid}
+          className="text-sm font-semibold text-gray-800 hover:text-primary rounded px-1 -mx-1"
+        >
+          {yearGridOpen ? `${yearBase}–${yearBase + 11}` : year}
+        </button>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => (yearGridOpen ? setYearBase(b => b - 12) : onStepYear(-1))}
+            aria-label={prevYearAriaLabel}
+            className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+            >
+              <path d="M18 15l-6-6-6 6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => (yearGridOpen ? setYearBase(b => b + 12) : onStepYear(1))}
+            aria-label={nextYearAriaLabel}
+            className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {yearGridOpen ? (
+        <div className="grid grid-cols-4 gap-1 flex-1 content-center">
+          {Array.from({ length: 12 }, (_, k) => yearBase + k).map(y => (
+            <button
+              key={y}
+              type="button"
+              onClick={() => selectYear(y)}
+              className={clsx(
+                'py-1.5 rounded text-xs font-medium transition-colors',
+                y === year ? 'bg-primary text-primary-content' : 'text-gray-700 hover:bg-gray-100',
+              )}
+            >
+              {y}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-4 gap-1 flex-1 content-center">
+          {monthLabels.map((label, i) => {
+            const isSelected = selectedMonth === i;
+            const disabled = isMonthDisabled?.(i) ?? false;
+            return (
+              <button
+                key={i}
+                type="button"
+                disabled={disabled}
+                onClick={() => onSelectMonth(i)}
+                className={clsx(
+                  'py-1.5 rounded text-xs font-medium transition-colors',
+                  disabled
+                    ? 'text-gray-300 cursor-not-allowed'
+                    : isSelected
+                      ? 'bg-primary text-primary-content'
+                      : 'text-gray-700 hover:bg-gray-100',
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex justify-end mt-2">
+        <button
+          type="button"
+          onClick={() => {
+            setYearGridOpen(false);
+            onToday();
+          }}
+          className="text-xs font-semibold text-primary hover:underline px-1 py-0.5"
+        >
+          {todayLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default MonthYearPanel;

--- a/src/shared/components/inputs/index.ts
+++ b/src/shared/components/inputs/index.ts
@@ -4,6 +4,8 @@ export { default as CheckboxGroup } from './CheckboxGroup';
 export type { CheckboxOption } from './CheckboxGroup';
 export { default as DateInput } from './DateInput';
 export { default as DateTimeInput } from './DateTimeInput';
+export { default as CalendarNavHeader } from './CalendarNavHeader';
+export { default as MonthYearPanel } from './MonthYearPanel';
 export { default as Dropdown } from './Dropdown';
 export type { ListBoxItem } from './Dropdown';
 export { default as MultiSelectDropdown } from './MultiSelectDropdown';

--- a/src/shared/utils/lazyWithRetry.ts
+++ b/src/shared/utils/lazyWithRetry.ts
@@ -1,0 +1,88 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
+/**
+ * Drop-in replacement for React.lazy that survives transient chunk-load failures.
+ *
+ * Dynamic import()s fail as a hard error when a chunk can't be fetched — a slow
+ * network dropping the request, the Vite dev server mid-transform, or (in prod) a
+ * redeploy that invalidated the old content-hashed chunk names an already-open tab
+ * still references. React.lazy has no retry, so a single failed fetch dead-ends in
+ * the ErrorBoundary.
+ *
+ * This wrapper:
+ *   1. Retries the import a couple of times with a short backoff (heals slow-network blips).
+ *   2. On persistent failure, force-reloads the page ONCE (guarded via sessionStorage)
+ *      so the browser fetches a fresh index.html with the new chunk hashes — recovering
+ *      from a stale deploy. The guard prevents a reload loop.
+ *   3. Clears the guard on any successful load, so a future stale-deploy can reload again.
+ */
+
+const RELOAD_GUARD_KEY = 'chunk-reload-once';
+const MAX_RETRIES = 2;
+const RETRY_DELAYS_MS = [500, 1200];
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Loosely detect a failed dynamic-import / chunk-load error. */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /dynamically imported module/i.test(message) ||
+    /Failed to fetch/i.test(message) ||
+    /ChunkLoadError/i.test(message) ||
+    /importing a module script failed/i.test(message) ||
+    /error loading dynamically imported module/i.test(message)
+  );
+}
+
+// Mirror React.lazy's own signature (ComponentType<any>) so pages that take props
+// — e.g. PricingAnalysisPage({ subject }), BlockProjectPage({ projectType }) — type-check.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function lazyWithRetry<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>
+): LazyExoticComponent<T> {
+  return lazy(async () => {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const module = await factory();
+        // Loaded fine — allow a future stale-deploy event to reload once again.
+        try {
+          window.sessionStorage.removeItem(RELOAD_GUARD_KEY);
+        } catch {
+          /* sessionStorage may be unavailable (private mode) — ignore */
+        }
+        return module;
+      } catch (error) {
+        if (attempt < MAX_RETRIES) {
+          await delay(RETRY_DELAYS_MS[attempt] ?? 1200);
+          continue;
+        }
+
+        // Out of retries. If this smells like a stale chunk, reload once to pick up
+        // fresh hashes. Guard against reload loops.
+        if (isChunkLoadError(error)) {
+          let alreadyReloaded = false;
+          try {
+            alreadyReloaded = window.sessionStorage.getItem(RELOAD_GUARD_KEY) === '1';
+            if (!alreadyReloaded) {
+              window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1');
+            }
+          } catch {
+            /* sessionStorage unavailable — fall through and rethrow */
+          }
+
+          if (!alreadyReloaded) {
+            window.location.reload();
+            // Never resolve; the page is being torn down and reloaded.
+            return new Promise<{ default: T }>(() => {});
+          }
+        }
+
+        // Already reloaded once (or not a chunk error) — let the ErrorBoundary handle it.
+        throw error;
+      }
+    }
+  });
+}
+
+export default lazyWithRetry;


### PR DESCRIPTION
## Summary
Bundles the ready frontend changes from the shared working batch (Task/SLA included; no LOS/PMA frontend work exists). Five cohesive concerns:

### Dashboard (pairs with API #282)
- **Total Appraisals**: overview vs by-type mode, created/completed metric toggle, per-type colors, banking-segment filter, shared `ChartTooltip`.
- **Company summary** (`ExternalTaskSummaryWidget`): Overdue / InProgress / Completed segments, legend toggle, custom tooltip.
- **Quotation summary**: new "Pending Fee/Reschedule Approvals" KPI (`pendingApprovals`).
- `ProgressSummaryWidget` uses the new `SegmentSelect`; `store.ts` drops persisted widgets whose type no longer exists; `CalendarPage` rework.
- Consumes new API params (`groupByType`, `bankingSegment`) and response fields (`pendingApprovals`, `overdueCount`, `inProgressCount`). i18n keys added for en/th/zh.

### Task list SLA chip (pairs with API #284)
- `slaDurationHours` budget chip under the due date; configurable pool-tab column visibility.

### lazyWithRetry chunk-load resilience
- New `lazyWithRetry` util; `router.tsx` + `ImageAnnotationEditor` + `DocumentChecklistTab` use it; `ErrorBoundary` shows a "new version available" message on chunk-load errors.

### Date-picker redesign (CA-431)
- New `CalendarNavHeader` / `MonthYearPanel`; `DatePickerInput` / `DateTimePickerInput` refactor fixes the clipped calendar popover.

### Operational reports (CA-453 / CA-454)
- Status filter becomes a searchable dropdown; report page remounts on slug change to reset stale filters.

### Appraisal PMA form
- Field relabel ("No."→"Number") + address-name lookups in mappers; return-path fallback `/appraisals/search`→`/appraisals/list`.

## Dependencies
Dashboard widgets need API #282 deployed; the task-list chip needs API #284. Other fixes are backend-independent.

## Notes
- `tsc -b` is not a clean gate in this repo (pre-existing errors); verify changed symbols + smoke-test.
- Watch the known recharts chunk-order behavior on `build:sit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)