### PR TITLE
feat(block): block reappraisal + unit maintenance UI updates

### DIFF
--- a/src/features/blockReappraisal/api/blockReappraisal.ts
+++ b/src/features/blockReappraisal/api/blockReappraisal.ts
@@ -34,6 +34,8 @@ export function useBlockReappraisalDueList(params: BlockReappraisalListParams = 
         lastAppraisedDateTo,
         remainingDayMin,
         remainingDayMax,
+        sortBy,
+        sortDir,
       } = params;
 
       const { data } = await axios.get('/block-reappraisal', {
@@ -45,6 +47,7 @@ export function useBlockReappraisalDueList(params: BlockReappraisalListParams = 
           ...(lastAppraisedDateTo && { lastAppraisedDateTo }),
           ...(remainingDayMin != null && { remainingDayMin }),
           ...(remainingDayMax != null && { remainingDayMax }),
+          ...(sortBy && { sortBy, sortDir }),
         },
       });
 

--- a/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
+++ b/src/features/blockReappraisal/pages/BlockReappraisalDetailPage.tsx
@@ -1,15 +1,15 @@
 import { useMemo, useState } from 'react';
+import type { TFunction } from 'i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import Icon from '@/shared/components/Icon';
 import Button from '@/shared/components/Button';
+import Input from '@/shared/components/Input';
+import { NumberInput } from '@/shared/components';
 import Modal from '@/shared/components/Modal';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { formatLocaleDate, formatLocaleDateTime } from '@/shared/utils/dateUtils';
