### PR TITLE
Reorganize DCF modal forms and fix labels

### DIFF
--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal.tsx
@@ -36,15 +36,6 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
-        <span>{t('dcf.common.remark')}</span>
-        <div className={'w-56'}>
-          <RHFInputCell
-            fieldName={`${name}.remark`}
-            inputType={'text'}
-            disabled={isReadOnly}
-            text={{ maxLength: 4000 }}
-          />
-        </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>{t('dcf.common.roomIncome')}</span>
@@ -125,6 +116,17 @@ export function MethodSpecifiedRoomIncomeWithGrowthByOccupancyRateModal({
           />
         </div>
         <span className={''}>{t('dcf.common.year')}</span>
+      </div>
+      <div className="flex flex-row gap-1.5">
+        <span className={'w-56'}>{t('dcf.common.remark')}</span>
+        <div className={'flex-1'}>
+          <RHFInputCell
+            fieldName={`${name}.remark`}
+            inputType={'text'}
+            disabled={isReadOnly}
+            text={{ maxLength: 4000 }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedRoomIncomeWithGrowthModal.tsx
@@ -36,15 +36,6 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
             number={{ decimalPlaces: 0, maxIntegerDigits: 6, allowNegative: false }}
           />
         </div>
-        <span>{t('dcf.common.remark')}</span>
-        <div className={'w-56'}>
-          <RHFInputCell
-            fieldName={`${name}.remark`}
-            inputType={'text'}
-            disabled={isReadOnly}
-            text={{ maxLength: 4000 }}
-          />
-        </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-56'}>{t('dcf.common.roomIncome')}</span>
@@ -95,6 +86,17 @@ export function MethodSpecifiedRoomIncomeWithGrowthModal({
           />
         </div>
         <span className={''}>{t('dcf.common.year')}</span>
+      </div>
+      <div className="flex flex-row gap-1.5">
+        <span className={'w-56'}>{t('dcf.common.remark')}</span>
+        <div className={'flex-1'}>
+          <RHFInputCell
+            fieldName={`${name}.remark`}
+            inputType={'text'}
+            disabled={isReadOnly}
+            text={{ maxLength: 4000 }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodSpecifiedValueWithGrowthModal.tsx
@@ -28,7 +28,10 @@ export function MethodSpecifiedValueWithGrowthModal({
             }}
           />
         </div>
-        <span className={''}>{t('dcf.common.increase')}</span>
+        <span>{t('dcf.common.bahtPerYear')}</span>
+      </div>
+      <div className="flex flex-row gap-1.5 items-center">
+        <span className={'w-56'}>{t('dcf.common.increase')}</span>
         <div className="w-24">
           <RHFInputCell
             fieldName={`${name}.increaseRatePct`}

--- a/src/i18n/locales/en/pricingAnalysis.json
+++ b/src/i18n/locales/en/pricingAnalysis.json
@@ -305,7 +305,7 @@
         "taxTableTitle": "Land and Building Tax",
         "yearLabel": "Year {{year}}",
         "row1Label": "(1) Government Land Price (with annual increase)",
-        "row2Label": "(2) Government Price for Buildings",
+        "row2Label": "(2) Government Price for Building",
         "row3Label": "(1+2) Total price of Government Property",
         "propertyTaxRow": "Property tax on Government Appraisal Price"
       },
@@ -317,7 +317,7 @@
         "unitPerRoomDay": "Baht/ Room/ Day"
       },
       "valueWithGrowth": {
-        "firstYearAmount": "First year amount"
+        "firstYearAmount": "First Year Amount"
       },
       "energyCostIndex": {
         "energyCostIndex": "Energy Cost Index",


### PR DESCRIPTION
- Move remark field to end of form in MethodSpecifiedRoomIncome modals for better UX
- Fix form layout in MethodSpecifiedValueWithGrowth modal by adding proper row structure
- Correct i18n labels: 'Buildings' → 'Building' and capitalize 'firstYearAmount'
- Use flex-1 for remark input to allow full width utilization