### PR TITLE
feat(quotation): listing search bar, multi-select status, sortable columns, customer column

### DIFF
--- a/src/features/quotation/api/quotation.ts
+++ b/src/features/quotation/api/quotation.ts
@@ -73,11 +73,15 @@ export const useGetAppraisalQuotations = (appraisalId: string | null | undefined
 export interface GetQuotationsParams {
   pageNumber?: number;
   pageSize?: number;
-  status?: string;
-  search?: string;
+  statuses?: string[];
+  quotationNo?: string;
+  appraisalNo?: string;
+  customerName?: string;
   cutOffTimeFrom?: string;
   cutOffTimeTo?: string;
   companyId?: string;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
 }
 
 export interface QuotationListItem {
@@ -90,6 +94,9 @@ export interface QuotationListItem {
   totalAppraisals: number;
   totalCompaniesInvited: number;
   totalQuotationsReceived: number;
+  customerName?: string | null;
+  customerCount: number;
+  customerNames?: string | null;
 }
 
 export interface PaginatedQuotations {
@@ -107,25 +114,35 @@ export const useGetQuotations = (params: GetQuotationsParams = {}) => {
   const queryKey = quotationKeys.list({
     pageNumber: params.pageNumber ?? 0,
     pageSize: params.pageSize ?? 10,
-    ...(params.status && { status: params.status }),
-    ...(params.search && { search: params.search }),
+    ...(params.statuses?.length && { statuses: params.statuses }),
+    ...(params.quotationNo && { quotationNo: params.quotationNo }),
+    ...(params.appraisalNo && { appraisalNo: params.appraisalNo }),
+    ...(params.customerName && { customerName: params.customerName }),
     ...(params.cutOffTimeFrom && { cutOffTimeFrom: params.cutOffTimeFrom }),
     ...(params.cutOffTimeTo && { cutOffTimeTo: params.cutOffTimeTo }),
     ...(params.companyId && { companyId: params.companyId }),
+    ...(params.sortBy && { sortBy: params.sortBy }),
+    ...(params.sortDir && { sortDir: params.sortDir }),
   });
 
   return useQuery({
     queryKey,
     queryFn: async (): Promise<PaginatedQuotations> => {
       const { data } = await axios.get('/quotations', {
+        // indexes:null → repeated params (?Statuses=A&Statuses=B) which Carter binds to string[]?
+        paramsSerializer: { indexes: null },
         params: {
           PageNumber: params.pageNumber ?? 0,
           PageSize: params.pageSize ?? 10,
-          ...(params.status && { Status: params.status }),
-          ...(params.search && { Search: params.search }),
+          ...(params.statuses?.length && { Statuses: params.statuses }),
+          ...(params.quotationNo && { QuotationNo: params.quotationNo }),
+          ...(params.appraisalNo && { AppraisalNo: params.appraisalNo }),
+          ...(params.customerName && { CustomerName: params.customerName }),
           ...(params.cutOffTimeFrom && { CutOffTimeFrom: params.cutOffTimeFrom }),
           ...(params.cutOffTimeTo && { CutOffTimeTo: params.cutOffTimeTo }),
           ...(params.companyId && { CompanyId: params.companyId }),
+          ...(params.sortBy && { SortBy: params.sortBy }),
+          ...(params.sortDir && { SortDir: params.sortDir }),
         },
       });
       const result = data.quotations ?? data;
@@ -157,6 +174,9 @@ export interface MyInvitationDto {
   quotedBy: string | null;
   companyStatus: string;
   hasSubmitted: boolean;
+  customerName?: string | null;
+  customerCount: number;
+  customerNames?: string | null;
 }
 
 export interface PaginatedMyInvitations {
@@ -169,10 +189,14 @@ export interface PaginatedMyInvitations {
 export interface GetMyInvitationsParams {
   pageNumber?: number;
   pageSize?: number;
-  status?: string;
-  search?: string;
+  statuses?: string[];
+  quotationNo?: string;
+  appraisalNo?: string;
+  customerName?: string;
   cutOffTimeFrom?: string;
   cutOffTimeTo?: string;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
 }
 
 /**
@@ -184,23 +208,33 @@ export const useGetMyInvitations = (params: GetMyInvitationsParams = {}) => {
   const queryKey = quotationKeys.myInvitations({
     pageNumber: params.pageNumber ?? 0,
     pageSize: params.pageSize ?? 10,
-    ...(params.status && { status: params.status }),
-    ...(params.search && { search: params.search }),
+    ...(params.statuses?.length && { statuses: params.statuses }),
+    ...(params.quotationNo && { quotationNo: params.quotationNo }),
+    ...(params.appraisalNo && { appraisalNo: params.appraisalNo }),
+    ...(params.customerName && { customerName: params.customerName }),
     ...(params.cutOffTimeFrom && { cutOffTimeFrom: params.cutOffTimeFrom }),
     ...(params.cutOffTimeTo && { cutOffTimeTo: params.cutOffTimeTo }),
+    ...(params.sortBy && { sortBy: params.sortBy }),
+    ...(params.sortDir && { sortDir: params.sortDir }),
   });
 
   return useQuery({
     queryKey,
     queryFn: async (): Promise<PaginatedMyInvitations> => {
       const { data } = await axios.get('/quotations/my-invitations', {
+        // indexes:null → repeated params (?Statuses=A&Statuses=B) which Carter binds to string[]?
+        paramsSerializer: { indexes: null },
         params: {
           PageNumber: params.pageNumber ?? 0,
           PageSize: params.pageSize ?? 10,
-          ...(params.status && { Status: params.status }),
-          ...(params.search && { Search: params.search }),
+          ...(params.statuses?.length && { Statuses: params.statuses }),
+          ...(params.quotationNo && { QuotationNo: params.quotationNo }),
+          ...(params.appraisalNo && { AppraisalNo: params.appraisalNo }),
+          ...(params.customerName && { CustomerName: params.customerName }),
           ...(params.cutOffTimeFrom && { CutOffTimeFrom: params.cutOffTimeFrom }),
           ...(params.cutOffTimeTo && { CutOffTimeTo: params.cutOffTimeTo }),
+          ...(params.sortBy && { SortBy: params.sortBy }),
+          ...(params.sortDir && { SortDir: params.sortDir }),
         },
       });
       const result = data.invitations ?? data;

--- a/src/features/quotation/components/SearchByInput.tsx
+++ b/src/features/quotation/components/SearchByInput.tsx
@@ -1,0 +1,114 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import clsx from 'clsx';
+import Icon from '@/shared/components/Icon';
+
+export interface SearchByOption {
+  value: string;
+  label: string;
+  /** Icon name (FA sprite) shown for the field — reflects what you're searching by. */
+  icon?: string;
+}
+
+interface SearchByInputProps {
+  /** Options for the "search by" field selector. */
+  options: SearchByOption[];
+  /** Currently selected field value. */
+  field: string;
+  onFieldChange: (field: string) => void;
+  /** Search term (controlled). */
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Combined search control: a "search by" field selector on the left, a divider, then
+ * the search input — all inside one bordered container. The field selector's menu sizes
+ * to its own content, so it can be wider than the pill.
+ */
+function SearchByInput({
+  options,
+  field,
+  onFieldChange,
+  value,
+  onChange,
+  placeholder,
+  className,
+}: SearchByInputProps) {
+  const selected = options.find(o => o.value === field);
+
+  return (
+    <div
+      className={clsx(
+        'flex items-center rounded-lg border border-gray-200 bg-white transition-colors',
+        'focus-within:ring-2 focus-within:ring-gray-200 focus-within:border-gray-400',
+        className,
+      )}
+    >
+      {/* Field selector */}
+      <Menu as="div" className="relative shrink-0">
+        <MenuButton
+          style={{ outline: 'none' }}
+          className="flex items-center gap-1.5 rounded-l-lg px-3 py-2 text-sm text-gray-700 whitespace-nowrap hover:bg-gray-50"
+        >
+          {selected?.icon && (
+            <Icon style="solid" name={selected.icon} className="size-3.5 text-primary" />
+          )}
+          {selected?.label ?? ''}
+          <Icon style="regular" name="chevron-down" className="size-3 text-gray-400" />
+        </MenuButton>
+        <MenuItems
+          anchor="bottom start"
+          className="mt-1 min-w-44 rounded-lg border border-gray-200 bg-white py-1 shadow-lg z-50 focus:outline-none"
+        >
+          {options.map(o => {
+            const isSelected = o.value === field;
+            return (
+              <MenuItem key={o.value}>
+                <button
+                  type="button"
+                  onClick={() => onFieldChange(o.value)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors data-focus:bg-gray-100"
+                >
+                  {o.icon && (
+                    <Icon
+                      style="solid"
+                      name={o.icon}
+                      className={clsx('size-3.5', isSelected ? 'text-primary' : 'text-gray-400')}
+                    />
+                  )}
+                  <span className={clsx('flex-1 truncate', isSelected && 'font-medium text-gray-900')}>
+                    {o.label}
+                  </span>
+                  {isSelected && (
+                    <Icon style="solid" name="check" className="size-3.5 text-gray-600" />
+                  )}
+                </button>
+              </MenuItem>
+            );
+          })}
+        </MenuItems>
+      </Menu>
+
+      {/* Divider */}
+      <div className="h-5 w-px shrink-0 bg-gray-200" />
+
+      {/* Search input */}
+      <div className="flex flex-1 items-center px-3">
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          // Inline outline:none — the global `:focus-visible` rule (src/index.css) is unlayered
+          // and beats Tailwind's layered outline utilities; an inline style outranks it.
+          style={{ outline: 'none' }}
+          className="w-full min-w-0 bg-transparent py-2 text-sm placeholder:text-gray-400"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default SearchByInput;

--- a/src/features/quotation/pages/ExtCompanyInvitationListPage.tsx
+++ b/src/features/quotation/pages/ExtCompanyInvitationListPage.tsx
@@ -3,12 +3,15 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@/shared/components/Icon';
 import Button from '@/shared/components/Button';
-import Input from '@/shared/components/Input';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { DateInput } from '@/shared/components/inputs';
+import MultiSelectDropdown from '@/shared/components/inputs/MultiSelectDropdown';
 import { formatLocaleDateTime } from '@/shared/utils/dateUtils';
 import MyInvitationStatusBadge from '../components/MyInvitationStatusBadge';
+import SearchByInput from '../components/SearchByInput';
+import SortableTh from '@/features/taskMonitor/components/SortableTh';
+import type { SortDir } from '@/features/taskMonitor/types';
 import { useGetMyInvitations } from '../api/quotation';
 
 /** Slice a DatePickerInput ISO value down to the `yyyy-MM-dd` slug the backend's
@@ -27,6 +30,9 @@ const VENDOR_STATUS_CODES = [
   'Declined',
   'Cancelled',
 ] as const;
+
+// Single search box + a "search by" selector: only the chosen field is sent to the backend.
+type SearchField = 'quotationNo' | 'appraisalNo' | 'customerName';
 
 const formatCurrency = (amount: number | null) => {
   if (amount == null) return '—';
@@ -50,32 +56,56 @@ const ExtCompanyInvitationListPage = () => {
   const [pageSize, setPageSize] = useState(10);
 
   // Filter state — date filters store ISO from DatePickerInput; sliced to yyyy-MM-dd at the API boundary.
+  const [searchField, setSearchField] = useState<SearchField>('quotationNo');
   const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
+  const [statuses, setStatuses] = useState<string[]>([]);
   const [cutOffTimeFrom, setCutOffTimeFrom] = useState<string | null>(null);
   const [cutOffTimeTo, setCutOffTimeTo] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortDir, setSortDir] = useState<SortDir | undefined>(undefined);
 
-  // Debounced search
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const handleSortChange = (key: string | undefined, dir: SortDir | undefined) => {
+    setSortBy(key);
+    setSortDir(dir);
+    setPageNumber(0);
+  };
+
+  // Debounced search term — only the value is debounced; switching field applies immediately.
+  const [debouncedTerm, setDebouncedTerm] = useState('');
+
+  const statusOptions = VENDOR_STATUS_CODES.map(code => ({
+    value: code,
+    label: t(`vendorStatus.${code}` as `vendorStatus.${(typeof VENDOR_STATUS_CODES)[number]}`),
+  }));
+  const searchFieldOptions = [
+    { value: 'quotationNo', label: t('filters.quotationNoPlaceholder'), icon: 'file-invoice' },
+    { value: 'appraisalNo', label: t('filters.appraisalNoPlaceholder'), icon: 'building' },
+    { value: 'customerName', label: t('filters.customerNamePlaceholder'), icon: 'user' },
+  ];
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearch(searchTerm);
+      setDebouncedTerm(searchTerm);
     }, 500);
     return () => clearTimeout(timer);
   }, [searchTerm]);
 
   useEffect(() => {
     setPageNumber(0);
-  }, [debouncedSearch, statusFilter, cutOffTimeFrom, cutOffTimeTo]);
+  }, [debouncedTerm, searchField, statuses, cutOffTimeFrom, cutOffTimeTo]);
 
+  const term = debouncedTerm || undefined;
   const { data, isLoading, isFetching, isError, error } = useGetMyInvitations({
     pageNumber,
     pageSize,
-    search: debouncedSearch || undefined,
-    status: statusFilter || undefined,
+    quotationNo: searchField === 'quotationNo' ? term : undefined,
+    appraisalNo: searchField === 'appraisalNo' ? term : undefined,
+    customerName: searchField === 'customerName' ? term : undefined,
+    statuses: statuses.length ? statuses : undefined,
     cutOffTimeFrom: toDateOnly(cutOffTimeFrom),
     cutOffTimeTo: toDateOnly(cutOffTimeTo),
+    sortBy,
+    sortDir,
   });
 
   const items = data?.items ?? [];
@@ -85,11 +115,11 @@ const ExtCompanyInvitationListPage = () => {
   const isFirstLoad = isLoading && items.length === 0;
   const isRefetching = isFetching && !isFirstLoad;
 
-  const hasFilters = searchTerm || statusFilter || cutOffTimeFrom || cutOffTimeTo;
+  const hasFilters = searchTerm || statuses.length || cutOffTimeFrom || cutOffTimeTo;
 
   const handleClearFilters = () => {
     setSearchTerm('');
-    setStatusFilter('');
+    setStatuses([]);
     setCutOffTimeFrom(null);
     setCutOffTimeTo(null);
   };
@@ -121,29 +151,32 @@ const ExtCompanyInvitationListPage = () => {
 
       {/* Filters Bar */}
       <div className="shrink-0 flex items-end gap-3 pb-1 flex-wrap">
-        {/* Search */}
-        <div className="flex-1 max-w-xs">
-          <Input
-            placeholder={t('filters.searchPlaceholder')}
+        {/* Search — one bar: "search by" selector + input */}
+        <div className="flex flex-col gap-1">
+          <label className="block text-xs font-medium text-gray-700">{t('filters.searchBy')}</label>
+          <SearchByInput
+            options={searchFieldOptions}
+            field={searchField}
+            onFieldChange={v => setSearchField(v as SearchField)}
             value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
-            leftIcon={<Icon style="solid" name="magnifying-glass" className="size-3.5" />}
+            onChange={setSearchTerm}
+            placeholder={t('filters.searchPlaceholder')}
+            className="w-96"
           />
         </div>
 
-        {/* Status Filter */}
-        <select
-          value={statusFilter}
-          onChange={e => setStatusFilter(e.target.value)}
-          className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white min-w-36 hover:border-gray-300"
-        >
-          <option value="">{t('filters.allStatuses')}</option>
-          {VENDOR_STATUS_CODES.map(code => (
-            <option key={code} value={code}>
-              {t(`vendorStatus.${code}` as `vendorStatus.${(typeof VENDOR_STATUS_CODES)[number]}`)}
-            </option>
-          ))}
-        </select>
+        {/* Status Filter — multi-select */}
+        <div className="flex flex-col gap-1">
+          <label className="block text-xs font-medium text-gray-700">{t('columns.status')}</label>
+          <MultiSelectDropdown
+            options={statusOptions}
+            value={statuses}
+            onChange={setStatuses}
+            placeholder={t('filters.allStatuses')}
+            showValuePrefix={false}
+            className="min-w-40"
+          />
+        </div>
 
         {/* Cut Off Time — From */}
         <div className="w-40">
@@ -179,30 +212,65 @@ const ExtCompanyInvitationListPage = () => {
           <table className="w-full text-sm">
             <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
               <tr className="border-b border-gray-200">
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.quotationNumber')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.status')}
-                </th>
-                <th className="text-center font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.noOfAppraisal')}
-                </th>
-                <th className="text-right font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.totalFeeAmount')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.receivedAt')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.cutOffTime')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.quotedBy')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.quotedAt')}
-                </th>
+                <SortableTh
+                  label={t('columns.quotationNumber')}
+                  sortKey="QuotationNumber"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.customerName')}
+                  sortKey="CustomerName"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.status')}
+                  sortKey="CompanyStatus"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.noOfAppraisal')}
+                  sortKey="TotalAppraisals"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                  className="text-center"
+                />
+                <SortableTh
+                  label={t('columns.totalFeeAmount')}
+                  sortKey="TotalFeeAmount"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                  className="text-right"
+                />
+                <SortableTh
+                  label={t('columns.receivedAt')}
+                  sortKey="ReceivedAt"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.cutOffTime')}
+                  sortKey="CutOffTime"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh label={t('columns.quotedBy')} />
+                <SortableTh
+                  label={t('columns.quotedAt')}
+                  sortKey="QuotedAt"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
               </tr>
             </thead>
             <tbody
@@ -212,6 +280,7 @@ const ExtCompanyInvitationListPage = () => {
                 <TableRowSkeleton
                   columns={[
                     { width: 'w-28' },
+                    { width: 'w-32' },
                     { width: 'w-12' },
                     { width: 'w-24' },
                     { width: 'w-24' },
@@ -224,7 +293,7 @@ const ExtCompanyInvitationListPage = () => {
                 />
               ) : items.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className="text-center py-16">
+                  <td colSpan={9} className="text-center py-16">
                     <div className="flex flex-col items-center gap-3">
                       <Icon name="inbox" style="regular" className="size-12 text-gray-300" />
                       <div className="text-center">
@@ -249,6 +318,17 @@ const ExtCompanyInvitationListPage = () => {
                   >
                     <td className="px-4 py-2.5">
                       <span className="font-medium text-primary">{item.quotationNumber}</span>
+                    </td>
+                    <td
+                      className="px-4 py-2.5 text-gray-600 max-w-[16rem]"
+                      title={item.customerNames ?? undefined}
+                    >
+                      <span className="inline-block max-w-full truncate align-bottom">
+                        {item.customerName ?? '—'}
+                      </span>
+                      {item.customerCount > 1 && (
+                        <span className="ml-1 text-xs text-gray-400">+{item.customerCount - 1}</span>
+                      )}
                     </td>
                     <td className="px-4 py-2.5">
                       <MyInvitationStatusBadge status={item.companyStatus} />

--- a/src/features/quotation/pages/QuotationListingPage.tsx
+++ b/src/features/quotation/pages/QuotationListingPage.tsx
@@ -4,13 +4,16 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import Icon from '@/shared/components/Icon';
 import Button from '@/shared/components/Button';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
-import Input from '@/shared/components/Input';
 import Pagination from '@/shared/components/Pagination';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { DateInput } from '@/shared/components/inputs';
 import CompanyAutocomplete from '@/shared/components/inputs/CompanyAutocomplete';
+import MultiSelectDropdown from '@/shared/components/inputs/MultiSelectDropdown';
 import { formatLocaleDateTime } from '@/shared/utils/dateUtils';
 import QuotationStatusBadge from '../components/QuotationStatusBadge';
+import SearchByInput from '../components/SearchByInput';
+import SortableTh from '@/features/taskMonitor/components/SortableTh';
+import type { SortDir } from '@/features/taskMonitor/types';
 import { useCancelQuotation, useGetQuotations, type QuotationListItem } from '../api/quotation';
 import { z } from 'zod';
 import { QuotationStatusSchema } from '../schemas/quotation';
@@ -22,6 +25,9 @@ type QuotationStatus = z.infer<typeof QuotationStatusSchema>;
 const toDateOnly = (iso: string | null | undefined) => (iso ? iso.slice(0, 10) : undefined);
 
 const QUOTATION_STATUS_OPTIONS: QuotationStatus[] = QuotationStatusSchema.options;
+
+// Single search box + a "search by" selector: only the chosen field is sent to the backend.
+type SearchField = 'quotationNo' | 'appraisalNo' | 'customerName';
 
 const TERMINAL_STATUSES = new Set(['Finalized', 'Cancelled', 'Closed']);
 
@@ -93,14 +99,30 @@ function QuotationListingPage() {
   const [pageSize, setPageSize] = useState(10);
 
   // Filter state — date filters store ISO from DatePickerInput; sliced to yyyy-MM-dd at the API boundary.
+  const [searchField, setSearchField] = useState<SearchField>('quotationNo');
   const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState(searchParams.get('status') ?? '');
+  const [statuses, setStatuses] = useState<string[]>(() => searchParams.getAll('status'));
   const [cutOffTimeFrom, setCutOffTimeFrom] = useState<string | null>(null);
   const [cutOffTimeTo, setCutOffTimeTo] = useState<string | null>(null);
   const [companyFilter, setCompanyFilter] = useState(''); // company Guid from the picker
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortDir, setSortDir] = useState<SortDir | undefined>(undefined);
 
-  // Debounced search — matches quotation number, requester, appraisal number, or customer
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const handleSortChange = (key: string | undefined, dir: SortDir | undefined) => {
+    setSortBy(key);
+    setSortDir(dir);
+    setPageNumber(0);
+  };
+
+  // Debounced search term — only the value is debounced; switching field applies immediately.
+  const [debouncedTerm, setDebouncedTerm] = useState('');
+
+  const statusOptions = QUOTATION_STATUS_OPTIONS.map(s => ({ value: s, label: t(`status.${s}`) }));
+  const searchFieldOptions = [
+    { value: 'quotationNo', label: t('filters.quotationNoPlaceholder'), icon: 'file-invoice' },
+    { value: 'appraisalNo', label: t('filters.appraisalNoPlaceholder'), icon: 'building' },
+    { value: 'customerName', label: t('filters.customerNamePlaceholder'), icon: 'user' },
+  ];
 
   // Delete confirmation state — backed by the existing /cancel endpoint
   // (Cancel is the soft-delete path; idempotent for non-terminal statuses).
@@ -116,7 +138,7 @@ function QuotationListingPage() {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedSearch(searchTerm);
+      setDebouncedTerm(searchTerm);
     }, 500);
     return () => clearTimeout(timer);
   }, [searchTerm]);
@@ -124,16 +146,21 @@ function QuotationListingPage() {
   // Reset to first page when filters change
   useEffect(() => {
     setPageNumber(0);
-  }, [debouncedSearch, statusFilter, cutOffTimeFrom, cutOffTimeTo, companyFilter]);
+  }, [debouncedTerm, searchField, statuses, cutOffTimeFrom, cutOffTimeTo, companyFilter]);
 
+  const term = debouncedTerm || undefined;
   const { data, isLoading, isFetching, isError, error } = useGetQuotations({
     pageNumber,
     pageSize,
-    search: debouncedSearch || undefined,
-    status: statusFilter || undefined,
+    quotationNo: searchField === 'quotationNo' ? term : undefined,
+    appraisalNo: searchField === 'appraisalNo' ? term : undefined,
+    customerName: searchField === 'customerName' ? term : undefined,
+    statuses: statuses.length ? statuses : undefined,
     cutOffTimeFrom: toDateOnly(cutOffTimeFrom),
     cutOffTimeTo: toDateOnly(cutOffTimeTo),
     companyId: companyFilter || undefined,
+    sortBy,
+    sortDir,
   });
 
   const items = data?.items ?? [];
@@ -144,11 +171,11 @@ function QuotationListingPage() {
   const isRefetching = isFetching && !isFirstLoad;
 
   const hasFilters =
-    searchTerm || statusFilter || cutOffTimeFrom || cutOffTimeTo || companyFilter;
+    searchTerm || statuses.length || cutOffTimeFrom || cutOffTimeTo || companyFilter;
 
   const handleClearFilters = () => {
     setSearchTerm('');
-    setStatusFilter('');
+    setStatuses([]);
     setCutOffTimeFrom(null);
     setCutOffTimeTo(null);
     setCompanyFilter('');
@@ -185,29 +212,32 @@ function QuotationListingPage() {
 
       {/* Filters Bar */}
       <div className="shrink-0 flex items-end gap-3 pb-1 flex-wrap">
-        {/* Search */}
-        <div className="flex-1 min-w-[20rem] max-w-lg">
-          <Input
-            placeholder={t('filters.searchPlaceholder')}
+        {/* Search — one bar: "search by" selector + input */}
+        <div className="flex flex-col gap-1">
+          <label className="block text-xs font-medium text-gray-700">{t('filters.searchBy')}</label>
+          <SearchByInput
+            options={searchFieldOptions}
+            field={searchField}
+            onFieldChange={v => setSearchField(v as SearchField)}
             value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
-            leftIcon={<Icon style="solid" name="magnifying-glass" className="size-3.5" />}
+            onChange={setSearchTerm}
+            placeholder={t('filters.searchPlaceholder')}
+            className="w-96"
           />
         </div>
 
-        {/* Status Filter */}
-        <select
-          value={statusFilter}
-          onChange={e => setStatusFilter(e.target.value)}
-          className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none bg-white min-w-36 hover:border-gray-300"
-        >
-          <option value="">{t('filters.allStatuses')}</option>
-          {QUOTATION_STATUS_OPTIONS.map(s => (
-            <option key={s} value={s}>
-              {t(`status.${s}`)}
-            </option>
-          ))}
-        </select>
+        {/* Status Filter — multi-select */}
+        <div className="flex flex-col gap-1">
+          <label className="block text-xs font-medium text-gray-700">{t('columns.status')}</label>
+          <MultiSelectDropdown
+            options={statusOptions}
+            value={statuses}
+            onChange={setStatuses}
+            placeholder={t('filters.allStatuses')}
+            showValuePrefix={false}
+            className="min-w-40"
+          />
+        </div>
 
         {/* Cut Off Time — From */}
         <div className="w-40">
@@ -250,33 +280,56 @@ function QuotationListingPage() {
         )}
       </div>
 
-      {/* Search hint */}
-      <p className="shrink-0 -mt-2 text-xs text-gray-400">{t('filters.searchHint')}</p>
-
       {/* Table */}
       <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
         <div className="flex-1 min-h-0 overflow-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 sticky top-0 z-10 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
               <tr className="border-b border-gray-200">
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.quotationNumber')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.status')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.cutOffTime')}
-                </th>
-                <th className="text-center font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.noOfAppraisal')}
-                </th>
-                <th className="text-center font-medium text-gray-600 px-4 py-2.5">
-                  {t('columns.response')}
-                </th>
-                <th className="text-left font-medium text-gray-600 px-4 py-2.5 whitespace-nowrap">
-                  {t('columns.createdDate')}
-                </th>
+                <SortableTh
+                  label={t('columns.quotationNumber')}
+                  sortKey="QuotationNumber"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.customerName')}
+                  sortKey="CustomerName"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.status')}
+                  sortKey="Status"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.cutOffTime')}
+                  sortKey="CutOffTime"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
+                <SortableTh
+                  label={t('columns.noOfAppraisal')}
+                  sortKey="TotalAppraisals"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                  className="text-center"
+                />
+                <SortableTh label={t('columns.response')} className="text-center" />
+                <SortableTh
+                  label={t('columns.createdDate')}
+                  sortKey="RequestDate"
+                  activeSortKey={sortBy}
+                  activeSortDir={sortDir}
+                  onSortChange={handleSortChange}
+                />
                 <th className="w-10 px-4 py-2.5" aria-label={t('common:actions.viewDetails')} />
               </tr>
             </thead>
@@ -287,6 +340,7 @@ function QuotationListingPage() {
                 <TableRowSkeleton
                   columns={[
                     { width: 'w-28' },
+                    { width: 'w-32' },
                     { width: 'w-24' },
                     { width: 'w-32' },
                     { width: 'w-12' },
@@ -298,7 +352,7 @@ function QuotationListingPage() {
                 />
               ) : items.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="text-center py-16">
+                  <td colSpan={8} className="text-center py-16">
                     <div className="flex flex-col items-center gap-2">
                       <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
                       <p className="text-gray-500 font-medium">{t('empty.noQuotations')}</p>
@@ -321,6 +375,19 @@ function QuotationListingPage() {
                     >
                       <td className="px-4 py-2.5">
                         <span className="font-medium text-primary">{item.quotationNumber}</span>
+                      </td>
+                      <td
+                        className="px-4 py-2.5 text-gray-600 max-w-[16rem]"
+                        title={item.customerNames ?? undefined}
+                      >
+                        <span className="inline-block max-w-full truncate align-bottom">
+                          {item.customerName ?? '—'}
+                        </span>
+                        {item.customerCount > 1 && (
+                          <span className="ml-1 text-xs text-gray-400">
+                            +{item.customerCount - 1}
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-2.5">
                         <QuotationStatusBadge status={item.status} />

--- a/src/i18n/locales/en/quotation.json
+++ b/src/i18n/locales/en/quotation.json
@@ -48,12 +48,15 @@
     "allStatuses": "All statuses",
     "cutOffFrom": "Cut Off From",
     "cutOffTo": "Cut Off To",
-    "searchPlaceholder": "Quotation no., appraisal no., or customer",
-    "searchHint": "Matches from the start. Use * as a wildcard (e.g. abc*).",
+    "searchBy": "Search by",
+    "searchPlaceholder": "Search...",
+    "quotationNoPlaceholder": "Quotation no.",
+    "appraisalNoPlaceholder": "Appraisal no.",
+    "customerNamePlaceholder": "Customer name",
     "company": "Company"
   },
   "columns": {
-    "quotationNumber": "Quotation #",
+    "quotationNumber": "Quotation Number",
     "status": "Status",
     "cutOffTime": "Cut Off Time",
     "noOfAppraisal": "No of Appraisal(s)",

--- a/src/i18n/locales/th/quotation.json
+++ b/src/i18n/locales/th/quotation.json
@@ -48,12 +48,15 @@
     "allStatuses": "ทุกสถานะ",
     "cutOffFrom": "วันที่ปิดรับ (จาก)",
     "cutOffTo": "วันที่ปิดรับ (ถึง)",
-    "searchPlaceholder": "เลขที่ใบเสนอราคา, เลขที่ประเมิน หรือลูกค้า",
-    "searchHint": "ค้นหาจากตัวขึ้นต้น ใช้ * เป็นไวลด์การ์ด (เช่น abc*)",
+    "searchBy": "ค้นหาโดย",
+    "searchPlaceholder": "ค้นหา...",
+    "quotationNoPlaceholder": "เลขที่ใบเสนอราคา",
+    "appraisalNoPlaceholder": "เลขที่ประเมิน",
+    "customerNamePlaceholder": "ชื่อลูกค้า",
     "company": "บริษัท"
   },
   "columns": {
-    "quotationNumber": "เลขที่ #",
+    "quotationNumber": "เลขที่ใบเสนอราคา",
     "status": "สถานะ",
     "cutOffTime": "เวลาปิดรับ",
     "noOfAppraisal": "จำนวนการประเมิน",

--- a/src/i18n/locales/zh/quotation.json
+++ b/src/i18n/locales/zh/quotation.json
@@ -48,12 +48,15 @@
     "allStatuses": "All statuses",
     "cutOffFrom": "Cut Off From",
     "cutOffTo": "Cut Off To",
-    "searchPlaceholder": "Quotation no., appraisal no., or customer",
-    "searchHint": "Matches from the start. Use * as a wildcard (e.g. abc*).",
+    "searchBy": "Search by",
+    "searchPlaceholder": "Search...",
+    "quotationNoPlaceholder": "Quotation no.",
+    "appraisalNoPlaceholder": "Appraisal no.",
+    "customerNamePlaceholder": "Customer name",
     "company": "Company"
   },
   "columns": {
-    "quotationNumber": "Quotation #",
+    "quotationNumber": "Quotation Number",
     "status": "Status",
     "cutOffTime": "Cut Off Time",
     "noOfAppraisal": "No of Appraisal(s)",


### PR DESCRIPTION
Frontend for the enhanced quotation listings — internal `/quotations` and external vendor `/ext/quotations`.

## Changes
1. **Combined search bar** — new `SearchByInput`: a "search by" field selector (Quotation No / Appraisal No / Customer Name, each with its own primary-colored icon) + a single input. Only the selected field is sent; the old three-box layout, magnifying-glass, and hint text are gone.
2. **Status → multi-select** — native `<select>` replaced with the shared `MultiSelectDropdown`; sent as repeated `Statuses` params (`paramsSerializer: { indexes: null }`).
3. **Sortable columns** — meaningful columns use the shared `SortableTh` (asc → desc → cleared), wired to `sortBy`/`sortDir` with a page reset. Non-meaningful columns (Response ratio, Quoted By) stay plain.
4. **Customer Name column** — representative name + a muted "+N" when a quotation has multiple distinct customers, with the full list on hover (`title`).
5. i18n `en` / `th` / `zh`.

## Scope
- 7 files under `src/features/quotation/` + the three `quotation.json` locales. (Unrelated working-tree changes intentionally excluded.)

## Verification
- `tsc -b`: no errors reference quotation files (repo has a pre-existing baseline).
- Backend SQL for the new params/fields validated directly against the DB in the paired PR.

## Notes
- Pairs with the backend PR (same branch name) in `collateral-appraisal-system-api` — **merge/deploy backend first**.
- Full UI click-through still pending a fresh app run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199jW8oipg3BF6o8f2thhM6