### PR TITLE
Fix stale form arrays when projection period shrinks

### DIFF
--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowPanel.tsx
@@ -314,7 +314,6 @@ export function DiscountedCashFlowPanel({
   const handleOnReset = () => setIsShowResetDialog(true);
   const handleOnConfirmReset = async () => {
     setIsShowResetDialog(false);
-    // ...
     setIsGenerated(false);
   };
 

--- a/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
+++ b/src/features/pricingAnalysis/components/dcf/DiscountedCashFlowTable.tsx
@@ -4,9 +4,13 @@ import { RHFInputCell } from '../table/RHFInputCell';
 import { DiscountedCashFlowSectionRenderer } from '@/features/pricingAnalysis/components/dcf/DiscountedCashFlowSectionRenderer';
 import type { DCFSection } from '../../types/dcf';
 import { StickyLabelTable } from '../layout/StickyLabelTable';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useDerivedFields } from '../../adapters/useDerivedFieldArray';
-import { buildMethodCalculationRules } from '../../domain/dcf/useCalculations';
+import {
+  buildMethodCalculationRules,
+  getMethodPerYearFieldPaths,
+} from '../../domain/dcf/useCalculations';
+import { useDebounce } from '@/shared/hooks/useDebounce';
 
 export interface SectionColor {
   bg: string;
@@ -98,12 +102,50 @@ export function DiscountedCashFlowTable({
   marketSurveys,
   ensureIncomeAnalysisId,
 }: DiscountedCashFlowTableProps) {
-  const { control } = useFormContext();
+  const { control, getValues, setValue } = useFormContext();
   const watchSections = useWatch({ control, name: 'sections' });
 
   const sections = useMemo(() => {
     return watchSections ?? [];
   }, [watchSections]);
+
+  const prevTotalNumberOfYearsRef = useRef(totalNumberOfYears);
+  useEffect(() => {
+    const prevTotalNumberOfYears = prevTotalNumberOfYearsRef.current;
+    prevTotalNumberOfYearsRef.current = totalNumberOfYears;
+    if (totalNumberOfYears >= prevTotalNumberOfYears) return;
+
+    const truncate = (path: string) => {
+      const current = getValues(path);
+      if (Array.isArray(current) && current.length > totalNumberOfYears) {
+        setValue(path, current.slice(0, totalNumberOfYears), { shouldDirty: true });
+      }
+    };
+
+    const currentSections = (getValues('sections') as DCFSection[]) ?? [];
+    currentSections.forEach((section, sectionIdx) => {
+      const sectionPath = `sections.${sectionIdx}`;
+      truncate(`${sectionPath}.totalSectionValues`);
+
+      (section.categories ?? []).forEach((category, categoryIdx) => {
+        const categoryPath = `${sectionPath}.categories.${categoryIdx}`;
+        truncate(`${categoryPath}.totalCategoryValues`);
+
+        (category.assumptions ?? []).forEach((assumption, assumptionIdx) => {
+          const assumptionPath = `${categoryPath}.assumptions.${assumptionIdx}`;
+          truncate(`${assumptionPath}.totalAssumptionValues`);
+
+          const methodType = assumption.method?.methodType;
+          if (!methodType) return;
+
+          const methodPath = `${assumptionPath}.method`;
+          getMethodPerYearFieldPaths(methodType).forEach(fieldPath => {
+            truncate(`${methodPath}.${fieldPath}`);
+          });
+        });
+      });
+    });
+  }, [totalNumberOfYears, getValues, setValue]);
 
   const methodCalculationRules = useMemo(() => {
     return buildMethodCalculationRules(sections, totalNumberOfYears);

--- a/src/features/pricingAnalysis/components/table/TDropdown.tsx
+++ b/src/features/pricingAnalysis/components/table/TDropdown.tsx
@@ -69,7 +69,6 @@ const TDropdown = forwardRef<HTMLButtonElement, DropdownProps>(
     const paramOptions = useParameterOptions(queryParameters);
     let dropdownOptions = useMemo<ListBoxItem[]>(() => {
       if (options !== undefined) return options;
-      console.log(paramOptions);
       return paramOptions;
     }, [options, paramOptions]);
 

--- a/src/features/pricingAnalysis/domain/dcf/useCalculations.ts
+++ b/src/features/pricingAnalysis/domain/dcf/useCalculations.ts
@@ -34,6 +34,23 @@ const methodCalculators: Partial<Record<MethodType, MethodRuleBuilder>> = {
   '14': buildMethodSpecifiedValueWithGrowthDerivedRules,
 };
 
+export function getMethodPerYearFieldPaths(methodType: MethodType): string[] {
+  const buildRules = methodCalculators[methodType];
+  if (!buildRules) return [];
+
+  const probeName = '__method__';
+  const prefix = `${probeName}.`;
+  const rules = buildRules({ name: probeName, totalNumberOfYears: 1 });
+
+  const paths = new Set<string>();
+  for (const rule of rules) {
+    if (rule.targetPath.startsWith(prefix) && rule.targetPath.endsWith('.0')) {
+      paths.add(rule.targetPath.slice(prefix.length, -2));
+    }
+  }
+  return Array.from(paths);
+}
+
 export function buildMethodCalculationRules(
   sections: DCFSection[] = [],
   totalNumberOfYears: number,


### PR DESCRIPTION
Issue:
When totalNumberOfYears decreased (e.g. from 30 to 20), per-year form
arrays were not being truncated, leaving stale data from the removed
years and causing rendering issues in components that map over them.

Solution:
Added a useEffect hook in DiscountedCashFlowTable that slices all
per-year arrays down to the new length whenever totalNumberOfYears
decreases. To avoid hard-coding field names per method type, extracted a
getMethodPerYearFieldPaths helper that probes each method's rule
builder with totalNumberOfYears: 1. Any derived-field rule whose
targetPath ends with .0 is targeting a per-year array; stripping the
sentinel prefix and .0 suffix yields the bare field paths to truncate.