### PR TITLE
CA-492 Refactor DCF tier-of-property-value modal UI

### DIFF
--- a/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
+++ b/src/features/pricingAnalysis/components/dcf/dcfMethods/MethodParameterBasedOnTierOfPropertyValueModal.tsx
@@ -99,22 +99,26 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-80'}>{t('dcf.methods.tierOfPropertyValue.totalGovLandPrice')}</span>
-        <div className={'flex flex-row w-44 gap-1.5'}>
-          <span className="w-44 text-right">
-            {landGovPrice ? Number(landGovPrice).toLocaleString() : 0}
-          </span>
-          <span>{t('dcf.common.baht')}</span>
+      <div className="border border-gray-300 rounded-xl bg-gray-50 p-2 flex flex-col gap-1.5">
+        <div className="flex flex-row gap-1.5 justify-between items-center">
+          <span className={'w-80'}>{t('dcf.methods.tierOfPropertyValue.totalGovLandPrice')}</span>
+          <div className={'flex flex-row w-44 gap-1.5'}>
+            <span className="w-44 text-right">
+              {landGovPrice ? Number(landGovPrice).toLocaleString() : 0}
+            </span>
+            <span>{t('dcf.common.baht')}</span>
+          </div>
         </div>
-      </div>
-      <div className="flex flex-row gap-1.5 items-center">
-        <span className={'w-80'}>{t('dcf.methods.tierOfPropertyValue.totalGovBuildingPrice')}</span>
-        <div className={'flex flex-row w-44 gap-1.5'}>
-          <span className="w-44 text-right">
-            {buildingGovPrice ? Number(buildingGovPrice).toLocaleString() : 0}
+        <div className="flex flex-row gap-1.5 justify-between items-center">
+          <span className={'w-80'}>
+            {t('dcf.methods.tierOfPropertyValue.totalGovBuildingPrice')}
           </span>
-          <span>{t('dcf.common.baht')}</span>
+          <div className={'flex flex-row w-44 gap-1.5'}>
+            <span className="w-44 text-right">
+              {buildingGovPrice ? Number(buildingGovPrice).toLocaleString() : 0}
+            </span>
+            <span>{t('dcf.common.baht')}</span>
+          </div>
         </div>
       </div>
       <div className="flex flex-row gap-1.5 items-center">
@@ -140,7 +144,7 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
         </div>
         <span className={''}>{t('dcf.common.year')}</span>
       </div>
-      <div className="flex flex-row gap-1.5">
+      <div className="flex flex-row gap-1.5 items-center">
         <span className={'w-80'}>{t('dcf.common.startIn')}</span>
         <div className={'w-44'}>
           <RHFInputCell
@@ -167,52 +171,59 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 </th>
               </tr>
               <tr>
-                <th colSpan={2} rowSpan={1} className="border-b border-r border-gray-300">
-                  {t('dcf.methods.tierOfPropertyValue.estimatedPrice')}
+                <th colSpan={2} className="border-b border-r border-gray-300">
+                  <div className="flex justify-end">
+                    {t('dcf.methods.tierOfPropertyValue.estimatedPrice')}
+                  </div>
                 </th>
                 <th colSpan={1} rowSpan={2} className="border-b border-r border-gray-300">
-                  {t('dcf.methods.tierOfPropertyValue.taxRate')}
+                  <div className="flex justify-end">
+                    {t('dcf.methods.tierOfPropertyValue.taxRate')}
+                  </div>
                 </th>
                 <th colSpan={1} rowSpan={2} className="border-b border-gray-300">
-                  {t('dcf.methods.tierOfPropertyValue.taxCeiling')}
+                  <div className="flex justify-end">
+                    {t('dcf.methods.tierOfPropertyValue.taxCeiling')}
+                  </div>
                 </th>
               </tr>
               <tr>
-                <th className="border-b border-gray-300">
-                  {t('dcf.methods.tierOfPropertyValue.from')}
+                <th className="border-b border-r border-gray-300">
+                  <div className="flex justify-end">
+                    {t('dcf.methods.tierOfPropertyValue.from')}
+                  </div>
                 </th>
                 <th className="border-b border-r border-gray-300">
