### PR TITLE
CA-220 Batch save: manual-mode values, method/approach selection, documents & remark

### DIFF
--- a/src/features/pricingAnalysis/api/index.ts
+++ b/src/features/pricingAnalysis/api/index.ts
@@ -21,6 +21,8 @@ import {
   type UpdateFinalValueResponseType,
   type UpdateMethodRequestType,
   type UpdateMethodResponseType,
+  type UpdateRemarkRequestType,
+  type UpdateRemarkResponseType,
 } from '../schemas';
 import { pricingAnalysisKeys } from './queryKeys';
 
@@ -337,9 +339,11 @@ export function useDeletePricingAnalysisMethod() {
  * Select a method as primary (sets others in the same approach to Alternative)
  * POST /pricing-analysis/{id}/methods/{methodId}/select
  */
+// Not invalidated here — this is only ever called in a per-approach loop from
+// saveSummary (useSelectionActions), which does one consolidated invalidate after
+// the whole batch lands so the UI updates in a single pass instead of ticking
+// checkboxes in as each call in the loop resolves.
 export function useSelectMethod() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async ({
       pricingAnalysisId,
@@ -350,6 +354,114 @@ export function useSelectMethod() {
     }): Promise<SelectMethodResponseType> => {
       const { data: response } = await axios.post(
         `/pricing-analysis/${pricingAnalysisId}/methods/${methodId}/select`,
+      );
+      return response;
+    },
+  });
+}
+
+// ==================== Select Approach Hook ====================
+
+/**
+ * Select an approach as the final approach for the analysis (sets all other approaches
+ * as unselected) and propagates its value to FinalAppraisedValue. Split out from
+ * SelectMethod on the backend — call this separately once the approach's method has
+ * already been selected via useSelectMethod.
+ * POST /pricing-analysis/{id}/approaches/{approachId}/select
+ *
+ * TODO: swap SelectApproachResponseType below for the generated schema type once the
+ * API client is regenerated from the updated OpenAPI spec (new endpoint just added
+ * server-side, not in schemas.ts yet).
+ */
+type SelectApproachResponseType = {
+  id: string;
+  approachType: string;
+  finalAppraisedValue: number | null;
+};
+
+// Not invalidated here — only called once from saveSummary (useSelectionActions),
+// which does a single consolidated invalidate after the whole batch lands.
+export function useSelectApproach() {
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      approachId,
+    }: {
+      pricingAnalysisId: string;
+      approachId: string;
+    }): Promise<SelectApproachResponseType> => {
+      const { data: response } = await axios.post(
+        `/pricing-analysis/${pricingAnalysisId}/approaches/${approachId}/select`,
+      );
+      return response;
+    },
+  });
+}
+
+// ==================== Pricing Analysis Document Hooks ====================
+
+/**
+ * TODO: swap these inline types for generated schema types once the API client is
+ * regenerated from the updated OpenAPI spec — these three endpoints were just added
+ * server-side and aren't in schemas.ts yet.
+ */
+type PricingAnalysisDocumentResponseType = {
+  id: string;
+  pricingAnalysisId: string;
+  documentId: string | null;
+  fileName: string | null;
+};
+
+type RemovePricingAnalysisDocumentResponseType = {
+  documentEntryId: string;
+  isSuccess: boolean;
+};
+
+/**
+ * Attach an already-uploaded document (via POST /documents on the Document module)
+ * to a pricing analysis.
+ * POST /pricing-analysis/{id}/documents
+ */
+// Not invalidated here — this is called in a per-file loop from saveSummary
+// (useSelectionActions), which does one consolidated invalidate after the whole
+// batch (values, selections, documents, remark) lands.
+export function useAttachPricingAnalysisDocument() {
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      documentId,
+      fileName,
+    }: {
+      pricingAnalysisId: string;
+      documentId: string;
+      fileName?: string | null;
+    }): Promise<PricingAnalysisDocumentResponseType> => {
+      const { data: response } = await axios.post(
+        `/pricing-analysis/${pricingAnalysisId}/documents`,
+        { documentId, fileName },
+      );
+      return response;
+    },
+  });
+}
+
+/**
+ * Delete a document entry from a pricing analysis entirely (not just unlink the file).
+ * DELETE /pricing-analysis/{id}/documents/{documentEntryId}
+ */
+export function useRemovePricingAnalysisDocument() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      documentEntryId,
+    }: {
+      pricingAnalysisId: string;
+      documentEntryId: string;
+    }): Promise<RemovePricingAnalysisDocumentResponseType> => {
+      const { data: response } = await axios.delete(
+        `/pricing-analysis/${pricingAnalysisId}/documents/${documentEntryId}`,
       );
       return response;
     },
