### PR TITLE
fix: render decision-summary sections on the appraisal route

### DIFF
--- a/src/features/appraisal/components/summary/DecisionSection.tsx
+++ b/src/features/appraisal/components/summary/DecisionSection.tsx
@@ -153,6 +153,11 @@ interface DecisionSectionProps {
   onAssigneeChange: (userId: string | null) => void;
   selectedReasonCode: string | null;
   onReasonChange: (code: string | null) => void;
+  // On the appraisal route the context has no workflow ids; the page resolves them
+  // from workflow progress and passes them in so the activity timeline still loads.
+  // Fall back to context (task route) when not provided.
+  workflowInstanceId?: string;
+  activityId?: string;
 }
 
 const DecisionSection = ({
@@ -164,12 +169,16 @@ const DecisionSection = ({
   onAssigneeChange,
   selectedReasonCode,
   onReasonChange,
+  workflowInstanceId: workflowInstanceIdProp,
+  activityId: activityIdProp,
 }: DecisionSectionProps) => {
   const { t } = useTranslation('appraisal');
   const isPageReadOnly = usePageReadOnly();
   const isTaskOwner = useIsTaskOwner();
-  const workflowInstanceId = useWorkflowInstanceId();
-  const activityId = useActivityId();
+  const ctxWorkflowInstanceId = useWorkflowInstanceId();
+  const ctxActivityId = useActivityId();
+  const workflowInstanceId = workflowInstanceIdProp ?? ctxWorkflowInstanceId;
+  const activityId = activityIdProp ?? ctxActivityId;
   const { taskId } = useParams<{ taskId: string }>();
   const [raiseFollowupOpen, setRaiseFollowupOpen] = useState(false);
 

--- a/src/features/appraisal/pages/DecisionSummaryPage.tsx
+++ b/src/features/appraisal/pages/DecisionSummaryPage.tsx
@@ -39,6 +39,7 @@ import {
   useCompleteActivity,
   useGetActivityActions,
   useGetTaskById,
+  useGetWorkflowProgress,
   useSaveTaskDecisionDraft,
 } from '../api/workflow';
 import {
@@ -464,7 +465,16 @@ const DecisionSummaryPage = () => {
   const activityId = useActivityId();
   const isTaskOwner = useIsTaskOwner();
 
-  // Section visibility by activity
+  // On the appraisal route (no taskId) the context has no workflow ids, so the live
+  // approval / activity-tracking / meeting sections would render empty. Resolve them
+  // from the appraisal's workflow progress and fall back to context on the task route.
+  const { data: workflowProgress } = useGetWorkflowProgress(taskId ? undefined : appraisalId);
+  const resolvedWorkflowInstanceId =
+    workflowInstanceId ?? workflowProgress?.workflowInstanceId ?? undefined;
+  const resolvedActivityId = activityId ?? workflowProgress?.currentActivityId ?? undefined;
+
+  // Section visibility by activity — intentionally keyed off the *context* activityId
+  // (undefined on the appraisal route) so Appraisal Search still shows all sections.
   const sectionConfig = activityId
     ? (ACTIVITY_SECTION_CONFIG[activityId] ?? { sections: [] })
     : null; // null = no activityId = show all sections
@@ -1088,8 +1098,8 @@ const DecisionSummaryPage = () => {
                   section below (avoids the "not active yet" placeholder next to real history). */}
               {showSection('committeeApproval') && !isTerminalStatus(appraisal?.status) && (
                 <LiveApprovalListSection
-                  workflowInstanceId={workflowInstanceId}
-                  activityId={activityId}
+                  workflowInstanceId={resolvedWorkflowInstanceId}
+                  activityId={resolvedActivityId}
                 />
               )}
 
@@ -1111,6 +1121,8 @@ const DecisionSummaryPage = () => {
                 onAssigneeChange={setSelectedAssigneeUserId}
                 selectedReasonCode={reasonCode}
                 onReasonChange={setReasonCode}
+                workflowInstanceId={resolvedWorkflowInstanceId}
+                activityId={resolvedActivityId}
               />
             </div>
           </div>
@@ -1147,7 +1159,11 @@ const DecisionSummaryPage = () => {
                     <Button
                       variant="outline"
                       type="submit"
-                      disabled={!appraisalId || (!isDirty && !draftDirty) || isSaving}
+                      disabled={
+                        (!appraisalId && !(isTaskOwner && !!taskId)) ||
+                        (!isDirty && !draftDirty) ||
+                        isSaving
+                      }
                     >
                       <Icon style="regular" name="floppy-disk" className="size-4 mr-2" />
                       {t('decisionSummaryPageExtra.saveButton')}


### PR DESCRIPTION
## Summary
On the appraisal route (no `taskId`) the `DecisionSummaryPage` context has no workflow ids, so the live **approval / activity-tracking / meeting** sections rendered empty. This resolves the ids from the appraisal's workflow progress and threads them through.

## Changes
- `DecisionSummaryPage.tsx` — fetch workflow progress via `useGetWorkflowProgress` when there is no `taskId`; derive `resolvedWorkflowInstanceId` / `resolvedActivityId` (fall back to context on the task route) and pass them to the child sections. Section visibility stays keyed off the *context* `activityId` so Appraisal Search still shows all sections. Enable Save for task owners on the task route.
- `DecisionSection.tsx` — accept optional `workflowInstanceId` / `activityId` props, falling back to context when not provided.

## Notes
- Task-route behavior is unchanged (props are `undefined` there, so context values are used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)