-                  {t('dcf.methods.tierOfPropertyValue.to')}
+                  <div className="flex justify-end">{t('dcf.methods.tierOfPropertyValue.to')}</div>
                 </th>
               </tr>
             </thead>
             <tbody>
-              {propertyTaxRanges.map(t => {
-                return (
-                  <>
-                    <tr>
-                      <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
-                        {t.minValue != undefined || t.minValue != null
-                          ? toNumber(t.minValue).toLocaleString()
-                          : '-'}
-                      </td>
-                      <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
-                        {t.maxValue != undefined || t.maxValue != null
-                          ? toNumber(t.maxValue).toLocaleString()
-                          : '-'}
-                      </td>
-                      <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
-                        {`${toFixed2(t.taxRate * 100)} %`}
-                      </td>
-                      <td className="border-b border-gray-300 px-1.5 py-2 text-right">
-                        {t.maxValue
-                          ? toDecimal((t.maxValue - t.minValue) * t.taxRate, 0).toLocaleString()
-                          : '-'}
-                      </td>
-                    </tr>
-                  </>
-                );
-              })}
+              {propertyTaxRanges.map(range => (
+                <tr key={range.minValue}>
+                  <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
+                    {range.minValue != undefined && range.minValue != null
+                      ? toNumber(range.minValue).toLocaleString()
+                      : '-'}
+                  </td>
+                  <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
+                    {range.maxValue != undefined && range.maxValue != null
+                      ? toNumber(range.maxValue).toLocaleString()
+                      : '-'}
+                  </td>
+                  <td className="border-b border-r border-gray-300 px-1.5 py-2 text-right">
+                    {`${toFixed2(range.taxRate * 100)} %`}
+                  </td>
+                  <td className="border-b border-gray-300 px-1.5 py-2 text-right">
+                    {range.maxValue
+                      ? toDecimal(
+                          (range.maxValue - range.minValue) * range.taxRate,
+                          0,
+                        ).toLocaleString()
+                      : '-'}
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </ScrollableTableContainer>
@@ -223,22 +234,35 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
           <table className={'table table-xs min-w-max border-separate border-spacing-0'}>
             <thead>
               <tr>
-                <th colSpan={totalNumberOfYears + 1} className="border-b border-gray-300">
+                <th
+                  colSpan={totalNumberOfYears + 1}
+                  className="border-b border-gray-300 text-center"
+                >
                   {t('dcf.methods.tierOfPropertyValue.taxTableTitle')}
                 </th>
               </tr>
               <tr>
-                <th></th>
+                <th className="border-b border-r border-gray-300 px-1.5 py-2"></th>
                 {Array.from({ length: totalNumberOfYears }, (_, i) => (
-                  <th key={i}>{t('dcf.methods.tierOfPropertyValue.yearLabel', { year: i + 1 })}</th>
+                  <th
+                    key={i}
+                    className={`border-b border-gray-300 px-1.5 py-2 text-right${i < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
+                    {t('dcf.methods.tierOfPropertyValue.yearLabel', { year: i + 1 })}
+                  </th>
                 ))}
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>{t('dcf.methods.tierOfPropertyValue.row1Label')}</td>
+                <td className="border-b border-r border-gray-300 px-1.5 py-2">
+                  {t('dcf.methods.tierOfPropertyValue.row1Label')}
+                </td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
-                  <td key={idx} className="text-right">
+                  <td
+                    key={idx}
+                    className={`border-b border-gray-300 px-1.5 py-2 text-right${idx < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
                     <RHFInputCell
                       fieldName={`${name}.propertyTax.landPrices.${idx}`}
                       inputType="display"
@@ -250,17 +274,27 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 ))}
               </tr>
               <tr>
-                <td>{t('dcf.methods.tierOfPropertyValue.row2Label')}</td>
+                <td className="border-b border-r border-gray-300 px-1.5 py-2">
+                  {t('dcf.methods.tierOfPropertyValue.row2Label')}
+                </td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
-                  <td key={idx} className="text-right">
+                  <td
+                    key={idx}
+                    className={`border-b border-gray-300 px-1.5 py-2 text-right${idx < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
                     <span>{buildingGovPrice ? buildingGovPrice.toLocaleString() : 0}</span>
                   </td>
                 ))}
               </tr>
               <tr>
-                <td>{t('dcf.methods.tierOfPropertyValue.row3Label')}</td>
+                <td className="border-b border-r border-gray-300 px-1.5 py-2">
+                  {t('dcf.methods.tierOfPropertyValue.row3Label')}
+                </td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
-                  <td key={idx} className="text-right">
+                  <td
+                    key={idx}
+                    className={`border-b border-gray-300 px-1.5 py-2 text-right${idx < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
                     <RHFInputCell
                       fieldName={`${name}.propertyTax.totalPropertyPrice.${idx}`}
                       inputType="display"
@@ -272,27 +306,42 @@ export function MethodParameterBasedOnTierOfPropertyValueModal({
                 ))}
               </tr>
               <tr>
-                <td>{t('dcf.methods.tierOfPropertyValue.propertyTaxRow')}</td>
+                <td className="border-b border-r border-gray-300 px-1.5 py-2">
+                  {t('dcf.methods.tierOfPropertyValue.propertyTaxRow')}
+                </td>
                 {Array.from({ length: totalNumberOfYears }, (_, idx) => (
-                  <td key={idx} className="text-right">
-                    <div className="flex flex-row justify-between items-center">
-                      <RHFInputCell
-                        fieldName={`${name}.propertyTax.totalPropertyTax.${idx}`}
-                        inputType="display"
-                        accessor={({ value }) => (
-                          <span className="text-right">{value ? value.toLocaleString() : 0}</span>
-                        )}
-                      />
-                      <RHFInputCell
-                        fieldName={`${name}.propertyTax.totalPropertyTaxRates.${idx}`}
-                        inputType="display"
-                        accessor={({ value }) => (
-                          <span className="text-right">
-                            ({value ? (Number(value) * 100).toLocaleString() : 0} %)
-                          </span>
-                        )}
-                      />
-                    </div>
+                  <td
+                    key={idx}
+                    className={`border-b border-gray-300 px-1.5 py-2 text-right${idx < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
+                    <RHFInputCell
+                      fieldName={`${name}.propertyTax.totalPropertyTax.${idx}`}
+                      inputType="display"
+                      accessor={({ value }) => (
+                        <span className="text-right">{value ? value.toLocaleString() : 0}</span>
+                      )}
+                    />
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <td className="border-r border-gray-300 px-1.5 py-2 text-gray-400">
+                  {t('dcf.methods.tierOfPropertyValue.taxRate')}
+                </td>
+                {Array.from({ length: totalNumberOfYears }, (_, idx) => (
+                  <td
+                    key={idx}
+                    className={`border-gray-300 px-1.5 py-2 text-right text-gray-400${idx < totalNumberOfYears - 1 ? ' border-r' : ''}`}
+                  >
+                    <RHFInputCell
+                      fieldName={`${name}.propertyTax.totalPropertyTaxRates.${idx}`}
+                      inputType="display"
+                      accessor={({ value }) => (
+                        <span className="text-right">
+                          {value ? (Number(value) * 100).toLocaleString() : 0} %
+                        </span>
+                      )}
+                    />
                   </td>
                 ))}
               </tr>


### PR DESCRIPTION
Restyle MethodParameterBasedOnTierOfPropertyValueModal: wrap gov price fields in a bordered container, improve table cell/heading alignment and borders, center the tax table title, and add consistent right-aligned cells. Replace fragment mapping with keyed rows, tighten null checks (use &&), simplify map variable naming, and adjust tax rate/percent display formatting. These are UI and safety/markup improvements only; no business logic changes.