@@ -421,6 +533,27 @@ export function useUpdateFinalValue() {
       queryClient.invalidateQueries({
         queryKey: pricingAnalysisKeys.detail(variables.pricingAnalysisId),
       });
+    },
+  });
+}
+
+// ==================== Remark Hooks ====================
+// Not invalidated here — only called once from saveSummary (useSelectionActions),
+// which does a single consolidated invalidate after the whole batch lands.
+export function useUpdateRemark() {
+  return useMutation({
+    mutationFn: async ({
+      pricingAnalysisId,
+      request,
+    }: {
+      pricingAnalysisId: string;
+      request: UpdateRemarkRequestType;
+    }): Promise<UpdateRemarkResponseType> => {
+      const { data: response } = await axios.put(
+        `/pricing-analysis/${pricingAnalysisId}/remark`,
+        request,
+      );
+      return response;
     },
   });
 }

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisAccordion.tsx
@@ -32,7 +32,13 @@ interface PricingAnalysisAccordionProps {
   onEnterEdit: () => void;
   onEditModeSave: () => void;
   onCancelEditMode: () => void;
-  onSummaryModeSave: () => void;
+  onSummaryModeSave: (
+    pdfFiles: File[],
+    remark: string,
+  ) =>
+    | { success: boolean; failedFileNames: string[] }
+    | Promise<{ success: boolean; failedFileNames: string[] }>;
+  isSummarySaving?: boolean;
   onToggleMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCalculationMethod: (arg: { approachType: string; methodType: string }) => void;
 
@@ -61,7 +67,20 @@ interface PricingAnalysisAccordionProps {
     confirmDelete: () => void;
     cancelDelete: () => void;
   };
-  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
+  onManualValueSync?: (arg: {
+    approachType: string;
+    methodType: string;
+    value: number;
+    methodId?: string;
+  }) => void;
+  onRequestRemoveDocument?: (documentEntryId: string, fileName?: string | null) => void;
+  removeDocumentConfirm?: {
+    isOpen: boolean;
+    pending: { documentEntryId: string; fileName?: string | null } | null;
+    confirmRemove: () => void;
+    cancelRemove: () => void;
+    isRemoving: boolean;
+  };
 }
 
 export const PricingAnalysisAccordion = ({
@@ -75,6 +94,7 @@ export const PricingAnalysisAccordion = ({
   onEnterEdit,
   onEditModeSave,
   onSummaryModeSave,
+  isSummarySaving,
   onToggleMethod,
 
   isConfirmDeselectedMethodOpen,
@@ -94,7 +114,9 @@ export const PricingAnalysisAccordion = ({
   pricingContext,
   modelThumbnailSrc,
   deleteConfirm,
-  onManualValueChange,
+  onManualValueSync,
+  onRequestRemoveDocument,
+  removeDocumentConfirm,
 }: PricingAnalysisAccordionProps) => {
   const { t } = useTranslation('pricingAnalysis');
   const serverData = useContext(ServerDataCtx);
@@ -266,6 +288,7 @@ export const PricingAnalysisAccordion = ({
                 onEnterEdit={onEnterEdit}
                 onEditModeSave={onEditModeSave}
                 onSummaryModeSave={onSummaryModeSave}
+                isSummarySaving={isSummarySaving}
                 onToggleMethod={onToggleMethod}
                 onSelectCalculationMethod={onSelectCalculationMethod}
                 onCancelEditMode={onCancelEditMode}
@@ -275,7 +298,9 @@ export const PricingAnalysisAccordion = ({
                 onDeleteMethod={onDeleteMethod}
                 pricingConfiguration={pricingConfiguration}
                 deleteConfirm={deleteConfirm}
-                onManualValueChange={onManualValueChange}
+                onManualValueSync={onManualValueSync}
+                onRequestRemoveDocument={onRequestRemoveDocument}
+                removeDocumentConfirm={removeDocumentConfirm}
               />
             </div>
           </div>

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachAccordion.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachAccordion.tsx
@@ -25,7 +25,13 @@ interface PricingAnalysisApproachAccordionProps {
   configMethods?: PricingAnalysisConfigType['methods'];
   onViewLayoutChange?: (layout: ViewLayout) => void;
   isManualMode?: boolean;
-  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
+  onManualValueSync?: (arg: {
+    approachType: string;
+    methodType: string;
+    value: number;
+    methodId?: string;
+  }) => void;
+  disabled?: boolean;
 }
 
 export const PricingAnalysisApproachAccordion = ({
@@ -43,7 +49,8 @@ export const PricingAnalysisApproachAccordion = ({
   configMethods,
   onViewLayoutChange,
   isManualMode,
-  onManualValueChange,
+  onManualValueSync,
+  disabled = false,
 }: PricingAnalysisApproachAccordionProps) => {
   const { t } = useTranslation('pricingAnalysis');
   const hasSelectedMethods = approach.methods.some(m => m.isIncluded);
@@ -146,6 +153,7 @@ export const PricingAnalysisApproachAccordion = ({
         onToggle={() => setIsOpen(!isOpen)}
         onSelectCandidateApproach={onSelectCandidateApproach}
         onViewLayoutChange={onViewLayoutChange}
+        disabled={disabled}
       />
       <div
         className={clsx(
@@ -167,7 +175,8 @@ export const PricingAnalysisApproachAccordion = ({
                 onSelectCandidateMethod={onSelectCandidateMethod}
                 onSelectCalculationMethod={onSelectCalculationMethod}
                 isManualMode={isManualMode}
-                onManualValueChange={onManualValueChange}
+                onManualValueSync={onManualValueSync}
+                disabled={disabled}
               />
             ))}
           </div>
@@ -185,7 +194,8 @@ export const PricingAnalysisApproachAccordion = ({
                 onSelectCandidateMethod={onSelectCandidateMethod}
                 onSelectCalculationMethod={onSelectCalculationMethod}
                 isManualMode={isManualMode}
-                onManualValueChange={onManualValueChange}
+                onManualValueSync={onManualValueSync}
+                disabled={disabled}
               />
             ))}
           </div>

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachCard.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachCard.tsx
@@ -13,6 +13,7 @@ interface PricingAnalysisApproachCardProps {
   onToggle: () => void;
   onSelectCandidateApproach: (approachType: string) => void;
   onViewLayoutChange?: (layout: ViewLayout) => void;
+  disabled?: boolean;
 }
 
 export const PricingAnalysisApproachCard = ({
@@ -23,6 +24,7 @@ export const PricingAnalysisApproachCard = ({
   onToggle,
   onSelectCandidateApproach,
   onViewLayoutChange,
+  disabled = false,
 }: PricingAnalysisApproachCardProps) => {
   const isReadOnly = usePageReadOnly();
   const hasSelectedMethods = approach.methods.some(m => m.isIncluded);
@@ -78,8 +80,9 @@ export const PricingAnalysisApproachCard = ({
         ) : (
           <button
             type="button"
+            disabled={disabled}
             onClick={() => onSelectCandidateApproach(approach.approachType)}
-            className="cursor-pointer shrink-0"
+            className={clsx('shrink-0', disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer')}
           >
             <div
               className={clsx(

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
@@ -399,7 +399,7 @@ export const PricingAnalysisApproachMethodSelector = ({
             <div className="border border-t border-gray-200 w-full"></div>
             <Button
               type="button"
-              disabled={isSummarySaving}
+              disabled={isSummarySaving || isReadOnly}
               isLoading={isSummarySaving}
               onClick={async () => {
                 const { success, failedFileNames } = await onSummaryModeSave(pdfFiles, remark);
@@ -414,7 +414,7 @@ export const PricingAnalysisApproachMethodSelector = ({
                 }
               }}
             >
-              Save
+              {t('footer.save')}
             </Button>
           </div>
         </div>

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisApproachMethodSelector.tsx
@@ -1,14 +1,16 @@
-import { Icon, Toggle } from '@/shared/components';
+import clsx from 'clsx';
+import { Button, Icon, Toggle } from '@/shared/components';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { Textarea } from '@/shared/components/inputs';
 import { PricingAnalysisApproachAccordion } from './PricingAnalysisApproachAccordion';
 import type { ViewLayout } from './PricingAnalysisMethodCard';
 import type { SelectionState } from '@features/pricingAnalysis/store/selectionReducer';
 import type { PricingAnalysisConfigType } from '../../schemas';
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useTranslation } from 'react-i18next';
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 const VIEW_LAYOUT_KEY = 'pricing-analysis-view-layout';
 
 function getStoredLayout(): ViewLayout {
@@ -36,7 +38,13 @@ interface PricingAnalysisApproachMethodSelectorProps {
   onEnterEdit: () => void;
   onEditModeSave: () => void;
   onCancelEditMode: () => void;
-  onSummaryModeSave: () => void;
+  onSummaryModeSave: (
+    pdfFiles: File[],
+    remark: string,
+  ) =>
+    | { success: boolean; failedFileNames: string[] }
+    | Promise<{ success: boolean; failedFileNames: string[] }>;
+  isSummarySaving?: boolean;
   onToggleMethod: (arg: { approachType: string; methodType: string }) => void;
   onSelectCalculationMethod: (arg: { approachType: string; methodType: string }) => void;
 
@@ -47,7 +55,20 @@ interface PricingAnalysisApproachMethodSelectorProps {
   onDeleteMethod?: (arg: { approachType: string; methodType: string }) => void;
   pricingConfiguration?: PricingAnalysisConfigType[];
   deleteConfirm?: DeleteConfirmState;
-  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
+  onManualValueSync?: (arg: {
+    approachType: string;
+    methodType: string;
+    value: number;
+    methodId?: string;
+  }) => void;
+  onRequestRemoveDocument?: (documentEntryId: string, fileName?: string | null) => void;
+  removeDocumentConfirm?: {
+    isOpen: boolean;
+    pending: { documentEntryId: string; fileName?: string | null } | null;
+    confirmRemove: () => void;
+    cancelRemove: () => void;
+    isRemoving: boolean;
+  };
 }
 
 export const PricingAnalysisApproachMethodSelector = ({
@@ -61,18 +82,26 @@ export const PricingAnalysisApproachMethodSelector = ({
 
   onSelectCandidateMethod,
   onSelectCandidateApproach,
+  onSummaryModeSave,
+  isSummarySaving = false,
 
   onAddMethod,
   onDeleteMethod,
   pricingConfiguration,
   deleteConfirm,
-  onManualValueChange,
+  onManualValueSync,
+  onRequestRemoveDocument,
+  removeDocumentConfirm,
 }: PricingAnalysisApproachMethodSelectorProps) => {
   const isReadOnly = usePageReadOnly();
   const { t } = useTranslation('pricingAnalysis');
   const [viewLayout, setViewLayout] = useState<ViewLayout>(getStoredLayout);
   const [pdfFiles, setPdfFiles] = useState<File[]>([]);
-  const [remark, setRemark] = useState('');
+  const [remark, setRemark] = useState(() => state.remark ?? '');
+
+  useEffect(() => {
+    setRemark(state.remark ?? '');
+  }, [state.remark]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleViewLayoutChange = useCallback((layout: ViewLayout) => {
@@ -118,6 +147,7 @@ export const PricingAnalysisApproachMethodSelector = ({
             options={[t('calculationMode.manualToggle'), t('calculationMode.systemToggle')]}
             checked={isSystemCalculation === 'System'}
             onChange={onSystemCalculationChange}
+            disabled={isSummarySaving}
           />
         )}
       </div>
@@ -130,11 +160,16 @@ export const PricingAnalysisApproachMethodSelector = ({
         {!isReadOnly && (
           <button
             type="button"
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium cursor-pointer ${
+            disabled={isSummarySaving}
+            className={clsx(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium',
+              isSummarySaving
+                ? 'cursor-not-allowed opacity-60'
+                : 'cursor-pointer',
               isEditing
                 ? 'bg-primary text-white hover:bg-primary/90'
-                : 'text-primary border border-primary/30 hover:bg-primary/5'
-            }`}
+                : 'text-primary border border-primary/30 hover:bg-primary/5',
+            )}
             onClick={() => {
               if (isEditing) {
                 onCancelEditMode();
@@ -210,52 +245,38 @@ export const PricingAnalysisApproachMethodSelector = ({
                 onSelectCandidateMethod={onSelectCandidateMethod}
                 onViewLayoutChange={handleViewLayoutChange}
                 isManualMode={isManualMode}
-                onManualValueChange={isManualMode ? onManualValueChange : undefined}
+                onManualValueSync={isManualMode ? onManualValueSync : undefined}
+                disabled={isSummarySaving}
               />
             ))}
           </div>
 
-          {/* Manual mode: PDF uploader & Remark */}
-          {isManualMode && !isReadOnly && (
+          {/* Manual mode: attached documents, PDF uploader & Remark */}
+          {isManualMode && (
             <div className="flex flex-col gap-4">
-              {/* PDF File Uploader */}
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-gray-600">
-                  {t('approaches.manualUploadPdf')}
-                </label>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".pdf"
-                  className="hidden"
-                  onChange={e => {
-                    const file = e.target.files?.[0];
-                    if (file) setPdfFiles(prev => [...prev, file]);
-                    e.target.value = '';
-                  }}
-                />
-                <button
-                  type="button"
-                  className="flex items-center justify-center gap-2 px-4 py-3 border border-dashed border-gray-300 rounded-xl bg-gray-50 text-sm text-gray-500 hover:bg-gray-100 hover:border-gray-400 cursor-pointer transition-colors"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <Icon name="file-pdf" style="regular" className="size-4" />
-                  {t('approaches.manualUploadClick')}
-                </button>
-                {pdfFiles.length > 0 && (
+              {/* Attached documents — already persisted (state.documents, loaded on INIT).
+                  Visible read-only even when the page is read-only; removal is not. */}
+              {(state.documents?.length ?? 0) > 0 && (
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium text-gray-600">
+                    {t('approaches.attachedDocuments')}
+                  </label>
                   <ul className="flex flex-col gap-1.5">
-                    {pdfFiles.map((file, idx) => (
+                    {state.documents!.map(doc => (
                       <li
-                        key={`${file.name}-${idx}`}
+                        key={doc.id}
                         className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg border border-gray-200 text-sm"
                       >
                         <button
                           type="button"
                           className="flex items-center gap-2 text-gray-700 truncate hover:text-primary cursor-pointer"
-                          onClick={() => {
-                            const url = URL.createObjectURL(file);
-                            window.open(url, '_blank');
-                          }}
+                          disabled={!doc.documentId}
+                          onClick={() =>
+                            window.open(
+                              `${API_BASE_URL}/documents/${doc.documentId}/download?download=false`,
+                              '_blank',
+                            )
+                          }
                           title={t('approaches.openPdf')}
                         >
                           <Icon
@@ -263,32 +284,155 @@ export const PricingAnalysisApproachMethodSelector = ({
                             style="solid"
                             className="size-4 text-red-500 shrink-0"
                           />
-                          <span className="truncate underline underline-offset-2">{file.name}</span>
+                          <span className="truncate underline underline-offset-2">
+                            {doc.fileName ?? t('approaches.untitledDocument')}
+                          </span>
                         </button>
-                        <button
-                          type="button"
-                          className="text-gray-400 hover:text-red-500 cursor-pointer"
-                          onClick={() => setPdfFiles(prev => prev.filter((_, i) => i !== idx))}
-                        >
-                          <Icon name="xmark" style="solid" className="size-3.5" />
-                        </button>
+                        {!isReadOnly && onRequestRemoveDocument && (
+                          <button
+                            type="button"
+                            disabled={isSummarySaving}
+                            className={clsx(
+                              'text-gray-400 hover:text-red-500',
+                              isSummarySaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                            )}
+                            onClick={() => onRequestRemoveDocument(doc.id, doc.fileName)}
+                          >
+                            <Icon name="xmark" style="solid" className="size-3.5" />
+                          </button>
+                        )}
                       </li>
                     ))}
                   </ul>
-                )}
-              </div>
+                </div>
+              )}
 
-              {/* Remark Textarea */}
-              <Textarea
-                label={t('approaches.manualRemark')}
-                rows={3}
-                placeholder={t('approaches.manualRemarkPlaceholder')}
-                value={remark}
-                onChange={e => setRemark(e.target.value)}
-              />
+              {!isReadOnly && (
+                <>
+                  {/* PDF File Uploader */}
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium text-gray-600">
+                      {t('approaches.manualUploadPdf')}
+                    </label>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".pdf"
+                      className="hidden"
+                      disabled={isSummarySaving}
+                      onChange={e => {
+                        const file = e.target.files?.[0];
+                        if (file) setPdfFiles(prev => [...prev, file]);
+                        e.target.value = '';
+                      }}
+                    />
+                    <button
+                      type="button"
+                      disabled={isSummarySaving}
+                      className={clsx(
+                        'flex items-center justify-center gap-2 px-4 py-3 border border-dashed border-primary rounded-xl bg-gray-50 text-sm text-primary hover:bg-gray-100 hover:border-gray-400 transition-colors',
+                        isSummarySaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                      )}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      <Icon name="file-pdf" style="regular" className="size-4" />
+                      {t('approaches.manualUploadClick')}
+                    </button>
+                    {pdfFiles.length > 0 && (
+                      <ul className="flex flex-col gap-1.5">
+                        {pdfFiles.map((file, idx) => (
+                          <li
+                            key={`${file.name}-${idx}`}
+                            className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg border border-gray-200 text-sm"
+                          >
+                            <button
+                              type="button"
+                              className="flex items-center gap-2 text-gray-700 truncate hover:text-primary cursor-pointer"
+                              onClick={() => {
+                                const url = URL.createObjectURL(file);
+                                window.open(url, '_blank');
+                              }}
+                              title={t('approaches.openPdf')}
+                            >
+                              <Icon
+                                name="file-pdf"
+                                style="solid"
+                                className="size-4 text-red-500 shrink-0"
+                              />
+                              <span className="truncate underline underline-offset-2">
+                                {file.name}
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              disabled={isSummarySaving}
+                              className={clsx(
+                                'text-gray-400 hover:text-red-500',
+                                isSummarySaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                              )}
+                              onClick={() => setPdfFiles(prev => prev.filter((_, i) => i !== idx))}
+                            >
+                              <Icon name="xmark" style="solid" className="size-3.5" />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  {/* Remark Textarea */}
+                  <Textarea
+                    label={t('approaches.manualRemark')}
+                    rows={3}
+                    placeholder={t('approaches.manualRemarkPlaceholder')}
+                    value={remark}
+                    onChange={e => setRemark(e.target.value)}
+                    showCharCount={true}
+                    disabled={isSummarySaving}
+                  />
+                </>
+              )}
             </div>
           )}
+
+          <div className="flex flex-col items-end justify-end gap-2">
+            <div className="border border-t border-gray-200 w-full"></div>
+            <Button
+              type="button"
+              disabled={isSummarySaving}
+              isLoading={isSummarySaving}
+              onClick={async () => {
+                const { success, failedFileNames } = await onSummaryModeSave(pdfFiles, remark);
+                if (success) {
+                  setPdfFiles([]);
+                  // remark is left as-is — it now reflects what was just saved, and will
+                  // resync from the server once the post-save detail refetch lands.
+                } else {
+                  // Only keep files that actually failed — successfully uploaded+attached
+                  // files must not be retried on the next Save click.
+                  setPdfFiles(prev => prev.filter(file => failedFileNames.includes(file.name)));
+                }
+              }}
+            >
+              Save
+            </Button>
+          </div>
         </div>
+      )}
+
+      {removeDocumentConfirm && (
+        <ConfirmDialog
+          isOpen={removeDocumentConfirm.isOpen}
+          onClose={removeDocumentConfirm.cancelRemove}
+          onConfirm={removeDocumentConfirm.confirmRemove}
+          title={t('approaches.removeDocumentTitle')}
+          message={t('approaches.removeDocumentMessage', {
+            fileName: removeDocumentConfirm.pending?.fileName ?? t('approaches.untitledDocument'),
+          })}
+          confirmText={t('confirm.confirmText')}
+          variant="danger"
+          isLoading={removeDocumentConfirm.isRemoving}
+        />
       )}
     </div>
   );

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
@@ -2,10 +2,13 @@ import { Icon } from '@/shared/components';
 import Badge from '@/shared/components/Badge';
 import { NumberInput } from '@/shared/components/inputs';
 import clsx from 'clsx';
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Method } from '../../types/selection';
 import { usePageReadOnly } from '@/shared/contexts/PageReadOnlyContext';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from '@/shared/hooks/useDebounce';
+
+const MANUAL_VALUE_DEBOUNCE_MS = 1000;
 
 export type ViewLayout = 'grid' | 'list';
 
@@ -20,7 +23,13 @@ interface PricingAnalysisMethodCardProps {
   onSelectCandidateMethod: (arg: { approachType: string; methodType: string }) => void;
   onDeleteMethod?: (arg: { approachType: string; methodType: string }) => void;
   isManualMode?: boolean;
-  onManualValueChange?: (arg: { approachType: string; methodType: string; value: number }) => void;
+  onManualValueSync?: (arg: {
+    approachType: string;
+    methodType: string;
+    value: number;
+    methodId?: string;
+  }) => void;
+  disabled?: boolean;
 }
 
 type MethodStatusKey = 'calculated' | 'pending' | 'notIncluded';
@@ -40,31 +49,57 @@ export const PricingAnalysisMethodCard = ({
   onSelectCandidateMethod,
   onDeleteMethod,
   isManualMode,
-  onManualValueChange,
+  onManualValueSync,
+  disabled = false,
 }: PricingAnalysisMethodCardProps) => {
   const isReadOnly = usePageReadOnly();
   const { t } = useTranslation('pricingAnalysis');
   const [manualInput, setManualInput] = useState<number | null>(method.appraisalValue || null);
-  const isEscapingRef = useRef(false);
+  const debouncedManualInput = useDebounce(manualInput, MANUAL_VALUE_DEBOUNCE_MS);
+
+  // Local-only sync: 1s after the user stops typing, push the value into the reducer
+  // so anything reading state.summarySelected mid-edit (approach totals, the
+  // SUMMARY_SELECT_METHOD "must have value" guard) sees it without waiting for blur.
+  // The equality check against method.appraisalValue is what stops this from looping:
+  // once the dispatch lands, method.appraisalValue catches up and the effect no-ops.
+  useEffect(() => {
+    if (!isManualMode || !onManualValueSync) return;
+    if (debouncedManualInput == null || debouncedManualInput < 0) return;
+    if (debouncedManualInput === method.appraisalValue) return;
+
+    onManualValueSync({
+      approachType,
+      methodType: method.methodType,
+      value: debouncedManualInput,
+      methodId: method.id,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedManualInput]);
 
   const handleManualChange = (e: { target: { name?: string; value: number | null } }) => {
     setManualInput(e.target.value);
   };
 
+  // Immediate flush on blur — no server call, just guarantees the reducer has the
+  // latest typed value even if the user clicks Save before the 1s debounce above
+  // settles (clicking Save already blurs this input, so this costs the user nothing
+  // extra — it's not the "must click away first" friction the debounce was meant to
+  // replace, since it never requires an action the user wasn't already taking).
   const handleManualBlur = () => {
-    if (isEscapingRef.current) {
-      isEscapingRef.current = false;
-      return;
-    }
-    const num = manualInput ?? 0;
-    if (num >= 0 && onManualValueChange) {
-      onManualValueChange({ approachType, methodType: method.methodType, value: num });
-    }
+    if (!isManualMode || !onManualValueSync) return;
+    if (manualInput == null || manualInput < 0) return;
+    if (manualInput === method.appraisalValue) return;
+
+    onManualValueSync({
+      approachType,
+      methodType: method.methodType,
+      value: manualInput,
+      methodId: method.id,
+    });
   };
 
   const handleManualKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
-      isEscapingRef.current = true;
       setManualInput(method.appraisalValue || null);
       (e.target as HTMLInputElement).blur();
     }
@@ -109,6 +144,7 @@ export const PricingAnalysisMethodCard = ({
       ? {}
       : {
           type: 'button' as const,
+          disabled,
           onClick: () => onSelectCalculationMethod({ approachType, methodType: method.methodType }),
         };
 
@@ -117,7 +153,7 @@ export const PricingAnalysisMethodCard = ({
         {...wrapperProps}
         className={clsx(
           'flex flex-col gap-2 p-4 rounded-xl border transition-all duration-200 text-left w-full',
-          isManualMode ? '' : 'cursor-pointer',
+          isManualMode ? '' : disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
           method.isSelected
             ? 'ring-2 ring-primary bg-primary/5 border-primary'
             : 'border-gray-200 hover:border-gray-300 hover:shadow-sm bg-white',
@@ -155,11 +191,15 @@ export const PricingAnalysisMethodCard = ({
           ) : (
             <button
               type="button"
+              disabled={disabled}
               onClick={e => {
                 e.stopPropagation();
                 onSelectCandidateMethod({ approachType, methodType: method.methodType });
               }}
-              className="cursor-pointer shrink-0"
+              className={clsx(
+                'shrink-0',
+                disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+              )}
             >
               <div
                 className={clsx(
@@ -242,6 +282,7 @@ export const PricingAnalysisMethodCard = ({
     ? {}
     : {
         type: 'button' as const,
+        disabled,
         onClick: () => onSelectCalculationMethod({ approachType, methodType: method.methodType }),
       };
 
@@ -250,7 +291,7 @@ export const PricingAnalysisMethodCard = ({
       {...listWrapperProps}
       className={clsx(
         'flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 w-full',
-        isManualMode ? '' : 'cursor-pointer',
+        isManualMode ? '' : disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
         method.isSelected ? 'bg-primary/5 ring-1 ring-primary/30' : 'hover:bg-gray-50',
       )}
     >
@@ -267,11 +308,15 @@ export const PricingAnalysisMethodCard = ({
       ) : (
         <button
           type="button"
+          disabled={disabled}
           onClick={e => {
             e.stopPropagation();
             onSelectCandidateMethod({ approachType, methodType: method.methodType });
           }}
-          className="cursor-pointer shrink-0"
+          className={clsx(
+            'shrink-0',
+            disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+          )}
         >
           <div
             className={clsx(
@@ -309,6 +354,7 @@ export const PricingAnalysisMethodCard = ({
         ) : (
           <NumberInput
             value={manualInput}
+            disabled={disabled}
             onChange={handleManualChange}
             onBlur={handleManualBlur}
             onKeyDown={handleManualKeyDown}

--- a/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
+++ b/src/features/pricingAnalysis/components/selection/PricingAnalysisMethodCard.tsx
@@ -54,7 +54,7 @@ export const PricingAnalysisMethodCard = ({
 }: PricingAnalysisMethodCardProps) => {
   const isReadOnly = usePageReadOnly();
   const { t } = useTranslation('pricingAnalysis');
-  const [manualInput, setManualInput] = useState<number | null>(method.appraisalValue || null);
+  const [manualInput, setManualInput] = useState<number | null>(method.appraisalValue ?? null);
   const debouncedManualInput = useDebounce(manualInput, MANUAL_VALUE_DEBOUNCE_MS);
 
   // Local-only sync: 1s after the user stops typing, push the value into the reducer
@@ -73,8 +73,15 @@ export const PricingAnalysisMethodCard = ({
       value: debouncedManualInput,
       methodId: method.id,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedManualInput]);
+  }, [
+    debouncedManualInput,
+    isManualMode,
+    onManualValueSync,
+    approachType,
+    method.methodType,
+    method.id,
+    method.appraisalValue,
+  ]);
 
   const handleManualChange = (e: { target: { name?: string; value: number | null } }) => {
     setManualInput(e.target.value);
@@ -100,7 +107,7 @@ export const PricingAnalysisMethodCard = ({
 
   const handleManualKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
-      setManualInput(method.appraisalValue || null);
+      setManualInput(method.appraisalValue ?? null);
       (e.target as HTMLInputElement).blur();
     }
   };

--- a/src/features/pricingAnalysis/hooks/useSelectionActions.ts
+++ b/src/features/pricingAnalysis/hooks/useSelectionActions.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import { useNavigate } from 'react-router-dom';
@@ -6,7 +6,12 @@ import { useBasePath } from '@/features/appraisal/context/AppraisalContext';
 import toast from 'react-hot-toast';
 import i18n from '@/i18n';
 
-const tp = (key: string) => i18n.t(`pricingAnalysis:${key}`);
+const tp = (key: string, options?: Record<string, unknown>) =>
+  // i18next's overload resolution can't match a dynamic Record<string, unknown> against
+  // its TOptions union when the key is a template-literal string; narrow cast on just the
+  // options argument (not the return value) since no interpolation-safe overload exists.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  i18n.t(`pricingAnalysis:${key}`, options as any);
 
 import type { SelectionAction, SelectionState } from '../store/selectionReducer';
 import type { Approach, Method } from '../types/selection';
@@ -15,9 +20,16 @@ import { pricingAnalysisKeys } from '../api/queryKeys';
 import {
   useAddPricingAnalysisApproach,
   useAddPricingAnalysisMethod,
+  useAttachPricingAnalysisDocument,
   useDeletePricingAnalysisMethod,
+  useRemovePricingAnalysisDocument,
+  useSelectApproach,
   useSelectMethod,
+  useUpdateMethodValue,
+  useUpdateRemark,
 } from '../api';
+import { createUploadSession, useUploadDocument } from '@features/request/api/documents';
+import type { UpdateMethodRequestType, UpdateRemarkRequestType } from '../schemas';
 import {
   isServerId,
   mapToServerApproachType,
@@ -140,6 +152,47 @@ export function useSelectionActions({
   };
 
   const selectMethodMutation = useSelectMethod();
+  const selectApproachMutation = useSelectApproach();
+  const updateMethodMutation = useUpdateMethodValue();
+  const uploadDocumentMutation = useUploadDocument();
+  const updateRemarkMutation = useUpdateRemark();
+  const attachDocumentMutation = useAttachPricingAnalysisDocument();
+  const removeDocumentMutation = useRemovePricingAnalysisDocument();
+  const {
+    isOpen: isRemoveDocumentOpen,
+    onOpen: openRemoveDocument,
+    onClose: closeRemoveDocument,
+  } = useDisclosure();
+  const [pendingRemoveDocument, setPendingRemoveDocument] = useState<{
+    documentEntryId: string;
+    fileName?: string | null;
+  } | null>(null);
+
+  const requestRemoveDocument = (documentEntryId: string, fileName?: string | null) => {
+    setPendingRemoveDocument({ documentEntryId, fileName });
+    openRemoveDocument();
+  };
+
+  const confirmRemoveDocument = async () => {
+    if (!pendingRemoveDocument) return;
+
+    try {
+      await removeDocumentMutation.mutateAsync({
+        pricingAnalysisId,
+        documentEntryId: pendingRemoveDocument.documentEntryId,
+      });
+      toast.success(tp('toasts.documentRemoved'));
+      setPendingRemoveDocument(null);
+      closeRemoveDocument();
+    } catch (err: any) {
+      toast.error(err?.apiError?.detail ?? tp('toasts.documentRemoveFailed'));
+    }
+  };
+
+  const cancelRemoveDocument = () => {
+    setPendingRemoveDocument(null);
+    closeRemoveDocument();
+  };
 
   const selectCandidateMethod = (arg: MethodKey) => {
     const appr = state.summarySelected.find((a: Approach) => a.approachType === arg.approachType);
@@ -151,18 +204,6 @@ export function useSelectionActions({
       return;
     }
     dispatch({ type: 'SUMMARY_SELECT_METHOD', payload: arg });
-
-    // Persist selection to server
-    if (method?.id && isServerId(method.id)) {
-      selectMethodMutation.mutate(
-        { pricingAnalysisId, methodId: method.id },
-        {
-          onError: (err: any) => {
-            toast.error(err?.apiError?.detail ?? tp('toasts.saveFailed'));
-          },
-        },
-      );
-    }
   };
 
   const selectCandidateApproach = (approachType: string) => {
@@ -176,17 +217,192 @@ export function useSelectionActions({
     dispatch({ type: 'SUMMARY_SELECT_APPROACH', payload: { approachType } });
   };
 
-  const saveSummary = async () => {
-    try {
-      dispatch({ type: 'EDIT_SAVE' });
+  const [isSaving, setIsSaving] = useState(false);
 
+  const uploadSessionIdRef = useRef<string | null>(null);
+  const sessionPromiseRef = useRef<Promise<string> | null>(null);
+
+  const getOrCreateSession = useCallback(async (): Promise<string> => {
+    if (uploadSessionIdRef.current) {
+      return uploadSessionIdRef.current;
+    }
+
+    if (sessionPromiseRef.current) {
+      return sessionPromiseRef.current;
+    }
+
+    sessionPromiseRef.current = createUploadSession()
+      .then(response => {
+        uploadSessionIdRef.current = response.sessionId;
+        return response.sessionId;
+      })
+      .catch(error => {
+        sessionPromiseRef.current = null;
+        throw error;
+      });
+
+    return sessionPromiseRef.current;
+  }, []);
+
+  const saveSummary = async (
+    pdfFiles: File[] = [],
+    remark?: string,
+  ): Promise<{ success: boolean; failedFileNames: string[] }> => {
+    const unprocessedIndices = new Set<number>(pdfFiles.map((_, i) => i));
+    const getFailedFileNames = () =>
+      pdfFiles.filter((_, i) => unprocessedIndices.has(i)).map(f => f.name);
+    const isEveryMethodSelected = state.summarySelected.every((a: Approach) =>
+      a.methods.some((m: Method) => m.isSelected),
+    );
+
+    // validate every method under approach must be selected
+    if (!isEveryMethodSelected) {
+      toast.error(tp('toasts.methodNotSelected'));
+      return { success: false, failedFileNames: getFailedFileNames() };
+    }
+
+    // Final approach must be selected
+    const finalApproach = state.summarySelected.find((a: Approach) => a.isSelected);
+    if (!finalApproach) {
+      toast.error(tp('toasts.approachNotSelected'));
+      return { success: false, failedFileNames: getFailedFileNames() };
+    }
+
+    const finalMethod = finalApproach.methods.find((m: Method) => m.isSelected);
+    if (!finalMethod) {
+      toast.error(tp('toasts.methodNotSelected'));
+      return { success: false, failedFileNames: getFailedFileNames() };
+    }
+
+    // Manual mode requires at least one supporting document — existing docs already
+    // attached to the analysis plus any new PDFs picked in this save, combined.
+    const isManualMode = state.systemCalculationMode !== 'System';
+    if (isManualMode) {
+      const totalDocuments = (state.documents?.length ?? 0) + pdfFiles.length;
+      if (totalDocuments === 0) {
+        toast.error(tp('toasts.documentRequired'));
+        return { success: false, failedFileNames: getFailedFileNames() };
+      }
+    }
+
+    setIsSaving(true);
+    try {
+      // ── Step 0: Documents ───────────────────────────────────────────────────
+      // Evidence must land before the selection below "locks in" a final value —
+      // selectApproach propagates ApproachValue → FinalAppraisedValue on the server,
+      // i.e. it's the actual finalization step. If we selected method/approach first
+      // and a PDF upload then failed, we'd be left with a finalized analysis missing
+      // the supporting documents that manual mode required in the first place.
+
+      // Manual-mode PDF uploads: each raw File still needs to go through the Document
+      // module's two-step flow (create session → multipart upload) before it has a
+      // documentId we can attach to the pricing analysis. One upload session is created
+      // for the whole batch (not per file), and each file's upload+attach is isolated in
+      // its own try/catch so one bad file doesn't stop the others in the same batch —
+      // but if *any* file fails, we stop before touching method/approach/remark below,
+      // so the analysis is never finalized against an incomplete document set.
+      if (pdfFiles.length > 0) {
+        const sessionId = await getOrCreateSession();
+        for (let i = 0; i < pdfFiles.length; i++) {
+          const file = pdfFiles[i];
+          try {
+            const uploaded = await uploadDocumentMutation.mutateAsync({
+              uploadSessionId: sessionId,
+              file,
+              documentType: 'PA_MANUAL',
+              documentCategory: 'support',
+            });
+            await attachDocumentMutation.mutateAsync({
+              pricingAnalysisId,
+              documentId: uploaded.documentId,
+              fileName: file.name,
+            });
+            unprocessedIndices.delete(i);
+          } catch {
+            // leave this index in unprocessedIndices so it's reported as failed/retryable
+          }
+        }
+
+        if (unprocessedIndices.size > 0) {
+          const failedFileNames = getFailedFileNames();
+          toast.error(tp('toasts.someFilesFailed', { files: failedFileNames.join(', ') }));
+          return { success: false, failedFileNames };
+        }
+      }
+
+      // ── Step 1: Persist dirty manual-mode values ────────────────────────────
+      // Must land before Step 2 (selectMethod) — the server's SelectMethod only
+      // propagates ApproachValue/FinalAppraisedValue `if (targetMethod.MethodValue.HasValue)`;
+      // it doesn't error if the value is missing, it just silently skips propagation.
+      // No per-item try/catch here (unlike the PDF loop below) — a failed value save
+      // must block the rest of the save, since selecting a method with a stale/missing
+      // value would silently fail to propagate on the server.
+      if (state.dirtyManualValueKeys.length > 0) {
+        const dirtyMethods = state.summarySelected
+          .flatMap(appr => appr.methods)
+          .filter(m => m.id && state.dirtyManualValueKeys.includes(m.id));
+
+        for (const method of dirtyMethods) {
+          if (!method.id || !isServerId(method.id)) continue;
+          await updateMethodMutation.mutateAsync({
+            id: pricingAnalysisId,
+            methodId: method.id,
+            request: { methodValue: method.appraisalValue } as UpdateMethodRequestType,
+          });
+        }
+      }
+
+      // ── Step 2: Select the currently-selected method, but only for approaches ──
+      // where that selection actually changed since the last successful save.
+      // Must still happen before selectApproach below — the server's SelectApproach
+      // guards on "approach already has a selected method", which for untouched
+      // approaches is already satisfied from a prior save (or from server data on load).
+      for (const approachType of state.dirtyMethodApproachTypes) {
+        const appr = state.summarySelected.find((a: Approach) => a.approachType === approachType);
+        const selectedMethod = appr?.methods.find((m: Method) => m.isSelected);
+        if (selectedMethod?.id && isServerId(selectedMethod.id)) {
+          await selectMethodMutation.mutateAsync({
+            pricingAnalysisId,
+            methodId: selectedMethod.id,
+          });
+        }
+      }
+
+      // ── Step 3: Select which approach is final — only if that choice changed ───
+      if (state.dirtyApproachSelection && finalApproach.id && isServerId(finalApproach.id)) {
+        await selectApproachMutation.mutateAsync({
+          pricingAnalysisId,
+          approachId: finalApproach.id,
+        });
+      }
+
+      // ── Step 4: Remark — persisted on the final selected method last, once ──
+      // everything it documents/justifies has already been committed. Compared
+      // against the last-known server value (not just truthiness) so clearing the
+      // box back to empty and saving actually propagates the clear.
+      const nextRemark = remark ?? '';
+      if (nextRemark !== (state.remark ?? '')) {
+        await updateRemarkMutation.mutateAsync({
+          pricingAnalysisId: pricingAnalysisId,
+          request: { remark: nextRemark } as UpdateRemarkRequestType,
+        });
+      }
+
+      dispatch({ type: 'EDIT_SAVE' });
+      // Clears dirtyManualValueKeys/dirtyMethodApproachTypes/dirtyApproachSelection now
+      // that everything dirty has landed server-side.
+      dispatch({ type: 'SUMMARY_SAVE' });
       await qc.invalidateQueries({
         queryKey: pricingAnalysisKeys.detail(pricingAnalysisId),
       });
 
       toast.success(tp('toasts.selectionSaved'));
+      return { success: true, failedFileNames: [] };
     } catch (err: any) {
       toast.error(err?.apiError?.detail ?? tp('toasts.saveFailed'));
+      return { success: false, failedFileNames: getFailedFileNames() };
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -286,10 +502,12 @@ export function useSelectionActions({
     selectCandidateMethod,
     selectCandidateApproach,
     saveSummary,
+    isSavingSummary: isSaving,
     cancelPricingAccordion,
     changeSystemCalculation,
     addMethod,
     requestDeleteMethod,
+    requestRemoveDocument,
 
     confirm: {
       isOpen: isConfirmOpen,
@@ -305,6 +523,14 @@ export function useSelectionActions({
       confirmDelete,
       cancelDelete,
       isDeleting: deleteMethodMutation.isPending,
+    },
+
+    removeDocumentConfirm: {
+      isOpen: isRemoveDocumentOpen,
+      pending: pendingRemoveDocument,
+      confirmRemove: confirmRemoveDocument,
+      cancelRemove: cancelRemoveDocument,
+      isRemoving: removeDocumentMutation.isPending,
     },
   };
 }

--- a/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
+++ b/src/features/pricingAnalysis/pages/PricingAnalysisPage.tsx
@@ -27,11 +27,9 @@ import { createInitialState } from '@features/pricingAnalysis/store/createInitia
 import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import { usePageReadOnly, PageReadOnlyContext } from '@/shared/contexts/PageReadOnlyContext';
 import toast from 'react-hot-toast';
-import { useSetFinalValue } from '@features/pricingAnalysis/api';
 import { PricingAnalysisAccordion } from '@features/pricingAnalysis/components/selection/PricingAnalysisAccordion';
 import { MethodSectionRenderer } from '@features/pricingAnalysis/components/MethodSectionRenderer';
 import type { PricingServerData } from '@features/pricingAnalysis/types/selection';
-import type { SetFinalValueRequestType } from '@features/pricingAnalysis/schemas';
 import { propertyGroupKeys } from '@features/appraisal/api/propertyGroup';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from '@shared/api/axiosInstance';
@@ -63,6 +61,9 @@ const initialState: SelectionState = {
   editSaved: [],
   summarySelected: [],
   systemCalculationMode: 'System',
+  dirtyManualValueKeys: [],
+  dirtyMethodApproachTypes: [],
+  dirtyApproachSelection: false,
 };
 
 // ─── Subject discriminant ─────────────────────────────────────────────────────
@@ -335,6 +336,8 @@ function PricingAnalysisContent({
         pricingAnalysisId,
         approaches,
         useSystemCalc: (pricingSelection as any)?.useSystemCalc,
+        remark: pricingSelection?.remark,
+        documents: pricingSelection?.documents,
       },
     });
 
@@ -401,39 +404,25 @@ function PricingAnalysisContent({
     setIsDirty(check);
   };
 
-  // (8b) Manual mode — set final value on blur
-  const setFinalValueMutation = useSetFinalValue();
-  const handleManualValueChange = useCallback(
+  // (8b) Update method value on manual mode when (1) immediately on blur (2) debounce ~1s after typeing stop
+  const handleManualValueSync = useCallback(
     ({
       approachType,
       methodType,
       value,
+      methodId,
     }: {
       approachType: string;
       methodType: string;
       value: number;
+      methodId?: string;
     }) => {
-      // Find the method's server ID from summarySelected
-      const approach = state.summarySelected?.find(a => a.approachType === approachType);
-      const method = approach?.methods.find(m => m.methodType === methodType);
-      if (!method?.id) return;
-
-      setFinalValueMutation.mutate(
-        {
-          pricingAnalysisId,
-          methodId: method.id,
-          request: {
-            finalValue: value,
-            finalValueRounded: value,
-          } as SetFinalValueRequestType,
-        },
-        {
-          onSuccess: () => toast.success(t('toasts.valueSaved')),
-          onError: () => toast.error(t('toasts.valueFailed')),
-        },
-      );
+      dispatch({
+        type: 'SUMMARY_UPDATE_METHOD_VALUE',
+        payload: { approachType, methodType, value, methodId },
+      });
     },
-    [state.summarySelected, pricingAnalysisId, setFinalValueMutation],
+    [dispatch],
   );
 
   // (9) Assemble server data for context
@@ -490,6 +479,7 @@ function PricingAnalysisContent({
                         }}
                         onSelectCalculationMethod={calcFlow.startCalculation}
                         onSummaryModeSave={selectionActions.saveSummary}
+                        isSummarySaving={selectionActions.isSavingSummary}
                         onEditModeSave={selectionActions.saveEdit}
                         onToggleMethod={selectionActions.toggleMethod}
                         onPricingAnalysisAccordionChange={onPricingAnalysisAccordionChange}
@@ -511,7 +501,9 @@ function PricingAnalysisContent({
                         pricingContext={pricingContext}
                         modelThumbnailSrc={modelThumbnailSrc}
                         deleteConfirm={selectionActions.deleteConfirm}
-                        onManualValueChange={handleManualValueChange}
+                        onManualValueSync={handleManualValueSync}
+                        onRequestRemoveDocument={selectionActions.requestRemoveDocument}
+                        removeDocumentConfirm={selectionActions.removeDocumentConfirm}
                       />
                       {!isCalcLoading && (
                         <MethodSectionRenderer

--- a/src/features/pricingAnalysis/schemas/index.ts
+++ b/src/features/pricingAnalysis/schemas/index.ts
@@ -12,6 +12,7 @@ import { schemas } from '@shared/schemas/v1';
 // -- Pricing Analysis --
 export const GetPricingAnalysisResponse = schemas.GetPricingAnalysisResponse;
 export type GetPricingAnalysisResponseType = z.infer<typeof schemas.GetPricingAnalysisResponse>;
+export type PricingAnalysisDocumentDtoType = z.infer<typeof schemas.PricingAnalysisDocumentDto>;
 
 // -- Approaches & Methods --
 export type AddPricingAnalysisApproachRequestType = z.infer<typeof schemas.AddApproachRequest>;
@@ -60,6 +61,10 @@ export type SetFinalValueRequestType = z.infer<typeof schemas.SetFinalValueReque
 export type SetFinalValueResponseType = z.infer<typeof schemas.SetFinalValueResponse>;
 export type UpdateFinalValueRequestType = z.infer<typeof schemas.UpdateFinalValueRequest>;
 export type UpdateFinalValueResponseType = z.infer<typeof schemas.UpdateFinalValueResponse>;
+
+// -- Remark --
+export type UpdateRemarkRequestType = z.infer<typeof schemas.UpdateRemarkRequest>;
+export type UpdateRemarkResponseType = z.infer<typeof schemas.UpdateRemarkResponse>;
 
 // -- Select Method --
 export type SelectMethodResponseType = z.infer<typeof schemas.SelectMethodResponse>;

--- a/src/features/pricingAnalysis/store/selectionReducer.ts
+++ b/src/features/pricingAnalysis/store/selectionReducer.ts
@@ -1,4 +1,5 @@
 import type { Approach, Method } from '../types/selection';
+import type { PricingAnalysisDocumentDtoType } from '../schemas';
 
 /*
 // state to collect approach & method which selected
@@ -27,7 +28,25 @@ export type SelectionState = {
 
   systemCalculationMode: SystemCalculationMode;
 
+  // Track dirty method value change
+  dirtyManualValueKeys: string[];
+  // Track selected method or approach change
+  dirtyMethodApproachTypes: string[];
+  /** True when the final approach selection has changed locally since the last successful
+   *  Save Summary. Populated by SUMMARY_SELECT_APPROACH, consumed by saveSummary to know
+   *  whether a selectApproach call is needed, cleared by SUMMARY_SAVE. */
+  dirtyApproachSelection: boolean;
+
   pricingAnalysisId?: string;
+
+  /** Analysis-level remark ("Notes & Assumptions"), loaded from the server on INIT and
+   *  persisted via UpdateRemark as part of the batched Save Summary click. */
+  remark?: string | null;
+
+  /** Documents already attached to this analysis (loaded from the server on INIT).
+   *  Distinct from the pending-upload queue in PricingAnalysisApproachMethodSelector —
+   *  these are already persisted; removal is immediate (not batched into Save Summary). */
+  documents?: PricingAnalysisDocumentDtoType[];
 
   activeMethod?: {
     pricingAnalysisId?: string;
@@ -45,6 +64,8 @@ export type SelectionAction =
         pricingAnalysisId?: string;
         approaches: Approach[];
         useSystemCalc?: boolean;
+        remark?: string | null;
+        documents?: PricingAnalysisDocumentDtoType[];
       };
     }
   | {
@@ -78,7 +99,15 @@ export type SelectionAction =
   | {
       type: 'CALCULATION_SAVE';
       payload: { approachType: string; methodType: string; appraisalValue: number };
-    }; // TODO: remove this state if api ready
+    } // TODO: remove this state if api ready
+  | {
+      /** Local-only sync fired both immediately on blur and ~1s after the user stops
+       *  typing in a manual-mode value input (see PricingAnalysisMethodCard). Does not
+       *  touch the server — saveSummary (useSelectionActions) persists dirtyManualValueKeys
+       *  as part of the batched Save click. */
+      type: 'SUMMARY_UPDATE_METHOD_VALUE';
+      payload: { approachType: string; methodType: string; value: number; methodId?: string };
+    };
 
 /** filter out approaches and methods that are not selected in editing mode
  * @param approaches - approaches which want to filter out
@@ -139,9 +168,16 @@ export function approachMethodReducer(
         summarySelected: cloneApproaches(visibleApproach),
         systemCalculationMode: action.payload.useSystemCalc === false ? 'FillIn' : 'System',
         pricingAnalysisId: action.payload.pricingAnalysisId,
+        remark: action.payload.remark ?? null,
+        documents: action.payload.documents ?? [],
         // Preserve activeMethod across re-INIT (e.g. detail query refetch after save)
         // so the open calculation panel doesn't unmount mid-edit.
         activeMethod: state.activeMethod,
+        // Preserve across re-INIT too (e.g. a background refetch firing between the user
+        // typing a manual value and clicking Save shouldn't drop the pending dirty flag).
+        dirtyManualValueKeys: state.dirtyManualValueKeys ?? [],
+        dirtyMethodApproachTypes: state.dirtyMethodApproachTypes ?? [],
+        dirtyApproachSelection: state.dirtyApproachSelection ?? false,
       };
     }
 
@@ -270,6 +306,18 @@ export function approachMethodReducer(
       )
         return state;
 
+      // Determine up front whether this actually changes the target approach's selected
+      // method — reselecting the already-selected method is a no-op, and must NOT flag
+      // the approach dirty (nothing to send to the server).
+      const targetApproachForMethod = state.summarySelected.find(
+        appr => appr.approachType === action.payload.approachType,
+      );
+      const currentlySelectedMethod = targetApproachForMethod
+        ? checkMethodIsSelected(targetApproachForMethod.methods)
+        : null;
+      const isRealMethodChange =
+        !!targetApproachForMethod && action.payload.methodType !== currentlySelectedMethod;
+
       // if any method has select, clear that method and enable selected one
       const nextState: SelectionState = {
         ...state,
@@ -290,6 +338,11 @@ export function approachMethodReducer(
             })),
           };
         }),
+        dirtyMethodApproachTypes:
+          isRealMethodChange &&
+          !state.dirtyMethodApproachTypes.includes(action.payload.approachType)
+            ? [...state.dirtyMethodApproachTypes, action.payload.approachType]
+            : state.dirtyMethodApproachTypes,
       };
       return nextState;
     }
@@ -313,12 +366,29 @@ export function approachMethodReducer(
           ...appr,
           isSelected: appr.approachType === action.payload.approachType,
         })),
+        // The guard above already early-returned if this approach was already the final
+        // one, so reaching here always means a real change.
+        dirtyApproachSelection: true,
       };
       return nextState;
     }
 
+    /** Fired by saveSummary once a Save Summary click has fully succeeded server-side.
+     *  Clears all three dirty trackers so the next save only sends new changes. */
     case 'SUMMARY_SAVE': {
-      return state;
+      if (
+        state.dirtyManualValueKeys.length === 0 &&
+        state.dirtyMethodApproachTypes.length === 0 &&
+        !state.dirtyApproachSelection
+      )
+        return state;
+
+      return {
+        ...state,
+        dirtyManualValueKeys: [],
+        dirtyMethodApproachTypes: [],
+        dirtyApproachSelection: false,
+      };
     }
 
     case 'CALCULATION_SELECTED': {
@@ -382,6 +452,38 @@ export function approachMethodReducer(
           };
         }),
       };
+      return nextState;
+    }
+
+    case 'SUMMARY_UPDATE_METHOD_VALUE': {
+      if (state.summarySelected == null) return state;
+      if (action.payload.value == null || action.payload.value < 0) return state;
+
+      const nextState: SelectionState = {
+        ...state,
+        summarySelected: state.summarySelected.map(appr => {
+          if (appr.approachType !== action.payload.approachType) return appr;
+
+          const updatedMethods = appr.methods.map(method => {
+            if (method.methodType !== action.payload.methodType) return method;
+            return { ...method, appraisalValue: action.payload.value };
+          });
+
+          const selectedMethod = updatedMethods.find(m => m.isSelected);
+          return {
+            ...appr,
+            methods: updatedMethods,
+            // Keep the approach's own appraisalValue in sync only when the edited
+            // method is the one currently selected — mirrors CALCULATION_SAVE.
+            appraisalValue: selectedMethod?.appraisalValue ?? appr.appraisalValue,
+          };
+        }),
+        dirtyManualValueKeys:
+          action.payload.methodId && !state.dirtyManualValueKeys.includes(action.payload.methodId)
+            ? [...state.dirtyManualValueKeys, action.payload.methodId]
+            : state.dirtyManualValueKeys,
+      };
+
       return nextState;
     }
 

--- a/src/i18n/locales/en/pricingAnalysis.json
+++ b/src/i18n/locales/en/pricingAnalysis.json
@@ -47,7 +47,11 @@
     "manualUploadClick": "Click to upload PDF",
     "manualRemark": "Remark",
     "manualRemarkPlaceholder": "Add any remarks or notes for this manual appraisal...",
-    "openPdf": "Open PDF"
+    "openPdf": "Open PDF",
+    "attachedDocuments": "Attached documents",
+    "untitledDocument": "Untitled document",
+    "removeDocumentTitle": "Remove document",
+    "removeDocumentMessage": "Remove \"{{fileName}}\"? This cannot be undone."
   },
   "methodStatus": {
     "calculated": "Calculated",
@@ -75,15 +79,20 @@
     "selectionSaved": "Selection saved",
     "calculateFirst": "Please calculate appraisal value.",
     "methodNotSelected": "Method does not select",
+    "approachNotSelected": "Approach does not select",
     "methodAdded": "Method added",
     "methodDeleted": "Method deleted",
+    "documentRemoved": "Document removed",
+    "documentRemoveFailed": "Failed to remove document",
+    "documentRequired": "At least one document is required",
     "saveSelectionFirst": "Save selection first to generate method and approach IDs before calculation.",
     "uploadXlsxOnly": "Only .xlsx files are accepted",
     "uploadMaxSize": "File must be ≤ 5 MB",
     "uploadFailed": "Upload failed",
     "uploadDeleted": "Upload deleted",
     "deleteFailed": "Delete failed",
-    "uploadSuccess": "Uploaded {{n}} rows"
+    "uploadSuccess": "Uploaded {{n}} rows",
+    "someFilesFailed": "Failed to save: {{files}}"
   },
   "footer": {
     "cancel": "Cancel",

--- a/src/i18n/locales/th/pricingAnalysis.json
+++ b/src/i18n/locales/th/pricingAnalysis.json
@@ -47,7 +47,11 @@
     "manualUploadClick": "คลิกเพื่ออัปโหลด PDF",
     "manualRemark": "หมายเหตุ",
     "manualRemarkPlaceholder": "เพิ่มหมายเหตุหรือบันทึกสำหรับการประเมินด้วยตนเองนี้...",
-    "openPdf": "เปิด PDF"
+    "openPdf": "เปิด PDF",
+    "attachedDocuments": "เอกสารที่แนบ",
+    "untitledDocument": "เอกสารไม่มีชื่อ",
+    "removeDocumentTitle": "ลบเอกสาร",
+    "removeDocumentMessage": "ลบ \"{{fileName}}\" ใช่หรือไม่? การดำเนินการนี้ไม่สามารถย้อนกลับได้"
   },
   "methodStatus": {
     "calculated": "คำนวณแล้ว",
@@ -77,13 +81,17 @@
     "methodNotSelected": "ไม่ได้เลือกวิธีการ",
     "methodAdded": "เพิ่มวิธีการแล้ว",
     "methodDeleted": "ลบวิธีการแล้ว",
+    "documentRemoved": "ลบเอกสารแล้ว",
+    "documentRemoveFailed": "ลบเอกสารไม่สำเร็จ",
+    "documentRequired": "ต้องมีเอกสารอย่างน้อย 1 ฉบับ",
     "saveSelectionFirst": "บันทึกการเลือกก่อนเพื่อสร้าง ID วิธีการและแนวทางก่อนการคำนวณ",
     "uploadXlsxOnly": "รับเฉพาะไฟล์ .xlsx เท่านั้น",
     "uploadMaxSize": "ไฟล์ต้องมีขนาดไม่เกิน 5 MB",
     "uploadFailed": "อัปโหลดไม่สำเร็จ",
     "uploadDeleted": "ลบการอัปโหลดแล้ว",
     "deleteFailed": "ลบไม่สำเร็จ",
-    "uploadSuccess": "อัปโหลด {{n}} แถวสำเร็จ"
+    "uploadSuccess": "อัปโหลด {{n}} แถวสำเร็จ",
+    "someFilesFailed": "บันทึกไม่สำเร็จ: {{files}}"
   },
   "footer": {
     "cancel": "ยกเลิก",

--- a/src/i18n/locales/th/pricingAnalysis.json
+++ b/src/i18n/locales/th/pricingAnalysis.json
@@ -80,6 +80,7 @@
     "calculateFirst": "กรุณาคำนวณมูลค่าประเมินก่อน",
     "methodNotSelected": "ไม่ได้เลือกวิธีการ",
     "methodAdded": "เพิ่มวิธีการแล้ว",
+    "approachNotSelected": "ไม่ได้เลือกแนวทาง",
     "methodDeleted": "ลบวิธีการแล้ว",
     "documentRemoved": "ลบเอกสารแล้ว",
     "documentRemoveFailed": "ลบเอกสารไม่สำเร็จ",

--- a/src/i18n/locales/zh/pricingAnalysis.json
+++ b/src/i18n/locales/zh/pricingAnalysis.json
@@ -47,7 +47,11 @@
     "manualUploadClick": "Click to upload PDF",
     "manualRemark": "Remark",
     "manualRemarkPlaceholder": "Add any remarks or notes for this manual appraisal...",
-    "openPdf": "Open PDF"
+    "openPdf": "Open PDF",
+    "attachedDocuments": "Attached documents",
+    "untitledDocument": "Untitled document",
+    "removeDocumentTitle": "Remove document",
+    "removeDocumentMessage": "Remove \"{{fileName}}\"? This cannot be undone."
   },
   "methodStatus": {
     "calculated": "Calculated",
@@ -77,13 +81,17 @@
     "methodNotSelected": "Method does not select",
     "methodAdded": "Method added",
     "methodDeleted": "Method deleted",
+    "documentRemoved": "Document removed",
+    "documentRemoveFailed": "Failed to remove document",
+    "documentRequired": "At least one document is required",
     "saveSelectionFirst": "Save selection first to generate method and approach IDs before calculation.",
     "uploadXlsxOnly": "Only .xlsx files are accepted",
     "uploadMaxSize": "File must be ≤ 5 MB",
     "uploadFailed": "Upload failed",
     "uploadDeleted": "Upload deleted",
     "deleteFailed": "Delete failed",
-    "uploadSuccess": "Uploaded {{n}} rows"
+    "uploadSuccess": "Uploaded {{n}} rows",
+    "someFilesFailed": "Failed to save: {{files}}"
   },
   "footer": {
     "cancel": "Cancel",

--- a/src/i18n/locales/zh/pricingAnalysis.json
+++ b/src/i18n/locales/zh/pricingAnalysis.json
@@ -79,6 +79,7 @@
     "selectionSaved": "Selection saved",
     "calculateFirst": "Please calculate appraisal value.",
     "methodNotSelected": "Method does not select",
+    "approachNotSelected": "Approach does not select",
     "methodAdded": "Method added",
     "methodDeleted": "Method deleted",
     "documentRemoved": "Document removed",

--- a/src/shared/schemas/v1.ts
+++ b/src/shared/schemas/v1.ts
@@ -1235,6 +1235,17 @@ const ApproachDto = z
     methods: z.array(MethodDto),
   })
   .passthrough();
+const PricingAnalysisDocumentDto = z
+  .object({
+    id: z.string().uuid(),
+    documentId: z.string().uuid().nullable(),
+    fileName: z.string().nullable(),
+    filePath: z.string().nullable(),
+    uploadedBy: z.string().nullable(),
+    uploadedByName: z.string().nullable(),
+    uploadedAt: z.string().datetime({ offset: true }).nullable(),
+  })
+  .passthrough();
 const GetPricingAnalysisResponse = z
   .object({
     id: z.string().uuid(),
@@ -1246,6 +1257,8 @@ const GetPricingAnalysisResponse = z
     valuationDate: z.string().datetime({ offset: true }).nullable(),
     useSystemCalc: z.boolean(),
     approaches: z.array(ApproachDto),
+    documents: z.array(PricingAnalysisDocumentDto),
+    remark: z.string().nullable(),
   })
   .passthrough();
 const UpdateMethodRequest = z
@@ -1418,6 +1431,17 @@ const SetFinalValueResponse = z
     buildingValue: z.number().nullable(),
     appraisalPriceWithBuilding: z.number().nullable(),
     appraisalPriceWithBuildingRounded: z.number().nullable(),
+  })
+  .passthrough();
+const UpdateRemarkRequest = z
+  .object({
+    remark: z.string(),
+  })
+  .passthrough();
+const UpdateRemarkResponse = z
+  .object({
+    id: z.string().uuid(),
+    remark: z.string(),
   })
   .passthrough();
 const SelectMethodResponse = z
@@ -4789,6 +4813,7 @@ export const schemas = {
   UpdatePricingAnalysisResponse,
   MethodDto,
   ApproachDto,
+  PricingAnalysisDocumentDto,
   GetPricingAnalysisResponse,
   UpdateMethodRequest,
   UpdateMethodResponse,
@@ -4806,6 +4831,8 @@ export const schemas = {
   StartPricingAnalysisResponse,
   SetFinalValueRequest,
   SetFinalValueResponse,
+  UpdateRemarkRequest,
+  UpdateRemarkResponse,
   SelectMethodResponse,
   ComparativeFactorInput,
   FactorScoreInput,


### PR DESCRIPTION
Problem
Manual mode fired an API call on every value blur (SetFinalValue) and every method selection (SelectMethod), so typing a number required clicking away to save, and selecting several methods across approaches meant waiting on a save per click. Document upload and remark had no persistence at all.

Solution
Moved all of it into one batched Save Summary click, using dirty-tracking so only changed data gets sent.

- Reducer: added dirtyManualValueKeys, dirtyMethodApproachTypes, dirtyApproachSelection, remark, documents to state. Method/approach selection only flags dirty on a real change (re-clicking the same selection is a no-op). New SUMMARY_UPDATE_METHOD_VALUE action updates typed values locally, no network call.
- PricingAnalysisMethodCard: manual value input syncs to local state only (blur + ~1s debounce), no server call on either.
- saveSummary now batches, in order: (1) upload/attach staged PDFs, blocks rest of save on failure, (2) persist dirty manual values via UpdateMethod, (3) persist dirty method selection via SelectMethod, (4) persist approach selection via new SelectApproach endpoint, (5) persist remark via UpdateRemark if changed. One invalidateQueries at the end, not per step.

New validation: manual mode blocks save if total documents (existing + staged) is 0.

New UX lockout: while saving, mode toggle, approach/method selection, Edit button, upload button, remark textarea, and document-removal buttons are disabled.

Document removal is not batched: already-persisted documents delete immediately on confirm (own invalidate), independent of Save. Pending files are removed from local staging instantly, no confirm, no network call.

API notes:
- useSelectMethod no longer invalidates queries itself (single call site, covered by saveSummary's consolidated invalidate).
- New endpoint POST /pricing-analysis/{id}/approaches/{approachId}/select.
- useSelectApproach, useAttachPricingAnalysisDocument, and document response/remove types are hand-typed inline (TODO) pending OpenAPI client regeneration.
- useSetFinalValue is no longer referenced by this feature.

Files: selectionReducer.ts, PricingAnalysisMethodCard.tsx, PricingAnalysisApproachAccordion.tsx, PricingAnalysisApproachCard.tsx, PricingAnalysisApproachMethodSelector.tsx, PricingAnalysisAccordion.tsx, useSelectionActions.ts, PricingAnalysisPage.tsx, api/index.ts, schemas/index.ts, shared/schemas/v1.ts, i18n locale files (en/th/zh).