-import { SoldDonut } from '@/features/blockUnitMaintenance/components/SoldDonut';
-import { ModelBreakdown } from '@/features/blockUnitMaintenance/components/ModelBreakdown';
-import type { ModelStat } from '@/features/blockUnitMaintenance/components/ModelBreakdown';
 import {
   useBlockReappraisalDetail,
   useCreateBlockReappraisal,
@@ -25,19 +25,234 @@ function formatNumber(n?: number | null): string {
   return n.toLocaleString();
 }
 
-function groupByModel(
+// Case-insensitive substring match across the unit's identifying fields
+// (covers both Condo and Land & Building layouts).
+function matchUnit(unit: BlockReappraisalUnitDetail, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  const haystack = [
+    unit.modelType,
+    unit.plotNumber,
+    unit.houseNumber,
+    unit.towerName,
+    unit.roomNumber,
+    unit.condoRegistrationNumber,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+// ─── Sold-status filter chips ─────────────────────────────────────────────────
+
+type StatusFilter = 'all' | 'sold' | 'available';
+
+function StatusChips({
+  value,
+  onChange,
+  counts,
+  t,
+}: {
+  value: StatusFilter;
+  onChange: (v: StatusFilter) => void;
+  counts: Record<StatusFilter, number>;
+  t: TFunction<readonly ['blockReappraisal', 'common']>;
+}) {
+  const chips: { key: StatusFilter; label: string }[] = [
+    { key: 'all', label: t('detail.filter.all') },
+    { key: 'sold', label: t('detail.filter.sold') },
+    { key: 'available', label: t('detail.filter.available') },
+  ];
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {chips.map(c => {
+        const active = c.key === value;
+        return (
+          <button
+            key={c.key}
+            type="button"
+            onClick={() => onChange(c.key)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+              active
+                ? 'bg-primary text-white border-primary'
+                : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+            }`}
+          >
+            <span>{c.label}</span>
+            <span
+              className={`tabular-nums px-1.5 py-px rounded-full text-[10px] ${
+                active ? 'bg-white/20' : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              {counts[c.key]}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Column sorting ───────────────────────────────────────────────────────────
+
+type SortKey =
+  | 'plotNumber'
+  | 'houseNumber'
+  | 'modelType'
+  | 'numberOfFloors'
+  | 'landArea'
+  | 'usableArea'
+  | 'sellingPrice'
+  | 'lastAppraisedValue'
+  | 'updatedAt';
+type SortDir = 'asc' | 'desc';
+
+function sortUnits(
   units: BlockReappraisalUnitDetail[],
-  predicate: (u: BlockReappraisalUnitDetail) => boolean,
-): ModelStat[] {
-  const map = new Map<string, number>();
-  for (const u of units) {
-    if (!predicate(u)) continue;
-    const key = u.modelType?.trim() || '—';
-    map.set(key, (map.get(key) ?? 0) + 1);
-  }
-  return Array.from(map.entries())
-    .map(([modelName, count]) => ({ modelName, count }))
-    .sort((a, b) => b.count - a.count);
+  key: SortKey | null,
+  dir: SortDir,
+): BlockReappraisalUnitDetail[] {
+  if (!key) return units;
+  const factor = dir === 'asc' ? 1 : -1;
+  return [...units].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    // Nulls always sort last, regardless of direction.
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return av.localeCompare(bv) * factor;
+    }
+    return (Number(av) - Number(bv)) * factor;
+  });
+}
+
+interface SortableThProps {
+  label: string;
+  columnKey: SortKey;
+  activeKey: SortKey | null;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align?: 'left' | 'right' | 'center';
+}
+
+function SortableTh({ label, columnKey, activeKey, dir, onSort, align = 'left' }: SortableThProps) {
+  const active = activeKey === columnKey;
+  const alignClass =
+    align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+  const justifyClass =
+    align === 'right' ? 'justify-end' : align === 'center' ? 'justify-center' : 'justify-start';
+  return (
+    <th className={`py-2 px-3 text-gray-500 font-medium whitespace-nowrap ${alignClass}`}>
+      <button
+        type="button"
+        onClick={() => onSort(columnKey)}
+        className={`inline-flex w-full items-center gap-1 hover:text-gray-700 transition-colors ${justifyClass} ${
+          active ? 'text-gray-700' : ''
+        }`}
+      >
+        <span>{label}</span>
+        <Icon
+          style="solid"
+          name={active ? (dir === 'asc' ? 'sort-up' : 'sort-down') : 'sort'}
+          className={`size-2.5 ${active ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </button>
+    </th>
+  );
+}
+
+// Estimate Price cell — sold / not-yet-valued units carry no estimate, so render a
+// muted dash instead of "0" to avoid a zero being read as a real valuation.
+function EstimateCell({ value }: { value: number | null }) {
+  const empty = value == null || value === 0;
+  return (
+    <td className={`py-1.5 px-3 tabular-nums text-right ${empty ? 'text-gray-300' : 'text-gray-700'}`}>
+      {empty ? '–' : value.toLocaleString()}
+    </td>
+  );
+}
+
+// ─── Due-date urgency badge ───────────────────────────────────────────────────
+
+// Whole-day difference between the due date and today (negative = overdue).
+function daysUntil(dateStr: string): number {
+  const due = new Date(dateStr);
+  const today = new Date();
+  due.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+  return Math.round((due.getTime() - today.getTime()) / 86_400_000);
+}
+
+function DueBadge({
+  days,
+  t,
+}: {
+  days: number;
+  t: TFunction<readonly ['blockReappraisal', 'common']>;
+}) {
+  const overdue = days < 0;
+  const soon = days >= 0 && days <= 30;
+  const tone = overdue
+    ? 'bg-red-50 text-red-700 border-red-100'
+    : soon
+      ? 'bg-amber-50 text-amber-700 border-amber-100'
+      : 'bg-green-50 text-green-700 border-green-100';
+  const label = overdue
+    ? t('detail.dueBadge.overdue', { days: Math.abs(days) })
+    : days === 0
+      ? t('detail.dueBadge.today')
+      : t('detail.dueBadge.inDays', { days });
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium border ${tone}`}
+    >
+      <Icon style="solid" name={overdue ? 'triangle-exclamation' : 'clock'} className="size-2.5" />
+      {label}
+    </span>
+  );
+}
+
+// ─── Compact metrics-bar helpers ──────────────────────────────────────────────
+
+// Colored dot + label + count, used for the Sold / Available tallies.
+function MiniStat({ dotClass, label, value }: { dotClass: string; label: string; value: number }) {
+  return (
+    <div className="flex items-center gap-1.5 whitespace-nowrap">
+      <span className={`size-2 rounded-full ${dotClass}`} />
+      <span className="text-xs text-gray-500">{label}</span>
+      <span className="text-sm font-semibold text-gray-900 tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+// Accent icon chip + label + value, used for the estimate KPIs inline.
+function MiniMetric({
+  icon,
+  iconBg,
+  iconColor,
+  label,
+  value,
+}: {
+  icon: string;
+  iconBg: string;
+  iconColor: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      <div className={`size-7 shrink-0 rounded-md flex items-center justify-center ${iconBg}`}>
+        <Icon style="solid" name={icon} className={`size-3.5 ${iconColor}`} />
+      </div>
+      <div className="flex flex-col leading-tight items-end text-right">
+        <span className="text-[10px] text-gray-400">{label}</span>
+        <span className="text-sm font-semibold text-gray-900 tabular-nums">{value}</span>
+      </div>
+    </div>
+  );
 }
 
 // ─── Create confirm modal ─────────────────────────────────────────────────────
@@ -99,21 +314,37 @@ function CreateSuccessModal({ open, result, onClose }: CreateSuccessModalProps) 
 
 // ─── Field display pair ───────────────────────────────────────────────────────
 
-function Field({ label, value }: { label: string; value?: string | number | null }) {
+function Field({
+  label,
+  value,
+  align,
+}: {
+  label: string;
+  value?: string | number | null;
+  align?: 'right';
+}) {
   return (
-    <div>
-      <dt className="text-xs text-gray-400">{label}</dt>
-      <dd className="text-xs font-medium text-gray-800 mt-0.5">{value ?? '-'}</dd>
+    <div className={`flex flex-col leading-tight ${align === 'right' ? 'items-end text-right' : ''}`}>
+      <span className="text-[11px] text-gray-400">{label}</span>
+      <span className="text-sm font-medium text-gray-800 tabular-nums mt-0.5">{value ?? '-'}</span>
     </div>
   );
 }
 
-// Neutral pill + colored dot (same style as the SLA status badge on the task list).
+// Neutral pill + colored dot. The "Sold" dot uses the same violet as the overview
+// donut's sold arc so the two visualizations read as one; "Available" stays green.
 function UnitStatusBadge({ isSold }: { isSold: boolean }) {
   const { t } = useTranslation('blockReappraisal');
   return (
-    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-medium rounded-full bg-gray-100 text-gray-700">
-      <span className={`size-1.5 rounded-full ${isSold ? 'bg-red-500' : 'bg-green-500'}`} />
+    <span
+      title={isSold ? t('units.soldHint') : t('units.availableHint')}
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-medium rounded-full border ${
+        isSold
+          ? 'bg-violet-50 text-violet-700 border-violet-100'
+          : 'bg-green-50 text-green-700 border-green-100'
+      }`}
+    >
+      <span className={`size-1.5 rounded-full ${isSold ? 'bg-violet-500' : 'bg-green-500'}`} />
       {isSold ? t('units.sold') : t('units.available')}
     </span>
   );
@@ -121,67 +352,81 @@ function UnitStatusBadge({ isSold }: { isSold: boolean }) {
 
 // ─── Read-only Condo units table ──────────────────────────────────────────────
 
-function CondoUnitsTable({ units }: { units: BlockReappraisalUnitDetail[] }) {
+interface UnitsTableProps {
+  units: BlockReappraisalUnitDetail[];
+  sortKey: SortKey | null;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+}
+
+function CondoUnitsTable({ units, sortKey, sortDir, onSort }: UnitsTableProps) {
   const { t, i18n } = useTranslation('blockReappraisal');
+  const sortProps = { activeKey: sortKey, dir: sortDir, onSort };
   return (
     <table className="w-full min-w-max text-xs">
       <thead className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
         <tr>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.floor')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.towerName')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.regNumber')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.roomNo')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.modelType')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.usableArea')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.sellingPrice')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.appraisalValue')}
-          </th>
-          <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <SortableTh label={t('units.cols.modelType')} columnKey="modelType" {...sortProps} />
+          <SortableTh
+            label={t('units.cols.usableArea')}
+            columnKey="usableArea"
+            align="right"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.sellingPrice')}
+            columnKey="sellingPrice"
+            align="right"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.appraisalValue')}
+            columnKey="lastAppraisedValue"
+            align="right"
+            {...sortProps}
+          />
+          <th className="text-center py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.isSold')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.lastUpdated')}
-          </th>
+          <SortableTh label={t('units.cols.lastUpdated')} columnKey="updatedAt" {...sortProps} />
         </tr>
       </thead>
       <tbody className="divide-y divide-gray-100">
         {units.map(u => (
-          <tr key={u.sequenceNumber} className="hover:bg-gray-50">
-            <td className="py-2 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
-            <td className="py-2 px-3 text-gray-700">{u.floor ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.towerName ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.condoRegistrationNumber ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.roomNumber ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.modelType ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+          <tr
+            key={u.sequenceNumber}
+            className={u.isSold ? 'bg-violet-50/40 hover:bg-violet-50' : 'hover:bg-gray-50'}
+          >
+            <td className="py-1.5 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.floor ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.towerName ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.condoRegistrationNumber ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.roomNumber ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.modelType ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-right">
               {formatNumber(u.usableArea)}
             </td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-right">
               {formatNumber(u.sellingPrice)}
             </td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
-              {formatNumber(u.lastAppraisedValue)}
-            </td>
-            <td className="py-2 px-3 text-center">
+            <EstimateCell value={u.lastAppraisedValue} />
+            <td className="py-1.5 px-3 text-center">
               <UnitStatusBadge isSold={u.isSold} />
             </td>
-            <td className="py-2 px-3 text-gray-700 whitespace-nowrap">
+            <td className="py-1.5 px-3 text-gray-700 whitespace-nowrap leading-tight">
               <div>{formatLocaleDateTime(u.updatedAt, i18n.language)}</div>
               {u.updatedBy && (
                 <div className="text-[10px] text-gray-400">
@@ -198,69 +443,80 @@ function CondoUnitsTable({ units }: { units: BlockReappraisalUnitDetail[] }) {
 
 // ─── Read-only Land & Building units table ────────────────────────────────────
 
-function LandBuildingUnitsTable({ units }: { units: BlockReappraisalUnitDetail[] }) {
+function LandBuildingUnitsTable({ units, sortKey, sortDir, onSort }: UnitsTableProps) {
   const { t, i18n } = useTranslation('blockReappraisal');
+  const sortProps = { activeKey: sortKey, dir: sortDir, onSort };
   return (
     <table className="w-full min-w-max text-xs">
       <thead className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
         <tr>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.plotNo')}
-          </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.houseNo')}
-          </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.modelType')}
-          </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.numFloors')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.landArea')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.usableArea')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.sellingPrice')}
-          </th>
-          <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.appraisalValue')}
-          </th>
-          <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+          <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">#</th>
+          <SortableTh label={t('units.cols.plotNo')} columnKey="plotNumber" {...sortProps} />
+          <SortableTh label={t('units.cols.houseNo')} columnKey="houseNumber" {...sortProps} />
+          <SortableTh label={t('units.cols.modelType')} columnKey="modelType" {...sortProps} />
+          <SortableTh
+            label={t('units.cols.numFloors')}
+            columnKey="numberOfFloors"
+            align="center"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.landArea')}
+            columnKey="landArea"
+            align="right"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.usableArea')}
+            columnKey="usableArea"
+            align="right"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.sellingPrice')}
+            columnKey="sellingPrice"
+            align="right"
+            {...sortProps}
+          />
+          <SortableTh
+            label={t('units.cols.appraisalValue')}
+            columnKey="lastAppraisedValue"
+            align="right"
+            {...sortProps}
+          />
+          <th className="text-center py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
             {t('units.cols.isSold')}
           </th>
-          <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-            {t('units.cols.lastUpdated')}
-          </th>
+          <SortableTh label={t('units.cols.lastUpdated')} columnKey="updatedAt" {...sortProps} />
         </tr>
       </thead>
       <tbody className="divide-y divide-gray-100">
         {units.map(u => (
-          <tr key={u.sequenceNumber} className="hover:bg-gray-50">
-            <td className="py-2 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
-            <td className="py-2 px-3 text-gray-700">{u.plotNumber ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.houseNumber ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.modelType ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700">{u.numberOfFloors ?? '-'}</td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+          <tr
+            key={u.sequenceNumber}
+            className={u.isSold ? 'bg-violet-50/40 hover:bg-violet-50' : 'hover:bg-gray-50'}
+          >
+            <td className="py-1.5 px-3 text-gray-500 tabular-nums">{u.sequenceNumber}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.plotNumber ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.houseNumber ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700">{u.modelType ?? '-'}</td>
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-center">
+              {u.numberOfFloors ?? '-'}
+            </td>
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-right">
               {formatNumber(u.landArea)}
             </td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-right">
               {formatNumber(u.usableArea)}
             </td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
+            <td className="py-1.5 px-3 text-gray-700 tabular-nums text-right">
               {formatNumber(u.sellingPrice)}
             </td>
-            <td className="py-2 px-3 text-gray-700 tabular-nums text-right">
-              {formatNumber(u.lastAppraisedValue)}
-            </td>
-            <td className="py-2 px-3 text-center">
+            <EstimateCell value={u.lastAppraisedValue} />
+            <td className="py-1.5 px-3 text-center">
               <UnitStatusBadge isSold={u.isSold} />
             </td>
-            <td className="py-2 px-3 text-gray-700 whitespace-nowrap">
+            <td className="py-1.5 px-3 text-gray-700 whitespace-nowrap leading-tight">
               <div>{formatLocaleDateTime(u.updatedAt, i18n.language)}</div>
               {u.updatedBy && (
                 <div className="text-[10px] text-gray-400">
@@ -298,10 +554,72 @@ function BlockReappraisalDetailPage() {
   const [successResult, setSuccessResult] = useState<BlockReappraisalCreateResult | null>(null);
   const [optOutConfirmOpen, setOptOutConfirmOpen] = useState(false);
 
-  // Overview chart stats derived from structure units
+  // Filter state (client-side, over the already-fetched unit list)
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [minValue, setMinValue] = useState<number | null>(null);
+  const [maxValue, setMaxValue] = useState<number | null>(null);
+
   const units = detail?.structure.units ?? [];
-  const soldStats = useMemo(() => groupByModel(units, u => u.isSold), [units]);
-  const availableStats = useMemo(() => groupByModel(units, u => !u.isSold), [units]);
+
+  // Chip counts computed over the full (unfiltered) list so badges stay stable.
+  const chipCounts: Record<StatusFilter, number> = {
+    all: units.length,
+    sold: units.filter(u => u.isSold).length,
+    available: units.filter(u => !u.isSold).length,
+  };
+
+  const filteredUnits = useMemo(() => {
+    return units.filter(u => {
+      if (!matchUnit(u, search.trim())) return false;
+      if (minValue != null && (u.lastAppraisedValue == null || u.lastAppraisedValue < minValue)) {
+        return false;
+      }
+      if (maxValue != null && (u.lastAppraisedValue == null || u.lastAppraisedValue > maxValue)) {
+        return false;
+      }
+      switch (statusFilter) {
+        case 'sold':
+          return u.isSold;
+        case 'available':
+          return !u.isSold;
+        case 'all':
+        default:
+          return true;
+      }
+    });
+  }, [units, search, statusFilter, minValue, maxValue]);
+
+  const filtersActive =
+    search !== '' || statusFilter !== 'all' || minValue != null || maxValue != null;
+
+  // Sorting (shared across both table layouts)
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const handleSort = (key: SortKey) => {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortDir('asc');
+    } else if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      // 3rd stage: clear the sort (back to natural order).
+      setSortKey(null);
+      setSortDir('asc');
+    }
+  };
+  const displayUnits = useMemo(
+    () => sortUnits(filteredUnits, sortKey, sortDir),
+    [filteredUnits, sortKey, sortDir],
+  );
+
+  // KPI strip — portfolio value at a glance (over the full, unfiltered unit list).
+  const valuedUnits = units.filter(u => (u.lastAppraisedValue ?? 0) > 0);
+  const totalEstimate = valuedUnits.reduce((sum, u) => sum + (u.lastAppraisedValue ?? 0), 0);
+  const avgEstimate = valuedUnits.length ? Math.round(totalEstimate / valuedUnits.length) : 0;
+
+  // Days until the reappraisal due date (negative = overdue).
+  const dueDays = detail ? daysUntil(detail.dueDate) : 0;
 
   const handleCreateConfirm = () => {
     if (!collateralMasterId) return;
@@ -369,6 +687,7 @@ function BlockReappraisalDetailPage() {
   }
 
   const condo = isCondo(detail.projectType);
+  const soldPct = detail.totalUnits > 0 ? (detail.soldUnits / detail.totalUnits) * 100 : 0;
 
   return (
     <div className="flex flex-col min-h-full min-w-0 gap-4">
@@ -381,25 +700,27 @@ function BlockReappraisalDetailPage() {
           >
             <Icon style="solid" name="arrow-left" className="size-3.5" />
           </button>
-          <div>
-            <div className="flex items-center gap-2 flex-wrap">
-              <h2 className="text-sm font-semibold text-gray-900">
-                {detail.projectName ?? t('detail.unnamedProject')}
-              </h2>
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium ${
-                  condo
-                    ? 'bg-blue-50 text-blue-700 border border-blue-100'
-                    : 'bg-amber-50 text-amber-700 border border-amber-100'
-                }`}
-              >
-                {condo ? t('projectType.condo') : t('projectType.landAndBuilding')}
-              </span>
-            </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-sm font-semibold text-gray-900">
+              {detail.projectName ?? t('detail.unnamedProject')}
+            </h2>
+            <span className="text-gray-300">·</span>
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium ${
+                condo
+                  ? 'bg-blue-50 text-blue-700 border border-blue-100'
+                  : 'bg-amber-50 text-amber-700 border border-amber-100'
+              }`}
+            >
+              {condo ? t('projectType.condo') : t('projectType.landAndBuilding')}
+            </span>
             {detail.oldAppraisalNumber && (
-              <p className="text-xs text-gray-500 mt-0.5">
-                {t('detail.oldAppraisalLabel')} {detail.oldAppraisalNumber}
-              </p>
+              <>
+                <span className="text-gray-300">·</span>
+                <span className="text-xs text-gray-500">
+                  {t('detail.oldAppraisalLabel')} {detail.oldAppraisalNumber}
+                </span>
+              </>
             )}
           </div>
         </div>
@@ -407,8 +728,9 @@ function BlockReappraisalDetailPage() {
         {/* Action buttons */}
         <div className="flex items-center gap-2 shrink-0">
           <Button
-            variant="danger"
+            variant="outline"
             size="sm"
+            className="!text-danger !border-danger/30 hover:!bg-danger/5"
             onClick={() => setOptOutConfirmOpen(true)}
             leftIcon={<Icon style="solid" name="ban" className="size-3" />}
           >
@@ -425,51 +747,81 @@ function BlockReappraisalDetailPage() {
         </div>
       </div>
 
-      {/* ── Summary card ── */}
-      <section className="shrink-0 bg-white rounded-lg border border-gray-200 p-4">
-        <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4">
+      {/* ── Summary strip ── */}
+      <section className="shrink-0 bg-white rounded-lg border border-gray-200 px-4 py-2.5">
+        <div className="flex items-center gap-x-6 gap-y-2 flex-wrap">
           <Field
             label={t('columns.lastAppraisedDate')}
             value={formatLocaleDate(detail.lastAppraisedDate, i18n.language)}
           />
-          <Field
-            label={t('detail.fields.dueDate')}
-            value={formatLocaleDate(detail.dueDate, i18n.language)}
-          />
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
+          {/* Due date + urgency badge */}
+          <div className="flex flex-col leading-tight">
+            <span className="text-[11px] text-gray-400">{t('detail.fields.dueDate')}</span>
+            <span className="text-sm font-medium text-gray-800 tabular-nums mt-0.5 flex items-center gap-2">
+              {formatLocaleDate(detail.dueDate, i18n.language)}
+              <DueBadge days={dueDays} t={t} />
+            </span>
+          </div>
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
           <Field
             label={t('columns.projectSellingPrice')}
             value={formatNumber(detail.projectSellingPrice)}
+            align="right"
           />
-          <Field
-            label={t('columns.remainingTotalUnit')}
-            value={`${detail.remainingUnits} / ${detail.totalUnits}`}
-          />
-        </dl>
+        </div>
       </section>
 
-      {/* ── Sold vs Available overview chart ── */}
-      <section className="shrink-0 bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-xs font-semibold text-gray-700 mb-4">{t('detail.overview.title')}</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-center px-2">
-          <ModelBreakdown
-            heading={t('detail.overview.sold')}
-            stats={soldStats}
-            emptyLabel={t('detail.overview.noSold')}
-            unitSuffix={t('detail.overview.unitSuffix')}
-          />
-          <div className="flex justify-center">
-            <SoldDonut
-              sold={detail.soldUnits}
-              total={detail.totalUnits}
-              soldLabel={t('detail.overview.donutSoldLabel')}
+      {/* ── Compact metrics bar (rich overview is collapsible) ── */}
+      <section className="shrink-0 bg-white rounded-lg border border-gray-200">
+        <div className="flex items-center gap-x-6 gap-y-3 px-4 py-2.5 flex-wrap">
+          {/* Sold progress gauge */}
+          <div className="flex items-center gap-3 min-w-[220px]">
+            <div className="flex flex-col leading-tight">
+              <span className="text-[11px] text-gray-400">{t('detail.overview.donutSoldLabel')}</span>
+              <span className="text-sm font-semibold text-gray-900 tabular-nums">
+                {soldPct.toFixed(1)}%
+                <span className="ml-1 text-xs font-normal text-gray-400">
+                  ({detail.soldUnits}/{detail.totalUnits})
+                </span>
+              </span>
+            </div>
+            <div className="flex-1 min-w-[64px] h-1.5 rounded-full bg-gray-100 overflow-hidden">
+              <div className="h-full rounded-full bg-violet-500" style={{ width: `${soldPct}%` }} />
+            </div>
+          </div>
+
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
+
+          {/* Sold / Available tallies */}
+          <div className="flex items-center gap-5">
+            <MiniStat dotClass="bg-violet-500" label={t('detail.overview.sold')} value={chipCounts.sold} />
+            <MiniStat
+              dotClass="bg-green-500"
+              label={t('detail.overview.available')}
+              value={chipCounts.available}
             />
           </div>
-          <ModelBreakdown
-            heading={t('detail.overview.available')}
-            stats={availableStats}
-            emptyLabel={t('detail.overview.noAvailable')}
-            unitSuffix={t('detail.overview.unitSuffix')}
-          />
+
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
+
+          {/* Estimate KPIs */}
+          <div className="flex items-center gap-6">
+            <MiniMetric
+              icon="money-bill"
+              iconBg="bg-violet-50"
+              iconColor="text-violet-600"
+              label={t('detail.kpi.totalEstimate')}
+              value={totalEstimate > 0 ? totalEstimate.toLocaleString() : '–'}
+            />
+            <MiniMetric
+              icon="chart-line"
+              iconBg="bg-indigo-50"
+              iconColor="text-indigo-600"
+              label={t('detail.kpi.avgEstimate')}
+              value={avgEstimate > 0 ? avgEstimate.toLocaleString() : '–'}
+            />
+          </div>
         </div>
       </section>
 
@@ -478,20 +830,83 @@ function BlockReappraisalDetailPage() {
         <div className="shrink-0 px-4 py-3 border-b border-gray-100 flex items-center justify-between">
           <h3 className="text-xs font-semibold text-gray-700">{t('detail.units.title')}</h3>
           <span className="text-xs text-gray-400 tabular-nums">
-            {detail.structure.units.length} {t('detail.units.count')}
+            {filtersActive
+              ? `${filteredUnits.length} / ${units.length}`
+              : units.length}{' '}
+            {t('detail.units.count')}
           </span>
         </div>
 
+        {/* ── Filter bar ── */}
+        {units.length > 0 && (
+          <div className="shrink-0 px-4 py-3 border-b border-gray-100 flex items-center gap-3 flex-wrap">
+            <div className="flex-1 min-w-[240px] max-w-md">
+              <Input
+                placeholder={t('detail.filter.searchPlaceholder')}
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                leftIcon={<Icon style="solid" name="magnifying-glass" className="size-3.5" />}
+              />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <NumberInput
+                className="w-28"
+                placeholder={t('detail.filter.estimateMin')}
+                value={minValue}
+                onChange={e => setMinValue(e.target.value)}
+              />
+              <span className="text-gray-400">–</span>
+              <NumberInput
+                className="w-28"
+                placeholder={t('detail.filter.estimateMax')}
+                value={maxValue}
+                onChange={e => setMaxValue(e.target.value)}
+              />
+            </div>
+            <StatusChips value={statusFilter} onChange={setStatusFilter} counts={chipCounts} t={t} />
+            {filtersActive && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSearch('');
+                  setStatusFilter('all');
+                  setMinValue(null);
+                  setMaxValue(null);
+                }}
+              >
+                <Icon style="regular" name="xmark" className="size-3.5 mr-1" />
+                {t('detail.filter.clear')}
+              </Button>
+            )}
+          </div>
+        )}
+
         <div className="flex-1 min-h-0 overflow-auto">
-          {detail.structure.units.length === 0 ? (
+          {units.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-full gap-2">
               <Icon style="regular" name="folder-open" className="size-8 text-gray-300" />
               <p className="text-xs text-gray-400">{t('detail.units.empty')}</p>
             </div>
+          ) : filteredUnits.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full gap-2">
+              <Icon style="regular" name="magnifying-glass" className="size-8 text-gray-300" />
+              <p className="text-xs text-gray-400">{t('detail.filter.noMatch')}</p>
+            </div>
           ) : condo ? (
-            <CondoUnitsTable units={detail.structure.units} />
+            <CondoUnitsTable
+              units={displayUnits}
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
           ) : (
-            <LandBuildingUnitsTable units={detail.structure.units} />
+            <LandBuildingUnitsTable
+              units={displayUnits}
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
           )}
         </div>
       </section>

--- a/src/features/blockReappraisal/pages/BlockReappraisalListPage.tsx
+++ b/src/features/blockReappraisal/pages/BlockReappraisalListPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '@/shared/components/Icon';
@@ -15,6 +15,49 @@ function formatNumber(n?: number | null): string {
   return n.toLocaleString();
 }
 
+// Clickable sort header — same caret style (sort / sort-up / sort-down) as the
+// rest of the app's list tables.
+const SortableTh = ({
+  field,
+  sortBy,
+  sortDir,
+  onSort,
+  align = 'left',
+  className = '',
+  children,
+}: {
+  field: string;
+  sortBy: string | null;
+  sortDir: 'asc' | 'desc';
+  onSort: (f: string) => void;
+  align?: 'left' | 'center' | 'right';
+  className?: string;
+  children: ReactNode;
+}) => {
+  const isActive = sortBy === field;
+  const alignCls =
+    align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+  const flexAlign = align === 'center' ? 'justify-center' : '';
+  const iconName = isActive ? (sortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort';
+  return (
+    <th
+      onClick={() => onSort(field)}
+      className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap select-none cursor-pointer hover:text-gray-700 ${alignCls} ${className} ${
+        isActive ? 'text-primary' : 'text-gray-500'
+      }`}
+    >
+      <div className={`inline-flex items-center gap-1 ${flexAlign}`}>
+        <span>{children}</span>
+        <Icon
+          style="solid"
+          name={iconName}
+          className={`size-2.5 ${isActive ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </div>
+    </th>
+  );
+};
+
 function BlockReappraisalListPage() {
   const navigate = useNavigate();
   const { t, i18n } = useTranslation(['blockReappraisal', 'common']);
@@ -22,6 +65,22 @@ function BlockReappraisalListPage() {
   const [pageNumber, setPageNumber] = useState(0);
   const [pageSize, setPageSize] = useState(20);
   const [filters, setFilters] = useState<BlockReappraisalFilterValues>({});
+  const [sortBy, setSortBy] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  // 3-stage sort: asc → desc → unsorted.
+  const toggleSort = (field: string) => {
+    if (sortBy !== field) {
+      setSortBy(field);
+      setSortDir('asc');
+    } else if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      setSortBy(null);
+      setSortDir('asc');
+    }
+    setPageNumber(0);
+  };
 
   // The text input stays instantly responsive (controlled by `filters.search`),
   // but the API call only fires once typing settles.
@@ -32,6 +91,7 @@ function BlockReappraisalListPage() {
     pageSize,
     ...filters,
     search: debouncedSearch,
+    ...(sortBy && { sortBy, sortDir }),
   };
 
   const { data, isLoading, isError, error } = useBlockReappraisalDueList(queryParams);
@@ -75,27 +135,57 @@ function BlockReappraisalListPage() {
       {/* ── Table ── */}
       <div className="flex-1 min-h-0 min-w-0 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden flex flex-col">
         <div className="flex-1 min-h-0 overflow-auto">
-          <table className="w-full min-w-max text-sm">
+          <table className="w-full text-sm">
             <thead className="sticky top-0 z-10">
               <tr className="bg-gray-50 border-b border-gray-200">
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                <SortableTh field="oldAppraisalNumber" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
                   {t('columns.oldAppraisalNumber')}
-                </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh
+                  field="projectName"
+                  sortBy={sortBy}
+                  sortDir={sortDir}
+                  onSort={toggleSort}
+                  className="w-full"
+                >
                   {t('columns.projectName')}
-                </th>
-                <th className="px-4 py-2.5 text-right text-xs font-medium text-gray-500 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh
+                  field="projectSellingPrice"
+                  sortBy={sortBy}
+                  sortDir={sortDir}
+                  onSort={toggleSort}
+                  align="right"
+                >
                   {t('columns.projectSellingPrice')}
-                </th>
-                <th className="px-4 py-2.5 text-center text-xs font-medium text-gray-500 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh
+                  field="remainingUnits"
+                  sortBy={sortBy}
+                  sortDir={sortDir}
+                  onSort={toggleSort}
+                  align="center"
+                >
                   {t('columns.remainingTotalUnit')}
-                </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-gray-500 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh
+                  field="lastAppraisedDate"
+                  sortBy={sortBy}
+                  sortDir={sortDir}
+                  onSort={toggleSort}
+                  align="center"
+                >
                   {t('columns.lastAppraisedDate')}
-                </th>
-                <th className="px-4 py-2.5 text-center text-xs font-medium text-gray-500 whitespace-nowrap">
+                </SortableTh>
+                <SortableTh
+                  field="remainingDay"
+                  sortBy={sortBy}
+                  sortDir={sortDir}
+                  onSort={toggleSort}
+                  align="center"
+                >
                   {t('columns.remainingDay')}
-                </th>
+                </SortableTh>
                 <th className="px-4 py-2.5 w-8 bg-gray-50" />
               </tr>
             </thead>
@@ -142,7 +232,7 @@ function BlockReappraisalListPage() {
                     }
                     className="group cursor-pointer transition-colors hover:bg-gray-50"
                   >
-                    <td className="px-3 py-2 text-xs text-gray-900 font-medium whitespace-nowrap">
+                    <td className="px-3 py-2 text-left text-xs text-primary font-medium whitespace-nowrap">
                       {item.oldAppraisalNumber ?? '-'}
                     </td>
                     <td className="px-3 py-2 text-xs text-gray-600">
@@ -154,11 +244,18 @@ function BlockReappraisalListPage() {
                     <td className="px-3 py-2 text-xs text-gray-600 tabular-nums text-center whitespace-nowrap">
                       {item.remainingUnits} / {item.totalUnits}
                     </td>
-                    <td className="px-3 py-2 text-xs text-gray-600 whitespace-nowrap">
+                    <td className="px-3 py-2 text-center text-xs text-gray-600 whitespace-nowrap">
                       {formatLocaleDate(item.lastAppraisedDate, i18n.language)}
                     </td>
-                    <td className="px-3 py-2 text-center text-xs text-gray-600 whitespace-nowrap">
-                      {item.remainingDay}
+                    <td className="px-3 py-2 text-center text-xs whitespace-nowrap">
+                      {item.remainingDay < 0 ? (
+                        <span className="text-red-600 font-medium">
+                          {t('remainingDayBadge.overdue')}{' '}
+                          {t('remainingDayBadge.daysLeft', { days: Math.abs(item.remainingDay) })}
+                        </span>
+                      ) : (
+                        <span className="text-gray-600">{item.remainingDay}</span>
+                      )}
                     </td>
                     <td className="px-3 py-2 w-8">
                       <Icon

--- a/src/features/blockReappraisal/types.ts
+++ b/src/features/blockReappraisal/types.ts
@@ -30,6 +30,10 @@ export interface BlockReappraisalListParams {
   remainingDayMin?: number;
   /** Inclusive upper bound on Remaining Day */
   remainingDayMax?: number;
+  /** Column key to sort by (e.g. 'projectName', 'remainingDay'). */
+  sortBy?: string;
+  /** Sort direction. */
+  sortDir?: 'asc' | 'desc';
 }
 
 export type BlockReappraisalFilterValues = Omit<

--- a/src/features/blockUnitMaintenance/components/ModelBreakdown.tsx
+++ b/src/features/blockUnitMaintenance/components/ModelBreakdown.tsx
@@ -9,6 +9,10 @@ interface ModelBreakdownProps {
   emptyLabel: string;
   /** Pre-translated suffix shown after each count (e.g. "units"). */
   unitSuffix: string;
+  /** Optional heading text color class (e.g. "text-violet-700"). Defaults to gray-900. */
+  accentClass?: string;
+  /** Optional leading dot background class (e.g. "bg-violet-500"). Hidden when omitted. */
+  dotClass?: string;
 }
 
 /**
@@ -21,10 +25,17 @@ export const ModelBreakdown = ({
   stats,
   emptyLabel,
   unitSuffix,
+  accentClass,
+  dotClass,
 }: ModelBreakdownProps) => {
   return (
     <div>
-      <h4 className="text-sm font-semibold text-gray-900 mb-2">{heading}</h4>
+      <h4
+        className={`text-sm font-semibold mb-2 flex items-center gap-1.5 ${accentClass ?? 'text-gray-900'}`}
+      >
+        {dotClass && <span className={`size-2 rounded-full ${dotClass}`} />}
+        {heading}
+      </h4>
       <div className="border-t border-gray-200">
         {stats.length === 0 ? (
           <div className="py-3 text-xs text-gray-400">{emptyLabel}</div>

--- a/src/features/blockUnitMaintenance/components/SoldDonut.tsx
+++ b/src/features/blockUnitMaintenance/components/SoldDonut.tsx
@@ -3,6 +3,8 @@ interface SoldDonutProps {
   total: number;
   /** Pre-translated "Sold" caption shown under the percentage. */
   soldLabel: string;
+  /** Outer diameter in px (default 180). Pass a smaller value for compact layouts. */
+  size?: number;
 }
 
 /**
@@ -11,10 +13,9 @@ interface SoldDonutProps {
  * in BlockReappraisalDetailPage without duplication. Labels are passed in
  * (already translated) so the component stays namespace-agnostic.
  */
-export const SoldDonut = ({ sold, total, soldLabel }: SoldDonutProps) => {
+export const SoldDonut = ({ sold, total, soldLabel, size = 180 }: SoldDonutProps) => {
   const pct = total > 0 ? (sold / total) * 100 : 0;
-  const size = 180;
-  const stroke = 18;
+  const stroke = size >= 160 ? 18 : 14;
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
   const arcFraction = 0.75;

--- a/src/features/blockUnitMaintenance/components/UnitRow.tsx
+++ b/src/features/blockUnitMaintenance/components/UnitRow.tsx
@@ -1,7 +1,7 @@
 import type { TFunction } from 'i18next';
 import { isCondo } from '@/features/blockProject/types';
 import type { ProjectType, ProjectUnitDetail, PurchaseMethod, UnitEditState } from '../types';
-import { formatLocaleDate } from '@/shared/utils/dateUtils';
+import { formatLocaleDateTime } from '@/shared/utils/dateUtils';
 import { useTranslation } from 'react-i18next';
 
 interface UnitRowProps {
@@ -55,27 +55,39 @@ export const UnitRow = ({
 
   const identityCells = isCondo(projectType) ? (
     <>
-      <td className="py-2 px-3 text-gray-600">{unit.sequenceNumber}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.floor ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.towerName ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-600">{unit.condoRegistrationNumber ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.roomNumber ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.modelType ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800 text-right">{fmt(unit.usableArea)}</td>
-      <td className="py-2 px-3 text-gray-800 text-right">{fmt(unit.sellingPrice)}</td>
-      <td className="py-2 px-3 text-gray-900 text-right">{fmt(unit.lastAppraisedValue)}</td>
+      <td className="py-1.5 px-3 text-gray-600">{unit.sequenceNumber}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.floor ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.towerName ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-600">{unit.condoRegistrationNumber ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.roomNumber ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.modelType ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-right">{fmt(unit.usableArea)}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-right">{fmt(unit.sellingPrice)}</td>
+      <td className="py-1.5 px-3 text-right">
+        {(unit.lastAppraisedValue ?? 0) > 0 ? (
+          <span className="text-gray-900">{fmt(unit.lastAppraisedValue)}</span>
+        ) : (
+          <span className="text-gray-300">–</span>
+        )}
+      </td>
     </>
   ) : (
     <>
-      <td className="py-2 px-3 text-gray-600">{unit.sequenceNumber}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.plotNumber ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.houseNumber ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.modelType ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800">{unit.numberOfFloors ?? '-'}</td>
-      <td className="py-2 px-3 text-gray-800 text-right">{fmt(unit.landArea)}</td>
-      <td className="py-2 px-3 text-gray-800 text-right">{fmt(unit.usableArea)}</td>
-      <td className="py-2 px-3 text-gray-800 text-right">{fmt(unit.sellingPrice)}</td>
-      <td className="py-2 px-3 text-gray-900 text-right">{fmt(unit.lastAppraisedValue)}</td>
+      <td className="py-1.5 px-3 text-gray-600">{unit.sequenceNumber}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.plotNumber ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.houseNumber ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800">{unit.modelType ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-center">{unit.numberOfFloors ?? '-'}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-right">{fmt(unit.landArea)}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-right">{fmt(unit.usableArea)}</td>
+      <td className="py-1.5 px-3 text-gray-800 text-right">{fmt(unit.sellingPrice)}</td>
+      <td className="py-1.5 px-3 text-right">
+        {(unit.lastAppraisedValue ?? 0) > 0 ? (
+          <span className="text-gray-900">{fmt(unit.lastAppraisedValue)}</span>
+        ) : (
+          <span className="text-gray-300">–</span>
+        )}
+      </td>
     </>
   );
 
@@ -90,10 +102,12 @@ export const UnitRow = ({
     <tr
       className={`border-b border-gray-100 hover:bg-gray-50 ${
         isDirty ? 'bg-amber-50/30' : ''
-      } ${isSelected ? 'bg-primary/5' : ''}`}
+      } ${isSelected ? 'bg-primary/5' : ''} ${
+        !isDirty && !isSelected && isSold ? 'bg-violet-50/40' : ''
+      }`}
     >
       {/* Dirty indicator + selection checkbox in one slim column */}
-      <td className="py-2 pl-3 pr-1 relative">
+      <td className="py-1.5 pl-3 pr-1 relative">
         {isDirty && (
           <span
             aria-label={t('detail.dirty')}
@@ -110,7 +124,7 @@ export const UnitRow = ({
       </td>
       {identityCells}
       {/* Sold checkbox */}
-      <td className="py-2 px-3 text-center">
+      <td className="py-1.5 px-3 text-center">
         <input
           type="checkbox"
           checked={isSold}
@@ -120,7 +134,7 @@ export const UnitRow = ({
         />
       </td>
       {/* Purchase by — segmented control */}
-      <td className="py-2 px-3">
+      <td className="py-1.5 px-3">
         <div role="group" aria-label={t('units.col.purchaseBy')} className="inline-flex">
           <button
             type="button"
@@ -145,7 +159,7 @@ export const UnitRow = ({
         </div>
       </td>
       {/* Loan bank name with autocomplete from existing values */}
-      <td className="py-2 px-3 min-w-[160px]">
+      <td className="py-1.5 px-3 min-w-[160px]">
         <input
           type="text"
           list={loanBankListId}
@@ -156,10 +170,14 @@ export const UnitRow = ({
           className="w-full text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary disabled:bg-gray-50 disabled:text-gray-400 disabled:cursor-not-allowed"
         />
       </td>
-      <td className="py-2 px-3 text-gray-900">
-        {formatLocaleDate(unit.updatedAt, i18n.language) ?? '-'}
+      <td className="py-1.5 px-3 text-gray-700 whitespace-nowrap leading-tight">
+        <div>{formatLocaleDateTime(unit.updatedAt, i18n.language)}</div>
+        {unit.updatedBy && (
+          <div className="text-[10px] text-gray-400">
+            {t('units.updatedByLine', { name: unit.updatedBy })}
+          </div>
+        )}
       </td>
-      <td className="py-2 px-3 text-gray-900">{unit.updatedBy ?? '-'}</td>
     </tr>
   );
 };

--- a/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
+++ b/src/features/blockUnitMaintenance/pages/BlockUnitMaintenanceDetailPage.tsx
@@ -11,21 +11,11 @@ import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import { TableRowSkeleton } from '@/shared/components/Skeleton';
 import { useGetProjectUnits, useUpdateUnitSaleStatus } from '../api/blockUnitMaintenance';
 import { UnitRow } from '../components/UnitRow';
-import { SoldDonut } from '../components/SoldDonut';
-import { ModelBreakdown } from '../components/ModelBreakdown';
-import type { ModelStat } from '../components/ModelBreakdown';
 import { isCondo } from '@/features/blockProject/types';
-import type { ProjectType, ProjectUnitDetail, PurchaseMethod, UnitEditState } from '../types';
+import type { ProjectUnitDetail, PurchaseMethod, UnitEditState } from '../types';
 import { NumberInput } from '@/shared/components';
 
 const LOAN_BANK_LIST_ID = 'block-unit-maint-loan-banks';
-
-// ─── Project type pill class by code ──────────────────────────────────────────
-
-function projectTypePillClass(code: ProjectType): string {
-  if (code === 'U') return 'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200';
-  return 'bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200';
-}
 
 // ─── Helper: filter + group ──────────────────────────────────────────────────
 
@@ -46,20 +36,41 @@ const matchUnit = (unit: ProjectUnitDetail, q: string): boolean => {
   return haystack.includes(needle);
 };
 
-const groupByModel = (
-  units: ProjectUnitDetail[],
-  predicate: (u: ProjectUnitDetail) => boolean,
-): ModelStat[] => {
-  const map = new Map<string, number>();
-  for (const u of units) {
-    if (!predicate(u)) continue;
-    const key = u.modelType?.trim() || '—';
-    map.set(key, (map.get(key) ?? 0) + 1);
-  }
-  return Array.from(map.entries())
-    .map(([modelName, count]) => ({ modelName, count }))
-    .sort((a, b) => b.count - a.count);
-};
+// ─── Compact metrics-bar helpers ──────────────────────────────────────────────
+
+// Colored dot + label + count, used for the Sold / Available tallies.
+const MiniStat = ({ dotClass, label, value }: { dotClass: string; label: string; value: number }) => (
+  <div className="flex items-center gap-1.5 whitespace-nowrap">
+    <span className={`size-2 rounded-full ${dotClass}`} />
+    <span className="text-xs text-gray-500">{label}</span>
+    <span className="text-sm font-semibold text-gray-900 tabular-nums">{value}</span>
+  </div>
+);
+
+// Accent icon chip + label + value, used for the estimate KPIs inline (value right-aligned).
+const MiniMetric = ({
+  icon,
+  iconBg,
+  iconColor,
+  label,
+  value,
+}: {
+  icon: string;
+  iconBg: string;
+  iconColor: string;
+  label: string;
+  value: string;
+}) => (
+  <div className="flex items-center gap-2 whitespace-nowrap">
+    <div className={`size-7 shrink-0 rounded-md flex items-center justify-center ${iconBg}`}>
+      <Icon style="solid" name={icon} className={`size-3.5 ${iconColor}`} />
+    </div>
+    <div className="flex flex-col leading-tight items-end text-right">
+      <span className="text-[10px] text-gray-400">{label}</span>
+      <span className="text-sm font-semibold text-gray-900 tabular-nums">{value}</span>
+    </div>
+  </div>
+);
 
 // ─── Status filter chips ─────────────────────────────────────────────────────
 
@@ -109,6 +120,80 @@ const StatusChips = ({
         );
       })}
     </div>
+  );
+};
+
+// ─── Column sorting ───────────────────────────────────────────────────────────
+
+type SortKey =
+  | 'plotNumber'
+  | 'houseNumber'
+  | 'modelType'
+  | 'numberOfFloors'
+  | 'landArea'
+  | 'usableArea'
+  | 'sellingPrice'
+  | 'lastAppraisedValue'
+  | 'updatedAt';
+type SortDir = 'asc' | 'desc';
+
+function sortUnits(
+  units: ProjectUnitDetail[],
+  key: SortKey | null,
+  dir: SortDir,
+): ProjectUnitDetail[] {
+  if (!key) return units;
+  const factor = dir === 'asc' ? 1 : -1;
+  return [...units].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    // Nulls always sort last, regardless of direction.
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return av.localeCompare(bv) * factor;
+    }
+    return (Number(av) - Number(bv)) * factor;
+  });
+}
+
+const SortableTh = ({
+  label,
+  columnKey,
+  activeKey,
+  dir,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  columnKey: SortKey;
+  activeKey: SortKey | null;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align?: 'left' | 'right' | 'center';
+}) => {
+  const active = activeKey === columnKey;
+  const alignClass = align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+  const justifyClass =
+    align === 'right' ? 'justify-end' : align === 'center' ? 'justify-center' : 'justify-start';
+  return (
+    <th className={`py-2 px-3 text-gray-500 font-medium whitespace-nowrap ${alignClass}`}>
+      <button
+        type="button"
+        onClick={() => onSort(columnKey)}
+        className={`inline-flex w-full items-center gap-1 hover:text-gray-700 transition-colors ${justifyClass} ${
+          active ? 'text-gray-700' : ''
+        }`}
+      >
+        <span>{label}</span>
+        <Icon
+          style="solid"
+          name={active ? (dir === 'asc' ? 'sort-up' : 'sort-down') : 'sort'}
+          className={`size-2.5 ${active ? 'text-primary' : 'text-gray-300'}`}
+        />
+      </button>
+    </th>
   );
 };
 
@@ -281,8 +366,12 @@ const BlockUnitMaintenanceDetailPage = () => {
 
   const totalUnits = liveUnits.length;
   const soldCount = liveUnits.filter(u => u.isSold).length;
-  const soldStats = useMemo(() => groupByModel(liveUnits, u => u.isSold), [liveUnits]);
-  const availableStats = useMemo(() => groupByModel(liveUnits, u => !u.isSold), [liveUnits]);
+  const soldPct = totalUnits > 0 ? (soldCount / totalUnits) * 100 : 0;
+
+  // Estimate KPIs (over the full live list).
+  const valuedUnits = liveUnits.filter(u => (u.lastAppraisedValue ?? 0) > 0);
+  const totalEstimate = valuedUnits.reduce((sum, u) => sum + (u.lastAppraisedValue ?? 0), 0);
+  const avgEstimate = valuedUnits.length ? Math.round(totalEstimate / valuedUnits.length) : 0;
 
   // Distinct loan bank names from the live data — used for autocomplete.
   const loanBankSuggestions = useMemo(() => {
@@ -327,6 +416,27 @@ const BlockUnitMaintenanceDetailPage = () => {
     });
   }, [liveUnits, search, statusFilter, minValue, maxValue]);
 
+  // Sorting (shared across both condo / land layouts)
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const handleSort = (key: SortKey) => {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortDir('asc');
+    } else if (sortDir === 'asc') {
+      setSortDir('desc');
+    } else {
+      // 3rd stage: clear the sort (back to natural order).
+      setSortKey(null);
+      setSortDir('asc');
+    }
+  };
+  const sortedUnits = useMemo(
+    () => sortUnits(filteredUnits, sortKey, sortDir),
+    [filteredUnits, sortKey, sortDir],
+  );
+  const sortProps = { activeKey: sortKey, dir: sortDir, onSort: handleSort };
+
   // Master checkbox state for the currently-filtered list.
   const filteredIds = useMemo(() => filteredUnits.map(u => u.id), [filteredUnits]);
   const allFilteredSelected = filteredIds.length > 0 && filteredIds.every(id => selected.has(id));
@@ -368,49 +478,94 @@ const BlockUnitMaintenanceDetailPage = () => {
       </datalist>
 
       {/* ─── Hero header (project name + ID + type pill) ───────────────────── */}
-      <div className="shrink-0 flex items-center gap-3 pb-3 border-b border-gray-200">
-        <Button variant="ghost" size="sm" onClick={handleBack}>
-          <Icon style="solid" name="chevron-left" className="size-3.5" />
-        </Button>
-        <Icon style="solid" name="folder-open" className="size-4 text-cyan-500" />
-        <h2 className="text-base font-semibold text-gray-900">{project?.projectName ?? '—'}</h2>
-        {project?.appraisalReportNo && (
-          <span className="px-2 py-0.5 text-[11px] font-medium bg-teal-50 text-teal-700 rounded">
-            ID: {project.appraisalReportNo}
-          </span>
-        )}
-        {project && projectTypeLabel && (
-          <span
-            className={`px-2 py-0.5 text-[11px] font-medium rounded ${projectTypePillClass(project.projectType)}`}
+      <div className="shrink-0 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleBack}
+            className="flex items-center justify-center size-7 rounded-md border border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
           >
-            {projectTypeLabel.toUpperCase()}
-          </span>
-        )}
-      </div>
-
-      {/* ─── Page title ───────────────────────────────────────────────────── */}
-      <div className="shrink-0">
-        <h3 className="text-sm font-semibold text-gray-900">{t('detail.title')}</h3>
-      </div>
-
-      {/* ─── Stats hero ───────────────────────────────────────────────────── */}
-      <div className="shrink-0 grid grid-cols-1 md:grid-cols-3 gap-6 items-center px-2">
-        <ModelBreakdown
-          heading={t('detail.sold')}
-          stats={soldStats}
-          emptyLabel={t('detail.noSold')}
-          unitSuffix={t('detail.unitSuffix')}
-        />
-        <div className="flex justify-center">
-          <SoldDonut sold={soldCount} total={totalUnits} soldLabel={t('detail.donutSoldLabel')} />
+            <Icon style="solid" name="arrow-left" className="size-3.5" />
+          </button>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-sm font-semibold text-gray-900">
+              {project?.projectName ?? '—'}
+            </h2>
+            {project && projectTypeLabel && (
+              <>
+                <span className="text-gray-300">·</span>
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium ${
+                    isCondo(project.projectType)
+                      ? 'bg-blue-50 text-blue-700 border border-blue-100'
+                      : 'bg-amber-50 text-amber-700 border border-amber-100'
+                  }`}
+                >
+                  {projectTypeLabel}
+                </span>
+              </>
+            )}
+            {project?.appraisalReportNo && (
+              <>
+                <span className="text-gray-300">·</span>
+                <span className="text-xs text-gray-500">ID: {project.appraisalReportNo}</span>
+              </>
+            )}
+          </div>
         </div>
-        <ModelBreakdown
-          heading={t('detail.available')}
-          stats={availableStats}
-          emptyLabel={t('detail.noAvailable')}
-          unitSuffix={t('detail.unitSuffix')}
-        />
       </div>
+
+      {/* ─── Compact metrics bar ──────────────────────────────────────────── */}
+      <section className="shrink-0 bg-white rounded-lg border border-gray-200">
+        <div className="flex items-center gap-x-6 gap-y-3 px-4 py-2.5 flex-wrap">
+          {/* Sold progress gauge */}
+          <div className="flex items-center gap-3 min-w-[220px]">
+            <div className="flex flex-col leading-tight">
+              <span className="text-[11px] text-gray-400">{t('detail.donutSoldLabel')}</span>
+              <span className="text-sm font-semibold text-gray-900 tabular-nums">
+                {soldPct.toFixed(1)}%
+                <span className="ml-1 text-xs font-normal text-gray-400">
+                  ({soldCount}/{totalUnits})
+                </span>
+              </span>
+            </div>
+            <div className="flex-1 min-w-[64px] h-1.5 rounded-full bg-gray-100 overflow-hidden">
+              <div className="h-full rounded-full bg-violet-500" style={{ width: `${soldPct}%` }} />
+            </div>
+          </div>
+
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
+
+          {/* Sold / Available tallies */}
+          <div className="flex items-center gap-5">
+            <MiniStat dotClass="bg-violet-500" label={t('detail.sold')} value={chipCounts.sold} />
+            <MiniStat
+              dotClass="bg-green-500"
+              label={t('detail.available')}
+              value={chipCounts.available}
+            />
+          </div>
+
+          <div className="hidden sm:block h-8 w-px bg-gray-200" />
+
+          {/* Estimate KPIs */}
+          <div className="flex items-center gap-6">
+            <MiniMetric
+              icon="money-bill"
+              iconBg="bg-violet-50"
+              iconColor="text-violet-600"
+              label={t('detail.kpi.totalEstimate')}
+              value={totalEstimate > 0 ? totalEstimate.toLocaleString() : '–'}
+            />
+            <MiniMetric
+              icon="chart-line"
+              iconBg="bg-indigo-50"
+              iconColor="text-indigo-600"
+              label={t('detail.kpi.avgEstimate')}
+              value={avgEstimate > 0 ? avgEstimate.toLocaleString() : '–'}
+            />
+          </div>
+        </div>
+      </section>
 
       {/* ─── Search bar + status chips ────────────────────────────────────── */}
       <div className="shrink-0 flex items-center gap-3 flex-wrap">
@@ -498,7 +653,7 @@ const BlockUnitMaintenanceDetailPage = () => {
             <thead className="bg-gray-50 sticky top-0 z-10 border-b border-gray-200">
               {project && isCondo(project.projectType) ? (
                 <tr>
-                  <th className="py-2.5 pl-3 pr-1 w-8">
+                  <th className="py-2 pl-3 pr-1 w-8">
                     <input
                       type="checkbox"
                       checked={allFilteredSelected}
@@ -510,52 +665,58 @@ const BlockUnitMaintenanceDetailPage = () => {
                       className="rounded border-gray-300 text-primary focus:ring-primary/20 cursor-pointer"
                     />
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     #
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium">
                     {t('detail.cols.floor')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('detail.cols.towerName')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('detail.cols.regNumber')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('detail.cols.roomNo')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.modelType')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.usableAreaSqm')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.sellingPriceBaht')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.appraisalValue')}
-                  </th>
-                  <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <SortableTh label={t('detail.cols.modelType')} columnKey="modelType" {...sortProps} />
+                  <SortableTh
+                    label={t('detail.cols.usableAreaSqm')}
+                    columnKey="usableArea"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.sellingPriceBaht')}
+                    columnKey="sellingPrice"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.appraisalValue')}
+                    columnKey="lastAppraisedValue"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <th className="text-center py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.isSold')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.purchaseBy')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.loanBankName')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.updatedAt')}
-                  </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.updatedBy')}
-                  </th>
+                  <SortableTh
+                    label={t('detail.cols.lastUpdated')}
+                    columnKey="updatedAt"
+                    {...sortProps}
+                  />
                 </tr>
               ) : (
                 <tr>
-                  <th className="py-2.5 pl-3 pr-1 w-8">
+                  <th className="py-2 pl-3 pr-1 w-8">
                     <input
                       type="checkbox"
                       checked={allFilteredSelected}
@@ -567,66 +728,74 @@ const BlockUnitMaintenanceDetailPage = () => {
                       className="rounded border-gray-300 text-primary focus:ring-primary/20 cursor-pointer"
                     />
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     #
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.plotNo')}
-                  </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.houseNo')}
-                  </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.modelName')}
-                  </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.numFloors')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.landAreaSqWa')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.usableAreaSqm')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.sellingPriceBaht')}
-                  </th>
-                  <th className="text-right py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.appraisalValue')}
-                  </th>
-                  <th className="text-center py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <SortableTh label={t('detail.cols.plotNo')} columnKey="plotNumber" {...sortProps} />
+                  <SortableTh label={t('detail.cols.houseNo')} columnKey="houseNumber" {...sortProps} />
+                  <SortableTh label={t('detail.cols.modelName')} columnKey="modelType" {...sortProps} />
+                  <SortableTh
+                    label={t('detail.cols.numFloors')}
+                    columnKey="numberOfFloors"
+                    align="center"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.landAreaSqWa')}
+                    columnKey="landArea"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.usableAreaSqm')}
+                    columnKey="usableArea"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.sellingPriceBaht')}
+                    columnKey="sellingPrice"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <SortableTh
+                    label={t('detail.cols.appraisalValue')}
+                    columnKey="lastAppraisedValue"
+                    align="right"
+                    {...sortProps}
+                  />
+                  <th className="text-center py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.isSold')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.purchaseBy')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
+                  <th className="text-left py-2 px-3 text-gray-500 font-medium whitespace-nowrap">
                     {t('units.col.loanBankName')}
                   </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.updatedAt')}
-                  </th>
-                  <th className="text-left py-2.5 px-3 text-gray-500 font-medium whitespace-nowrap">
-                    {t('detail.cols.updatedBy')}
-                  </th>
+                  <SortableTh
+                    label={t('detail.cols.lastUpdated')}
+                    columnKey="updatedAt"
+                    {...sortProps}
+                  />
                 </tr>
               )}
             </thead>
             <tbody>
               {isLoading ? (
                 <TableRowSkeleton
-                  columns={Array.from({ length: 13 }, () => ({ width: 'w-16' }))}
+                  columns={Array.from({ length: 14 }, () => ({ width: 'w-16' }))}
                   rows={8}
                 />
               ) : isError ? (
                 <tr>
-                  <td colSpan={13} className="px-4 py-10 text-center text-sm text-red-500">
+                  <td colSpan={14} className="px-4 py-10 text-center text-sm text-red-500">
                     {t('errors.unitLoadFailed')}
                   </td>
                 </tr>
               ) : filteredUnits.length === 0 ? (
                 <tr>
-                  <td colSpan={13} className="px-4 py-16">
+                  <td colSpan={14} className="px-4 py-16">
                     <div className="flex flex-col items-center gap-2">
                       <Icon style="regular" name="folder-open" className="size-10 text-gray-300" />
                       <p className="text-sm text-gray-500">{t('units.empty')}</p>
@@ -634,7 +803,7 @@ const BlockUnitMaintenanceDetailPage = () => {
                   </td>
                 </tr>
               ) : project ? (
-                filteredUnits.map(unit => {
+                sortedUnits.map(unit => {
                   const editState: UnitEditState = edits.get(unit.id) ?? {
                     isSold: unit.isSold,
                     purchaseBy: unit.purchaseBy as PurchaseMethod | null,

--- a/src/features/blockUnitMaintenance/pages/BlockUnitMaintenancePage.tsx
+++ b/src/features/blockUnitMaintenance/pages/BlockUnitMaintenancePage.tsx
@@ -34,6 +34,7 @@ const SortableTh = ({
   sortDir,
   onSort,
   align = 'left',
+  className = '',
   children,
 }: {
   field: string;
@@ -41,19 +42,19 @@ const SortableTh = ({
   sortDir: 'asc' | 'desc';
   onSort: (f: string) => void;
   align?: 'left' | 'center' | 'right';
+  className?: string;
   children: React.ReactNode;
 }) => {
   const isActive = sortBy === field;
   const alignCls =
     align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
-  const flexAlign =
-    align === 'right' ? 'flex-row-reverse' : align === 'center' ? 'justify-center' : '';
+  const flexAlign = align === 'center' ? 'justify-center' : '';
   const iconName = isActive ? (sortDir === 'asc' ? 'sort-up' : 'sort-down') : 'sort';
   return (
     <th
       onClick={() => onSort(field)}
-      className={`font-medium px-4 py-2.5 whitespace-nowrap select-none cursor-pointer hover:text-gray-900 ${alignCls} ${
-        isActive ? 'text-primary' : 'text-gray-600'
+      className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap select-none cursor-pointer hover:text-gray-700 ${alignCls} ${className} ${
+        isActive ? 'text-primary' : 'text-gray-500'
       }`}
     >
       <div className={`inline-flex items-center gap-1 ${flexAlign}`}>
@@ -181,6 +182,7 @@ const BlockUnitMaintenancePage = () => {
         </div>
         <div className="w-56">
           <Input
+            label={t('list.filter.developerLabel')}
             placeholder={t('list.filter.developerPlaceholder')}
             value={developer}
             onChange={e => {
@@ -209,7 +211,7 @@ const BlockUnitMaintenancePage = () => {
       {/* Table card */}
       <div className="flex-1 min-h-0 bg-white rounded-lg border border-gray-200 overflow-hidden flex flex-col">
         <div className="flex-1 min-h-0 overflow-auto">
-          <table className="w-full text-sm table-fixed">
+          <table className="w-full text-sm">
             <colgroup>
               <col className="w-36" />
               <col className="w-48" />
@@ -233,10 +235,11 @@ const BlockUnitMaintenancePage = () => {
                   sortBy={sortBy}
                   sortDir={sortDir}
                   onSort={toggleSort}
+                  className="w-full"
                 >
                   {t('list.col.projectName')}
                 </SortableTh>
-                <th className="font-medium px-4 py-2.5 text-gray-600 text-left whitespace-nowrap">
+                <th className="px-4 py-2.5 text-xs font-medium text-gray-500 text-left whitespace-nowrap">
                   {t('list.col.projectType')}
                 </th>
                 <SortableTh field="developer" sortBy={sortBy} sortDir={sortDir} onSort={toggleSort}>
@@ -298,15 +301,15 @@ const BlockUnitMaintenancePage = () => {
                       <td className="px-4 py-2.5 text-gray-700 truncate">
                         {item.projectName ?? '—'}
                       </td>
-                      <td className="px-4 py-2.5 text-gray-700">
+                      <td className="px-4 py-2.5 text-gray-700 whitespace-nowrap">
                         {projectTypeDescMap.get(item.projectType) ?? item.projectType}
                       </td>
-                      <td className="px-4 py-2.5 text-gray-600 truncate">
+                      <td className="px-4 py-2.5 text-gray-600 whitespace-nowrap">
                         {item.developer ?? '—'}
                       </td>
                       <td className="px-4 py-2.5">
                         <div className="flex items-center gap-2">
-                          <div className="flex-1 h-2 rounded-full bg-gray-100 overflow-hidden">
+                          <div className="w-20 h-1.5 rounded-full bg-gray-100 overflow-hidden">
                             <div
                               className="h-full bg-gradient-to-r from-violet-400 to-indigo-500 transition-[width]"
                               style={{ width: `${pct}%` }}

--- a/src/i18n/locales/en/blockReappraisal.json
+++ b/src/i18n/locales/en/blockReappraisal.json
@@ -10,11 +10,11 @@
     "landAndBuilding": "Land & Building"
   },
   "columns": {
-    "oldAppraisalNumber": "Old Appraisal Report No.",
+    "oldAppraisalNumber": "Prev Appraisal Number",
     "projectName": "Project Name",
     "projectSellingPrice": "Project Selling Price (Baht)",
-    "remainingTotalUnit": "Remaining / Total Unit",
-    "lastAppraisedDate": "Last Appraised Date",
+    "remainingTotalUnit": "Available / Total Unit",
+    "lastAppraisedDate": "Last Appraisal Date",
     "remainingDay": "Remaining Day"
   },
   "remainingDayBadge": {
@@ -25,7 +25,7 @@
     "title": "Filters",
     "fields": {
       "search": "Search",
-      "lastAppraisedDate": "Last Appraised Date",
+      "lastAppraisedDate": "Last Appraisal Date",
       "remainingDay": "Remaining Day"
     },
     "placeholders": {
@@ -54,7 +54,7 @@
   },
   "actions": {
     "createRequest": "Initiate reappraisal request",
-    "notRequired": "Reappraisal Not Required"
+    "notRequired": "Reappraisal not required"
   },
   "detail": {
     "backToList": "Back to list",
@@ -62,6 +62,25 @@
     "oldAppraisalLabel": "Old Appraisal No.:",
     "fields": {
       "dueDate": "Due Date"
+    },
+    "filter": {
+      "searchPlaceholder": "House Number / Plot / Room / Model",
+      "estimateMin": "Estimate min",
+      "estimateMax": "Estimate max",
+      "all": "All",
+      "sold": "Sold",
+      "available": "Available",
+      "clear": "Clear filters",
+      "noMatch": "No units match the filters"
+    },
+    "dueBadge": {
+      "overdue": "Overdue by {{days}}d",
+      "today": "Due today",
+      "inDays": "Due in {{days}}d"
+    },
+    "kpi": {
+      "totalEstimate": "Total Est. Value (Baht)",
+      "avgEstimate": "Avg Est. Value (Baht)"
     },
     "overview": {
       "title": "Unit Overview",
@@ -101,6 +120,8 @@
   "units": {
     "sold": "Sold",
     "available": "Available",
+    "soldHint": "Sold unit",
+    "availableHint": "Available (unsold) unit",
     "updatedByLine": "by {{name}}",
     "cols": {
       "floor": "Floor Number",
@@ -108,7 +129,7 @@
       "regNumber": "Reg. Number",
       "roomNo": "Room Number",
       "modelType": "Model Name",
-      "usableArea": "Usable Area (Sq.M.)",
+      "usableArea": "Usable Area (Sq.M)",
       "sellingPrice": "Selling Price (Baht)",
       "appraisalValue": "Estimate Price (Baht)",
       "plotNo": "Plot No",

--- a/src/i18n/locales/en/blockUnitMaintenance.json
+++ b/src/i18n/locales/en/blockUnitMaintenance.json
@@ -27,7 +27,8 @@
     },
     "filter": {
       "searchPlaceholder": "Search appraisal number, project name…",
-      "developerPlaceholder": "Filter by developer"
+      "developerLabel": "Developer",
+      "developerPlaceholder": "Developer name"
     }
   },
   "detail": {
@@ -51,8 +52,8 @@
       "sold": "Sold",
       "available": "Available",
       "soldLoan": "Sold via Loan",
-      "appraisalMin": "Appraisal min",
-      "appraisalMax": "Appraisal max"
+      "appraisalMin": "Estimate min",
+      "appraisalMax": "Estimate max"
     },
     "bulk": {
       "selectedCount_one": "{{count}} selected",
@@ -65,26 +66,32 @@
     },
     "donutSoldLabel": "Sold Unit",
     "unitSuffix": "Unit",
+    "kpi": {
+      "totalEstimate": "Total Est. Value (Baht)",
+      "avgEstimate": "Avg Est. Value (Baht)"
+    },
     "cols": {
-      "floor": "Floor",
+      "floor": "Floor Number",
       "towerName": "Tower Name",
       "regNumber": "Reg. Number",
-      "roomNo": "Room No",
-      "modelType": "Model Type",
-      "usableAreaSqm": "Usable Area (sq.m.)",
+      "roomNo": "Room Number",
+      "modelType": "Model Name",
+      "usableAreaSqm": "Usable Area (Sq.M)",
       "sellingPriceBaht": "Selling Price (Baht)",
-      "appraisalValue": "Appraisal Value",
+      "appraisalValue": "Estimate Price (Baht)",
       "plotNo": "Plot No",
       "houseNo": "House No",
       "modelName": "Model Name",
       "numFloors": "No. of Floors",
       "landAreaSqWa": "Land Area (Sq.Wa)",
       "updatedAt": "Updated At",
-      "updatedBy": "Updated By"
+      "updatedBy": "Updated By",
+      "lastUpdated": "Last Updated"
     }
   },
   "units": {
     "title": "Units",
+    "updatedByLine": "by {{name}}",
     "empty": "No units found for this project",
     "saveChanges": "Save Changes",
     "saving": "Saving...",

--- a/src/i18n/locales/zh/blockReappraisal.json
+++ b/src/i18n/locales/zh/blockReappraisal.json
@@ -10,11 +10,11 @@
     "landAndBuilding": "Land & Building"
   },
   "columns": {
-    "oldAppraisalNumber": "Old Appraisal Report No.",
+    "oldAppraisalNumber": "Prev Appraisal Number",
     "projectName": "Project Name",
     "projectSellingPrice": "Project Selling Price (Baht)",
-    "remainingTotalUnit": "Remaining / Total Unit",
-    "lastAppraisedDate": "Last Appraised Date",
+    "remainingTotalUnit": "Available / Total Unit",
+    "lastAppraisedDate": "Last Appraisal Date",
     "remainingDay": "Remaining Day"
   },
   "remainingDayBadge": {
@@ -25,7 +25,7 @@
     "title": "Filters",
     "fields": {
       "search": "Search",
-      "lastAppraisedDate": "Last Appraised Date",
+      "lastAppraisedDate": "Last Appraisal Date",
       "remainingDay": "Remaining Day"
     },
     "placeholders": {
@@ -54,7 +54,7 @@
   },
   "actions": {
     "createRequest": "Initiate reappraisal request",
-    "notRequired": "Reappraisal Not Required"
+    "notRequired": "Reappraisal not required"
   },
   "detail": {
     "backToList": "Back to list",
@@ -62,6 +62,25 @@
     "oldAppraisalLabel": "Old Appraisal No.:",
     "fields": {
       "dueDate": "Due Date"
+    },
+    "filter": {
+      "searchPlaceholder": "门牌号 / 地块 / 房号 / 户型",
+      "estimateMin": "估价下限",
+      "estimateMax": "估价上限",
+      "all": "全部",
+      "sold": "已售",
+      "available": "可售",
+      "clear": "清除筛选",
+      "noMatch": "没有符合筛选条件的单元"
+    },
+    "dueBadge": {
+      "overdue": "已逾期 {{days}} 天",
+      "today": "今日到期",
+      "inDays": "{{days}} 天后到期"
+    },
+    "kpi": {
+      "totalEstimate": "估价总值（泰铢）",
+      "avgEstimate": "平均估价（泰铢）"
     },
     "overview": {
       "title": "Unit Overview",
@@ -101,6 +120,8 @@
   "units": {
     "sold": "Sold",
     "available": "Available",
+    "soldHint": "已售单元",
+    "availableHint": "可售（未售）单元",
     "updatedByLine": "by {{name}}",
     "cols": {
       "floor": "Floor Number",
@@ -108,7 +129,7 @@
       "regNumber": "Reg. Number",
       "roomNo": "Room Number",
       "modelType": "Model Name",
-      "usableArea": "Usable Area (Sq.M.)",
+      "usableArea": "Usable Area (Sq.M)",
       "sellingPrice": "Selling Price (Baht)",
       "appraisalValue": "Estimate Price (Baht)",
       "plotNo": "Plot No",


### PR DESCRIPTION
## Summary
- Updates blockReappraisal list/detail pages, API and types.
- Updates blockUnitMaintenance pages and components (ModelBreakdown, SoldDonut, UnitRow).
- Adds en/zh i18n strings.

Pairs with the backend `feature/block-reappraisal` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)