### PR TITLE
CA-465, CA-467, CA-485, CA-487, CA-488, CA-491 + SIT defects

### DIFF
--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowMethodModal.tsx
@@ -209,11 +209,6 @@ export function DiscountedCashFlowMethodModal({
               <div className="flex flex-row gap-1.5">
                 <span className="w-56">Category</span>
                 <div className="w-80">
-                  {/* <RHFInputCell
-                  fieldName="targetCategoryClientId"
-                  inputType="select"
-                  options={categoryOptions}
-                /> */}
                   <span className="text-sm">
                     {currentSection?.categories?.find(
                       c => c.clientId === getValues('targetCategoryClientId'),
@@ -233,7 +228,8 @@ export function DiscountedCashFlowMethodModal({
                   />
                 </div>
                 {assumptionType === 'M99' ? (
-                  <div className="flex">
+                  <div className="flex items-center gap-1.5">
+                    <span>Description</span>
                     <RHFInputCell fieldName="assumptionName" inputType="text" />
                   </div>
                 ) : (

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
@@ -24,7 +24,10 @@ import {
   useSaveIncomeAnalysis,
   useGetIncomeAnalysis,
   usePreviewIncomeAnalysis,
+  useResetMethod,
 } from '../../api';
+import { useQueryClient } from '@tanstack/react-query';
+import { pricingAnalysisKeys } from '../../api/queryKeys';
 import { mapDCFFormToSaveRequest } from '../../mappers/formToSaveRequest';
 import { mapIncomeAnalysisToDCFForm } from '../../mappers/analysisToForm';
 import { useDebounce } from '@/shared/hooks/useDebounce';
@@ -102,6 +105,8 @@ export function DiscountedCashFlowPanel({
 
   const saveMutation = useSaveIncomeAnalysis();
   const previewMutation = usePreviewIncomeAnalysis();
+  const resetMutation = useResetMethod();
+  const queryClient = useQueryClient();
 
   // Watch the full section tree + scalar rate fields to trigger preview on any edit.
   const watchedSections = useWatch({ control: methods.control, name: 'sections' });
@@ -309,13 +314,35 @@ export function DiscountedCashFlowPanel({
   // While fetching, suppress the picker so it never flashes before restore.
   const isLoading = !isGenerated && !incomeAnalysisQuery.isSuccess;
 
-  // reset handler
   const [isShowResetDialog, setIsShowResetDialog] = useState<boolean>(false);
   const handleOnReset = () => setIsShowResetDialog(true);
   const handleOnConfirmReset = async () => {
     setIsShowResetDialog(false);
-    // ...
-    setIsGenerated(false);
+    if (!activeMethod?.pricingAnalysisId || !activeMethod?.methodId) return;
+    try {
+      await resetMutation.mutateAsync(
+        {
+          pricingAnalysisId: activeMethod.pricingAnalysisId,
+          methodId: activeMethod.methodId,
+        },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({
+              queryKey: pricingAnalysisKeys.incomeAnalysis(
+                activeMethod.pricingAnalysisId!,
+                activeMethod.methodId!,
+              ),
+            });
+          },
+        },
+      );
+      setIsGenerated(false);
+      setSelectedTemplateCode('');
+      reset();
+      toast.success(t('toasts.resetSuccess'));
+    } catch {
+      toast.error(t('toasts.failedReset'));
+    }
   };
 
   const handleOnSubmit = handleSubmit(async (values: DCFFormType) => {
@@ -491,7 +518,7 @@ export function DiscountedCashFlowPanel({
             <MethodFooterActions
               onCancel={onCancelCalculationMethod}
               onReset={handleOnReset}
-              showReset={isShowResetDialog}
+              showReset={!!incomeAnalysisQuery.data}
               isSubmitting={formState.isSubmitting || saveMutation.isPending}
             />
           </div>
@@ -501,7 +528,7 @@ export function DiscountedCashFlowPanel({
           isOpen={isShowResetDialog}
           onClose={() => setIsShowResetDialog(false)}
           onConfirm={handleOnConfirmReset}
-          message="Are you sure you want to reset this method? All calculation data will be cleared."
+          message={t('confirm.resetMethod')}
         />
       </form>
     </FormProvider>

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
@@ -7,6 +7,7 @@ import { StickyLabelTable } from '../layout/StickyLabelTable';
 import { useMemo } from 'react';
 import { useDerivedFields } from '../../adapters/useDerivedFieldArray';
 import { buildMethodCalculationRules } from '../../domain/dcf/useCalculations';
+import { useTranslation } from 'react-i18next';
 
 export interface SectionColor {
   bg: string;
@@ -98,6 +99,7 @@ export function DiscountedCashFlowTable({
   marketSurveys,
   ensureIncomeAnalysisId,
 }: DiscountedCashFlowTableProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const { control } = useFormContext();
   const watchSections = useWatch({ control, name: 'sections' });
 
@@ -155,6 +157,7 @@ export function DiscountedCashFlowTable({
             <tr className="bg-white">
               <td className="flex-1 text-xs px-1 py-1 font-medium whitespace-nowrap border-b border-gray-300">
                 <div className="flex flex-row justify-end items-center gap-1.5">
+                  <span>{t('dcf.common.projectionPeriod')}</span>
                   <div className="w-16">
                     <RHFInputCell
                       fieldName="totalNumberOfYears"
@@ -168,7 +171,9 @@ export function DiscountedCashFlowTable({
                       }}
                     />
                   </div>
-                  <span>Years</span>
+                  <span>{t('dcf.common.years')}</span>
+                  <span>/</span>
+                  <span>{t('dcf.common.daysPerYear')}</span>
                   <div className="w-16">
                     <RHFInputCell
                       fieldName="totalNumberOfDayInYear"
@@ -182,7 +187,7 @@ export function DiscountedCashFlowTable({
                       }}
                     />
                   </div>
-                  <span>Days in a year</span>
+                  <span>{t('dcf.common.days')}</span>
                 </div>
               </td>
               {Array.from({ length: totalNumberOfYears }, (_, i) => (
@@ -192,7 +197,7 @@ export function DiscountedCashFlowTable({
                     'text-right text-xs px-1 py-1 font-medium whitespace-nowrap border-b border-gray-300 min-w-[120px]',
                   )}
                 >
-                  Year {i + 1}
+                  {t('dcf.common.yearColumn', { year: i + 1 })}
                 </th>
               ))}
             </tr>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
@@ -9,8 +9,9 @@ import { RHFInputCell } from '@features/pricingAnalysis/components/table/RHFInpu
 import { ScrollableTableContainer } from '@features/pricingAnalysis/components/ScrollableTableContainer.tsx';
 import { useDerivedFields } from '@features/pricingAnalysis/adapters/useDerivedFieldArray.tsx';
 import { useMemo } from 'react';
-import { type UseFormGetValues } from 'react-hook-form';
+import { useWatch, type UseFormGetValues } from 'react-hook-form';
 import { propertyTaxRanges } from '@/features/pricingAnalysis/data/dcfParameters';
+import { useTranslation } from 'react-i18next';
 
 export function MethodParameterBasedOnTierOfPropertyValueModal({
   name,
@@ -23,6 +24,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
   getOuterFormValues: UseFormGetValues<any>;
   isReadOnly?: boolean;
 }) {
+  const { t } = useTranslation('pricingAnalysis');
   const landGovPrice = (properties ?? [])
     .filter(p => p.propertyType === 'L' || p.propertyType === 'LSL' || p.propertyType === 'LS')
     .flatMap((p: any) => p.titles ?? [])
@@ -37,7 +39,6 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
     .reduce((sum: number, d: any) => sum + toNumber(d.priceAfterDepreciation ?? 0), 0);
 
   const totalNumberOfYears = toNumber(getOuterFormValues('totalNumberOfYears'));
-
   const rules = useMemo(() => {
     return Array.from({ length: totalNumberOfYears }, (_, idx) => [
       {
@@ -99,25 +100,27 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-80'}>Total government land appraisal price</span>
+        <span className={'w-80'}>{t('dcf.methods.tierOfPropertyValue.totalGovLandPrice')}</span>
         <div className={'flex flex-row w-44 gap-1.5'}>
           <span className="w-44 text-right">
             {landGovPrice ? Number(landGovPrice).toLocaleString() : 0}
           </span>
-          <span>Baht</span>
+          <span>{t('dcf.common.baht')}</span>
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-80'}>Total government building appraisal price</span>
+        <span className={'w-80'}>{t('dcf.methods.tierOfPropertyValue.totalGovBuildingPrice')}</span>
         <div className={'flex flex-row w-44 gap-1.5'}>
           <span className="w-44 text-right">
             {buildingGovPrice ? Number(buildingGovPrice).toLocaleString() : 0}
           </span>
-          <span>Baht</span>
+          <span>{t('dcf.common.baht')}</span>
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-80'}>Government land prices increase by</span>
+        <span className={'w-80'}>
+          {t('dcf.methods.tierOfPropertyValue.govLandPriceIncreaseBy')}
+        </span>
         <div className="w-44">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -126,7 +129,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -135,10 +138,10 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-80'}>Start in</span>
+        <span className={'w-80'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -160,23 +163,27 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
             <thead>
               <tr>
                 <th colSpan={4} className="border-b border-gray-300 text-center">
-                  Land and Building Tax Rates
+                  {t('dcf.methods.tierOfPropertyValue.taxRatesTableTitle')}
                 </th>
               </tr>
               <tr>
                 <th colSpan={2} rowSpan={1} className="border-b border-r border-gray-300">
-                  Estimated Price (Baht)
+                  {t('dcf.methods.tierOfPropertyValue.estimatedPrice')}
                 </th>
                 <th colSpan={1} rowSpan={2} className="border-b border-r border-gray-300">
-                  Tax Rate
+                  {t('dcf.methods.tierOfPropertyValue.taxRate')}
                 </th>
                 <th colSpan={1} rowSpan={2} className="border-b border-gray-300">
-                  Tax Ceiling (Baht)
+                  {t('dcf.methods.tierOfPropertyValue.taxCeiling')}
                 </th>
               </tr>
               <tr>
-                <th className="border-b border-gray-300">From</th>
-                <th className="border-b border-r border-gray-300">To</th>
+                <th className="border-b border-gray-300">
+                  {t('dcf.methods.tierOfPropertyValue.from')}
+                </th>
+                <th className="border-b border-r border-gray-300">
+                  {t('dcf.methods.tierOfPropertyValue.to')}
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -195,7 +202,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                           : '-'}
                       </td>
                       <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
-                        {toFixed2(t.taxRate * 100)}
+                        {`${toFixed2(t.taxRate * 100)} %`}
                       </td>
                       <td className="border-b border-gray-300 px-1.5 py-2 text-right">
                         {t.maxValue
@@ -217,19 +224,19 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
             <thead>
               <tr>
                 <th colSpan={totalNumberOfYears + 1} className="border-b border-gray-300">
-                  Land and Building Tax
+                  {t('dcf.methods.tierOfPropertyValue.taxTableTitle')}
                 </th>
               </tr>
               <tr>
                 <th></th>
                 {Array.from({ length: totalNumberOfYears }, (_, i) => (
-                  <th key={i}>Year {i + 1}</th>
+                  <th key={i}>{t('dcf.methods.tierOfPropertyValue.yearLabel', { year: i + 1 })}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>(1) Government land prices increase by 10% every 4 years</td>
+                <td>{t('dcf.methods.tierOfPropertyValue.row1Label')}</td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
                   <td key={idx} className="text-right">
                     <RHFInputCell
@@ -243,7 +250,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 ))}
               </tr>
               <tr>
-                <td>(2) Government building prices</td>
+                <td>{t('dcf.methods.tierOfPropertyValue.row2Label')}</td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
                   <td key={idx} className="text-right">
                     <span>{buildingGovPrice ? buildingGovPrice.toLocaleString() : 0}</span>
@@ -251,7 +258,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 ))}
               </tr>
               <tr>
-                <td>(1+2) Total price of government property</td>
+                <td>{t('dcf.methods.tierOfPropertyValue.row3Label')}</td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
                   <td key={idx} className="text-right">
                     <RHFInputCell
@@ -265,7 +272,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 ))}
               </tr>
               <tr>
-                <td>Property tax</td>
+                <td>{t('dcf.methods.tierOfPropertyValue.propertyTaxRow')}</td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
                   <td key={idx} className="text-right">
                     <div className="flex flex-row justify-between items-center">

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculationModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodPositionBasedSalaryCalculationModal.tsx
@@ -6,6 +6,7 @@ import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toNumber } from '../../../domain/calculation';
 import { jobPositionParameters } from '@/features/pricingAnalysis/data/dcfParameters';
+import { useTranslation } from 'react-i18next';
 
 interface MethodPositionBasedSalaryCalculationModalProps {
   name: string;
@@ -17,6 +18,7 @@ export function MethodPositionBasedSalaryCalculationModal({
   getOuterFormValues,
   isReadOnly,
 }: MethodPositionBasedSalaryCalculationModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const {
     getValues,
     formState: { errors },
@@ -110,22 +112,22 @@ export function MethodPositionBasedSalaryCalculationModal({
             <table className={'table table-sm'}>
               <thead>
                 <tr>
-                  <th className="px-1.5 py-1.5 bg-gray-100">Job Position</th>
+                  <th className="px-1.5 py-1.5 bg-gray-100">{t('dcf.methods.positionBasedSalary.jobPosition')}</th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Salary</span>
-                      <span>Bath / Person / Month</span>
+                      <span>{t('dcf.methods.positionBasedSalary.salary')}</span>
+                      <span>{t('dcf.methods.positionBasedSalary.unitPerPersonMonth')}</span>
                     </div>
                   </th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Number of Employees</span>
+                      <span>{t('dcf.methods.positionBasedSalary.numberOfEmployees')}</span>
                     </div>
                   </th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Total Salary</span>
-                      <span>Bath / Year</span>
+                      <span>{t('dcf.methods.positionBasedSalary.totalSalary')}</span>
+                      <span>{t('dcf.common.bahtPerYear')}</span>
                     </div>
                   </th>
                 </tr>
@@ -159,7 +161,7 @@ export function MethodPositionBasedSalaryCalculationModal({
                               type="button"
                               onClick={() => handleOnRemove(index)}
                               className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                              title="Delete"
+                              title={t('dcf.common.delete')}
                             >
                               <Icon style="solid" name="trash" className="size-1" />
                             </button>
@@ -206,7 +208,7 @@ export function MethodPositionBasedSalaryCalculationModal({
                         onClick={() => handleOnAdd()}
                         className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                       >
-                        + Add Job Position
+                        {t('dcf.methods.positionBasedSalary.addJobPosition')}
                       </button>
                     </td>
                     <td></td>
@@ -215,7 +217,7 @@ export function MethodPositionBasedSalaryCalculationModal({
                   </tr>
                 )}
                 <tr>
-                  <td className="sticky bottom-0 px-1.5 bg-white">Total</td>
+                  <td className="sticky bottom-0 px-1.5 bg-white">{t('dcf.common.total')}</td>
                   <td className="sticky bottom-0 px-1.5 bg-white">
                     <div className="text-right">
                       <RHFInputCell
@@ -257,7 +259,7 @@ export function MethodPositionBasedSalaryCalculationModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Salary</span>
+          <span className={'w-56'}>{t('dcf.methods.positionBasedSalary.totalSalary')}</span>
           <div className={'w-56 text-right'}>
             <RHFInputCell
               fieldName={`${name}.sumTotalSalaryPerYear`}
@@ -267,10 +269,10 @@ export function MethodPositionBasedSalaryCalculationModal({
               )}
             />
           </div>
-          <span>Baht / Year</span>
+          <span>{t('dcf.common.bahtPerYear')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -283,7 +285,7 @@ export function MethodPositionBasedSalaryCalculationModal({
               }}
             />
           </div>
-          <span className={''}>% every</span>
+          <span className={''}>{t('dcf.common.percentEvery')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -297,10 +299,10 @@ export function MethodPositionBasedSalaryCalculationModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -314,7 +316,7 @@ export function MethodPositionBasedSalaryCalculationModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionModal.tsx
@@ -2,6 +2,7 @@ import { RHFInputCell } from '../../table/RHFInputCell';
 import { getDCFFilteredAssumptions } from '../../../domain/getDCFFilteredAssumptions';
 import type { DCFSection } from '../../../types/dcf';
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
 export function MethodProportionModal({
   name,
@@ -12,6 +13,7 @@ export function MethodProportionModal({
   getOuterFormValues: UseFormGetValues<any>;
   isReadOnly?: boolean;
 }) {
+  const { t } = useTranslation('pricingAnalysis');
   const sections = (getOuterFormValues('sections') ?? []).filter(
     (s: DCFSection) => s.identifier !== 'empty',
   );
@@ -42,9 +44,9 @@ export function MethodProportionModal({
   ];
 
   return (
-    <div className="flex flex-col gap2">
+    <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Proportions</span>
+        <span className={'w-56'}>{t('dcf.common.proportions')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.proportionPct`}
@@ -53,7 +55,7 @@ export function MethodProportionModal({
           />
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={''}>% of</span>
+          <span className={''}>{t('dcf.methods.proportion.percentOf')}</span>
           <div className="w-64">
             <RHFInputCell
               fieldName={`${name}.refTarget.clientId`}
@@ -65,7 +67,7 @@ export function MethodProportionModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -79,7 +81,7 @@ export function MethodProportionModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCostModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodProportionOfTheNewReplacementCostModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodProportionOfTheNewReplacementCostModalProps {
@@ -11,10 +12,11 @@ export function MethodProportionOfTheNewReplacementCostModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodProportionOfTheNewReplacementCostModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Proportions</span>
+        <span className={'w-56'}>{t('dcf.common.proportions')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.proportionPct`}
@@ -28,11 +30,11 @@ export function MethodProportionOfTheNewReplacementCostModal({
           />
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={''}>% of new replacement cost</span>
+          <span className={''}>{t('dcf.methods.proportionOfNewReplacementCost.percentOfNewReplacementCost')}</span>
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Increase Rate</span>
+        <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -45,7 +47,7 @@ export function MethodProportionOfTheNewReplacementCostModal({
             }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -59,10 +61,10 @@ export function MethodProportionOfTheNewReplacementCostModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -76,7 +78,7 @@ export function MethodProportionOfTheNewReplacementCostModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodRoomCostBasedOnExpensesPerRoomPerDayModal.tsx
@@ -6,6 +6,7 @@ import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toNumber } from '../../../domain/calculation';
 import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameters';
+import { useTranslation } from 'react-i18next';
 
 interface MethodRoomCostBasedOnExpensesPerRoomPerDayModalProps {
   name: string;
@@ -17,6 +18,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
   getOuterFormValues,
   isReadOnly,
 }: MethodRoomCostBasedOnExpensesPerRoomPerDayModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const {
     getValues,
     formState: { errors },
@@ -115,28 +117,28 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
             <table className={'table table-sm'}>
               <thead>
                 <tr>
-                  <th className="px-1.5 py-1.5 bg-gray-100">Room Type</th>
+                  <th className="px-1.5 py-1.5 bg-gray-100">{t('dcf.common.roomType')}</th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Room Cost</span>
-                      <span>Bath / Room / Day</span>
+                      <span>{t('dcf.methods.roomCostBasedOnExpenses.roomCost')}</span>
+                      <span>{t('dcf.methods.roomCostBasedOnExpenses.unitPerRoomDay')}</span>
                     </div>
                   </th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Saleable Area</span>
+                      <span>{t('dcf.common.saleableArea')}</span>
                     </div>
                   </th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Total Room Expenses</span>
-                      <span>Bath / Day</span>
+                      <span>{t('dcf.methods.roomCostBasedOnExpenses.totalRoomExpenses')}</span>
+                      <span>{t('dcf.methods.roomCostBasedOnExpenses.unitPerDay')}</span>
                     </div>
                   </th>
                   <th className="px-1.5 py-1.5 bg-gray-100">
                     <div className="flex flex-col gap-1.5">
-                      <span>Total Room Expenses</span>
-                      <span>Bath / Year</span>
+                      <span>{t('dcf.methods.roomCostBasedOnExpenses.totalRoomExpenses')}</span>
+                      <span>{t('dcf.common.bahtPerYear')}</span>
                     </div>
                   </th>
                 </tr>
@@ -170,7 +172,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                               type="button"
                               onClick={() => handleOnRemove(index)}
                               className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                              title="Delete"
+                              title={t('dcf.common.delete')}
                             >
                               <Icon style="solid" name="trash" className="size-1" />
                             </button>
@@ -230,7 +232,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
                         onClick={() => handleOnAdd()}
                         className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                       >
-                        + Add Room
+                        {t('dcf.common.addRoom')}
                       </button>
                     </td>
                     <td></td>
@@ -282,7 +284,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Room Expenses</span>
+          <span className={'w-56'}>{t('dcf.methods.roomCostBasedOnExpenses.totalRoomExpenses')}</span>
           <div className={'w-56 text-right'}>
             <RHFInputCell
               fieldName={`${name}.sumTotalRoomExpensePerYear`}
@@ -292,10 +294,10 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
               )}
             />
           </div>
-          <span>Baht / Year</span>
+          <span>{t('dcf.common.bahtPerYear')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -308,7 +310,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
               }}
             />
           </div>
-          <span className={''}>every</span>
+          <span className={''}>{t('dcf.common.every')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -322,10 +324,10 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -339,7 +341,7 @@ export function MethodRoomCostBasedOnExpensesPerRoomPerDayModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedEnergyCostIndexModalProps {
@@ -11,10 +12,11 @@ export function MethodSpecifiedEnergyCostIndexModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodSpecifiedEnergyCostIndexModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
     <div className="flex flex-col gap-2 mb-4">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Energy Cost Index</span>
+        <span className={'w-56'}>{t('dcf.methods.energyCostIndex.energyCostIndex')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.energyCostIndex`}
@@ -25,7 +27,7 @@ export function MethodSpecifiedEnergyCostIndexModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Energy Cost Increase Rate</span>
+        <span className={'w-56'}>{t('dcf.methods.energyCostIndex.energyCostIncreaseRate')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -34,7 +36,7 @@ export function MethodSpecifiedEnergyCostIndexModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -43,10 +45,10 @@ export function MethodSpecifiedEnergyCostIndexModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -60,7 +62,7 @@ export function MethodSpecifiedEnergyCostIndexModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedEnergyCostIndexModal.tsx
@@ -20,6 +20,7 @@ export function MethodSpecifiedEnergyCostIndexModal({
             fieldName={`${name}.energyCostIndex`}
             inputType={'number'}
             disabled={isReadOnly}
+            number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
       </div>
@@ -39,6 +40,7 @@ export function MethodSpecifiedEnergyCostIndexModal({
             fieldName={`${name}.increaseRateYrs`}
             inputType={'number'}
             disabled={isReadOnly}
+            number={{ decimalPlaces: 0, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
         <span className={''}>year(s)</span>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayPropsModalProps {
@@ -11,10 +12,11 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayPropsModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Food and Beverage Expenses</span>
+        <span className={'w-56'}>{t('dcf.methods.foodAndBeverageExpenses.label')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
@@ -23,10 +25,10 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
           />
         </div>
-        <span className={''}>Baht/ Room/ Day</span>
+        <span className={''}>{t('dcf.methods.foodAndBeverageExpenses.unitPerRoomDay')}</span>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Increase</span>
+        <span className={'w-56'}>{t('dcf.common.increase')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -35,7 +37,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -44,10 +46,10 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -61,7 +63,7 @@ export function MethodSpecifiedFoodAndBeverageExpensesPerRoomPerDayModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerMonthModal.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@/shared/components';
 import { RHFInputCell } from '../../table/RHFInputCell';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { roomTypeParameters } from '@/features/pricingAnalysis/data/dcfParameters';
@@ -33,6 +34,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
   // Local state to cache the id obtained by ensureIncomeAnalysisId so the
   // button can function before the first save.
   const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
+  const { t } = useTranslation('pricingAnalysis');
 
   const {
     getValues,
@@ -130,24 +132,24 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
           <table className={'table table-sm'}>
             <thead>
               <tr>
-                <th className="px-1.5 py-1.5 bg-gray-100">Room Type</th>
+                <th className="px-1.5 py-1.5 bg-gray-100">{t('dcf.common.roomType')}</th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Room Income</span>
-                    <span>Bath / Room / Month</span>
+                    <span>{t('dcf.common.roomIncome')}</span>
+                    <span>{t('dcf.methods.rentalIncomePerMonth.unitPerRoomMonth')}</span>
                   </div>
                 </th>
-                <th className="px-1.5 py-1.5 bg-gray-100">Saleable Area</th>
+                <th className="px-1.5 py-1.5 bg-gray-100">{t('dcf.common.saleableArea')}</th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Total Room Income</span>
-                    <span>Bath / Month</span>
+                    <span>{t('dcf.common.totalRoomIncome')}</span>
+                    <span>{t('dcf.common.bahtPerMonth')}</span>
                   </div>
                 </th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Total Room Income</span>
-                    <span>Bath / Year</span>
+                    <span>{t('dcf.common.totalRoomIncome')}</span>
+                    <span>{t('dcf.common.bahtPerYear')}</span>
                   </div>
                 </th>
               </tr>
@@ -181,7 +183,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                             type="button"
                             onClick={() => handleOnRemove(index)}
                             className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
+                            title={t('dcf.common.delete')}
                           >
                             <Icon style="solid" name="trash" className="size-1" />
                           </button>
@@ -289,7 +291,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                       onClick={() => handleOnAdd()}
                       className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                     >
-                      + Add Room
+                      {t('dcf.common.addRoom')}
                     </button>
                   </td>
                   <td></td>
@@ -298,7 +300,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
                 </tr>
               )}
               <tr>
-                <td className="sticky bottom-0 px-1.5 bg-white"></td>
+                <td className="sticky bottom-0 px-1.5 bg-white">{t('dcf.common.totals')}</td>
                 <td className="sticky bottom-0 px-1.5 bg-white"></td>
                 <td className="sticky bottom-0 px-1.5 bg-white">
                   <div className="text-right">
@@ -340,7 +342,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Room Income</span>
+          <span className={'w-56'}>{t('dcf.common.roomIncome')}</span>
           <div className={'w-56 text-right'}>
             <RHFInputCell
               fieldName={`${name}.sumRoomIncomePerYear`}
@@ -350,10 +352,10 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
               )}
             />
           </div>
-          <span>Baht/ Year</span>
+          <span>{t('dcf.common.bahtPerYear')}</span>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Number of Saleable Area</span>
+          <span className={'w-56'}>{t('dcf.common.totalNumberOfSaleableArea')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
@@ -364,7 +366,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
           </div>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-56'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -377,7 +379,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
               }}
             />
           </div>
-          <span className={''}>every</span>
+          <span className={''}>{t('dcf.common.every')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -391,10 +393,10 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -408,7 +410,7 @@ export function MethodSpecifiedRentalIncomePerMonthModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@/shared/components';
 import { RHFInputCell } from '../../table/RHFInputCell';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toDecimal, toNumber } from '../../../domain/calculation';
@@ -16,6 +17,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodSpecifiedRentalIncomePerSquareMeterModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   const {
     formState: { errors },
   } = useFormContext();
@@ -128,7 +130,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
     <div className="flex flex-col gap-2">
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Building Area</span>
+          <span className={'w-56'}>{t('dcf.methods.rentalIncomePerSquareMeter.totalBuildingArea')}</span>
           <div className={'w-44 text-right'}>
             <RHFInputCell
               fieldName={`${name}.totalBuildingArea`}
@@ -141,7 +143,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span>Sq. Meter</span>
+          <span>{t('dcf.common.sqMeter')}</span>
         </div>
       </div>
       {rowsError && <p className="text-xs text-danger-600">{rowsError}</p>}
@@ -150,29 +152,31 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
           <table className={'table table-sm'}>
             <thead>
               <tr>
-                <th className="px-1.5 py-1.5 bg-gray-100">Area Description</th>
+                <th className="px-1.5 py-1.5 bg-gray-100">
+                  {t('dcf.methods.rentalIncomePerSquareMeter.areaDescription')}
+                </th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Rental Price</span>
-                    <span>Bath / Sq.M / Month</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.rentalPrice')}</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.unitPerSqmMonth')}</span>
                   </div>
                 </th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Total Saleable Area</span>
-                    <span>Sq. M</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.totalSaleableArea')}</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.sqM')}</span>
                   </div>
                 </th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Total Rental Income</span>
-                    <span>Bath / Month</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.totalRentalIncome')}</span>
+                    <span>{t('dcf.common.bahtPerMonth')}</span>
                   </div>
                 </th>
                 <th className="px-1.5 py-1.5 bg-gray-100">
                   <div className="flex flex-col gap-1.5">
-                    <span>Total Rental Income</span>
-                    <span>Bath / Year</span>
+                    <span>{t('dcf.methods.rentalIncomePerSquareMeter.totalRentalIncome')}</span>
+                    <span>{t('dcf.common.bahtPerYear')}</span>
                   </div>
                 </th>
               </tr>
@@ -194,7 +198,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                             type="button"
                             onClick={() => handleOnRemove(index)}
                             className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
+                            title={t('dcf.common.delete')}
                           >
                             <Icon style="solid" name="trash" className="size-1" />
                           </button>
@@ -250,7 +254,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                       onClick={() => handleOnAdd()}
                       className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                     >
-                      + Add Room
+                      {t('dcf.common.addRoom')}
                     </button>
                   </td>
                   <td></td>
@@ -311,7 +315,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Average Rental Price</span>
+          <span className={'w-56'}>{t('dcf.methods.rentalIncomePerSquareMeter.averageRentalPrice')}</span>
           <div className={'w-44 text-right'}>
             <RHFInputCell
               fieldName={`${name}.avgRentalRatePerMonth`}
@@ -321,10 +325,10 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               )}
             />
           </div>
-          <span>Baht/ Sq. Meter/ Month</span>
+          <span>{t('dcf.methods.rentalIncomePerSquareMeter.unitBahtSqmMonth')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Total Saleable Area</span>
+          <span className={'w-56'}>{t('dcf.methods.rentalIncomePerSquareMeter.totalSaleableArea')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
@@ -333,10 +337,10 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
             />
           </div>
-          <span className={''}>Sq. Meter</span>
+          <span className={''}>{t('dcf.common.sqMeter')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -349,7 +353,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={''}>every</span>
+          <span className={''}>{t('dcf.common.every')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -363,10 +367,10 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Occupancy Rate - First Year</span>
+          <span className={'w-56'}>{t('dcf.common.occupancyRateFirstYear')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
@@ -380,7 +384,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={''}>% with growth</span>
+          <span className={''}>{t('dcf.common.percentWithGrowth')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
@@ -394,7 +398,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={''}>% every</span>
+          <span className={''}>{t('dcf.common.percentEvery')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
@@ -408,10 +412,10 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -425,7 +429,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRentalIncomePerSquareMeterModal.tsx
@@ -126,6 +126,24 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
 
   return (
     <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 mb-4">
+        <div className="flex flex-row gap-1.5 items-center">
+          <span className={'w-56'}>Total Building Area</span>
+          <div className={'w-44 text-right'}>
+            <RHFInputCell
+              fieldName={`${name}.totalBuildingArea`}
+              inputType={'number'}
+              disabled={isReadOnly}
+              number={{
+                decimalPlaces: 2,
+                maxIntegerDigits: 11,
+                allowNegative: false,
+              }}
+            />
+          </div>
+          <span>Sq. Meter</span>
+        </div>
+      </div>
       {rowsError && <p className="text-xs text-danger-600">{rowsError}</p>}
       <div className="border border-gray-300 rounded-xl p-1.5 overflow-auto">
         <ScrollableTableContainer maxHeight={'274px'} className="flex-1 min-h-0">
@@ -196,7 +214,7 @@ export function MethodSpecifiedRentalIncomePerSquareMeterModal({
                         fieldName={`${name}.areaDetail.${index}.saleableArea`}
                         inputType="number"
                         disabled={isReadOnly}
-                        number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
+                        number={{ decimalPlaces: 2, maxIntegerDigits: 11, allowNegative: false }}
                       />
                     </td>
                     <td className="px-1.5 py-1.5 border-b border-gray-300">

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeBySeasonalRatesModal.tsx
@@ -18,6 +18,7 @@ import { MarketReferenceButton } from '../../MarketReferenceButton';
 import { PricingAnalysisSubjectType } from '@/features/pricingAnalysis/api/references';
 import type { MarketComparableDetailType } from '@/features/pricingAnalysis/schemas';
 import type { TemplateDtoType } from '@/shared/schemas/v1';
+import { useTranslation } from 'react-i18next';
 
 type SeasonRateInput = {
   seasonId: string;
@@ -119,6 +120,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
   // Local state to cache the id obtained by ensureIncomeAnalysisId so the
   // button can function before the first save.
   const [ensuredId, setEnsuredId] = useState<string | undefined>(undefined);
+  const { t } = useTranslation('pricingAnalysis');
   const {
     control,
     getValues,
@@ -178,7 +180,6 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
             const numberOfMonths =
               getValues(`${name}.seasonDetails.${seasonIndex}.numberOfMonths`) ?? 0;
             const avgTotalRoomIncomePerSeason = avgTotalRoomIncomePerDay * numberOfMonths * 30;
-            console.log(getValues(`${name}.seasonDetails.${seasonIndex}.numberOfMonths`));
             return toNumber(avgTotalRoomIncomePerSeason);
           },
         };
@@ -203,16 +204,14 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
 
   useDerivedFields({ rules });
 
-  console.log(seasonCount);
-
   const rowsError = (errors as any)?.method?.detail?.roomDetails?.message as string | undefined;
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       {rowsError && <p className="text-xs text-danger-600">{rowsError}</p>}
       <div className="flex items-center gap-3">
         <div className="w-56">
-          <span>Number of seasons</span>
+          <span>{t('dcf.methods.roomIncomeBySeasonalRates.numberOfSeasons')}</span>
         </div>
         <div className="w-56">
           <RHFInputCell
@@ -223,7 +222,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               if (v) handleSeasonCountChange(v);
               return v;
             }}
-            number={{ decimalPlaces: 0, maxIntegerDigits: 1, allowNegative: false }}
+            number={{ decimalPlaces: 0, maxIntegerDigits: 2, allowNegative: false }}
           />
         </div>
       </div>
@@ -234,7 +233,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
             <thead>
               <tr>
                 <th rowSpan={2} className="border-b border-r border-gray-300">
-                  Room Type
+                  {t('dcf.common.roomType')}
                 </th>
                 {Array.from({ length: seasonCount }, (_, seasonIndex) => (
                   <th
@@ -244,7 +243,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                   >
                     <div className="flex flex-col gap-2 p-1.5">
                       <div className="flex flex-row items-center">
-                        <span className="w-64">Season Name</span>
+                        <span className="w-64">
+                          {t('dcf.methods.roomIncomeBySeasonalRates.seasonName')}
+                        </span>
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.seasonName`}
                           inputType="text"
@@ -253,7 +254,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                         />
                       </div>
                       <div className="flex flex-row items-center">
-                        <span className="w-64">No. Of Month</span>
+                        <span className="w-64">
+                          {t('dcf.methods.roomIncomeBySeasonalRates.numberOfMonths')}
+                        </span>
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.numberOfMonths`}
                           inputType="number"
@@ -267,7 +270,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                         />
                       </div>
                       <div className="flex flex-row items-center">
-                        <span className="w-64">Season Description</span>
+                        <span className="w-64">
+                          {t('dcf.methods.roomIncomeBySeasonalRates.seasonDescription')}
+                        </span>
                         <RHFInputCell
                           fieldName={`${name}.seasonDetails.${seasonIndex}.description`}
                           inputType="text"
@@ -282,15 +287,21 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               <tr>
                 {Array.from({ length: seasonCount }, (_, seasonIndex) => (
                   <Fragment key={seasonIndex}>
-                    <th className="border-b border-gray-300 text-right">Room Income</th>
-                    <th className="border-b border-gray-300 text-right">Saleable Area</th>
+                    <th className="flex flex-col border-b border-gray-300 text-right">
+                      <span>{t('dcf.methods.roomIncomeBySeasonalRates.roomIncomeHeader')}</span>
+                      <span>{t('dcf.common.bahtPerRoomPerDay')}</span>
+                    </th>
+                    <th className="border-b border-gray-300 text-right">
+                      {t('dcf.common.saleableArea')}
+                    </th>
                     <th
                       className={clsx(
-                        'border-b border-gray-300 text-right',
+                        'flex flex-col border-b border-gray-300 text-right',
                         seasonCount > 1 ? 'border-r' : 0,
                       )}
                     >
-                      Total / Day
+                      <span>{t('dcf.common.totalRoomIncome')}</span>
+                      <span>{t('dcf.common.bahtPerDay')}</span>
                     </th>
                   </Fragment>
                 ))}
@@ -326,7 +337,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                             type="button"
                             onClick={() => remove(rowIndex)}
                             className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
+                            title={t('dcf.common.delete')}
                           >
                             <Icon style="solid" name="trash" className="size-1" />
                           </button>
@@ -338,7 +349,6 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                       const cell = rows[rowIndex]?.seasons?.[seasonIndex];
                       const total =
                         (Number(cell?.roomIncome) || 0) * (Number(cell?.saleableArea) || 0);
-                      console.log(rows, cell, total);
 
                       return (
                         <Fragment key={`${field.id}-${seasonIndex}`}>
@@ -442,7 +452,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                       onClick={() => append(createEmptyRow(seasonCount))}
                       className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                     >
-                      + Add Room Type
+                      {t('dcf.methods.roomIncomeBySeasonalRates.addRoomType')}
                     </button>
                   </td>
                   {Array.from({ length: seasonCount }, (_, seasonIndex) => {
@@ -465,7 +475,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
 
             <tfoot>
               <tr>
-                <td className="border-b border-r border-gray-300 p-1.5">Totals</td>
+                <td className="border-b border-r border-gray-300 p-1.5">
+                  {t('dcf.common.totals')}
+                </td>
                 {Array.from({ length: seasonCount }, (_, seasonIndex) => {
                   const totals = calculateSeasonTotals(rows, seasonIndex);
 
@@ -488,7 +500,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                 })}
               </tr>
               <tr>
-                <td className="border-b border-r border-gray-300 p-1.5">Average/ Room/ Day</td>
+                <td className="border-b border-r border-gray-300 p-1.5">
+                  {t('dcf.methods.roomIncomeBySeasonalRates.averageRoomPerDay')}
+                </td>
                 {Array.from({ length: seasonCount }, (_, seasonIndex) => {
                   const totals = calculateSeasonTotals(rows, seasonIndex);
                   const avg = totals.totalRoomIncomePerDay / totals.saleableArea;
@@ -509,7 +523,9 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
                 })}
               </tr>
               <tr>
-                <td className="border-b border-r border-gray-300 p-1.5">Average/ Room/ Season</td>
+                <td className="border-b border-r border-gray-300 p-1.5">
+                  {t('dcf.methods.roomIncomeBySeasonalRates.averageRoomPerSeason')}
+                </td>
                 {Array.from({ length: seasonCount }, (_, seasonIndex) => {
                   const totals = calculateSeasonTotals(rows, seasonIndex);
                   const avg = totals.totalRoomIncomePerDay / totals.saleableArea;
@@ -536,7 +552,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Average Room Rate</span>
+          <span className={'w-56'}>{t('dcf.common.averageRoomRate')}</span>
           <div className={'w-44 text-right'}>
             <RHFInputCell
               fieldName={`${name}.avgRoomRate`}
@@ -548,7 +564,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
           </div>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Number of Saleable Area</span>
+          <span className={'w-56'}>{t('dcf.common.totalNumberOfSaleableArea')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.totalSaleableArea`}
@@ -559,7 +575,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
           </div>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -572,7 +588,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={''}>every</span>
+          <span className={''}>{t('dcf.common.every')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -586,10 +602,10 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Occupancy Rate - First Year</span>
+          <span className={'w-56'}>{t('dcf.common.occupancyRateFirstYear')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
@@ -603,7 +619,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={''}>% with growth</span>
+          <span className={''}>{t('dcf.common.percentWithGrowth')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
@@ -617,7 +633,7 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={''}>% every</span>
+          <span className={''}>{t('dcf.common.percentEvery')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
@@ -631,10 +647,10 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -648,7 +664,18 @@ export function MethodSpecifiedRoomIncomeBySeasonalRatesModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
+        </div>
+        <div className="flex flex-row gap-1.5">
+          <span className={'w-56'}>{t('dcf.common.remark')}</span>
+          <div className={'flex-1'}>
+            <RHFInputCell
+              fieldName={`${name}.remark`}
+              inputType={'text'}
+              disabled={isReadOnly}
+              text={{ maxLength: 200 }}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
@@ -332,6 +332,17 @@ export function MethodSpecifyRoomIncomePerDayModal({
           </div>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
+          <span className={'w-56'}>Remark</span>
+          <div className={'flex-1'}>
+            <RHFInputCell
+              fieldName={`${name}.remark`}
+              inputType={'text'}
+              disabled={isReadOnly}
+              text={{ maxLength: 200 }}
+            />
+          </div>
+        </div>
+        <div className="flex flex-row gap-1.5 items-center">
           <span className={'w-56'}>Increase Rate</span>
           <div className={'w-44'}>
             <RHFInputCell

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@/shared/components';
 import { RHFInputCell } from '../../table/RHFInputCell';
 import { useDerivedFields, type DerivedFieldRule } from '../../../adapters/useDerivedFieldArray';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useFieldArray, useFormContext, type UseFormGetValues } from 'react-hook-form';
 import { ScrollableTableContainer } from '../../ScrollableTableContainer';
 import { toDecimal, toNumber } from '../../../domain/calculation';
@@ -30,6 +31,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
   templateList?: TemplateDtoType[] | undefined;
   ensureIncomeAnalysisId?: () => Promise<string | undefined>;
 }) {
+  const { t } = useTranslation('pricingAnalysis');
   const {
     getValues,
     setValue,
@@ -128,10 +130,19 @@ export function MethodSpecifyRoomIncomePerDayModal({
           <table className={'table table-sm'}>
             <thead>
               <tr>
-                <th className="px-1.5 py-1.5 bg-gray-100">Room Type</th>
-                <th className="px-1.5 py-1.5 bg-gray-100">Room Income</th>
-                <th className="px-1.5 py-1.5 bg-gray-100">Saleable Area</th>
-                <th className="px-1.5 py-1.5 bg-gray-100">Total Room Income</th>
+                <th className="px-1.5 py-1.5 bg-gray-100">
+                  <span className="text-sm">{t('dcf.common.roomType')}</span>
+                </th>
+                <th className="flex flex-col gap-1.5 px-1.5 py-1.5 bg-gray-100">
+                  <span className="text-sm">
+                    {t('dcf.methods.roomIncomePerDay.roomIncomeHeader')}
+                  </span>
+                  <span className="text-sm">{t('dcf.common.bahtPerRoomPerDay')}</span>
+                </th>
+                <th className="px-1.5 py-1.5 bg-gray-100">{t('dcf.common.saleableArea')}</th>
+                <th className="px-1.5 py-1.5 bg-gray-100">
+                  {t('dcf.methods.roomIncomePerDay.totalRoomIncomeHeader')}
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -161,7 +172,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
                             type="button"
                             onClick={() => handleOnRemove(index)}
                             className="size-5 flex-shrink-0 flex items-center justify-center cursor-pointer rounded text-gray-300 hover:text-danger-600 hover:bg-danger-50 transition-colors opacity-100"
-                            title="Delete"
+                            title={t('dcf.common.delete')}
                           >
                             <Icon style="solid" name="trash" className="size-1" />
                           </button>
@@ -258,7 +269,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
                       onClick={() => handleOnAdd()}
                       className="px-3 py-1.5 w-full border border-dashed border-primary rounded-lg cursor-pointer text-primary hover:bg-primary/10"
                     >
-                      + Add Room
+                      {t('dcf.common.addRoom')}
                     </button>
                   </td>
                   <td></td>
@@ -267,7 +278,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
                 </tr>
               )}
               <tr>
-                <td className="sticky bottom-0 px-1.5 bg-white"></td>
+                <td className="sticky bottom-0 px-1.5 bg-white">{t('dcf.common.total')}</td>
                 <td className="sticky bottom-0 px-1.5 bg-white">
                   <div className="text-right">
                     <RHFInputCell
@@ -308,7 +319,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
       </div>
       <div className="flex flex-col gap-2 mb-4">
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Average Room Rate</span>
+          <span className={'w-56'}>{t('dcf.common.averageRoomRate')}</span>
           <div className={'w-44 text-right'}>
             <RHFInputCell
               fieldName={`${name}.avgRoomRate`}
@@ -320,7 +331,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
           </div>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Total Number of Saleable Area</span>
+          <span className={'w-56'}>{t('dcf.common.totalNumberOfSaleableArea')}</span>
           <div className={'w-44 text-right'}>
             <RHFInputCell
               fieldName={`${name}.sumSaleableArea`}
@@ -330,18 +341,9 @@ export function MethodSpecifyRoomIncomePerDayModal({
               )}
             />
           </div>
-          <span>Remark</span>
-          <div className={'flex-1'}>
-            <RHFInputCell
-              fieldName={`${name}.remark`}
-              inputType={'text'}
-              disabled={isReadOnly}
-              text={{ maxLength: 200 }}
-            />
-          </div>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Increase Rate</span>
+          <span className={'w-56'}>{t('dcf.common.increaseRate')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRatePct`}
@@ -354,7 +356,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={''}>every</span>
+          <span className={''}>{t('dcf.common.every')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.increaseRateYrs`}
@@ -368,10 +370,10 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={'w-44'}>year(s)</span>
+          <span className={'w-44'}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Occupancy Rate - First Year</span>
+          <span className={'w-56'}>{t('dcf.common.occupancyRateFirstYear')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateFirstYearPct`}
@@ -385,7 +387,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={''}>% with growth</span>
+          <span className={''}>{t('dcf.common.percentWithGrowth')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRatePct`}
@@ -399,7 +401,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={''}>% every</span>
+          <span className={''}>{t('dcf.common.percentEvery')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.occupancyRateYrs`}
@@ -413,10 +415,10 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
         </div>
         <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Start In</span>
+          <span className={'w-56'}>{t('dcf.common.startIn')}</span>
           <div className={'w-44'}>
             <RHFInputCell
               fieldName={`${name}.startIn`}
@@ -430,7 +432,18 @@ export function MethodSpecifyRoomIncomePerDayModal({
               }}
             />
           </div>
-          <span className={''}>year(s)</span>
+          <span className={''}>{t('dcf.common.year')}</span>
+        </div>
+        <div className="flex flex-row gap-1.5 items-center">
+          <span className={'w-56'}>{t('dcf.common.remark')}</span>
+          <div className={'flex-1'}>
+            <RHFInputCell
+              fieldName={`${name}.remark`}
+              inputType={'text'}
+              disabled={isReadOnly}
+              text={{ maxLength: 200 }}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomePerDayModal.tsx
@@ -330,9 +330,7 @@ export function MethodSpecifyRoomIncomePerDayModal({
               )}
             />
           </div>
-        </div>
-        <div className="flex flex-row gap-1.5 items-center">
-          <span className={'w-56'}>Remark</span>
+          <span>Remark</span>
           <div className={'flex-1'}>
             <RHFInputCell
               fieldName={`${name}.remark`}

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModalProps {
@@ -11,10 +12,11 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Saleable Area</span>
+        <span className={'w-56'}>{t('dcf.common.saleableArea')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.saleableArea`}
@@ -25,7 +27,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Total Number of Saleable Area</span>
+        <span className={'w-56'}>{t('dcf.common.totalNumberOfSaleableArea')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.totalNumberOfSaleableArea`}
@@ -34,7 +36,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
-        <span>Remark</span>
+        <span>{t('dcf.common.remark')}</span>
         <div className={'w-56'}>
           <RHFInputCell
             fieldName={`${name}.remark`}
@@ -45,7 +47,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Room Income</span>
+        <span className={'w-56'}>{t('dcf.common.roomIncome')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
@@ -54,10 +56,10 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
           />
         </div>
-        <span className={''}>Bath/ Year</span>
+        <span className={''}>{t('dcf.common.bahtPerYear')}</span>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Increase</span>
+        <span className={'w-56'}>{t('dcf.common.increase')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -66,7 +68,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -75,10 +77,10 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Occupancy Rate - First Year</span>
+        <span className={'w-56'}>{t('dcf.common.occupancyRateFirstYear')}</span>
         <div className={'w-24'}>
           <RHFInputCell
             fieldName={`${name}.occupancyRateFirstYearPct`}
@@ -87,7 +89,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>% with growth</span>
+        <span className={''}>{t('dcf.common.percentWithGrowth')}</span>
         <div className={'w-24'}>
           <RHFInputCell
             fieldName={`${name}.occupancyRatePct`}
@@ -96,7 +98,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className={'w-24'}>
           <RHFInputCell
             fieldName={`${name}.occupancyRateYrs`}
@@ -105,10 +107,10 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -122,7 +124,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 interface MethodSpecifiedRoomIncomeWithGrowthModalProps {
@@ -11,10 +12,11 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
   isReadOnly,
   getOuterFormValues,
 }: MethodSpecifiedRoomIncomeWithGrowthModalProps) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Saleable Area</span>
+        <span className={'w-56'}>{t('dcf.common.saleableArea')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.saleableArea`}
@@ -25,7 +27,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Total Number of Saleable Area</span>
+        <span className={'w-56'}>{t('dcf.common.totalNumberOfSaleableArea')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.totalNumberOfSaleableArea`}
@@ -34,7 +36,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
-        <span>Remark</span>
+        <span>{t('dcf.common.remark')}</span>
         <div className={'w-56'}>
           <RHFInputCell
             fieldName={`${name}.remark`}
@@ -45,7 +47,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Room Income</span>
+        <span className={'w-56'}>{t('dcf.common.roomIncome')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
@@ -54,10 +56,10 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 15, allowNegative: false }}
           />
         </div>
-        <span className={''}>Bath/ Year</span>
+        <span className={''}>{t('dcf.common.bahtPerYear')}</span>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>Increase</span>
+        <span className={'w-56'}>{t('dcf.common.increase')}</span>
         <div className="w-44">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -66,7 +68,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             number={{ decimalPlaces: 2, maxIntegerDigits: 3, allowNegative: false }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-44">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -75,10 +77,10 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 3, maxValue: 100, allowNegative: false }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -92,7 +94,7 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
@@ -1,4 +1,5 @@
 import type { UseFormGetValues } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { RHFInputCell } from '../../table/RHFInputCell';
 
 export function MethodSpecifiedValueWithGrowthModal({
@@ -10,10 +11,11 @@ export function MethodSpecifiedValueWithGrowthModal({
   isReadOnly?: boolean;
   getOuterFormValues: UseFormGetValues<any>;
 }) {
+  const { t } = useTranslation('pricingAnalysis');
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-56'}>First year amount</span>
+        <span className={'w-56'}>{t('dcf.methods.valueWithGrowth.firstYearAmount')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.firstYearAmt`}
@@ -26,7 +28,7 @@ export function MethodSpecifiedValueWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>increase</span>
+        <span className={''}>{t('dcf.common.increase')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}
@@ -39,7 +41,7 @@ export function MethodSpecifiedValueWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>% every</span>
+        <span className={''}>{t('dcf.common.percentEvery')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRateYrs`}
@@ -53,10 +55,10 @@ export function MethodSpecifiedValueWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
       <div className="flex flex-row gap-1.5">
-        <span className={'w-56'}>Start In</span>
+        <span className={'w-56'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
             fieldName={`${name}.startIn`}
@@ -70,7 +72,7 @@ export function MethodSpecifiedValueWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>year(s)</span>
+        <span className={''}>{t('dcf.common.year')}</span>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/types/dcf.ts
+++ b/src/features/pricingAnalysis/types/dcf.ts
@@ -22,6 +22,7 @@ interface MethodSpecifiedRoomIncomePerDay {
   occupancyRatePct: number; // collect to db
   occupancyRateYrs: number; // collect to db
   startIn: number;
+  remark?: string; // collect to db
 
   // table
   saleableArea: number[];

--- a/src/features/pricingAnalysis/types/dcf.ts
+++ b/src/features/pricingAnalysis/types/dcf.ts
@@ -151,6 +151,7 @@ interface MethodSpecifiedRentalIncomePerSquareMeter {
   sumTotalRentalIncomePerYear: number;
   avgRentalRatePerMonth: number;
   totalSaleableArea: number; // collect to db
+  totalBuildingArea: number; // collect to db
   increaseRatePct: number; // collect to db
   increaseRateYrs: number; // collect to db
   occupancyRateFirstYearPct: number; // collect to db

--- a/src/features/pricingAnalysis/types/dcf.ts
+++ b/src/features/pricingAnalysis/types/dcf.ts
@@ -67,6 +67,7 @@ interface MethodSpecifiedRoomIncomeBySeasonalRates {
   occupancyRatePct: number; // collect to db
   occupancyRateYrs: number; // collect to db
   startIn: number;
+  remark?: string; // collect to db
 
   // table
   saleableArea: number[];

--- a/src/i18n/locales/en/pricingAnalysis.json
+++ b/src/i18n/locales/en/pricingAnalysis.json
@@ -211,7 +211,119 @@
     "title": "Discounted Cash Flow",
     "highestBestUsed": "Highest and Best Used",
     "assumptions": "Assumptions",
-    "viewSummary": "View Assumption Summary"
+    "viewSummary": "View Assumption Summary",
+    "common": {
+      "startIn": "Start In",
+      "year": "year(s)",
+      "every": "every",
+      "percentEvery": "% every",
+      "percentWithGrowth": "% with growth",
+      "increaseRate": "Increase Rate",
+      "increase": "Increase Rate",
+      "remark": "Remark",
+      "roomType": "Room Type",
+      "roomIncome": "Room Income",
+      "totalRoomIncome": "Total Room Income",
+      "saleableArea": "Saleable Area",
+      "totalNumberOfSaleableArea": "Total Number of Saleable Area",
+      "occupancyRateFirstYear": "Occupancy Rate - First Year",
+      "averageRoomRate": "Average Room Rate",
+      "delete": "Delete",
+      "addRoom": "+ Add Room",
+      "total": "Total",
+      "totals": "Totals",
+      "bahtPerDay": "Baht/ Day",
+      "bahtPerYear": "Baht/ Year",
+      "bahtPerMonth": "Baht/ Month",
+      "sqMeter": "Sq. Meter",
+      "baht": "Baht",
+      "proportions": "Proportions",
+      "bahtPerRoomPerDay": "Baht/ Room/ Day",
+      "projectionPeriod": "Projection Period:",
+      "daysPerYear": "Days per Year:",
+      "years": "years",
+      "days": "days",
+      "yearColumn": "Year {{year}}"
+    },
+    "methods": {
+      "roomIncomePerDay": {
+        "roomIncomeHeader": "Room Income",
+        "totalRoomIncomeHeader": "Total Room Income"
+      },
+      "roomIncomeBySeasonalRates": {
+        "numberOfSeasons": "Number of seasons",
+        "seasonName": "Season Name",
+        "numberOfMonths": "No. Of Month",
+        "seasonDescription": "Season Description",
+        "roomIncomeHeader": "Room Income",
+        "totalPerDay": "Total / Day",
+        "addRoomType": "+ Add Room Type",
+        "averageRoomPerDay": "Average/ Room/ Day",
+        "averageRoomPerSeason": "Average/ Room/ Season"
+      },
+      "rentalIncomePerSquareMeter": {
+        "totalBuildingArea": "Total Building Area",
+        "areaDescription": "Area Description",
+        "rentalPrice": "Rental Price",
+        "unitPerSqmMonth": "Bath / Sq.M / Month",
+        "totalSaleableArea": "Total Saleable Area",
+        "sqM": "Sq. M",
+        "totalRentalIncome": "Total Rental Income",
+        "averageRentalPrice": "Average Rental Price",
+        "unitBahtSqmMonth": "Baht/ Sq. Meter/ Month"
+      },
+      "proportion": {
+        "percentOf": "% of"
+      },
+      "rentalIncomePerMonth": {
+        "unitPerRoomMonth": "Bath / Room / Month"
+      },
+      "positionBasedSalary": {
+        "jobPosition": "Job Position",
+        "salary": "Salary",
+        "unitPerPersonMonth": "Bath / Person / Month",
+        "numberOfEmployees": "Number of Employees",
+        "totalSalary": "Total Salary",
+        "addJobPosition": "+ Add Job Position"
+      },
+      "roomCostBasedOnExpenses": {
+        "roomCost": "Room Cost",
+        "unitPerRoomDay": "Bath / Room / Day",
+        "totalRoomExpenses": "Total Room Expenses",
+        "unitPerDay": "Bath / Day"
+      },
+      "tierOfPropertyValue": {
+        "totalGovLandPrice": "Total government land appraisal price",
+        "totalGovBuildingPrice": "Total government building appraisal price",
+        "govLandPriceIncreaseBy": "Government land prices increase by",
+        "taxRatesTableTitle": "Land and Building Tax Rates",
+        "estimatedPrice": "Estimated Price (Baht)",
+        "taxRate": "Tax Rate (%)",
+        "taxCeiling": "Tax Ceiling (Baht)",
+        "from": "From",
+        "to": "To",
+        "taxTableTitle": "Land and Building Tax",
+        "yearLabel": "Year {{year}}",
+        "row1Label": "(1) Government Land Price (with annual increase)",
+        "row2Label": "(2) Government Price for Buildings",
+        "row3Label": "(1+2) Total price of Government Property",
+        "propertyTaxRow": "Property tax on Government Appraisal Price"
+      },
+      "proportionOfNewReplacementCost": {
+        "percentOfNewReplacementCost": "% of new replacement cost"
+      },
+      "foodAndBeverageExpenses": {
+        "label": "Food and Beverage Expenses",
+        "unitPerRoomDay": "Baht/ Room/ Day"
+      },
+      "valueWithGrowth": {
+        "firstYearAmount": "First year amount"
+      },
+      "energyCostIndex": {
+        "energyCostIndex": "Energy Cost Index",
+        "energyCostIncreaseRate": "Energy Cost Increase Rate"
+      }
+    }
   },
   "profitRent": {
     "title": "Profit Rent Analysis",

--- a/src/i18n/locales/th/pricingAnalysis.json
+++ b/src/i18n/locales/th/pricingAnalysis.json
@@ -211,7 +211,119 @@
     "title": "กระแสเงินสดลดราคา",
     "highestBestUsed": "การใช้ประโยชน์สูงสุดและดีที่สุด",
     "assumptions": "สมมติฐาน",
-    "viewSummary": "ดูสรุปสมมติฐาน"
+    "viewSummary": "ดูสรุปสมมติฐาน",
+    "common": {
+      "startIn": "เริ่มในปีที่",
+      "year": "ปี",
+      "every": "ทุก",
+      "percentEvery": "% ทุก",
+      "percentWithGrowth": "% พร้อมการเติบโต",
+      "increaseRate": "อัตราการเพิ่มขึ้น",
+      "increase": "อัตราการเพิ่มขึ้น",
+      "remark": "หมายเหตุ",
+      "roomType": "ประเภทห้อง",
+      "roomIncome": "รายได้ห้อง",
+      "totalRoomIncome": "รายได้ห้องรวม",
+      "saleableArea": "พื้นที่ขายได้",
+      "totalNumberOfSaleableArea": "พื้นที่ขายได้รวม",
+      "occupancyRateFirstYear": "อัตราการเข้าพัก - ปีแรก",
+      "averageRoomRate": "อัตราค่าห้องเฉลี่ย",
+      "delete": "ลบ",
+      "addRoom": "+ เพิ่มห้อง",
+      "total": "รวม",
+      "totals": "ยอดรวม",
+      "bahtPerDay": "บาท/ วัน",
+      "bahtPerYear": "บาท/ ปี",
+      "bahtPerMonth": "บาท/ เดือน",
+      "sqMeter": "ตร.ม.",
+      "baht": "บาท",
+      "proportions": "สัดส่วน",
+      "bahtPerRoomPerDay": "บาท/ ห้อง/ วัน",
+      "projectionPeriod": "ระยะเวลาประมาณการ:",
+      "daysPerYear": "จำนวนวันต่อปี:",
+      "years": "ปี",
+      "days": "วัน",
+      "yearColumn": "ปีที่ {{year}}"
+    },
+    "methods": {
+      "roomIncomePerDay": {
+        "roomIncomeHeader": "รายได้ห้อง",
+        "totalRoomIncomeHeader": "รายได้ห้องรวม"
+      },
+      "roomIncomeBySeasonalRates": {
+        "numberOfSeasons": "จำนวนฤดูกาล",
+        "seasonName": "ชื่อฤดูกาล",
+        "numberOfMonths": "จำนวนเดือน",
+        "seasonDescription": "รายละเอียดฤดูกาล",
+        "roomIncomeHeader": "รายได้ห้อง",
+        "totalPerDay": "รวม/ วัน",
+        "addRoomType": "+ เพิ่มประเภทห้อง",
+        "averageRoomPerDay": "เฉลี่ย/ ห้อง/ วัน",
+        "averageRoomPerSeason": "เฉลี่ย/ ห้อง/ ฤดูกาล"
+      },
+      "rentalIncomePerSquareMeter": {
+        "totalBuildingArea": "พื้นที่อาคารรวม",
+        "areaDescription": "รายละเอียดพื้นที่",
+        "rentalPrice": "ราคาเช่า",
+        "unitPerSqmMonth": "บาท / ตร.ม. / เดือน",
+        "totalSaleableArea": "พื้นที่ขายได้รวม",
+        "sqM": "ตร.ม.",
+        "totalRentalIncome": "รายได้ค่าเช่ารวม",
+        "averageRentalPrice": "ราคาเช่าเฉลี่ย",
+        "unitBahtSqmMonth": "บาท/ ตร.ม./ เดือน"
+      },
+      "proportion": {
+        "percentOf": "% ของ"
+      },
+      "rentalIncomePerMonth": {
+        "unitPerRoomMonth": "บาท / ห้อง / เดือน"
+      },
+      "positionBasedSalary": {
+        "jobPosition": "ตำแหน่งงาน",
+        "salary": "เงินเดือน",
+        "unitPerPersonMonth": "บาท / คน / เดือน",
+        "numberOfEmployees": "จำนวนพนักงาน",
+        "totalSalary": "เงินเดือนรวม",
+        "addJobPosition": "+ เพิ่มตำแหน่งงาน"
+      },
+      "roomCostBasedOnExpenses": {
+        "roomCost": "ต้นทุนห้อง",
+        "unitPerRoomDay": "บาท / ห้อง / วัน",
+        "totalRoomExpenses": "ค่าใช้จ่ายห้องรวม",
+        "unitPerDay": "บาท / วัน"
+      },
+      "tierOfPropertyValue": {
+        "totalGovLandPrice": "ราคาประเมินที่ดินราชการรวม",
+        "totalGovBuildingPrice": "ราคาประเมินอาคารราชการรวม",
+        "govLandPriceIncreaseBy": "ราคาที่ดินราชการเพิ่มขึ้นทุก",
+        "taxRatesTableTitle": "อัตราภาษีที่ดินและสิ่งปลูกสร้าง",
+        "estimatedPrice": "ราคาประเมิน (บาท)",
+        "taxRate": "อัตราภาษี (%)",
+        "taxCeiling": "เพดานภาษี (บาท)",
+        "from": "จาก",
+        "to": "ถึง",
+        "taxTableTitle": "ภาษีที่ดินและสิ่งปลูกสร้าง",
+        "yearLabel": "ปีที่ {{year}}",
+        "row1Label": "(1) ราคาที่ดินราชการ (พร้อมการเพิ่มขึ้นรายปี)",
+        "row2Label": "(2) ราคาประเมินราชการสำหรับอาคาร",
+        "row3Label": "(1+2) ราคาทรัพย์สินราชการรวม",
+        "propertyTaxRow": "ภาษีทรัพย์สินจากราคาประเมินราชการ"
+      },
+      "proportionOfNewReplacementCost": {
+        "percentOfNewReplacementCost": "% ของต้นทุนทดแทนใหม่"
+      },
+      "foodAndBeverageExpenses": {
+        "label": "ค่าใช้จ่ายอาหารและเครื่องดื่ม",
+        "unitPerRoomDay": "บาท/ ห้อง/ วัน"
+      },
+      "valueWithGrowth": {
+        "firstYearAmount": "จำนวนเงินปีแรก"
+      },
+      "energyCostIndex": {
+        "energyCostIndex": "ดัชนีต้นทุนพลังงาน",
+        "energyCostIncreaseRate": "อัตราการเพิ่มขึ้นของต้นทุนพลังงาน"
+      }
+    }
   },
   "profitRent": {
     "title": "การวิเคราะห์กำไรจากค่าเช่า",

--- a/src/i18n/locales/zh/pricingAnalysis.json
+++ b/src/i18n/locales/zh/pricingAnalysis.json
@@ -211,7 +211,119 @@
     "title": "Discounted Cash Flow",
     "highestBestUsed": "Highest and Best Used",
     "assumptions": "Assumptions",
-    "viewSummary": "View Assumption Summary"
+    "viewSummary": "View Assumption Summary",
+    "common": {
+      "startIn": "开始年份",
+      "year": "年",
+      "every": "每",
+      "percentEvery": "% 每",
+      "percentWithGrowth": "% 并增长",
+      "increaseRate": "增长率",
+      "increase": "增长率",
+      "remark": "备注",
+      "roomType": "房型",
+      "roomIncome": "客房收入",
+      "totalRoomIncome": "客房收入合计",
+      "saleableArea": "可售面积",
+      "totalNumberOfSaleableArea": "可售面积合计",
+      "occupancyRateFirstYear": "入住率 - 第一年",
+      "averageRoomRate": "平均房价",
+      "delete": "删除",
+      "addRoom": "+ 添加房间",
+      "total": "合计",
+      "totals": "总计",
+      "bahtPerDay": "泰铢/ 天",
+      "bahtPerYear": "泰铢/ 年",
+      "bahtPerMonth": "泰铢/ 月",
+      "sqMeter": "平方米",
+      "baht": "泰铢",
+      "proportions": "比例",
+      "bahtPerRoomPerDay": "泰铢/ 间/ 天",
+      "projectionPeriod": "预测期:",
+      "daysPerYear": "每年天数:",
+      "years": "年",
+      "days": "天",
+      "yearColumn": "第 {{year}} 年"
+    },
+    "methods": {
+      "roomIncomePerDay": {
+        "roomIncomeHeader": "客房收入",
+        "totalRoomIncomeHeader": "客房收入合计"
+      },
+      "roomIncomeBySeasonalRates": {
+        "numberOfSeasons": "季节数量",
+        "seasonName": "季节名称",
+        "numberOfMonths": "月数",
+        "seasonDescription": "季节说明",
+        "roomIncomeHeader": "客房收入",
+        "totalPerDay": "合计/ 天",
+        "addRoomType": "+ 添加房型",
+        "averageRoomPerDay": "平均/ 间/ 天",
+        "averageRoomPerSeason": "平均/ 间/ 季"
+      },
+      "rentalIncomePerSquareMeter": {
+        "totalBuildingArea": "建筑面积合计",
+        "areaDescription": "区域说明",
+        "rentalPrice": "租金价格",
+        "unitPerSqmMonth": "泰铢 / 平方米 / 月",
+        "totalSaleableArea": "可售面积合计",
+        "sqM": "平方米",
+        "totalRentalIncome": "租金收入合计",
+        "averageRentalPrice": "平均租金价格",
+        "unitBahtSqmMonth": "泰铢/ 平方米/ 月"
+      },
+      "proportion": {
+        "percentOf": "% 占"
+      },
+      "rentalIncomePerMonth": {
+        "unitPerRoomMonth": "泰铢 / 间 / 月"
+      },
+      "positionBasedSalary": {
+        "jobPosition": "职位",
+        "salary": "薪资",
+        "unitPerPersonMonth": "泰铢 / 人 / 月",
+        "numberOfEmployees": "员工人数",
+        "totalSalary": "薪资合计",
+        "addJobPosition": "+ 添加职位"
+      },
+      "roomCostBasedOnExpenses": {
+        "roomCost": "客房成本",
+        "unitPerRoomDay": "泰铢 / 间 / 天",
+        "totalRoomExpenses": "客房费用合计",
+        "unitPerDay": "泰铢 / 天"
+      },
+      "tierOfPropertyValue": {
+        "totalGovLandPrice": "政府评估土地总价",
+        "totalGovBuildingPrice": "政府评估建筑总价",
+        "govLandPriceIncreaseBy": "政府地价增长",
+        "taxRatesTableTitle": "土地和建筑物税率",
+        "estimatedPrice": "评估价格 (泰铢)",
+        "taxRate": "税率 (%)",
+        "taxCeiling": "税额上限 (泰铢)",
+        "from": "从",
+        "to": "到",
+        "taxTableTitle": "土地和建筑物税",
+        "yearLabel": "第 {{year}} 年",
+        "row1Label": "(1) 政府地价 (每年递增)",
+        "row2Label": "(2) 政府建筑评估价格",
+        "row3Label": "(1+2) 政府财产总价",
+        "propertyTaxRow": "基于政府评估价格的财产税"
+      },
+      "proportionOfNewReplacementCost": {
+        "percentOfNewReplacementCost": "% 重置成本"
+      },
+      "foodAndBeverageExpenses": {
+        "label": "餐饮费用",
+        "unitPerRoomDay": "泰铢/ 间/ 天"
+      },
+      "valueWithGrowth": {
+        "firstYearAmount": "第一年金额"
+      },
+      "energyCostIndex": {
+        "energyCostIndex": "能源成本指数",
+        "energyCostIncreaseRate": "能源成本增长率"
+      }
+    }
   },
   "profitRent": {
     "title": "Profit Rent Analysis",


### PR DESCRIPTION
====== UAT ======
CA-465:
- method room income per day
add label 'Baht/ Room/ Day'
add label 'Total'
add remark field
- method seasonal
add label 'Baht/ Room/ Day'
CA-467:
- update 'Project Period: { n } years / Days per Year: { n } days
CA-485:
- add label 'Description'
CA-487:
- add label 'Description'
CA-488
- add label 'Increase Rate'
CA-491
- update header 'Tax Rate(%)'
- update '%' suffix
- update '(1) Government Land Price (with annual increase)'
- update '(2) Government Price for Buildings'
- update 'Property tax on Government Appraisal Price'
====== SIT ======
- add reset button
- update field length on energy cost index method
- add remark on some modal