### PR TITLE
feat(pma): PMA property form redesign + activity-scoped tab + read-only fix

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -761,7 +761,7 @@ export const router = createBrowserRouter([
           {
             index: true,
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <PropertyInformationPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -769,7 +769,7 @@ export const router = createBrowserRouter([
           {
             path: 'condo/:propertyId',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <CondoPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -777,7 +777,7 @@ export const router = createBrowserRouter([
           {
             path: 'land-building/:propertyId',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <LandBuildingPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -846,7 +846,7 @@ export const router = createBrowserRouter([
           {
             path: 'condo/:propertyId/pma',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <CondoPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -870,7 +870,7 @@ export const router = createBrowserRouter([
           {
             path: 'land-building/:propertyId/pma',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <LandBuildingPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1247,7 +1247,7 @@ export const router = createBrowserRouter([
           {
             index: true,
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <PropertyInformationPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1255,7 +1255,7 @@ export const router = createBrowserRouter([
           {
             path: 'condo/new',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <CondoPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1263,7 +1263,7 @@ export const router = createBrowserRouter([
           {
             path: 'condo/:propertyId',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <CondoPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1271,7 +1271,7 @@ export const router = createBrowserRouter([
           {
             path: 'land-building/:propertyId',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <LandBuildingPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1279,7 +1279,7 @@ export const router = createBrowserRouter([
           {
             path: 'land-building/new',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <LandBuildingPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1348,7 +1348,7 @@ export const router = createBrowserRouter([
           {
             path: 'condo/:propertyId/pma',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <CondoPMAPage />
               </AppraisalReadOnlyWrapper>
             ),
@@ -1372,7 +1372,7 @@ export const router = createBrowserRouter([
           {
             path: 'land-building/:propertyId/pma',
             element: (
-              <AppraisalReadOnlyWrapper pageName="Property Information">
+              <AppraisalReadOnlyWrapper pageName="Property Information (PMA)">
                 <LandBuildingPMAPage />
               </AppraisalReadOnlyWrapper>
             ),

--- a/src/features/appraisal/components/GroupContainer.tsx
+++ b/src/features/appraisal/components/GroupContainer.tsx
@@ -23,6 +23,7 @@ type ViewMode = 'grid' | 'list';
 interface GroupContainerProps {
   group: PropertyGroup;
   viewMode: ViewMode;
+  isPma?: boolean;
   onDeleteGroup: (groupId: string) => void;
   onRenameGroup: (groupId: string, newName: string) => void;
   onContextMenu: (e: React.MouseEvent, property: PropertyItem, groupId: string) => void;
@@ -41,6 +42,7 @@ export const GroupContainer = React.memo(
   ({
     group,
     viewMode,
+    isPma = false,
     onDeleteGroup,
     onRenameGroup,
     onContextMenu,
@@ -194,7 +196,7 @@ export const GroupContainer = React.memo(
                       style="solid"
                     />
                   </DisclosureButton>
-                  {isEditing && !readOnly ? (
+                  {isEditing && !readOnly && !isPma ? (
                     <input
                       ref={inputRef}
                       value={editValue}
@@ -205,9 +207,9 @@ export const GroupContainer = React.memo(
                     />
                   ) : (
                     <h2
-                      className={`text-xs font-semibold text-gray-900 ${readOnly ? '' : 'cursor-pointer hover:text-primary'} transition-colors`}
-                      onClick={readOnly ? undefined : () => setIsEditing(true)}
-                      title={readOnly ? undefined : 'Click to rename'}
+                      className={`text-xs font-semibold text-gray-900 ${readOnly || isPma ? '' : 'cursor-pointer hover:text-primary'} transition-colors`}
+                      onClick={readOnly || isPma ? undefined : () => setIsEditing(true)}
+                      title={readOnly || isPma ? undefined : 'Click to rename'}
                     >
                       {group.name}
                     </h2>
@@ -228,7 +230,7 @@ export const GroupContainer = React.memo(
                       ))}
                     </>
                   )}
-                  {!readOnly && (
+                  {!readOnly && !isPma && (
                     <button
                       onClick={() => onDeleteGroup(group.id)}
                       disabled={isDeletingGroup}
@@ -244,18 +246,20 @@ export const GroupContainer = React.memo(
                   )}
                 </div>
                 <div className="flex items-center gap-1">
-                  <button
-                    className="relative p-1.5 text-gray-500 hover:text-orange-600 hover:bg-orange-50 cursor-pointer rounded-md transition-colors"
-                    onClick={() => handleOnClickPricingButton()}
-                    title="Pricing Analysis"
-                  >
-                    <Icon name="badge-dollar" className="text-base" />
-                    <span
-                      className={`absolute top-1 right-1 w-1.5 h-1.5 rounded-full ${
-                        group.pricingAnalysisId ? 'bg-emerald-500' : 'bg-gray-300'
-                      }`}
-                    />
-                  </button>
+                  {!isPma && (
+                    <button
+                      className="relative p-1.5 text-gray-500 hover:text-orange-600 hover:bg-orange-50 cursor-pointer rounded-md transition-colors"
+                      onClick={() => handleOnClickPricingButton()}
+                      title="Pricing Analysis"
+                    >
+                      <Icon name="badge-dollar" className="text-base" />
+                      <span
+                        className={`absolute top-1 right-1 w-1.5 h-1.5 rounded-full ${
+                          group.pricingAnalysisId ? 'bg-emerald-500' : 'bg-gray-300'
+                        }`}
+                      />
+                    </button>
+                  )}
                 </div>
               </div>
 
@@ -497,7 +501,7 @@ export const GroupContainer = React.memo(
                         <div className="flex flex-col items-center justify-center py-4 text-gray-400">
                           <Icon name="folder-open" className="text-2xl mb-2" />
                           <p className="text-xs mb-3">Drop properties here or add below</p>
-                          {!readOnly && <PropertyTypeDropdown groupId={group.id} />}
+                          {!readOnly && !isPma && <PropertyTypeDropdown groupId={group.id} />}
                         </div>
                       )}
                     </div>
@@ -506,7 +510,7 @@ export const GroupContainer = React.memo(
                     <div className="flex flex-col items-center justify-center py-8 text-gray-400 bg-gray-50/50 rounded-lg">
                       <Icon name="folder-open" className="text-2xl mb-2" />
                       <p className="text-xs mb-3">Drop properties here or add below</p>
-                      {!readOnly && <PropertyTypeDropdown groupId={group.id} />}
+                      {!readOnly && !isPma && <PropertyTypeDropdown groupId={group.id} />}
                     </div>
                   ) : (
                     <PropertyTable
@@ -521,7 +525,7 @@ export const GroupContainer = React.memo(
                   )}
 
                   {/* Add Property Button (only when items exist) */}
-                  {!readOnly && group.items.length > 0 && (
+                  {!readOnly && !isPma && group.items.length > 0 && (
                     <div className="mt-2 flex justify-center">
                       <PropertyTypeDropdown groupId={group.id} />
                     </div>

--- a/src/features/appraisal/components/tabs/PropertiesTab.tsx
+++ b/src/features/appraisal/components/tabs/PropertiesTab.tsx
@@ -70,6 +70,7 @@ export const PropertiesTab = ({ viewMode, onViewModeChange }: PropertiesTabProps
   const basePath = useBasePath();
   const appraisalId = useAppraisalId();
   const propertyBasePath = usePropertyBasePath();
+  const isPma = propertyBasePath === 'property-pma';
 
   // Pre-flight validation gate for pricing analysis (plug-and-play; reusable elsewhere)
   const { open: openPricingValidation, modal: pricingValidationModal } = usePricingValidationGate();
@@ -457,7 +458,10 @@ export const PropertiesTab = ({ viewMode, onViewModeChange }: PropertiesTabProps
 
   const contextMenuItems = readOnly
     ? [{ label: t('properties.contextMenu.view'), icon: 'eye', onClick: handleEdit }]
-    : [
+    : isPma
+      ? // PMA mode: only Edit (opens the PMA editor); Move/Copy/Paste/Delete are hidden.
+        [{ label: t('properties.contextMenu.edit'), icon: 'pen-to-square', onClick: handleEdit }]
+      : [
         {
           label: t('properties.contextMenu.edit'),
           icon: 'pen-to-square',
@@ -561,7 +565,7 @@ export const PropertiesTab = ({ viewMode, onViewModeChange }: PropertiesTabProps
         </div>
 
         {/* Add New Group Button */}
-        {!readOnly && (
+        {!readOnly && !isPma && (
           <Button
             variant="primary"
             onClick={handleAddGroup}
@@ -599,6 +603,7 @@ export const PropertiesTab = ({ viewMode, onViewModeChange }: PropertiesTabProps
                 key={group.id}
                 group={group}
                 viewMode={viewMode}
+                isPma={isPma}
                 onDeleteGroup={handleDeleteGroup}
                 onRenameGroup={handleRenameGroup}
                 onContextMenu={handleContextMenu}

--- a/src/features/appraisal/configs/fields.ts
+++ b/src/features/appraisal/configs/fields.ts
@@ -2687,23 +2687,7 @@ export const landAndBuildingPMAFields: FormField[] = [
 // =============================================================================
 // Condominium PMA fields
 // =============================================================================
-export const condoPMAFields: FormField[] = [
-  {
-    type: 'text-input',
-    label: 'Construction on Title Deed Number',
-    name: 'builtOnTitleNumber',
-    wrapperClassName: 'col-span-6',
-    required: true,
-    maxLength: 200,
-  },
-  {
-    type: 'text-input',
-    label: 'Condominium Registration Number',
-    name: 'condoRegistrationNumber',
-    wrapperClassName: 'col-span-3',
-    required: true,
-    maxLength: 10,
-  },
+export const condoPmaDetailFields: FormField[] = [
   {
     type: 'text-input',
     label: 'Room Number',
@@ -2730,12 +2714,31 @@ export const condoPMAFields: FormField[] = [
   },
   {
     type: 'text-input',
-    label: 'Condominium Name',
+    label: 'Condo Name',
     name: 'condoName',
     wrapperClassName: 'col-span-6',
     required: true,
     maxLength: 100,
   },
+  {
+    type: 'text-input',
+    label: 'Condo Registration Number',
+    name: 'condoRegistrationNumber',
+    wrapperClassName: 'col-span-3',
+    required: true,
+    maxLength: 10,
+  },
+  {
+    type: 'text-input',
+    label: 'Construction on Title Deed Number',
+    name: 'builtOnTitleNumber',
+    wrapperClassName: 'col-span-6',
+    required: true,
+    maxLength: 200,
+  },
+];
+
+export const condoPmaAddressFields: FormField[] = [
   {
     type: 'location-selector',
     label: 'Sub District',
@@ -2767,6 +2770,8 @@ export const condoPMAFields: FormField[] = [
     wrapperClassName: 'col-span-3',
   },
 ];
+
+export const condoPMAFields: FormField[] = [...condoPmaDetailFields, ...condoPmaAddressFields];
 
 export const allCondoPMAFields: FormField[] = [...pmaField, ...condoPMAFields];
 

--- a/src/features/appraisal/context/AppraisalContext.tsx
+++ b/src/features/appraisal/context/AppraisalContext.tsx
@@ -180,6 +180,7 @@ const PAGE_NAME_TO_ITEM_KEY: Record<string, string> = {
   Administration: 'appraisal.administration',
   'Appointment & Fee': 'appraisal.appointment',
   'Property Information': 'appraisal.property',
+  'Property Information (PMA)': 'appraisal.property-pma',
   'Document Checklist': 'appraisal.documents',
   'Summary & Decision': 'appraisal.summary',
   '360 Summary': 'appraisal.360',

--- a/src/features/appraisal/forms/CondoPMAForm.tsx
+++ b/src/features/appraisal/forms/CondoPMAForm.tsx
@@ -1,35 +1,87 @@
-import { FormFields, type FormField } from '@/shared/components/form';
+import { Badge } from '@/shared/components';
+import { FormFields } from '@/shared/components/form';
 import Icon from '@/shared/components/Icon';
-import { pmaField, condoPMAFields } from '../configs/fields';
+import { useRelativeTime } from '@/shared/hooks/useFormatters';
+import { pmaField, condoPmaDetailFields, condoPmaAddressFields } from '../configs/fields';
 
-const CondoPMAForm = () => {
+type CondoPMAFormProps = {
+  externalSyncStatus?: string | null;
+  externalSyncError?: string | null;
+  externalSyncedAt?: string | null;
+};
+
+const CondoPMAForm = ({
+  externalSyncStatus,
+  externalSyncError,
+  externalSyncedAt,
+}: CondoPMAFormProps) => {
+  const relTime = useRelativeTime();
+  const synced = externalSyncedAt ? relTime(externalSyncedAt) : null;
+
   return (
     <div className="flex flex-col gap-6">
-      {/* PMA Section */}
-      <div id="pma-section">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-9 h-9 rounded-lg bg-emerald-100 flex items-center justify-center">
-            <Icon name="file-invoice-dollar" style="solid" className="w-5 h-5 text-emerald-600" />
+      {/* Property Section — sync status badge sits on this header line */}
+      <div id="property-section">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-blue-100 flex items-center justify-center">
+              <Icon name="city" style="solid" className="w-5 h-5 text-blue-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">Updating PMA Property</h2>
           </div>
-          <h2 className="text-lg font-semibold text-gray-900">PMA</h2>
+          {externalSyncStatus && externalSyncStatus !== 'NotSynced' && (
+            <div
+              className="flex items-center gap-2 shrink-0"
+              title={externalSyncStatus === 'Failed' ? (externalSyncError ?? undefined) : undefined}
+            >
+              {externalSyncStatus === 'Delivered' && (
+                <>
+                  <Badge type="externalSyncStatus" value="Delivered" size="sm">
+                    Synced
+                  </Badge>
+                  {synced && (
+                    <span className="text-xs text-gray-400" title={synced.absolute}>
+                      · {synced.relative}
+                    </span>
+                  )}
+                </>
+              )}
+              {externalSyncStatus === 'Pending' && (
+                <Badge type="externalSyncStatus" value="Pending" size="sm">
+                  Pending sync
+                </Badge>
+              )}
+              {externalSyncStatus === 'Failed' && (
+                <>
+                  <Badge type="externalSyncStatus" value="Failed" size="sm">
+                    Sync failed
+                  </Badge>
+                  <span className="text-xs text-gray-400">· Save to retry</span>
+                </>
+              )}
+            </div>
+          )}
         </div>
         <div className="h-px bg-gray-200 mb-4" />
+        <div className="text-xs font-medium text-primary mb-2">Title Information</div>
         <div className="grid grid-cols-9 gap-4">
-          <FormFields fields={pmaField} />
+          <FormFields fields={condoPmaDetailFields} />
+        </div>
+
+        {/* Address sub-group */}
+        <div className="mt-5">
+          <div className="text-xs font-medium text-primary mb-2">Address</div>
+          <div className="grid grid-cols-9 gap-4">
+            <FormFields fields={condoPmaAddressFields} />
+          </div>
         </div>
       </div>
 
-      {/* Property Section */}
-      <div id="property-section">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-9 h-9 rounded-lg bg-blue-100 flex items-center justify-center">
-            <Icon name="city" style="solid" className="w-5 h-5 text-blue-600" />
-          </div>
-          <h2 className="text-lg font-semibold text-gray-900">Property</h2>
-        </div>
-        <div className="h-px bg-gray-200 mb-4" />
+      {/* Value Section (prices) */}
+      <div id="value-section">
+        <div className="text-xs font-medium text-primary mb-2">Value Information</div>
         <div className="grid grid-cols-9 gap-4">
-          <FormFields fields={condoPMAFields} />
+          <FormFields fields={pmaField} />
         </div>
       </div>
     </div>

--- a/src/features/appraisal/forms/LandBuildingPMAForm.tsx
+++ b/src/features/appraisal/forms/LandBuildingPMAForm.tsx
@@ -41,7 +41,7 @@ const LandBuildingPMAForm = ({
   return (
     <div className="flex flex-col gap-6">
       {/* Property Section — sync status badge sits on this header line */}
-      <div id="property-section" className="rounded-lg border border-gray-200 p-5">
+      <div id="property-section">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <div className="w-9 h-9 rounded-lg bg-amber-100 flex items-center justify-center">
@@ -83,35 +83,24 @@ const LandBuildingPMAForm = ({
           )}
         </div>
         <div className="h-px bg-gray-200 mb-4" />
+        <div className="text-xs font-medium text-primary mb-2">Title Information</div>
         <div className="grid grid-cols-12 gap-4">
           <FormFields fields={landPmaTitleFields} />
-        </div>
-
-        {/* Land Area sub-group */}
-        <div className="rounded-md border border-gray-100 bg-gray-50/40 p-3 mt-5">
-          <div className="text-xs font-medium text-gray-500 mb-2">Land Area</div>
-          <div className="grid grid-cols-12 gap-4">
-            <FormFields fields={landPmaAreaFields} />
-          </div>
-          <p className="text-xs text-gray-400 mt-2">
-            Total Sq.Wa = Rai × 400 + Ngan × 100 + Sq.Wa
-          </p>
+          <FormFields fields={landPmaAreaFields} />
         </div>
 
         {/* Address sub-group */}
         <div className="mt-5">
-          <div className="text-xs font-medium text-gray-500 mb-2">Address</div>
+          <div className="text-xs font-medium text-primary mb-2">Address</div>
           <div className="grid grid-cols-12 gap-4">
             <FormFields fields={landPmaAddressFields} />
           </div>
-          <p className="text-xs text-gray-400 mt-2">
-            District &amp; Province auto-fill from Sub District.
-          </p>
         </div>
       </div>
 
       {/* Value Section (prices) */}
-      <div id="value-section" className="rounded-lg border border-gray-200 p-5">
+      <div id="value-section">
+        <div className="text-xs font-medium text-primary mb-2">Value Information</div>
         <div className="grid grid-cols-9 gap-4">
           <FormFields fields={pmaField} />
         </div>

--- a/src/features/appraisal/pages/CondoPMAPage.tsx
+++ b/src/features/appraisal/pages/CondoPMAPage.tsx
@@ -11,8 +11,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 //import { useGetCondoPMAPropertyById, useUpdateCondoPMAProperty } from '../api';
 import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import { mapCondoPMAPropertyResponseToForm } from '../utils/mappers';
-import { Badge, Button, CancelButton, Icon, ResizableSidebar, Section } from '@/shared/components';
-import NavAnchors from '@/shared/components/sections/NavAnchors';
+import { Button, CancelButton, Icon, ResizableSidebar, Section } from '@/shared/components';
 import { FormProvider } from '@/shared/components/form';
 import { useUnsavedChangesWarning } from '@/shared/hooks/useUnsavedChangesWarning';
 import UnsavedChangesDialog from '@/shared/components/UnsavedChangesDialog';
@@ -158,52 +157,6 @@ const CondoPMAPage = () => {
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {/* NavAnchors */}
-      <div className="shrink-0 pb-4 flex items-center justify-between">
-        <NavAnchors
-          containerId="form-scroll-container"
-          anchors={[
-            { label: 'PMA', id: 'pma-section', icon: 'file-invoice-dollar' },
-            { label: 'Property', id: 'property-section', icon: 'city' },
-          ]}
-        />
-        {isEditMode &&
-          propertyData?.externalSyncStatus &&
-          propertyData.externalSyncStatus !== 'NotSynced' && (
-            <div
-              className="flex items-center gap-2 shrink-0"
-              title={
-                propertyData.externalSyncStatus === 'Failed'
-                  ? (propertyData.externalSyncError ?? undefined)
-                  : undefined
-              }
-            >
-              {propertyData.externalSyncStatus === 'Delivered' && (
-                <Badge type="externalSyncStatus" value="Delivered" size="sm">
-                  Synced
-                </Badge>
-              )}
-              {propertyData.externalSyncStatus === 'Pending' && (
-                <Badge type="externalSyncStatus" value="Pending" size="sm">
-                  Syncing…
-                </Badge>
-              )}
-              {propertyData.externalSyncStatus === 'Failed' && (
-                <>
-                  <Badge type="externalSyncStatus" value="Failed" size="sm">
-                    Sync failed
-                  </Badge>
-                  {propertyData.externalSyncError && (
-                    <span className="text-xs text-red-600 truncate max-w-xs">
-                      — {propertyData.externalSyncError}
-                    </span>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-      </div>
-
       <FormProvider methods={methods} schema={condoPMAFormSchema}>
         <form onSubmit={handleSubmit(onSubmit)} className="flex-1 min-h-0 flex flex-col">
           {/* Scrollable Form Content */}
@@ -224,7 +177,11 @@ const CondoPMAPage = () => {
                     anchor
                     className="flex flex-col gap-6 min-w-0 overflow-hidden"
                   >
-                    <CondoPMAForm />
+                    <CondoPMAForm
+                      externalSyncStatus={isEditMode ? propertyData?.externalSyncStatus : undefined}
+                      externalSyncError={isEditMode ? propertyData?.externalSyncError : undefined}
+                      externalSyncedAt={isEditMode ? propertyData?.externalSyncedAt : undefined}
+                    />
                   </Section>
                 </div>
               </ResizableSidebar.Main>

--- a/src/features/appraisal/pages/PropertyInformationPage.tsx
+++ b/src/features/appraisal/pages/PropertyInformationPage.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { usePageReadOnly, PageReadOnlyContext } from '@/shared/contexts/PageReadOnlyContext';
 import { useIsCiAppraisal, useAppraisalId } from '@/features/appraisal/context/AppraisalContext';
 import { useEnrichedPropertyGroups } from '@/features/appraisal/hooks/useEnrichedPropertyGroups';
+import { usePropertyBasePath } from '@/features/appraisal/hooks/usePropertyBasePath';
 import Icon from '@shared/components/Icon';
 import {
   GalleryTab,
@@ -31,6 +32,7 @@ const VALID_TABS: TabId[] = ['properties', 'markets', 'gallery', 'photos', 'laws
 export default function PropertyInformationPage() {
   const { t } = useTranslation('appraisal');
   const isReadOnly = usePageReadOnly();
+  const isPma = usePropertyBasePath() === 'property-pma';
 
   // The Machinery Summary tab is appraisal-level (one record per appraisal) and
   // only relevant when the appraisal actually contains machinery.
@@ -55,7 +57,10 @@ export default function PropertyInformationPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab') as TabId | null;
   const isTabAvailable = (id: TabId | null): id is TabId =>
-    !!id && VALID_TABS.includes(id) && (id !== 'machinery' || hasMachinery);
+    !!id &&
+    VALID_TABS.includes(id) &&
+    (id !== 'machinery' || hasMachinery) &&
+    (!isPma || id === 'properties');
   const activeTab: TabId = isTabAvailable(tabParam) ? tabParam : 'properties';
 
   // Seed `?tab=properties` on first arrival so the URL is the source of truth
@@ -65,13 +70,15 @@ export default function PropertyInformationPage() {
       setSearchParams({ tab: 'properties' }, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tabParam, hasMachinery, setSearchParams]);
+  }, [tabParam, hasMachinery, isPma, setSearchParams]);
 
   const handleTabChange = (tabId: TabId) => {
     setSearchParams({ tab: tabId }, { replace: true });
   };
 
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
+
+  const visibleTabs = isPma ? TABS.filter(tab => tab.id === 'properties') : TABS;
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -98,7 +105,7 @@ export default function PropertyInformationPage() {
         {/* Tab Navigation - Compact */}
         <div className="shrink-0 pb-4">
           <nav className="flex gap-0.5 bg-gray-50/80 p-0.5 rounded-lg border border-gray-100">
-            {TABS.map(tab => {
+            {visibleTabs.map(tab => {
               const isActive = activeTab === tab.id;
               return (
                 <button

--- a/src/shared/config/appraisalMenuConditions.ts
+++ b/src/shared/config/appraisalMenuConditions.ts
@@ -17,15 +17,9 @@ export type AppraisalMenuCondition = {
  * canEdit value.
  */
 export const appraisalMenuConditions: Record<string, AppraisalMenuCondition> = {
-  // Property Information — shown for all appraisal types except PMA.
-  // For block appraisals the href is overridden in useNavigation to point at the block page.
-  'appraisal.property': {
-    showWhen: ctx => !ctx.isPma,
-  },
-  // Property Information (PMA variant)
-  'appraisal.property-pma': {
-    showWhen: ctx => ctx.isPma === true,
-  },
+  // Property Information — the normal property page. Visibility is activity-scoped via
+  // ActivityMenuOverrides (hidden on int-pma-input, where the PMA variant takes over), so no
+  // code-side showWhen here. For block appraisals the href is overridden in useNavigation.
   // Block Condo / Village items are collapsed into "Property Information" above — always hide.
   'appraisal.block-condo': {
     showWhen: () => false,


### PR DESCRIPTION
## What
Frontend for the PMA property tab: form redesign, PMA-mode page trims, activity-scoped tab, and the read-only fix. Pairs with the backend PR (`appraisal/pma-property-tab` on the api repo, #294).

## Changes
- **PMA form redesign** (Land & Condo): field order aligned to the Title Information page, "Number" naming, small section captions (*Title / Address / Value Information*, primary color), read-only computed **Total Sq.Wa**, ฿ price prefixes, and the sync-status badge.
- **PMA-mode Property page**: only the *Properties* tab; hides group add/delete/rename, add-property, per-group Pricing Analysis, and the mutating context-menu items (keeps Edit + Grid/List toggle).
- **Activity-scoped tab**: removed the `isPma` `showWhen` gates on `appraisal.property` / `appraisal.property-pma` — visibility is now driven by the DB menu / ActivityMenuOverrides (PMA tab shows only on `int-pma-input`).
- **Read-only fix**: the `property-pma` routes now resolve read-only from `appraisal.property-pma` (`PAGE_NAME_TO_ITEM_KEY` + router `pageName`). Previously they keyed off the normal `appraisal.property` item, which is hidden on `int-pma-input`, so the page failed closed to read-only.

## Verify
- On an `int-pma-input` task → PMA tab shows and is **editable** (IntAppraisalStaff); other activities show the normal Property tab.
- `tsc` clean for the touched files (repo has ~500 unrelated baseline errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)